### PR TITLE
CASSANDRA-20910: Harden final alive admission for foreign nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -110,7 +110,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -143,7 +143,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -201,7 +201,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -267,7 +267,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -298,10 +298,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -378,7 +378,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -408,10 +408,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -534,7 +534,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -565,7 +565,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -621,7 +621,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -654,7 +654,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -740,7 +740,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -814,7 +814,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -847,7 +847,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -905,7 +905,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -936,10 +936,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1016,7 +1016,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1050,7 +1050,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1136,7 +1136,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1169,7 +1169,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1227,7 +1227,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1260,7 +1260,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1346,7 +1346,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1377,10 +1377,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1457,7 +1457,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1487,10 +1487,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1567,7 +1567,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1601,7 +1601,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1659,7 +1659,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1693,7 +1693,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1855,7 +1855,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1886,7 +1886,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -1942,7 +1942,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1973,10 +1973,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2077,7 +2077,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2108,10 +2108,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2188,7 +2188,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2218,10 +2218,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2298,7 +2298,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2329,7 +2329,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2385,7 +2385,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2419,7 +2419,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2477,7 +2477,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2508,10 +2508,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2588,7 +2588,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2618,10 +2618,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2698,7 +2698,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2764,7 +2764,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2797,7 +2797,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2883,7 +2883,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2957,7 +2957,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2991,7 +2991,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3077,7 +3077,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3107,10 +3107,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3211,7 +3211,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3241,10 +3241,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3345,7 +3345,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3376,10 +3376,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3480,7 +3480,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3513,7 +3513,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3599,7 +3599,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3715,7 +3715,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3748,7 +3748,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3834,7 +3834,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3907,7 +3907,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3941,7 +3941,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3999,7 +3999,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4029,7 +4029,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -4085,7 +4085,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4158,7 +4158,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4189,10 +4189,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4269,7 +4269,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4299,10 +4299,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4403,7 +4403,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4436,7 +4436,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4494,7 +4494,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4525,10 +4525,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4651,7 +4651,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4685,7 +4685,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4743,7 +4743,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4776,7 +4776,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4834,7 +4834,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4867,7 +4867,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4953,7 +4953,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4984,10 +4984,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5064,7 +5064,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5094,10 +5094,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5174,7 +5174,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5208,7 +5208,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5266,7 +5266,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5296,10 +5296,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5376,7 +5376,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5410,7 +5410,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5468,7 +5468,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5498,10 +5498,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5602,7 +5602,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5633,10 +5633,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5713,7 +5713,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5746,7 +5746,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5804,7 +5804,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5834,10 +5834,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5938,7 +5938,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5968,10 +5968,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6048,7 +6048,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6079,10 +6079,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6135,7 +6135,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6165,10 +6165,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6243,7 +6243,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6277,7 +6277,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6335,7 +6335,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6365,10 +6365,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6445,7 +6445,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6479,7 +6479,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6537,7 +6537,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6568,10 +6568,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6648,7 +6648,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6682,7 +6682,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6740,7 +6740,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6770,10 +6770,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6826,7 +6826,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6859,7 +6859,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6945,7 +6945,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6978,7 +6978,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7064,7 +7064,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7098,7 +7098,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7156,7 +7156,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7265,7 +7265,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7296,10 +7296,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7352,7 +7352,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7382,10 +7382,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7438,7 +7438,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7502,7 +7502,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7536,7 +7536,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7594,7 +7594,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7624,10 +7624,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7702,7 +7702,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7736,7 +7736,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7898,7 +7898,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7971,7 +7971,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8004,7 +8004,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8090,7 +8090,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8120,10 +8120,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8200,7 +8200,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8230,10 +8230,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8334,7 +8334,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8367,7 +8367,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8453,7 +8453,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8561,7 +8561,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8591,10 +8591,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8671,7 +8671,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8704,7 +8704,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8762,7 +8762,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8836,7 +8836,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8900,7 +8900,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8930,10 +8930,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9008,7 +9008,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9042,7 +9042,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9100,7 +9100,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9130,10 +9130,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9234,7 +9234,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9267,7 +9267,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9325,7 +9325,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9431,7 +9431,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.net.CrossClusterNodesTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9467,302 +9467,663 @@ workflows:
     - j8_build:
         requires:
         - start_j8_build
+        upstream:
+          start_j8_build:
+          - success
     - start_j8_unit_tests:
         type: approval
     - j8_unit_tests:
         requires:
         - start_j8_unit_tests
         - j8_build
+        upstream:
+          start_j8_unit_tests:
+          - success
+          j8_build:
+          - success
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - j8_build
+        upstream:
+          start_j8_unit_tests_repeat:
+          - success
+          j8_build:
+          - success
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
         requires:
         - start_j8_jvm_dtests
         - j8_build
+        upstream:
+          start_j8_jvm_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_jvm_dtests_vnode:
         type: approval
     - j8_jvm_dtests_vnode:
         requires:
         - start_j8_jvm_dtests_vnode
         - j8_build
+        upstream:
+          start_j8_jvm_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j8_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j8_build:
+          - success
     - start_j11_jvm_dtests_vnode:
         type: approval
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
         - j8_build
