### PR TITLE
CASSANDRA-21218: Fix typos in documentation

### DIFF
--- a/doc/modules/cassandra/pages/architecture/accord-architecture.adoc
+++ b/doc/modules/cassandra/pages/architecture/accord-architecture.adoc
@@ -245,7 +245,7 @@ history, and are used for invalidating older `TxnId`s, so that a newly
 bootstrapped node may have a complete log as of a point in time `TxnId`,
 and replicas could purge/GC earlier transaction metadata.
 
-SyncPoints are not expected to be processed by the the whole cluster,
+SyncPoints are not expected to be processed by the whole cluster,
 and we do not want transaction processing to be held up, so while these
 are processed much like a transaction, they are invisible to real
 transactions which may proceed before SyncPoint is witnessed by the node

--- a/doc/modules/cassandra/pages/developing/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/ddl.adoc
@@ -33,7 +33,7 @@ equivalent to `mytable`) but case sensitivity can be forced by using
 double-quotes (`"myTable"` is different from `mytable`).
 
 Further, a table is always part of a keyspace and a table name can be
-provided fully-qualified by the keyspace it is part of. If is is not
+provided fully-qualified by the keyspace it is part of. If it is not
 fully-qualified, the table is assumed to be in the _current_ keyspace
 (see xref:cassandra:developing/cql/ddl.adoc#use-statement[USE] statement).
 

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
@@ -23,7 +23,7 @@ In order to calculate the size of partitions, use the following formula:
 
 The number of values (or cells) in the partition (N~v~) is equal to the
 number of static columns (N~s~) plus the product of the number of rows
-(N~r~) and the number of of values per row. The number of values per row
+(N~r~) and the number of values per row. The number of values per row
 is defined as the number of columns (N~c~) minus the number of primary
 key columns (N~pk~) and static columns (N~s~).
 

--- a/doc/modules/cassandra/pages/managing/operating/repair.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/repair.adoc
@@ -1,6 +1,6 @@
 = Repair
 
-Cassandra is designed to remain available if one of it's nodes is down
+Cassandra is designed to remain available if one of its nodes is down
 or unreachable. However, when a node is down or unreachable, it needs to
 eventually discover the writes it missed. Hints attempt to inform a node
 of missed writes, but are a best effort, and aren't guaranteed to inform
@@ -104,7 +104,7 @@ providing enough slack to allow for delays.
   default, incremental repairs are estimated, add the `--full` flag to
   estimate a full repair.
 `-vd, --validate`::
-  Verifies that the repaired data is the same across all nodes. Similiar
+  Verifies that the repaired data is the same across all nodes. Similar
   to `--preview`, this builds and compares merkle trees of repaired
   data, but doesn't do any streaming. This is useful for
   troubleshooting. If this shows that the repaired data is out of sync,


### PR DESCRIPTION
Fix typos in documentation

Fixed the following typos in the documentation:
- repair.adoc (line 3): "it's nodes" → "its nodes"
- repair.adoc (line 107): "Similiar" → "Similar"
- ddl.adoc (line 36): "If is is not" → "If it is not"
- data-modeling_refining.adoc (line 26): "number of of values" → "number of values"
- accord-architecture.adoc (line 248): "by the the whole cluster" → "by the whole cluster"

patch by Shanzitaa; reviewed by TBD for CASSANDRA-21218

