### PR TITLE
CASSANDRA-21196: Include tools in applyCompatibilityMode check

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Include tools in applyCompatibilityMode to ensure they are not limited in sstable formats they support (CASSANDRA-21196)
  * Harden the possible range of values for max dictionary size and max total sample size for dictionary training (CASSANDRA-21194)
  * Implement a guardrail ensuring that minimum training frequency parameter is provided in ZstdDictionaryCompressor (CASSANDRA-21192)
  * Replace manual referencing with ColumnFamilyStore.selectAndReference when training a dictionary (CASSANDRA-21188)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1896,7 +1896,7 @@ public class DatabaseDescriptor
 
     private static void applyCompatibilityMode()
     {
-        if (isClientInitialized())
+        if (isClientOrToolInitialized())
             // tools or clients should not limit the sstable formats they support
             storageCompatibilityMode = StorageCompatibilityMode.NONE;
         else if (conf != null && conf.storage_compatibility_mode != null)


### PR DESCRIPTION
```
## CASSANDRA-21196: Include tools in applyCompatibilityMode check

### Problem
The `applyCompatibilityMode()` method only checked `isClientInitialized()` 
when setting `StorageCompatibilityMode.NONE`, despite the comment stating 
"tools or clients should not limit the sstable formats they support." 
Tools were inadvertently falling through to the `else if` branch and 
potentially having their sstable format support restricted.

### Solution
Added `isClientorToolInitialized()` to the condition so tools correctly receive 
`StorageCompatibilityMode.NONE`, consistent with the existing behavior 
for clients.

patch by Tina Haiser; reviewed by <Reviewers> for CASSANDRA-21196

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

