### PR TITLE
Fix native memory leak in SSLFactory cache and resolve buffer offset corruption in EncryptionUtils

### DIFF
--- a/src/java/org/apache/cassandra/security/EncryptionUtils.java
+++ b/src/java/org/apache/cassandra/security/EncryptionUtils.java
@@ -257,7 +257,8 @@ public class EncryptionUtils
         {
             int readLength = dst.remaining();
             // we should only be performing encrypt/decrypt operations with on-heap buffers, so calling BB.array() should be legit here
-            fileDataInput.readFully(dst.array(), dst.position(), readLength);
+            fileDataInput.readFully(dst.array(), dst.arrayOffset() + dst.position(), readLength);
+            dst.position(dst.position() + readLength);
             return readLength;
         }
 

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -233,6 +233,7 @@ public final class SSLFactory
      */
     public static void clearSslContextCache()
     {
+        cachedSslContexts.values().forEach(ReferenceCountUtil::release);
         cachedSslContexts.clear();
     }
 
@@ -244,7 +245,11 @@ public final class SSLFactory
         cachedSslContexts.forEachKey(1, cacheKey -> {
             if (Objects.equals(options, cacheKey.encryptionOptions))
             {
-                cachedSslContexts.remove(cacheKey);
+                SslContext ctx = cachedSslContexts.remove(cacheKey);
+                if (ctx != null)
+                {
+                    ReferenceCountUtil.release(ctx);
+                }
                 keysToCheck.remove(cacheKey);
             }
         });


### PR DESCRIPTION
**Problem** : 
The SSLFactory class was leaking unmanaged tcnative/OpenSSL native memory because it removed SslContext objects from its cache without releasing their Netty reference counts, eventually leading to JVM crashes. Concurrently, EncryptionUtils possessed a critical memory corruption risk and ReadableByteChannel contract violation by improperly writing directly to dst.array() without calculating dst.arrayOffset() and failing to advance the buffer's position cursor after fulfilling the byte reads.

**Fix** :
In SSLFactory.java, guaranteed ReferenceCountUtil.release(ctx) is explicitly invoked every time a context is evicted from the cachedSslContexts map, ensuring the cache drops its baseline ownership cleanly without triggering double releases or disrupting active SSLEngine channels. In EncryptionUtils.java, DataInputReadChannel.read was updated to correctly index reads via dst.arrayOffset() + dst.position() and appropriately advance the buffer cursor using dst.position(dst.position() + readLength)