+        upstream:
+          start_j11_jvm_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j8_simulator_dtests:
         type: approval
     - j8_simulator_dtests:
         requires:
         - start_j8_simulator_dtests
         - j8_build
+        upstream:
+          start_j8_simulator_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlshlib_tests:
         type: approval
     - j8_cqlshlib_tests:
         requires:
         - start_j8_cqlshlib_tests
         - j8_build
+        upstream:
+          start_j8_cqlshlib_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlshlib_cython_tests:
         type: approval
     - j8_cqlshlib_cython_tests:
         requires:
         - start_j8_cqlshlib_cython_tests
         - j8_build
+        upstream:
+          start_j8_cqlshlib_cython_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j8_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j8_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j8_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j8_build:
+          - success
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j8_build
+        upstream:
+          start_j11_unit_tests_repeat:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_j8_utests_long
         - j8_build
+        upstream:
+          start_j8_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j8_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_j8_utests_cdc
         - j8_build
+        upstream:
+          start_j8_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j8_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j8_build:
+          - success
+    - start_j8_utests_cdc_repeat:
+        type: approval
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_j8_utests_cdc_repeat
+        - j8_build
+        upstream:
+          start_j8_utests_cdc_repeat:
+          - success
+          j8_build:
+          - success
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j8_build
+        upstream:
+          start_j11_utests_cdc_repeat:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_j8_utests_compression
         - j8_build
+        upstream:
+          start_j8_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j8_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j8_build:
+          - success
+    - start_j8_utests_compression_repeat:
+        type: approval
+    - j8_utests_compression_repeat:
+        requires:
+        - start_j8_utests_compression_repeat
+        - j8_build
+        upstream:
+          start_j8_utests_compression_repeat:
+          - success
+          j8_build:
+          - success
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j8_build
+        upstream:
+          start_j11_utests_compression_repeat:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_j8_utests_stress
         - j8_build
+        upstream:
+          start_j8_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j8_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_j8_utests_fqltool
         - j8_build
+        upstream:
+          start_j8_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j8_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - start_j8_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j8_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
+    - start_j8_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j8_utests_system_keyspace_directory_repeat
+        - j8_build
+        upstream:
+          start_j8_utests_system_keyspace_directory_repeat:
+          - success
+          j8_build:
+          - success
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j8_build
+        upstream:
+          start_j11_utests_system_keyspace_directory_repeat:
+          - success
+          j8_build:
+          - success
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_j8_dtest_jars_build
+        upstream:
+          j8_build:
+          - success
+          start_j8_dtest_jars_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
         - j8_dtest_jars_build
+        upstream:
+          start_jvm_upgrade_dtests:
+          - success
+          j8_dtest_jars_build:
+          - success
     - start_j8_dtests:
         type: approval
     - j8_dtests:
         requires:
         - start_j8_dtests
         - j8_build
+        upstream:
+          start_j8_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_vnode:
         type: approval
     - j8_dtests_vnode:
         requires:
         - start_j8_dtests_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j8_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large_vnode:
         type: approval
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - start_upgrade_dtests
         - j8_build
+        upstream:
+          start_upgrade_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests:
         type: approval
     - j8_cqlsh_dtests_py3:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests_offheap:
         type: approval
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests_offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
   java8_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -9770,221 +10131,499 @@ workflows:
     - j8_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j8_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
+    - j8_unit_tests_repeat:
+        requires:
+        - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_simulator_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_jvm_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_jvm_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_jvm_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlshlib_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlshlib_cython_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
+    - j11_unit_tests_repeat:
+        requires:
+        - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - j11_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
+    - j8_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - j8_build
+        upstream:
+          j8_build:
+          - success
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_jvm_upgrade_dtests
+        upstream:
+          j8_build:
+          - success
+          start_jvm_upgrade_dtests:
+          - success
     - j8_jvm_upgrade_dtests:
         requires:
         - j8_dtest_jars_build
+        upstream:
+          j8_dtest_jars_build:
+          - success
     - j8_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - j8_build
         - start_upgrade_dtests
+        upstream:
+          j8_build:
+          - success
+          start_upgrade_dtests:
+          - success
     - j8_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_cqlsh_dtests_offheap:
         type: approval
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
   java11_separate_tests:
     jobs:
     - start_j11_build:
@@ -9992,142 +10631,314 @@ workflows:
     - j11_build:
         requires:
         - start_j11_build
+        upstream:
+          start_j11_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j11_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j11_build:
+          - success
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
+        upstream:
+          start_j11_unit_tests_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j11_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests_vnode:
         type: approval
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_jvm_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j11_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j11_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j11_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_cdc_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_compression_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j11_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory_repeat:
+          - success
+          j11_build:
+          - success
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10135,108 +10946,243 @@ workflows:
     - j11_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j11_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success

