### PR TITLE
CASSANDRA-21196: Include tools in applyCompatibilityMode check

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.7
+ * Include tools in applyCompatibilityMode to ensure they are not limited in sstable formats they support (CASSANDRA-21196)
  * Dynamically skip sharding L0 when SAI Vector index present (CASSANDRA-19661)
  * Optionally force IndexStatusManager to use the optimized index status format (CASSANDRA-21132) 
  * No need to evict already prepared statements, as it creates a race condition between multiple threads (CASSANDRA-17401)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1599,7 +1599,7 @@ public class DatabaseDescriptor
 
     private static void applyCompatibilityMode()
     {
-        if (isClientInitialized())
+        if (isClientOrToolInitialized())
             // tools or clients should not limit the sstable formats they support
             storageCompatibilityMode = StorageCompatibilityMode.NONE;
         else if (conf != null && conf.storage_compatibility_mode != null)


### PR DESCRIPTION
## CASSANDRA-21196: Include tools in applyCompatibilityMode check

### Problem
The `applyCompatibilityMode()` method only checked `isClientInitialized()` 
when setting `StorageCompatibilityMode.NONE`, despite the comment stating 
"tools or clients should not limit the sstable formats they support." 
Tools were inadvertently falling through to the `else if` branch and 
potentially having their sstable format support restricted.

### Solution
Added `isClientOrToolInitialized()` to the condition so tools correctly receive 
`StorageCompatibilityMode.NONE`, consistent with the existing behavior 
for clients.

patch by Tina Haiser; reviewed by @driftx  for CASSANDRA-21196