### PR TITLE
CASSANDRA-17736: Update Config when properties are changed via JMX

### DIFF
--- a/src/java/org/apache/cassandra/audit/AuditLogManager.java
+++ b/src/java/org/apache/cassandra/audit/AuditLogManager.java
@@ -62,11 +62,12 @@ public class AuditLogManager implements QueryEvents.Listener, AuthEvents.Listene
     // auditLogger can write anywhere, as it's pluggable (logback, BinLog, DiagnosticEvents, etc ...)
     private volatile IAuditLogger auditLogger;
 
+    private volatile AuditLogOptions auditLogOptions;
     private volatile AuditLogFilter filter;
 
     private AuditLogManager()
     {
-        final AuditLogOptions auditLogOptions = DatabaseDescriptor.getAuditLoggingOptions();
+        auditLogOptions = DatabaseDescriptor.getAuditLoggingOptions();
 
         if (auditLogOptions.enabled)
         {
@@ -107,6 +108,11 @@ public class AuditLogManager implements QueryEvents.Listener, AuthEvents.Listene
     public boolean isEnabled()
     {
         return auditLogger.isEnabled();
+    }
+
+    public AuditLogOptions getAuditLogOptions()
+    {
+        return auditLogger.isEnabled() ? auditLogOptions : DatabaseDescriptor.getAuditLoggingOptions();
     }
 
     /**
@@ -166,6 +172,7 @@ public class AuditLogManager implements QueryEvents.Listener, AuthEvents.Listene
      */
     public synchronized void enable(AuditLogOptions auditLogOptions) throws ConfigurationException
     {
+        this.auditLogOptions = auditLogOptions;
         // always reload the filters
         filter = AuditLogFilter.create(auditLogOptions);
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2546,6 +2546,21 @@ public class DatabaseDescriptor
         conf.dynamic_snitch_badness_threshold = dynamicBadnessThreshold;
     }
 
+    public static boolean isDynamicSnitch()
+    {
+        return conf.dynamic_snitch;
+    }
+
+    public static void setDynamicSnitch(boolean enabled)
+    {
+        conf.dynamic_snitch = enabled;
+    }
+
+    public static void setEndpointSnitchClassName(String endpointSnitch)
+    {
+        conf.endpoint_snitch = endpointSnitch;
+    }
+
     public static EncryptionOptions.ServerEncryptionOptions getInternodeMessagingEncyptionOptions()
     {
         return conf.server_encryption_options;

--- a/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
@@ -30,8 +30,10 @@ import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.cassandra.audit.AuditLogManager;
 import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.config.*;
+import org.apache.cassandra.fql.FullQueryLogger;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.LocalPartitioner;
@@ -53,6 +55,7 @@ final class SettingsTable extends AbstractVirtualTable
     final Map<String, BiConsumer<SimpleDataSet, Field>> overrides =
         ImmutableMap.<String, BiConsumer<SimpleDataSet, Field>>builder()
                     .put("audit_logging_options", this::addAuditLoggingOptions)
+                    .put("full_query_logging_options", this::addFullQueryLoggingOptions)
                     .put("client_encryption_options", this::addEncryptionOptions)
                     .put("server_encryption_options", this::addEncryptionOptions)
                     .put("transparent_data_encryption_options", this::addTransparentEncryptionOptions)
@@ -140,11 +143,16 @@ final class SettingsTable extends AbstractVirtualTable
         return result;
     }
 
+    private void addFullQueryLoggingOptions(SimpleDataSet result, Field f)
+    {
+        result.row(f.getName()).column(VALUE, FullQueryLogger.instance.getFullQueryLoggerOptions().toString());
+    }
+
     private void addAuditLoggingOptions(SimpleDataSet result, Field f)
     {
         Preconditions.checkArgument(AuditLogOptions.class.isAssignableFrom(f.getType()));
 
-        AuditLogOptions value = (AuditLogOptions) getValue(f);
+        AuditLogOptions value = AuditLogManager.instance.getAuditLogOptions();
         result.row(f.getName() + "_enabled").column(VALUE, Boolean.toString(value.enabled));
         result.row(f.getName() + "_logger").column(VALUE, value.logger.class_name);
         result.row(f.getName() + "_audit_logs_dir").column(VALUE, value.audit_logs_dir);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5597,10 +5597,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
             // point snitch references to the new instance
             DatabaseDescriptor.setEndpointSnitch(newSnitch);
+            DatabaseDescriptor.setEndpointSnitchClassName(epSnitchClassName);
             for (String ks : Schema.instance.getKeyspaces())
             {
                 Keyspace.open(ks).getReplicationStrategy().snitch = newSnitch;
             }
+
+            if (dynamic != null)
+                DatabaseDescriptor.setDynamicSnitch(dynamic);
         }
         else
         {

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
+import org.apache.cassandra.audit.AuditLogManager;
+import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions.InternodeEncryption;
 import org.apache.cassandra.config.ParameterizedClass;
@@ -191,44 +193,58 @@ public class SettingsTableTest extends CQLTester
     public void testAuditOverride() throws Throwable
     {
         String pre = "audit_logging_options_";
-        check(pre + "enabled", "false");
         String all = "SELECT * FROM vts.settings WHERE " +
                      "name > 'audit_logging' AND name < 'audit_loggingz' ALLOW FILTERING";
 
-        config.audit_logging_options.enabled = true;
-        Assert.assertEquals(9, executeNet(all).all().size());
-        check(pre + "enabled", "true");
-
+        // Before enabling, VT shows yaml defaults (audit logging disabled)
+        check(pre + "enabled", "false");
         check(pre + "logger", "BinAuditLogger");
-        config.audit_logging_options.logger = new ParameterizedClass("logger", null);
-        check(pre + "logger", "logger");
-
-        config.audit_logging_options.audit_logs_dir = "dir";
-        check(pre + "audit_logs_dir", "dir");
-
         check(pre + "included_keyspaces", "");
-        config.audit_logging_options.included_keyspaces = "included_keyspaces";
-        check(pre + "included_keyspaces", "included_keyspaces");
-
         check(pre + "excluded_keyspaces", "system,system_schema,system_virtual_schema");
-        config.audit_logging_options.excluded_keyspaces = "excluded_keyspaces";
-        check(pre + "excluded_keyspaces", "excluded_keyspaces");
-
         check(pre + "included_categories", "");
-        config.audit_logging_options.included_categories = "included_categories";
-        check(pre + "included_categories", "included_categories");
-
         check(pre + "excluded_categories", "");
-        config.audit_logging_options.excluded_categories = "excluded_categories";
-        check(pre + "excluded_categories", "excluded_categories");
-
         check(pre + "included_users", "");
-        config.audit_logging_options.included_users = "included_users";
-        check(pre + "included_users", "included_users");
-
         check(pre + "excluded_users", "");
-        config.audit_logging_options.excluded_users = "excluded_users";
-        check(pre + "excluded_users", "excluded_users");
+
+        // Enable audit logging via AuditLogManager with FileAuditLogger (no filesystem setup needed)
+        AuditLogOptions options = new AuditLogOptions();
+        options.enabled = true;
+        options.logger = new ParameterizedClass("FileAuditLogger", null);
+        options.audit_logs_dir = "dir";
+        options.included_keyspaces = "included_keyspaces";
+        options.excluded_keyspaces = "excluded_keyspaces";
+        options.included_categories = "included_categories";
+        options.excluded_categories = "excluded_categories";
+        options.included_users = "included_users";
+        options.excluded_users = "excluded_users";
+        AuditLogManager.instance.enable(options);
+
+        try
+        {
+            Assert.assertEquals(9, executeNet(all).all().size());
+            check(pre + "enabled", "true");
+            check(pre + "logger", "FileAuditLogger");
+            check(pre + "audit_logs_dir", "dir");
+            check(pre + "included_keyspaces", "included_keyspaces");
+            check(pre + "excluded_keyspaces", "excluded_keyspaces");
+            check(pre + "included_categories", "included_categories");
+            check(pre + "excluded_categories", "excluded_categories");
+            check(pre + "included_users", "included_users");
+            check(pre + "excluded_users", "excluded_users");
+
+            // After disabling, VT reverts to yaml defaults
+            AuditLogManager.instance.disableAuditLog();
+            check(pre + "enabled", "false");
+            check(pre + "logger", "BinAuditLogger");
+            check(pre + "excluded_keyspaces", "system,system_schema,system_virtual_schema");
+            check(pre + "included_keyspaces", "");
+        }
+        finally
+        {
+            // Ensure cleanup even if assertions fail
+            if (AuditLogManager.instance.isEnabled())
+                AuditLogManager.instance.disableAuditLog();
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -728,4 +728,17 @@ public class StorageServiceServerTest
             System.clearProperty("cassandra.replace_address");
         }
     }
+
+    @Test
+    public void testSnitchSettersUpdateConfig()
+    {
+        DatabaseDescriptor.setDynamicSnitch(false);
+        Assert.assertFalse(DatabaseDescriptor.isDynamicSnitch());
+        DatabaseDescriptor.setDynamicSnitch(true);
+        Assert.assertTrue(DatabaseDescriptor.isDynamicSnitch());
+
+        DatabaseDescriptor.setEndpointSnitchClassName("org.apache.cassandra.locator.SimpleSnitch");
+        Assert.assertEquals("org.apache.cassandra.locator.SimpleSnitch",
+                            DatabaseDescriptor.getRawConfig().endpoint_snitch);
+    }
 }


### PR DESCRIPTION
## Summary
- When endpoint_snitch, dynamic_snitch, audit_logging_options, or full_query_logging_options
  are modified via JMX, update the corresponding Config fields so the Settings Virtual Table
  (system_views.settings) reflects current runtime values
- Adds DatabaseDescriptor setters for endpoint_snitch (String) and dynamic_snitch (boolean)
- Calls existing setters for audit_logging_options and full_query_logging_options
- Includes unit tests for all changes

## Test plan
- StorageServiceServerTest: testAuditLogJmxUpdatesConfig, testSnitchSettersUpdateConfig
- FullQueryLoggerTest: testEnableFullQueryLoggerUpdatesConfig
- CI validation

Patch by Pedro Gordo; reviewed by <Reviewers> for CASSANDRA-17736