### PR TITLE
[CASSANDRA-21289][trunk] Avoid capturing lambda allocation in UnfilteredSerializer.deserializeRowBody

### DIFF
--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -429,6 +430,11 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
     public void apply(Consumer<ColumnMetadata> function)
     {
         BTree.apply(columns, function);
+    }
+
+    public <A> void apply(BiConsumer<A, ColumnMetadata> function, A argument)
+    {
+        BTree.apply(columns, function, argument);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
+++ b/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
@@ -21,16 +21,21 @@ import java.io.DataInput;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.context.CounterContext;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.io.util.TrackedDataInputPlus;
+import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.DroppedColumn;
 import org.apache.cassandra.schema.TableMetadata;
 
+@NotThreadSafe
 public class DeserializationHelper
 {
     /**
@@ -58,6 +63,14 @@ public class DeserializationHelper
     private final boolean hasDroppedColumns;
     private final Map<ByteBuffer, DroppedColumn> droppedColumns;
     private DroppedColumn currentDroppedComplex;
+
+    // reusable fields to avoid extra allocation during cells processing
+    // within org.apache.cassandra.db.rows.UnfilteredSerializer.deserializeRowBody
+    DataInputPlus in;
+    SerializationHeader header;
+    Row.Builder builder;
+    LivenessInfo livenessInfo;
+    boolean hasComplexDeletion;
 
     // Reusable per-partition tracker for row-size-bounded reads in SSTable deserialization.
     private TrackedDataInputPlus trackedInput;

--- a/src/java/org/apache/cassandra/db/rows/UnfilteredSerializer.java
+++ b/src/java/org/apache/cassandra/db/rows/UnfilteredSerializer.java
@@ -625,20 +625,12 @@ public class UnfilteredSerializer
 
             try
             {
-                DataInputPlus finalIn = in;
-                columns.apply(column -> {
-                    try
-                    {
-                        if (column.isSimple())
-                            readSimpleColumn(column, finalIn, header, helper, builder, livenessInfo);
-                        else
-                            readComplexColumn(column, finalIn, header, helper, hasComplexDeletion, builder, livenessInfo);
-                    }
-                    catch (IOException e)
-                    {
-                        throw new WrappedException(e);
-                    }
-                });
+                helper.in = in;
+                helper.header = header;
+                helper.builder = builder;
+                helper.livenessInfo = livenessInfo;
+                helper.hasComplexDeletion = hasComplexDeletion;
+                columns.apply(UnfilteredSerializer::readColumn, helper);
             }
             catch (WrappedException e)
             {
@@ -660,7 +652,22 @@ public class UnfilteredSerializer
         }
     }
 
-    private void readSimpleColumn(ColumnMetadata column, DataInputPlus in, SerializationHeader header, DeserializationHelper helper, Row.Builder builder, LivenessInfo rowLiveness)
+    private static void readColumn(DeserializationHelper helper, ColumnMetadata column)
+    {
+        try
+        {
+            if (column.isSimple())
+                readSimpleColumn(column, helper.in, helper.header, helper, helper.builder, helper.livenessInfo);
+            else
+                readComplexColumn(column, helper.in, helper.header, helper, helper.hasComplexDeletion, helper.builder, helper.livenessInfo);
+        }
+        catch (IOException e)
+        {
+            throw new WrappedException(e);
+        }
+    }
+
+    private static void readSimpleColumn(ColumnMetadata column, DataInputPlus in, SerializationHeader header, DeserializationHelper helper, Row.Builder builder, LivenessInfo rowLiveness)
     throws IOException
     {
         if (helper.includes(column))
@@ -675,7 +682,7 @@ public class UnfilteredSerializer
         }
     }
 
-    private void readComplexColumn(ColumnMetadata column, DataInputPlus in, SerializationHeader header, DeserializationHelper helper, boolean hasComplexDeletion, Row.Builder builder, LivenessInfo rowLiveness)
+    private static void readComplexColumn(ColumnMetadata column, DataInputPlus in, SerializationHeader header, DeserializationHelper helper, boolean hasComplexDeletion, Row.Builder builder, LivenessInfo rowLiveness)
     throws IOException
     {
         if (helper.includes(column))
@@ -732,7 +739,7 @@ public class UnfilteredSerializer
         in.skipBytesFully(markerSize);
     }
 
-    private void skipComplexColumn(DataInputPlus in, ColumnMetadata column, SerializationHeader header, boolean hasComplexDeletion)
+    private static void skipComplexColumn(DataInputPlus in, ColumnMetadata column, SerializationHeader header, boolean hasComplexDeletion)
     throws IOException
     {
         if (hasComplexDeletion)


### PR DESCRIPTION
Avoid capturing lambda allocation in UnfilteredSerializer.deserializeRowBody

The same idea was applied previously in UnfilteredSerializer#serializeRowBody. A state is passed into a consumer function using the existing helper object.

patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21289