### PR TITLE
CASSANDRA-21209 fail and throw when trainer create larger buffer than possible

### DIFF
--- a/src/java/org/apache/cassandra/db/compression/ZstdDictionaryTrainer.java
+++ b/src/java/org/apache/cassandra/db/compression/ZstdDictionaryTrainer.java
@@ -318,8 +318,20 @@ public class ZstdDictionaryTrainer implements ICompressionDictionaryTrainer
         {
             totalSampleSize.set(0);
             sampleCount.set(0);
-            zstdTrainer = new ZstdDictTrainer(trainingConfig.maxTotalSampleSize, trainingConfig.maxDictionarySize, compressionLevel);
-            config = trainingConfig;
+            try
+            {
+                zstdTrainer = new ZstdDictTrainer(trainingConfig.maxTotalSampleSize, trainingConfig.maxDictionarySize, compressionLevel);
+                config = trainingConfig;
+            }
+            catch (OutOfMemoryError e)
+            {
+                String sizeStr = FileUtils.stringifyFileSize(trainingConfig.maxTotalSampleSize, true);
+                throw new IllegalStateException(
+                String.format("Unable to allocate %s direct buffer for dictionary training. " +
+                              "Consider reducing max total sample size or increasing JVM max direct memory (-XX:MaxDirectMemorySize).",
+                              sizeStr),
+                e);
+            }
         }
     }
 


### PR DESCRIPTION
wrap the trainer creation in a try-catch and throw a IllegalStateException when there is not enough memory to create the buffer.

https://issues.apache.org/jira/browse/CASSANDRA-21209