--- a/src/java/org/apache/cassandra/gms/ApplicationState.java
+++ b/src/java/org/apache/cassandra/gms/ApplicationState.java
@@ -90,7 +90,7 @@ public enum ApplicationState
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 
-    public static final Map<String, Object> initialJsonPayload = new HashMap<>()
+    public static final Map<String, Object> initialJsonPayload = new HashMap<String, Object>()
     {{
         put(JsonPayload.CLUSTER_NAME.name(), DatabaseDescriptor.getClusterName());
         put(JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());

--- a/src/java/org/apache/cassandra/gms/ApplicationState.java
+++ b/src/java/org/apache/cassandra/gms/ApplicationState.java
@@ -17,6 +17,14 @@
  */
 package org.apache.cassandra.gms;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.service.StorageService;
+
 /**
  * The various "states" exchanged through Gossip.
  *
@@ -57,6 +65,11 @@ public enum ApplicationState
      **/
     SSTABLE_VERSIONS,
     DISK_USAGE,
+    /**
+     * Free style JSON paylod Map<key, value>. Pprevios Enum ordinals approach could easily create
+     * collisions on upgrades, incompatibilities, mismatches, etc.
+     */
+    JSON_PAYLOAD,
     // DO NOT EDIT OR REMOVE PADDING STATES BELOW - only add new states above.  See CASSANDRA-16484
     X1,
     X2,
@@ -67,5 +80,49 @@ public enum ApplicationState
     X7,
     X8,
     X9,
-    X10,
+    X10;
+
+    public enum JsonPayload
+    {
+        CLUSTER_NAME,
+        PARTITIONER_NAME;
+    }
+
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+    public static final Map<String, Object> initialJsonPayload = new HashMap<>()
+    {{
+        put(JsonPayload.CLUSTER_NAME.name(), DatabaseDescriptor.getClusterName());
+        put(JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());
+    }};
+
+    public static Map<String, Object> deserializeJsonPayload(VersionedValue value)
+    {
+        try
+        {
+            if (value == null)
+                return null;
+            else
+                return jsonMapper.readValue(value.value, Map.class);
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static VersionedValue serializeJsonPayload(Map<String, Object> payload)
+    {
+        try
+        {
+            if (payload == null)
+                return null;
+            else
+                return StorageService.instance.valueFactory.datacenter(jsonMapper.writeValueAsString(payload));
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/gms/GossipDigest.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigest.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.gms;
 
 import java.io.*;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -44,6 +46,12 @@ public class GossipDigest implements Comparable<GossipDigest>
         endpoint = ep;
         generation = gen;
         maxVersion = version;
+    }
+
+    @VisibleForTesting
+    public static GossipDigest getUnsafeForTest(InetAddressAndPort ep, int gen, int version)
+    {
+        return new GossipDigest(ep, gen, version);
     }
 
     InetAddressAndPort getEndpoint()

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -47,9 +49,21 @@ public class GossipDigestAck
         this.epStateMap = epStateMap;
     }
 
+    @VisibleForTesting
+    public static GossipDigestAck getInstanceUnsafeForTesting(List<GossipDigest> gDigestList, Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        return new GossipDigestAck(gDigestList, epStateMap);
+    }
+
     List<GossipDigest> getGossipDigestList()
     {
         return gDigestList;
+    }
+
+    @VisibleForTesting
+    public Map<InetAddressAndPort, EndpointState> getEndpointStateMapUnsafeForTest()
+    {
+        return epStateMap;
     }
 
     Map<InetAddressAndPort, EndpointState> getEndpointStateMap()

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2.java
@@ -21,6 +21,8 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -42,6 +44,12 @@ public class GossipDigestAck2
     GossipDigestAck2(Map<InetAddressAndPort, EndpointState> epStateMap)
     {
         this.epStateMap = epStateMap;
+    }
+
+    @VisibleForTesting
+    public static GossipDigestAck2 getInstanceUnsafeForTesting(Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        return new GossipDigestAck2(epStateMap);
     }
 }
 

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
@@ -33,11 +33,10 @@ public class GossipDigestAck2VerbHandler extends GossipVerbHandler<GossipDigestA
 
     public void doVerb(Message<GossipDigestAck2> message)
     {
+        InetAddressAndPort from = message.from();
         if (logger.isTraceEnabled())
-        {
-            InetAddressAndPort from = message.from();
             logger.trace("Received a GossipDigestAck2Message from {}", from);
-        }
+
         if (!Gossiper.instance.isEnabled())
         {
             if (logger.isTraceEnabled())
@@ -45,6 +44,12 @@ public class GossipDigestAck2VerbHandler extends GossipVerbHandler<GossipDigestA
             return;
         }
         Map<InetAddressAndPort, EndpointState> remoteEpStateMap = message.payload.epStateMap;
+
+        // Cross-cluster safety checks
+        if (!Gossiper.maybeBelongsInCluster(from, remoteEpStateMap.get(from)))
+            return;
+        remoteEpStateMap = Gossiper.removeForeignClusterNodes(remoteEpStateMap);
+
         /* Notify the Failure Detector */
         Gossiper.instance.notifyFailureDetector(remoteEpStateMap);
         Gossiper.instance.applyStateLocally(remoteEpStateMap);

--- a/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
@@ -55,6 +55,11 @@ public class GossipDigestAckVerbHandler extends GossipVerbHandler<GossipDigestAc
         Map<InetAddressAndPort, EndpointState> epStateMap = gDigestAckMessage.getEndpointStateMap();
         logger.trace("Received ack with {} digests and {} states", gDigestList.size(), epStateMap.size());
 
+        // Cross-cluster safety checks
+        if (!Gossiper.maybeBelongsInCluster(from, epStateMap.get(from)))
+            return;
+        epStateMap = Gossiper.removeForeignClusterNodes(epStateMap);
+
         if (Gossiper.instance.isInShadowRound())
         {
             if (logger.isDebugEnabled())

--- a/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,9 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
 
+import static org.apache.cassandra.gms.Gossiper.removeForeignClusterNodes;
 import static org.apache.cassandra.net.Verb.GOSSIP_DIGEST_ACK;
 
 public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSyn>
@@ -112,11 +115,29 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
         super.doVerb(message);
     }
 
+    @VisibleForTesting
+    public static Message<GossipDigestAck> createNormalReplyUnsafeForTest(List<GossipDigest> gDigestList)
+    {
+        return createNormalReply(gDigestList);
+    }
+
     private static Message<GossipDigestAck> createNormalReply(List<GossipDigest> gDigestList)
     {
         List<GossipDigest> deltaGossipDigestList = new ArrayList<>();
         Map<InetAddressAndPort, EndpointState> deltaEpStateMap = new HashMap<>();
         Gossiper.instance.examineGossiper(gDigestList, deltaGossipDigestList, deltaEpStateMap);
+
+        InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
+        // Send cluster and partitioner names for cluster foreign node checks
+        if (deltaEpStateMap.get(nodeAddress) != null)
+        {
+            if (!deltaEpStateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
+                deltaEpStateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                                     ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+
+        }
+        deltaEpStateMap = removeForeignClusterNodes(deltaEpStateMap);
+
         logger.trace("sending {} digests and {} deltas", deltaGossipDigestList.size(), deltaEpStateMap.size());
 
         return Message.out(GOSSIP_DIGEST_ACK, new GossipDigestAck(deltaGossipDigestList, deltaEpStateMap));
@@ -125,6 +146,18 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
     private static Message<GossipDigestAck> createShadowReply()
     {
         Map<InetAddressAndPort, EndpointState> stateMap = Gossiper.instance.examineShadowState();
+
+        InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
+        // Send cluster and partitioner names for cluster foreign node checks
+        if (stateMap.get(nodeAddress) != null)
+        {
+            if (!stateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
+                stateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                              ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+
+        }
+        stateMap = removeForeignClusterNodes(stateMap);
+
         logger.trace("sending 0 digests and {} deltas", stateMap.size());
         return Message.out(GOSSIP_DIGEST_ACK, new GossipDigestAck(Collections.emptyList(), stateMap));
     }

--- a/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
@@ -36,6 +36,15 @@ public class GossipShutdownVerbHandler implements IVerbHandler
             logger.debug("Ignoring shutdown message from {} because gossip is disabled", message.from());
             return;
         }
+
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring shutdown from {} which doesn't belong in this cluster", message.from());
+            return;
+        }
+
         Gossiper.instance.markAsShutdown(message.from());
     }
 

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -44,6 +44,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import org.apache.cassandra.concurrent.*;
 import org.apache.cassandra.concurrent.FutureTask;
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -1237,7 +1239,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return ImmutableSet.copyOf(seedsInShadowRound);
     }
 
-    long getLastProcessedMessageAt()
+    @VisibleForTesting
+    public long getLastProcessedMessageAt()
     {
         return lastProcessedMessageAt;
     }
@@ -1383,6 +1386,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     private void markAlive(final InetAddressAndPort addr, final EndpointState localState)
     {
+        if (!Gossiper.maybeBelongsInCluster(addr, localState))
+        {
+            logger.error("Not sending ECHO to {} which doesn't belong in this cluster", addr);
+        }
+
         localState.markDead();
 
         Message<NoPayload> echoMessage = Message.out(ECHO_REQ, noPayload);
@@ -1576,6 +1584,14 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
             EndpointState localEpStatePtr = endpointStateMap.get(ep);
             EndpointState remoteState = entry.getValue();
+
+            // Cross-cluster safety checks
+            if (!maybeBelongsInCluster(ep, remoteState))
+            {
+                logger.error("Cannot apply state locally for {} because it doesn't seem to belong in this cluster {}", ep, remoteState);
+                continue;
+            }
+
             if (!hasMajorVersion3OrUnknownNodes())
                 remoteState.removeMajorVersion3LegacyApplicationStates();
 
@@ -2612,5 +2628,71 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             }
         }
         return mismatches;
+    }
+
+    /**
+     * If available checks for cluster and partitioner name to match. Useful to avoid accidental cross cluster node joins.
+     *
+     * @param nodeAddress The address of the node we're checking against
+     * @param epState     The state Gossip sent us
+     * @return            False if any of the 2 are present and don't match. Otherwise defaults to True
+     */
+    public static boolean maybeBelongsInCluster(InetAddressAndPort nodeAddress, EndpointState epState)
+    {
+        if (nodeAddress!= null && epState != null)
+        {
+            Map<String, Object> jsonMap = ApplicationState.deserializeJsonPayload(epState.getApplicationState(ApplicationState.JSON_PAYLOAD));
+            if (jsonMap != null)
+            {
+                String auxValue = (String) jsonMap.get(ApplicationState.JsonPayload.CLUSTER_NAME.name());
+                if (auxValue != null && !auxValue.equals(DatabaseDescriptor.getClusterName()))
+                {
+                    logger.error("Gossip from {} rejected, its cluster name {} doesn't match the local one {} triggered at {}",
+                                 nodeAddress,
+                                 auxValue,
+                                 DatabaseDescriptor.getClusterName(),
+                                 ExceptionUtils.getStackTrace(new Exception("Cross cluster node detected")));
+                    return false;
+                }
+
+                auxValue = (String) jsonMap.get(ApplicationState.JsonPayload.PARTITIONER_NAME.name());
+                if (auxValue != null && !auxValue.equals(DatabaseDescriptor.getPartitionerName()))
+                {
+                    logger.error("Gossip from {} rejected, its partitioner name {} doesn't match the local one {} triggered at {}",
+                                 nodeAddress,
+                                 auxValue,
+                                 DatabaseDescriptor.getPartitionerName(),
+                                 ExceptionUtils.getStackTrace(new Exception("Cross cluster node detected")));
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Modifies and removes nodes from the map that joined in err and are foreign to this cluster
+     *
+     * @param epStateMap
+     * @return The purged map
+     */
+    public static Map<InetAddressAndPort, EndpointState> removeForeignClusterNodes(Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        if (epStateMap == null)
+            return null;
+
+        Iterator<Map.Entry<InetAddressAndPort, EndpointState>> it = epStateMap.entrySet().iterator();
+        while (it.hasNext())
+        {
+            Entry<InetAddressAndPort, EndpointState> entry = it.next();
+            if (!maybeBelongsInCluster(entry.getKey(), entry.getValue()))
+            {
+                logger.error("Ignoring Gossip from node {} because its state has info from other clusters {}", entry.getKey(), entry.getValue());
+                it.remove();
+            }
+        }
+
+        return epStateMap;
     }
 }

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1409,6 +1409,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     public void realMarkAlive(final InetAddressAndPort addr, final EndpointState localState)
     {
         checkProperThreadForStateMutation();
+        if (!Gossiper.maybeBelongsInCluster(addr, localState))
+        {
+            logger.error("Not marking {} alive because it doesn't belong in this cluster", addr);
+            return;
+        }
         if (logger.isTraceEnabled())
             logger.trace("marking as alive {}", addr);
         localState.markAlive();

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -21,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.tracing.Tracing;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -35,6 +37,14 @@ class ResponseVerbHandler implements IVerbHandler
     @Override
     public void doVerb(Message message)
     {
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring received response {} from {} which doesn't belong in this cluster", message.id(), message.from());
+            return;
+        }
+
         RequestCallbacks.CallbackInfo callbackInfo = MessagingService.instance().callbacks.remove(message.id(), message.from());
         if (callbackInfo == null)
         {

--- a/src/java/org/apache/cassandra/service/EchoVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/EchoVerbHandler.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.service;
  * under the License.
  *
  */
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -35,6 +37,14 @@ public class EchoVerbHandler implements IVerbHandler<NoPayload>
 
     public void doVerb(Message<NoPayload> message)
     {
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring ECHO request from {} which doesn't belong in this cluster", message.from());
+            return;
+        }
+
         // only respond if we are not shutdown
         if (!StorageService.instance.isShutdown())
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.ICluster;
@@ -61,6 +62,7 @@ public class BootstrapTest extends TestBaseImpl
         // for each test case, the MIGRATION_DELAY time is adjusted accordingly
         savedMigrationDelay = CassandraRelevantProperties.MIGRATION_DELAY.getLong();
         CassandraRelevantProperties.MIGRATION_DELAY.setLong(ManagementFactory.getRuntimeMXBean().getUptime() + savedMigrationDelay);
+        DatabaseDescriptor.clientInitialization();
     }
 
     @After

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.cassandra.distributed.test.ring;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
@@ -38,6 +40,12 @@ import static org.apache.cassandra.distributed.api.TokenSupplier.evenlyDistribut
 
 public class CleanupFailureTest extends TestBaseImpl
 {
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
     @Test
     public void cleanupDuringDecommissionTest() throws Throwable
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/NodeNotInRingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/NodeNotInRingTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.action.GossipHelper;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
@@ -39,6 +40,8 @@ public class NodeNotInRingTest extends TestBaseImpl
     @Test
     public void nodeNotInRingTest() throws Throwable
     {
+        DatabaseDescriptor.clientInitialization();
+
         try (Cluster cluster = builder().withNodes(3)
                                         .withConfig(config -> config.with(NETWORK, GOSSIP))
                                         .start())

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/PendingWritesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/PendingWritesTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.distributed.Cluster;
@@ -56,6 +57,7 @@ public class PendingWritesTest extends TestBaseImpl
         int originalNodeCount = 2;
         int expandedNodeCount = originalNodeCount + 1;
 
+        DatabaseDescriptor.clientInitialization();
         try (Cluster cluster = builder().withNodes(originalNodeCount)
                                         .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(expandedNodeCount))
                                         .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(expandedNodeCount, "dc0", "rack0"))

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
-import org.apache.cassandra.cql3.ColumnSpecification;
 import org.awaitility.Awaitility;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
+import org.apache.cassandra.cql3.ColumnSpecification;
 import org.awaitility.Awaitility;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,7 +78,7 @@ public class GossipInfoTableTest extends CQLTester
 
             assertThat(resultSet.size()).isEqualTo(1);
             UntypedResultSet.Row row = resultSet.one();
-            assertThat(row.getColumns().size()).isEqualTo(64);
+            assertThat(row.getColumns().size()).isEqualTo(66);
 
             assertThat(endpoint).isNotNull();
             assertThat(localState).isNotNull();
@@ -105,6 +106,7 @@ public class GossipInfoTableTest extends CQLTester
             assertValue(row, "status_with_port", localState, ApplicationState.STATUS_WITH_PORT);
             assertValue(row, "sstable_versions", localState, ApplicationState.SSTABLE_VERSIONS);
             assertValue(row, "disk_usage", localState, ApplicationState.DISK_USAGE);
+            assertValue(row, "json_payload", localState, ApplicationState.JSON_PAYLOAD);
             assertValue(row, "x_11_padding", localState, ApplicationState.X_11_PADDING);
             assertValue(row, "x1", localState, ApplicationState.X1);
             assertValue(row, "x2", localState, ApplicationState.X2);
@@ -136,6 +138,7 @@ public class GossipInfoTableTest extends CQLTester
             assertVersion(row, "status_with_port_version", localState, ApplicationState.STATUS_WITH_PORT);
             assertVersion(row, "sstable_versions_version", localState, ApplicationState.SSTABLE_VERSIONS);
             assertVersion(row, "disk_usage_version", localState, ApplicationState.DISK_USAGE);
+            assertValue(row, "json_payload_version", localState, ApplicationState.JSON_PAYLOAD);
             assertVersion(row, "x_11_padding", localState, ApplicationState.X_11_PADDING);
             assertVersion(row, "x1", localState, ApplicationState.X1);
             assertVersion(row, "x2", localState, ApplicationState.X2);

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -24,6 +24,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -225,6 +226,29 @@ public class GossiperTest
         assertTrue(Gossiper.instance.upgradeFromVersionSupplier.get().canMemoize());
         assertFalse(Gossiper.instance.hasMajorVersion3OrUnknownNodes());
         assertFalse(Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_3_4));
+    }
+
+    @Test
+    public void testRealMarkAliveRejectsForeignClusterNode() throws Exception
+    {
+        InetAddressAndPort foreignHost = InetAddressAndPort.getByName("127.0.0.250");
+        EndpointState foreignState = new EndpointState(new HeartBeatState((int) (System.currentTimeMillis() / 1000), 1));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put(ApplicationState.JsonPayload.CLUSTER_NAME.name(), "foreign-cluster");
+        payload.put(ApplicationState.JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());
+        foreignState.addApplicationState(ApplicationState.JSON_PAYLOAD, ApplicationState.serializeJsonPayload(payload));
+
+        Gossiper.instance.liveEndpoints.remove(foreignHost);
+        try
+        {
+            Gossiper.instance.realMarkAlive(foreignHost, foreignState);
+            assertFalse("Foreign endpoint should not be admitted to live endpoints", Gossiper.instance.liveEndpoints.contains(foreignHost));
+        }
+        finally
+        {
+            Gossiper.instance.liveEndpoints.remove(foreignHost);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
+++ b/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.GossipDigest;
+import org.apache.cassandra.gms.GossipDigestAck;
+import org.apache.cassandra.gms.GossipDigestAck2;
+import org.apache.cassandra.gms.GossipDigestAck2VerbHandler;
+import org.apache.cassandra.gms.GossipDigestAckVerbHandler;
+import org.apache.cassandra.gms.GossipDigestSyn;
+import org.apache.cassandra.gms.GossipDigestSynVerbHandler;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.HeartBeatState;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.SeedProvider;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.service.EchoVerbHandler;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.gms.ApplicationState.JSON_PAYLOAD;
+import static org.apache.cassandra.gms.ApplicationState.JsonPayload.CLUSTER_NAME;
+import static org.apache.cassandra.gms.ApplicationState.JsonPayload.PARTITIONER_NAME;
+import static org.apache.cassandra.gms.ApplicationState.deserializeJsonPayload;
+import static org.apache.cassandra.gms.ApplicationState.serializeJsonPayload;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CrossClusterNodesTest
+{
+    static final IPartitioner partitioner = new RandomPartitioner();
+
+    private static final Logger testLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    private static final ListAppender<ILoggingEvent> logListAppender = new ListAppender<>();
+    private static VersionedValue ORIG_CLUSTER_NAME;
+    private static VersionedValue FOREIGN_CLUSTER_NAME;
+    private static final String FOREIGN_PARTITIONER_NAME = "Foreign_Partitioner_Name";
+
+    private final StorageService ss = StorageService.instance;
+    private final TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+    private final ArrayList<Token> endpointTokens = new ArrayList<>();
+    private final ArrayList<Token> keyTokens = new ArrayList<>();
+    private final List<InetAddressAndPort> hosts = new ArrayList<>();
+    private final List<UUID> hostIds = new ArrayList<>();
+
+    private SeedProvider originalSeedProvider;
+    private InetAddressAndPort remoteHostAddress;
+    private EndpointState nodeEpState;
+
+    @BeforeClass
+    static public void initTest()
+    {
+        System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
+
+        DatabaseDescriptor.daemonInitialization();
+        CommitLog.instance.start();
+        logListAppender.start();
+        testLogger.addAppender(logListAppender);
+        Gossiper.instance.start(0);
+
+        ORIG_CLUSTER_NAME = StorageService.instance.valueFactory.datacenter(StorageService.instance.getClusterName());
+        FOREIGN_CLUSTER_NAME = StorageService.instance.valueFactory.datacenter("Foreign_Cluster_Name");
+    }
+
+    @Before
+    public void setup() throws UnknownHostException
+    {
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        tmd.clearUnsafe();
+
+        remoteHostAddress = hosts.get(1);
+        nodeEpState = Gossiper.instance.getEndpointStateForEndpoint(remoteHostAddress);
+        logListAppender.start();
+    }
+
+    @After
+    public void tearDown()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWith("", ""));
+        DatabaseDescriptor.setSeedProvider(originalSeedProvider);
+        logListAppender.list.clear();
+    }
+
+    @Test
+    public void testSYNHandlerRejectsForeignNode()
+    {
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+
+        // Bad cluster
+        GossipDigestSyn digest = new GossipDigestSyn(FOREIGN_CLUSTER_NAME.value, DatabaseDescriptor.getPartitionerName(), Collections.emptyList());
+        Message<GossipDigestSyn> message = Message.synthetic(remoteHostAddress, Verb.SYNC_REQ, digest);
+        GossipDigestSynVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("ClusterName mismatch")));
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains(FOREIGN_CLUSTER_NAME.value)));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+
+        // Bad partitioner
+        logListAppender.start();
+        digest = new GossipDigestSyn(DatabaseDescriptor.getClusterName(), FOREIGN_PARTITIONER_NAME, Collections.emptyList());
+        message = Message.synthetic(remoteHostAddress, Verb.SYNC_REQ, digest);
+        GossipDigestSynVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Partitioner mismatch")));
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains(FOREIGN_PARTITIONER_NAME)));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testSYNHandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        List<GossipDigest> digests = Gossiper.instance.endpointStateMap.keySet().stream().
+                                                                                 map(e -> GossipDigest.getUnsafeForTest(e,0,0)).
+                                                                                 collect(Collectors.toList());
+        digests.add(GossipDigest.getUnsafeForTest(InetAddressAndPort.getByName("127.0.0.3"), 0,0));
+
+        Message<GossipDigestAck> ackReply = GossipDigestSynVerbHandler.createNormalReplyUnsafeForTest(digests);
+
+        assertNull(ackReply.payload.getEndpointStateMapUnsafeForTest().get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testSYNHandlerAddsClusterAndPartitioner()
+    {
+        assertFalse(Gossiper.instance.getEndpointStateForEndpoint(FBUtilities.getBroadcastAddressAndPort()).
+                                      containsApplicationState(JSON_PAYLOAD));
+
+        List<GossipDigest> digests = Gossiper.instance.endpointStateMap.keySet().stream().
+                                                                                 map(e -> GossipDigest.getUnsafeForTest(e, 0, 0)).
+                                                                                 collect(Collectors.toList());
+
+        Message<GossipDigestAck> ackReply = GossipDigestSynVerbHandler.createNormalReplyUnsafeForTest(digests);
+
+        Map<String, Object> jsonPayload = deserializeJsonPayload(ackReply.
+                                                                 payload.
+                                                                 getEndpointStateMapUnsafeForTest().
+                                                                 get(FBUtilities.getBroadcastAddressAndPort()).
+                                                                 getApplicationState(JSON_PAYLOAD));
+        assertEquals(jsonPayload.get(CLUSTER_NAME.name()), ORIG_CLUSTER_NAME.value);
+        assertEquals(jsonPayload.get(PARTITIONER_NAME.name()), DatabaseDescriptor.getPartitionerName());
+    }
+
+    @Test
+    public void testACKHandlerRejectsForeignNode()
+    {
+        GossipDigestAck digest = GossipDigestAck.getInstanceUnsafeForTesting(Collections.emptyList(), ImmutableMap.of(remoteHostAddress, nodeEpState));
+        Message<GossipDigestAck> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK, digest);
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+        GossipDigestAckVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testACKHandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        {{
+            put(remoteHostAddress, nodeEpState);
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+
+        GossipDigestAck digest = GossipDigestAck.getInstanceUnsafeForTesting(Collections.emptyList(), pollutedEpStateMap);
+        Message<GossipDigestAck> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK, digest);
+        GossipDigestAckVerbHandler.instance.doVerb(message);
+
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testACK2HandlerRejectsForeignNode()
+    {
+        GossipDigestAck2 digest = GossipDigestAck2.getInstanceUnsafeForTesting(ImmutableMap.of(remoteHostAddress, nodeEpState));
+        Message<GossipDigestAck2> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK2, digest);
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+        GossipDigestAck2VerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testACK2HandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        {{
+            put(remoteHostAddress, nodeEpState);
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+
+        GossipDigestAck2 digest = GossipDigestAck2.getInstanceUnsafeForTesting(pollutedEpStateMap);
+        Message<GossipDigestAck2> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK2, digest);
+        GossipDigestAck2VerbHandler.instance.doVerb(message);
+
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testECHORequest()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Message<NoPayload> message = Message.synthetic(remoteHostAddress, Verb.ECHO_REQ, null);
+
+        EchoVerbHandler.instance.doVerb(message);
+
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testECHOHandler()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Message<NoPayload> message = Message.synthetic(remoteHostAddress, Verb.ECHO_RSP, null);
+
+        ResponseVerbHandler.instance.doVerb(message);
+
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testApplyStateLocally()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Gossiper.instance.applyStateLocally(ImmutableMap.of(remoteHostAddress, nodeEpState));
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testMaybeBelongsInCluster()
+    {
+        EndpointState testEpState = fakeState();
+
+        // Works with no data
+        assertTrue(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Works with data
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithNonForeignNode());
+        assertTrue(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Rejects bad cluster
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        assertFalse(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Rejects bad partitioner
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithBadPartitioner());
+        assertFalse(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+    }
+
+    @Test
+    public void testRemoveCrossClusterNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        {{
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+        pollutedEpStateMap.putAll(Gossiper.instance.endpointStateMap);
+
+        Map<InetAddressAndPort, EndpointState> sanitizedEpStateMap = Gossiper.removeForeignClusterNodes(pollutedEpStateMap);
+
+        assertEquals(sanitizedEpStateMap.size(), Gossiper.instance.endpointStateMap.size());
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    private static VersionedValue getPayloadWithForeignNode()
+    {
+        return getPayloadWith(CLUSTER_NAME.name(), FOREIGN_CLUSTER_NAME.value);
+    }
+
+    private static VersionedValue getPayloadWithNonForeignNode()
+    {
+        return getPayloadWith(CLUSTER_NAME.name(), ORIG_CLUSTER_NAME.value);
+    }
+
+    private static VersionedValue getPayloadWithBadPartitioner()
+    {
+        return getPayloadWith(PARTITIONER_NAME.name(), FOREIGN_PARTITIONER_NAME);
+    }
+
+    private static VersionedValue getPayloadWith(String key, String value)
+    {
+        Map<String, Object> payload = new HashMap<>()
+        {{
+            put(key, value);
+        }};
+
+        return serializeJsonPayload(payload);
+    }
+
+    private static EndpointState fakeState()
+    {
+        return new EndpointState(new HeartBeatState((int) System.currentTimeMillis()/1000, 1234));
+    }
+}

--- a/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
+++ b/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
@@ -207,7 +207,7 @@ public class CrossClusterNodesTest
     {
         EndpointState foreignNodeEpState = fakeState();
         foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
-        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
         {{
             put(remoteHostAddress, nodeEpState);
             put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
@@ -240,7 +240,7 @@ public class CrossClusterNodesTest
     {
         EndpointState foreignNodeEpState = fakeState();
         foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
-        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
         {{
             put(remoteHostAddress, nodeEpState);
             put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
@@ -312,7 +312,7 @@ public class CrossClusterNodesTest
     {
         EndpointState foreignNodeEpState = fakeState();
         foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
-        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<>()
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
         {{
             put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
         }};
@@ -341,7 +341,7 @@ public class CrossClusterNodesTest
 
     private static VersionedValue getPayloadWith(String key, String value)
     {
-        Map<String, Object> payload = new HashMap<>()
+        Map<String, Object> payload = new HashMap<String, Object>()
         {{
             put(key, value);
         }};


### PR DESCRIPTION
 ## Summary
  Follow-up hardening for CASSANDRA-20910 on 4.1.

  This PR adds a regression test and a minimal final-admission guard so a foreign-identity endpoint cannot be marked alive in the `realMarkAlive` path.

  This is a companion, stacked follow-up to #4618
  ## What This PR Changes
  - Adds `testRealMarkAliveRejectsForeignClusterNode` in `GossiperTest`
  - Adds an early return in `Gossiper.realMarkAlive(...)` when `maybeBelongsInCluster(...)` is false

  ## Invariant Enforced
  - A peer with mismatched cluster identity must never transition into live membership, including at final alive admission.

  ## Test Plan
  Using JDK 11:

  ```bash
  JDK11_HOME=$(jenv prefix 11.0.30)
  JAVA_HOME="$JDK11_HOME" PATH="$JAVA_HOME/bin:$PATH" ant -Duse.jdk11=true testsome -Dtest.name=org.apache.cassandra.gms.GossiperTest

  Validation performed:

  - Before fix: new test fails (Foreign endpoint should not be admitted to live endpoints)
  - After fix: GossiperTest passes
