### PR TITLE
 CASSANDRA-16939: Only remove shutdown hook for fatal heap OOMs

### DIFF
--- a/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
+++ b/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
@@ -191,7 +191,8 @@ public final class JVMStabilityInspector
             inspectThrowable(t.getCause(), fn, isUncaughtException);
     }
 
-    public static final Set<String> FORCE_HEAP_OOM_IGNORE_SET = ImmutableSet.of("Java heap space", "GC Overhead limit exceeded");
+    @VisibleForTesting
+    static final Set<String> FORCE_HEAP_OOM_IGNORE_SET = ImmutableSet.of("Java heap space", "GC Overhead limit exceeded");
 
     /**
      * Returns true if the given OOM is a fatal heap-related error (heap space exhaustion or GC overhead),

--- a/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
+++ b/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
@@ -124,7 +124,12 @@ public final class JVMStabilityInspector
 
             logger.error("OutOfMemory error letting the JVM handle the error:", t);
 
-            StorageService.instance.removeShutdownHook();
+            // Only remove the shutdown hook for fatal heap OOMs where the JVM will exit
+            // and the drain hook could hang due to lack of heap memory. For non-fatal OOMs
+            // (e.g. direct buffer, native thread), keep the hook for graceful shutdown.
+            // See CASSANDRA-16939.
+            if (isHeapSpaceOom((OutOfMemoryError) t))
+                StorageService.instance.removeShutdownHook();
 
             forceHeapSpaceOomMaybe((OutOfMemoryError) t);
 
@@ -186,7 +191,17 @@ public final class JVMStabilityInspector
             inspectThrowable(t.getCause(), fn, isUncaughtException);
     }
 
-    private static final Set<String> FORCE_HEAP_OOM_IGNORE_SET = ImmutableSet.of("Java heap space", "GC Overhead limit exceeded");
+    public static final Set<String> FORCE_HEAP_OOM_IGNORE_SET = ImmutableSet.of("Java heap space", "GC Overhead limit exceeded");
+
+    /**
+     * Returns true if the given OOM is a fatal heap-related error (heap space exhaustion or GC overhead),
+     * as opposed to a non-fatal OOM like direct buffer or native thread exhaustion.
+     */
+    @VisibleForTesting
+    static boolean isHeapSpaceOom(OutOfMemoryError oom)
+    {
+        return FORCE_HEAP_OOM_IGNORE_SET.contains(oom.getMessage());
+    }
 
     /**
      * Intentionally produce a heap space OOM upon seeing a non heap memory OOM.

--- a/test/unit/org/apache/cassandra/utils/JVMStabilityInspectorTest.java
+++ b/test/unit/org/apache/cassandra/utils/JVMStabilityInspectorTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.utils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.util.Arrays;
 
@@ -237,6 +238,56 @@ public class JVMStabilityInspectorTest
         finally
         {
             JVMStabilityInspector.replaceKiller(originalKiller);
+        }
+    }
+
+    @Test
+    public void testShutdownHookNotRemovedForNonFatalOom() throws Exception
+    {
+        testShutdownHookRemovalOnOom("Direct buffer memory", false);
+    }
+
+    @Test
+    public void testShutdownHookRemovedForFatalOom() throws Exception
+    {
+        for (String message : JVMStabilityInspector.FORCE_HEAP_OOM_IGNORE_SET)
+            testShutdownHookRemovalOnOom(message, true);
+    }
+
+    private void testShutdownHookRemovalOnOom(String oomMessage, boolean expectHookRemoved) throws Exception
+    {
+        Thread testHook = new Thread(() -> {}, "TestDrainHook"); // checkstyle: permit this instantiation
+        Runtime.getRuntime().addShutdownHook(testHook);
+
+        Field drainField = StorageService.class.getDeclaredField("drainOnShutdown");
+        drainField.setAccessible(true);
+        Thread originalHook = (Thread) drainField.get(StorageService.instance);
+
+        try
+        {
+            drainField.set(StorageService.instance, testHook);
+
+            Assertions.assertThatThrownBy(() -> JVMStabilityInspector.inspectThrowable(new OutOfMemoryError(oomMessage)))
+                      .isInstanceOf(OutOfMemoryError.class);
+
+            if (expectHookRemoved)
+                assertFalse("Shutdown hook should be removed for fatal OOM (" + oomMessage + ')',
+                            Runtime.getRuntime().removeShutdownHook(testHook));
+            else
+                assertTrue("Shutdown hook should not be removed for non-fatal OOM (" + oomMessage + ')',
+                           Runtime.getRuntime().removeShutdownHook(testHook));
+        }
+        finally
+        {
+            drainField.set(StorageService.instance, originalHook);
+            try
+            {
+                Runtime.getRuntime().removeShutdownHook(testHook);
+            }
+            catch (IllegalStateException ignored)
+            {
+                // Already removed or JVM shutting down
+            }
         }
     }
 }


### PR DESCRIPTION
  **Description**:
  CASSANDRA-16939: Only remove shutdown hook for fatal heap
  OOMs

  Previously, `StorageService.removeShutdownHook()` was
  called unconditionally
  for all `OutOfMemoryError`s in
  `JVMStabilityInspector.inspectThrowable()`.
  This removed the drain shutdown hook even for non-fatal
  OOMs like
  "Direct buffer memory" or "unable to create new native
  thread", preventing
  graceful shutdown afterward even though the JVM was
  otherwise healthy.

  The fix guards `removeShutdownHook()` with a new
  `isHeapSpaceOom()` method
  that reuses the existing `FORCE_HEAP_OOM_IGNORE_SET` to
  only remove the hook
  for fatal heap OOMs ("Java heap space", "GC Overhead limit
  exceeded").

  **Changes:**
  - `JVMStabilityInspector.java`: Guard
  `removeShutdownHook()` with `isHeapSpaceOom()` check
  - `JVMStabilityInspectorTest.java`: Added tests verifying
  shutdown hook is preserved
    for non-fatal OOMs and removed for fatal OOMs

  **Tests:**
  - All existing tests pass (8/8, 0 failures)
  - Checkstyle clean (0 violations)

  patch by Shanizta Siddiqua; reviewed by <Reviewers> for
  CASSANDRA-16939

