### PR TITLE
Add replica slot grouping to maintain write availability during topol…

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1124,6 +1124,15 @@ range_request_timeout: 10000ms
 # Lowest acceptable value is 10 ms.
 # Min unit: ms
 write_request_timeout: 2000ms
+
+# When enabled, endpoints transitioning the same replica position during topology changes
+# (bootstrap, decommission, replace, move) are treated as a single logical "slot".
+# blockFor stays at base quorum instead of being inflated by pending replicas,
+# while still requiring both members of a transitioning slot to ack for durability.
+# This maintains write availability during topology changes without sacrificing durability.
+# Default: false (slot grouping inactive; pending replicas inflate blockFor)
+# replica_slot_grouping_enabled: false
+
 # How long the coordinator should wait for counter writes to complete.
 # Lowest acceptable value is 10 ms.
 # Min unit: ms

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -138,6 +138,12 @@ public class Config
     @Replaces(oldName = "write_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound write_request_timeout = new DurationSpec.LongMillisecondsBound("2000ms");
 
+    // When enabled, endpoints transitioning the same replica position during topology changes
+    // are treated as a single logical "slot". blockFor stays at base quorum instead of being
+    // inflated by pending replicas, while still requiring both members of a slot to ack.
+    // Default: false (slot grouping inactive; pending replicas inflate blockFor)
+    public volatile boolean replica_slot_grouping_enabled = false;
+
     @Replaces(oldName = "counter_write_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound counter_write_request_timeout = new DurationSpec.LongMillisecondsBound("5000ms");
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1855,6 +1855,16 @@ public class DatabaseDescriptor
         conf.write_request_timeout = new DurationSpec.LongMillisecondsBound(timeOutInMillis);
     }
 
+    public static boolean isReplicaSlotGroupingEnabled()
+    {
+        return conf.replica_slot_grouping_enabled;
+    }
+
+    public static void setReplicaSlotGroupingEnabled(boolean value)
+    {
+        conf.replica_slot_grouping_enabled = value;
+    }
+
     public static long getCounterWriteRpcTimeout(TimeUnit unit)
     {
         return conf.counter_write_request_timeout.to(unit);

--- a/src/java/org/apache/cassandra/locator/ReplicaPlan.java
+++ b/src/java/org/apache/cassandra/locator/ReplicaPlan.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.locator;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Iterables;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
@@ -170,16 +172,27 @@ public interface ReplicaPlan<E extends Endpoints<E>, P extends ReplicaPlan<E, P>
         final EndpointsForToken pending;
         final EndpointsForToken liveAndDown;
         final EndpointsForToken live;
+        @Nullable
+        private final SlotGroupMaps.SlotGroupInfo slotInfo;
 
         public ForWrite(Keyspace keyspace, AbstractReplicationStrategy replicationStrategy, ConsistencyLevel consistencyLevel, EndpointsForToken pending, EndpointsForToken liveAndDown, EndpointsForToken live, EndpointsForToken contact)
+        {
+            this(keyspace, replicationStrategy, consistencyLevel, pending, liveAndDown, live, contact, null);
+        }
+
+        public ForWrite(Keyspace keyspace, AbstractReplicationStrategy replicationStrategy, ConsistencyLevel consistencyLevel, EndpointsForToken pending, EndpointsForToken liveAndDown, EndpointsForToken live, EndpointsForToken contact, @Nullable SlotGroupMaps.SlotGroupInfo slotInfo)
         {
             super(keyspace, replicationStrategy, consistencyLevel, contact);
             this.pending = pending;
             this.liveAndDown = liveAndDown;
             this.live = live;
+            this.slotInfo = slotInfo;
         }
 
         public int writeQuorum() { return consistencyLevel.blockForWrite(replicationStrategy, pending()); }
+
+        @Nullable
+        public SlotGroupMaps.SlotGroupInfo slotInfo() { return slotInfo; }
 
         /** Replicas that a region of the ring is moving to; not yet ready to serve reads, but should receive writes */
         public EndpointsForToken pending() { return pending; }
@@ -203,7 +216,7 @@ public interface ReplicaPlan<E extends Endpoints<E>, P extends ReplicaPlan<E, P>
 
         private ForWrite copy(ConsistencyLevel newConsistencyLevel, EndpointsForToken newContact)
         {
-            return new ForWrite(keyspace, replicationStrategy, newConsistencyLevel, pending(), liveAndDown(), live(), newContact);
+            return new ForWrite(keyspace, replicationStrategy, newConsistencyLevel, pending(), liveAndDown(), live(), newContact, slotInfo);
         }
 
         ForWrite withConsistencyLevel(ConsistencyLevel newConsistencylevel) { return copy(newConsistencylevel, contacts()); }
@@ -211,7 +224,7 @@ public interface ReplicaPlan<E extends Endpoints<E>, P extends ReplicaPlan<E, P>
 
         public String toString()
         {
-            return "ReplicaPlan.ForWrite [ CL: " + consistencyLevel + " keyspace: " + keyspace + " liveAndDown: " + liveAndDown + " live: " + live + " contacts: " + contacts() +  " ]";
+            return "ReplicaPlan.ForWrite [ CL: " + consistencyLevel + " keyspace: " + keyspace + " liveAndDown: " + liveAndDown + " live: " + live + " contacts: " + contacts() + " slotInfo: " + slotInfo + " ]";
         }
     }
 

--- a/src/java/org/apache/cassandra/locator/ReplicaPlans.java
+++ b/src/java/org/apache/cassandra/locator/ReplicaPlans.java
@@ -56,6 +56,7 @@ import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.metrics.SlotGroupingMetrics;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.service.reads.AlwaysSpeculativeRetryPolicy;
@@ -465,7 +466,12 @@ public class ReplicaPlans
         AbstractReplicationStrategy replicationStrategy = liveAndDown.replicationStrategy();
         EndpointsForToken contacts = selector.select(consistencyLevel, liveAndDown, live);
         assureSufficientLiveReplicasForWrite(replicationStrategy, consistencyLevel, live.all(), liveAndDown.pending());
-        return new ReplicaPlan.ForWrite(keyspace, replicationStrategy, consistencyLevel, liveAndDown.pending(), liveAndDown.all(), live.all(), contacts);
+
+        SlotGroupMaps.SlotGroupInfo slotInfo = getValidatedSlotInfo(keyspace, liveAndDown);
+
+        return new ReplicaPlan.ForWrite(keyspace, replicationStrategy, consistencyLevel,
+                                         liveAndDown.pending(), liveAndDown.all(),
+                                         live.all(), contacts, slotInfo);
     }
 
     public interface Selector
@@ -752,5 +758,38 @@ public class ReplicaPlans
 
         // If we get there, merge this range and the next one
         return new ReplicaPlan.ForRangeRead(keyspace, replicationStrategy, consistencyLevel, newRange, mergedCandidates, contacts, left.vnodeCount() + right.vnodeCount());
+    }
+
+    /**
+     * Look up and validate slot grouping info for a write operation.
+     * Returns null (falling back to default write path) if the feature is disabled,
+     * no slot info is available, or any replica is missing from the slot groups (stale).
+     */
+    public static SlotGroupMaps.SlotGroupInfo getValidatedSlotInfo(
+        Keyspace keyspace,
+        ReplicaLayout.ForTokenWrite liveAndDown)
+    {
+        if (!DatabaseDescriptor.isReplicaSlotGroupingEnabled())
+            return null;
+
+        Token token = liveAndDown.token();
+        SlotGroupMaps.SlotGroupInfo candidate = StorageService.instance.
+            getTokenMetadata().getSlotInfoForToken(token, keyspace.getName());
+
+        if (candidate == null)
+            return null;
+
+        for (Replica replica : liveAndDown.all())
+        {
+            if (!candidate.endpointToSlot.containsKey(replica.endpoint()))
+            {
+                SlotGroupingMetrics.staleFallbacks.inc();
+                logger.debug("Slot info stale: replica {} not in" +
+                             " slot groups, falling back to default" +
+                             " write path", replica.endpoint());
+                return null;
+            }
+        }
+        return candidate;
     }
 }

--- a/src/java/org/apache/cassandra/locator/ReplicaSlotGroup.java
+++ b/src/java/org/apache/cassandra/locator/ReplicaSlotGroup.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Represents a replica slot during topology changes.
+ * 
+ * A slot can be:
+ * - Stable: Contains only a natural endpoint (no pending transition)
+ * - Transitioning: Contains both a natural endpoint (current owner) and a pending endpoint (future owner)
+ * 
+ * For transitioning slots, BOTH endpoints must acknowledge a write for the slot to be satisfied.
+ * This ensures durability regardless of whether the transition completes or aborts.
+ * 
+ * Key design constraint: For any given token, there can be at most ONE pending replica,
+ * so slot groups are always either size 1 (stable) or size 2 (transitioning).
+ */
+public final class ReplicaSlotGroup
+{
+    // The natural (current) replica for this slot - always present
+    private final InetAddressAndPort naturalEndpoint;
+
+    // The pending replica transitioning into this slot - null if stable
+    @Nullable
+    private final InetAddressAndPort pendingEndpoint;
+
+    private ReplicaSlotGroup(InetAddressAndPort naturalEndpoint, @Nullable InetAddressAndPort pendingEndpoint)
+    {
+        this.naturalEndpoint = naturalEndpoint;
+        this.pendingEndpoint = pendingEndpoint;
+    }
+
+    /**
+     * Create a stable slot (no transition happening).
+     *
+     * @param naturalEndpoint The current owner of this replica slot
+     */
+    public static ReplicaSlotGroup stableSlot(InetAddressAndPort naturalEndpoint)
+    {
+        Objects.requireNonNull(naturalEndpoint, "naturalEndpoint cannot be null");
+        return new ReplicaSlotGroup(naturalEndpoint, null);
+    }
+
+    /**
+     * Create a transitioning slot.
+     * During a topology change, the natural endpoint is giving up this slot
+     * to the pending endpoint.
+     *
+     * @param naturalEndpoint The current owner (will lose this slot after transition)
+     * @param pendingEndpoint The future owner (will gain this slot after transition)
+     */
+    public static ReplicaSlotGroup transitioningSlot(InetAddressAndPort naturalEndpoint,
+                                                    InetAddressAndPort pendingEndpoint)
+    {
+        Objects.requireNonNull(naturalEndpoint, "naturalEndpoint cannot be null");
+        Objects.requireNonNull(pendingEndpoint, "pendingEndpoint cannot be null for transitioning slot");
+        return new ReplicaSlotGroup(naturalEndpoint, pendingEndpoint);
+    }
+
+    /**
+     * @return true if this slot is transitioning (has both natural and pending endpoints)
+     */
+    public boolean isTransitioning()
+    {
+        return pendingEndpoint != null;
+    }
+
+    /**
+     * @return The natural (current) endpoint for this slot
+     */
+    public InetAddressAndPort naturalEndpoint()
+    {
+        return naturalEndpoint;
+    }
+
+    /**
+     * @return The pending endpoint for this slot, or null if this is a stable slot
+     */
+    @Nullable
+    public InetAddressAndPort pendingEndpoint()
+    {
+        return pendingEndpoint;
+    }
+
+    /**
+     * Check if this slot is satisfied by the given acked endpoints.
+     * - Stable slot: natural endpoint must have acked
+     * - Transitioning slot: BOTH natural AND pending must have acked
+     *
+     * @param ackedEndpoints Set of endpoints that have acknowledged the write
+     * @return true if this slot's requirements are satisfied
+     */
+    public boolean isSatisfied(Set<InetAddressAndPort> ackedEndpoints)
+    {
+        if (!ackedEndpoints.contains(naturalEndpoint))
+        {
+            return false;
+        }
+        if (pendingEndpoint != null && !ackedEndpoints.contains(pendingEndpoint))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return The number of acknowledgments required to satisfy this slot (1 for stable, 2 for transitioning)
+     */
+    public int requiredAcks()
+    {
+        return pendingEndpoint != null ? 2 : 1;
+    }
+
+    /**
+     * @return All endpoint members of this slot
+     */
+    public Set<InetAddressAndPort> members()
+    {
+        if (pendingEndpoint == null)
+        {
+            return Collections.singleton(naturalEndpoint);
+        }
+        return ImmutableSet.of(naturalEndpoint, pendingEndpoint);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReplicaSlotGroup that = (ReplicaSlotGroup) o;
+        return Objects.equals(naturalEndpoint, that.naturalEndpoint) &&
+               Objects.equals(pendingEndpoint, that.pendingEndpoint);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(naturalEndpoint, pendingEndpoint);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (pendingEndpoint == null)
+        {
+            return "Slot[" + naturalEndpoint + "]";
+        }
+        return "Slot[" + naturalEndpoint + " -> " + pendingEndpoint + "]";
+    }
+}

--- a/src/java/org/apache/cassandra/locator/SlotGroupMaps.java
+++ b/src/java/org/apache/cassandra/locator/SlotGroupMaps.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Stores pre-computed replica slot groups indexed by token boundaries for efficient lookup at write time.
+ * 
+ * This class is designed for the write hot path:
+ * - Slot groups are computed once on topology change
+ * - Lookups use binary search: O(log n)
+ * - Endpoint-to-slot mapping is pre-computed for O(1) lookup
+ * - No allocation or computation at write time - just a reference lookup
+ * 
+ * Thread safety: This class is immutable after construction. The internal NavigableMap
+ * and SlotGroupInfo instances are not modified after being added.
+ */
+public class SlotGroupMaps
+{
+    /**
+     * Pre-computed info for a token range - avoids per-write computation.
+     *
+     * Maps each endpoint (natural or pending) to its ReplicaSlotGroup for O(1) lookup.
+     * Multiple endpoints can map to the same slot (transitioning slot with natural + pending).
+     *
+     * This class is immutable and shared across all writes to the same token range.
+     */
+    public static class SlotGroupInfo
+    {
+        /** Maps each endpoint (natural or pending) to its ReplicaSlotGroup */
+        public final Map<InetAddressAndPort, ReplicaSlotGroup> endpointToSlot;
+
+        /**
+         * Creates a SlotGroupInfo with pre-computed endpoint-to-slot mapping.
+         *
+         * @param slotGroups The slot groups for a token range
+         */
+        public SlotGroupInfo(List<ReplicaSlotGroup> slotGroups)
+        {
+            Map<InetAddressAndPort, ReplicaSlotGroup> epToSlot = new HashMap<>();
+
+            for (ReplicaSlotGroup slot : slotGroups)
+            {
+                epToSlot.put(slot.naturalEndpoint(), slot);
+                if (slot.pendingEndpoint() != null)
+                {
+                    epToSlot.put(slot.pendingEndpoint(), slot);
+                }
+            }
+
+            this.endpointToSlot = Collections.unmodifiableMap(epToSlot);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SlotGroupInfo{endpointToSlot=" + endpointToSlot + "}";
+        }
+    }
+
+    /**
+     * Sorted map: token boundary -> SlotGroupInfo for the range ending at that token.
+     * For token T, this gives slots for range (predecessor(T), T].
+     * 
+     * Using NavigableMap allows O(log n) lookup via ceilingEntry().
+     */
+    private final NavigableMap<Token, SlotGroupInfo> tokenToSlotInfo;
+
+    /**
+     * Creates an empty SlotGroupMaps.
+     */
+    public SlotGroupMaps()
+    {
+        this.tokenToSlotInfo = new TreeMap<>();
+    }
+
+    /**
+     * Add slot groups for a token range boundary.
+     * Pre-computes endpoint-to-slot mapping for O(1) response handling.
+     *
+     * @param token The token that ends this range
+     * @param slotGroups The slot groups for this range
+     */
+    public void addSlotGroups(Token token, List<ReplicaSlotGroup> slotGroups)
+    {
+        tokenToSlotInfo.put(token, new SlotGroupInfo(slotGroups));
+    }
+
+    /**
+     * Get slot group info for a given token using binary search.
+     * Finds the first token >= searchToken (the range containing searchToken).
+     *
+     * Performance: O(log n) where n is the number of token boundaries.
+     *
+     * @param searchToken The token to look up
+     * @return SlotGroupInfo with pre-computed mappings, or null if not found
+     */
+    @Nullable
+    public SlotGroupInfo getSlotInfoForToken(Token searchToken)
+    {
+        // Find first token >= searchToken: O(log n)
+        Map.Entry<Token, SlotGroupInfo> entry = tokenToSlotInfo.ceilingEntry(searchToken);
+        if (entry != null)
+        {
+            return entry.getValue();
+        }
+        // Wrap around to first token in ring (handles tokens after the last boundary)
+        entry = tokenToSlotInfo.firstEntry();
+        return entry != null ? entry.getValue() : null;
+    }
+
+    /**
+     * @return true if this map contains any slot groups
+     */
+    public boolean isEmpty()
+    {
+        return tokenToSlotInfo.isEmpty();
+    }
+
+    /**
+     * @return The number of token boundaries stored
+     */
+    public int size()
+    {
+        return tokenToSlotInfo.size();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SlotGroupMaps{size=" + tokenToSlotInfo.size() + "}";
+    }
+
+    /**
+     * Builds a SlotGroupMaps from transit pairs and natural replica information.
+     * Used identically on both Cassandra 4.1 (TokenMetadata) and trunk (TCM).
+     *
+     * The caller provides:
+     * - Token boundaries and transit pair mappings (from a version-specific calculator)
+     * - A function to resolve natural replicas for a token (version-specific)
+     */
+    public static class Builder
+    {
+        /**
+         * Build SlotGroupMaps from transit pairs and a natural replica provider.
+         *
+         * @param allTokens all token boundaries to build slot groups for
+         * @param tokenToPendingSlot per-token mapping of (pendingEndpoint, replacedNaturalEndpoint)
+         * @param naturalReplicasFn function: token -> EndpointsForRange (natural replicas for that token)
+         * @return SlotGroupMaps with pre-computed slot groups for each token boundary
+         */
+        public static SlotGroupMaps build(
+            Set<Token> allTokens,
+            Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot,
+            Function<Token, EndpointsForRange> naturalReplicasFn)
+        {
+            SlotGroupMaps result = new SlotGroupMaps();
+
+            for (Token token : allTokens)
+            {
+                EndpointsForRange naturalReplicas = naturalReplicasFn.apply(token);
+                Pair<InetAddressAndPort, InetAddressAndPort> pendingInfo = tokenToPendingSlot.get(token);
+
+                List<ReplicaSlotGroup> slotGroups = new ArrayList<>();
+
+                for (Replica replica : naturalReplicas)
+                {
+                    InetAddressAndPort naturalEp = replica.endpoint();
+
+                    if (pendingInfo != null && naturalEp.equals(pendingInfo.right))
+                    {
+                        slotGroups.add(ReplicaSlotGroup.transitioningSlot(naturalEp, pendingInfo.left));
+                    }
+                    else
+                    {
+                        slotGroups.add(ReplicaSlotGroup.stableSlot(naturalEp));
+                    }
+                }
+
+                result.addSlotGroups(token, slotGroups);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/locator/SlotResponseTracker.java
+++ b/src/java/org/apache/cassandra/locator/SlotResponseTracker.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Generic per-slot ack counting for replica slot grouping.
+ *
+ * Thread-safe: the map structure is immutable after construction; only the atomic counters
+ * and flags are mutated. Used by both the normal write path (AbstractWriteResponseHandler)
+ * and all three Paxos V2 phases (Prepare, Propose, Commit).
+ *
+ * A slot is "satisfied" when all its members have responded successfully.
+ * A slot is "failed" when any member has failed, making satisfaction impossible.
+ */
+public class SlotResponseTracker
+{
+    private final SlotGroupMaps.SlotGroupInfo slotInfo;
+    private final int totalSlots;
+    private final Map<ReplicaSlotGroup, AtomicInteger> acksPerSlot;
+    private final Map<ReplicaSlotGroup, AtomicBoolean> failedPerSlot;
+    private final AtomicInteger satisfiedSlotCount = new AtomicInteger(0);
+    private final AtomicInteger failedSlotCount = new AtomicInteger(0);
+
+    public SlotResponseTracker(SlotGroupMaps.SlotGroupInfo slotInfo)
+    {
+        this.slotInfo = slotInfo;
+
+        Set<ReplicaSlotGroup> uniqueSlots = new HashSet<>(slotInfo.endpointToSlot.values());
+        this.totalSlots = uniqueSlots.size();
+        Map<ReplicaSlotGroup, AtomicInteger> counters = new HashMap<>(totalSlots);
+        Map<ReplicaSlotGroup, AtomicBoolean> failed = new HashMap<>(totalSlots);
+        for (ReplicaSlotGroup slot : uniqueSlots)
+        {
+            counters.put(slot, new AtomicInteger(0));
+            failed.put(slot, new AtomicBoolean(false));
+        }
+        this.acksPerSlot = counters;
+        this.failedPerSlot = failed;
+    }
+
+    /**
+     * Record a successful response from an endpoint.
+     *
+     * @return the new satisfied slot count if this response caused a slot to become satisfied,
+     *         or -1 otherwise. The returned count is the atomic snapshot at the moment of
+     *         satisfaction, safe for == comparisons.
+     */
+    public int recordSuccess(InetAddressAndPort from)
+    {
+        ReplicaSlotGroup slot = slotInfo.endpointToSlot.get(from);
+        assert slot != null;
+
+        int acks = acksPerSlot.get(slot).incrementAndGet();
+        if (acks == slot.requiredAcks())
+            return satisfiedSlotCount.incrementAndGet();
+        return -1;
+    }
+
+    /**
+     * Record a failure from an endpoint, marking its slot as failed. A failed slot can never
+     * be satisfied since all members must ack. Thread-safe: compareAndSet ensures each slot
+     * is counted at most once.
+     *
+     * @return the new failed slot count if this failure caused a new slot to fail, or -1 if
+     *         already failed. The returned count is the atomic snapshot at the moment of
+     *         failure, safe for == comparisons.
+     */
+    public int recordFailure(InetAddressAndPort from)
+    {
+        ReplicaSlotGroup slot = slotInfo.endpointToSlot.get(from);
+        assert slot != null;
+
+        AtomicBoolean failed = failedPerSlot.get(slot);
+        if (failed != null && failed.compareAndSet(false, true))
+            return failedSlotCount.incrementAndGet();
+        return -1;
+    }
+
+    /**
+     * @return true if enough slots are still alive (not failed) to potentially reach the
+     *         required quorum. For lock-free callers that need exactly-once semantics, use
+     *         the return value of {@link #recordFailure} with {@link #canSucceedWithFailed}.
+     */
+    public boolean canSucceed(int required)
+    {
+        return totalSlots - failedSlotCount.get() >= required;
+    }
+
+    /**
+     * Check using a specific failed count snapshot (from {@link #recordFailure}) rather than
+     * the current state. Safe for exactly-once checks in lock-free contexts.
+     */
+    public boolean canSucceedWithFailed(int failedCount, int required)
+    {
+        return totalSlots - failedCount >= required;
+    }
+
+    /**
+     * Reset all counters. Only safe when no concurrent calls are possible
+     * (e.g. inside a synchronized block).
+     */
+    public void reset()
+    {
+        for (AtomicInteger counter : acksPerSlot.values())
+            counter.set(0);
+        for (AtomicBoolean failed : failedPerSlot.values())
+            failed.set(false);
+        satisfiedSlotCount.set(0);
+        failedSlotCount.set(0);
+    }
+
+    /** @return number of slots where all members responded */
+    public int satisfiedCount()
+    {
+        return satisfiedSlotCount.get();
+    }
+}

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.locator.ReplicaCollection.Builder.Conflict;
+import org.apache.cassandra.metrics.SlotGroupingMetrics;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.BiMultiValMap;
 import org.apache.cassandra.utils.Pair;
@@ -99,6 +100,10 @@ public class TokenMetadata
     // this is a cache of the calculation from {tokenToEndpointMap, bootstrapTokens, leavingEndpoints}
     // NOTE: this may contain ranges that conflict with the those implied by sortedTokens when a range is changing its transient status
     private final ConcurrentMap<String, PendingRangeMaps> pendingRanges = new ConcurrentHashMap<String, PendingRangeMaps>();
+
+    // Pre-computed slot groups for replica slot grouping feature.
+    // Maps keyspace name -> SlotGroupMaps (token-indexed slot groups).
+    private final ConcurrentMap<String, SlotGroupMaps> slotGroupMaps = new ConcurrentHashMap<>();
 
     // nodes which are migrating to the new tokens in the ring
     private final Set<Pair<Token, InetAddressAndPort>> movingEndpoints = new HashSet<>();
@@ -890,6 +895,99 @@ public class TokenMetadata
             if (logger.isTraceEnabled())
                 logger.trace("Calculated pending ranges for {}:\n{}", keyspaceName, (pendingRanges.isEmpty() ? "<empty>" : printPendingRanges()));
         }
+    }
+
+    /**
+     * Calculate slot groups for the given keyspace and strategy.
+     * Slot groups map each token boundary to a set of ReplicaSlotGroups,
+     * enabling O(1) response counting during topology changes.
+     *
+     * This is computed separately from pending ranges and controlled by feature flag.
+     *
+     * If validation fails (multiple pending for same token), slot groups are NOT stored
+     * and the feature falls back to existing behavior for this keyspace.
+     */
+    public void calculateSlotGroups(AbstractReplicationStrategy strategy, String keyspaceName)
+    {
+        if (!DatabaseDescriptor.isReplicaSlotGroupingEnabled())
+        {
+            slotGroupMaps.remove(keyspaceName);  // Ensure clean state when disabled
+            return;
+        }
+
+        long startedAt = currentTimeMillis();
+        synchronized (slotGroupMaps)
+        {
+            // Create clone of current state
+            BiMultiValMap<Token, InetAddressAndPort> bootstrapTokensClone;
+            Set<InetAddressAndPort> leavingEndpointsClone;
+            Set<Pair<Token, InetAddressAndPort>> movingEndpointsClone;
+            TokenMetadata beforeMetadata;
+
+            lock.readLock().lock();
+            try
+            {
+                if (bootstrapTokens.isEmpty() && leavingEndpoints.isEmpty() && movingEndpoints.isEmpty())
+                {
+                    if (logger.isTraceEnabled())
+                        logger.trace("No bootstrapping, leaving or moving nodes -> no slot groups for {}",
+                                     keyspaceName);
+                    slotGroupMaps.remove(keyspaceName);
+                    return;
+                }
+
+                bootstrapTokensClone = new BiMultiValMap<>(this.bootstrapTokens);
+                leavingEndpointsClone = new HashSet<>(this.leavingEndpoints);
+                movingEndpointsClone = new HashSet<>(this.movingEndpoints);
+                beforeMetadata = this.cloneOnlyTokenMap();
+            }
+            finally
+            {
+                lock.readLock().unlock();
+            }
+
+            // Delegate transit pair derivation to extracted calculator
+            TokenMetadataTransitPairCalculator calculator = new TokenMetadataTransitPairCalculator(
+                strategy, beforeMetadata, bootstrapTokensClone, leavingEndpointsClone, movingEndpointsClone);
+            TokenMetadataTransitPairCalculator.TransitPairResult result = calculator.computeTransitPairs(keyspaceName);
+
+            if (!result.valid)
+            {
+                SlotGroupingMetrics.constraintViolations.inc();
+                logger.warn("Slot group calculation for {} failed due to" +
+                            " constraint violation, falling back to" +
+                            " existing behavior", keyspaceName);
+                slotGroupMaps.remove(keyspaceName);
+                return;
+            }
+
+            SlotGroupMaps newSlotGroups = SlotGroupMaps.Builder.build(
+                result.allTokens,
+                result.tokenToPendingSlot,
+                token -> strategy.calculateNaturalReplicas(token, beforeMetadata));
+
+            slotGroupMaps.put(keyspaceName, newSlotGroups);
+
+            long took = currentTimeMillis() - startedAt;
+            if (logger.isDebugEnabled())
+                logger.debug("Slot group calculation for {} completed (took: {}ms, {} token boundaries)",
+                             keyspaceName, took, newSlotGroups.size());
+        }
+    }
+
+    public SlotGroupMaps.SlotGroupInfo getSlotInfoForToken(Token token, String keyspaceName)
+    {
+        SlotGroupMaps maps = slotGroupMaps.get(keyspaceName);
+        if (maps == null)
+        {
+            return null;  // No slot groups computed (feature disabled or no topology change)
+        }
+        return maps.getSlotInfoForToken(token);
+    }
+
+    public SlotGroupMaps getSlotGroupMaps(String keyspaceName)
+    {
+        return slotGroupMaps.get(keyspaceName);
     }
 
     public void unsafeCalculatePendingRanges(AbstractReplicationStrategy strategy, String keyspaceName)

--- a/src/java/org/apache/cassandra/locator/TokenMetadataTransitPairCalculator.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadataTransitPairCalculator.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.utils.BiMultiValMap;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Computes transit pairs (pending endpoint -> replaced natural endpoint) for replica slot grouping
+ * using TokenMetadata-based topology simulation. This is specific to Cassandra 4.1's TokenMetadata model.
+ *
+ * On Cassandra trunk (TCM), this class is replaced by a TcmTransitPairCalculator that derives
+ * the same information from DataPlacement and MovementMap.
+ *
+ * Algorithm: Process each pending replica INDEPENDENTLY against the original beforeMetadata.
+ * For each topology change (bootstrap, leave, move):
+ *   1. Clone beforeMetadata
+ *   2. Apply ONLY this change
+ *   3. Compare before vs after for each token boundary
+ *   4. Find new pending replicas and who they're replacing
+ *   5. Check for overlap (constraint violation)
+ *   6. Discard clone, use original beforeMetadata for next change
+ */
+public class TokenMetadataTransitPairCalculator
+{
+    private static final Logger logger = LoggerFactory.getLogger(TokenMetadataTransitPairCalculator.class);
+
+    /**
+     * Result of transit pair computation.
+     */
+    public static class TransitPairResult
+    {
+        /** Per-token mapping: token -> (pendingEndpoint, replacedNaturalEndpoint) */
+        public final Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot;
+        /** All token boundaries that need slot groups built */
+        public final Set<Token> allTokens;
+        /** Whether computation succeeded (false = constraint violation, should fall back) */
+        public final boolean valid;
+
+        private TransitPairResult(Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot,
+                                  Set<Token> allTokens,
+                                  boolean valid)
+        {
+            this.tokenToPendingSlot = tokenToPendingSlot;
+            this.allTokens = allTokens;
+            this.valid = valid;
+        }
+
+        public static TransitPairResult success(
+            Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot,
+            Set<Token> allTokens)
+        {
+            return new TransitPairResult(tokenToPendingSlot, allTokens, true);
+        }
+
+        public static TransitPairResult constraintViolation()
+        {
+            return new TransitPairResult(null, null, false);
+        }
+    }
+
+    private final AbstractReplicationStrategy strategy;
+    private final TokenMetadata beforeMetadata;
+    private final BiMultiValMap<Token, InetAddressAndPort> bootstrapTokens;
+    private final Set<InetAddressAndPort> leavingEndpoints;
+    private final Set<Pair<Token, InetAddressAndPort>> movingEndpoints;
+
+    public TokenMetadataTransitPairCalculator(AbstractReplicationStrategy strategy,
+                                              TokenMetadata beforeMetadata,
+                                              BiMultiValMap<Token, InetAddressAndPort> bootstrapTokens,
+                                              Set<InetAddressAndPort> leavingEndpoints,
+                                              Set<Pair<Token, InetAddressAndPort>> movingEndpoints)
+    {
+        this.strategy = strategy;
+        this.beforeMetadata = beforeMetadata;
+        this.bootstrapTokens = bootstrapTokens;
+        this.leavingEndpoints = leavingEndpoints;
+        this.movingEndpoints = movingEndpoints;
+    }
+
+    /**
+     * Compute transit pairs for a keyspace.
+     *
+     * @param keyspaceName The keyspace name (used for logging)
+     * @return TransitPairResult with valid=true on success, valid=false on constraint violation
+     */
+    public TransitPairResult computeTransitPairs(String keyspaceName)
+    {
+        Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot = new HashMap<>();
+        Set<Token> allTokens = new TreeSet<>(beforeMetadata.sortedTokens());
+
+        // Process each BOOTSTRAP independently
+        Multimap<InetAddressAndPort, Token> bootstrapAddresses = bootstrapTokens.inverse();
+        for (InetAddressAndPort endpoint : bootstrapAddresses.keySet())
+        {
+            Collection<Token> tokens = bootstrapAddresses.get(endpoint);
+
+            TokenMetadata afterMetadata = beforeMetadata.cloneOnlyTokenMap();
+            afterMetadata.updateNormalTokens(tokens, endpoint);
+            allTokens.addAll(tokens);
+
+            if (!findAffectedTokensAndRecord(beforeMetadata, afterMetadata,
+                    allTokens, tokenToPendingSlot, keyspaceName))
+            {
+                return TransitPairResult.constraintViolation();
+            }
+        }
+
+        // Process each LEAVE independently
+        for (InetAddressAndPort endpoint : leavingEndpoints)
+        {
+            TokenMetadata afterMetadata = beforeMetadata.cloneOnlyTokenMap();
+            afterMetadata.removeEndpoint(endpoint);
+
+            if (!findAffectedTokensAndRecord(beforeMetadata, afterMetadata,
+                    allTokens, tokenToPendingSlot, keyspaceName))
+            {
+                return TransitPairResult.constraintViolation();
+            }
+        }
+
+        // Process each MOVE independently
+        for (Pair<Token, InetAddressAndPort> moving : movingEndpoints)
+        {
+            Token newToken = moving.left;
+            InetAddressAndPort endpoint = moving.right;
+
+            TokenMetadata afterMetadata = beforeMetadata.cloneOnlyTokenMap();
+            afterMetadata.updateNormalToken(newToken, endpoint);
+            allTokens.add(newToken);
+
+            if (!findAffectedTokensAndRecord(beforeMetadata, afterMetadata,
+                    allTokens, tokenToPendingSlot, keyspaceName))
+            {
+                return TransitPairResult.constraintViolation();
+            }
+        }
+
+        return TransitPairResult.success(tokenToPendingSlot, allTokens);
+    }
+
+    /**
+     * Find tokens affected by a topology change.
+     *
+     * Compares beforeMetadata vs afterMetadata for each token boundary.
+     * For any token where a new replica appears (in after but not in before),
+     * that's a pending replica taking over a slot.
+     *
+     * @return false if constraint violated (token already has a pending), true otherwise
+     */
+    private boolean findAffectedTokensAndRecord(
+        TokenMetadata beforeMeta,
+        TokenMetadata afterMeta,
+        Set<Token> allTokens,
+        Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot,
+        String keyspaceName)
+    {
+        for (Token token : allTokens)
+        {
+            EndpointsForRange beforeReplicas = strategy.calculateNaturalReplicas(token, beforeMeta);
+            EndpointsForRange afterReplicas = strategy.calculateNaturalReplicas(token, afterMeta);
+
+            for (InetAddressAndPort pendingEp : afterReplicas.endpoints())
+            {
+                if (!beforeReplicas.endpoints().contains(pendingEp))
+                {
+                    // Find who this pending is replacing (in before but not in after)
+                    InetAddressAndPort replacedEp = null;
+                    for (InetAddressAndPort ep : beforeReplicas.endpoints())
+                    {
+                        if (!afterReplicas.endpoints().contains(ep))
+                        {
+                            replacedEp = ep;
+                            break;
+                        }
+                    }
+
+                    // Check for constraint violation: token already affected by another pending?
+                    Pair<InetAddressAndPort, InetAddressAndPort> existing = tokenToPendingSlot.get(token);
+                    if (existing != null)
+                    {
+                        logger.warn("Keyspace {} token {} already has pending {}" +
+                                   " but {} also affects it - constraint violated",
+                                   keyspaceName, token, existing.left, pendingEp);
+                        return false;
+                    }
+
+                    tokenToPendingSlot.put(token, Pair.create(pendingEp, replacedEp));
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/SlotGroupingMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/SlotGroupingMetrics.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import com.codahale.metrics.Counter;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+/**
+ * Metrics for the replica slot grouping feature.
+ */
+public class SlotGroupingMetrics
+{
+    private static final String TYPE_NAME = "SlotGrouping";
+
+    public static final Counter staleFallbacks = Metrics.counter(
+        DefaultNameFactory.createMetricName(
+            TYPE_NAME, "StaleFallbacks", null));
+
+    public static final Counter constraintViolations = Metrics.counter(
+        DefaultNameFactory.createMetricName(
+            TYPE_NAME, "ConstraintViolations", null));
+}

--- a/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
@@ -32,6 +32,8 @@ import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.locator.ReplicaPlan.ForWrite;
+import org.apache.cassandra.locator.SlotGroupMaps;
+import org.apache.cassandra.locator.SlotResponseTracker;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.concurrent.Condition;
 import org.slf4j.Logger;
@@ -81,6 +83,22 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
     private final Dispatcher.RequestTime requestTime;
     private @Nullable final Supplier<Mutation> hintOnFailure;
 
+    // ============== Slot grouping support for topology changes ==============
+    // These fields enable O(1) response counting when replica slot grouping is enabled.
+    // They are null when the feature is disabled or no topology change is happening.
+
+    /**
+     * Pre-computed slot info from TokenMetadata (shared across writes to same token range).
+     * Maps each endpoint to its ReplicaSlotGroup for O(1) lookup.
+     * Validated at ReplicaPlan construction: if any write contact is missing, slotInfo is null
+     * to fall back to default behavior and avoid dropped acks.
+     */
+    @Nullable
+    protected final SlotGroupMaps.SlotGroupInfo slotInfo;
+
+    @Nullable
+    protected final SlotResponseTracker slotTracker;
+
     /**
       * Delegate to another WriteResponseHandler or possibly this one to track if the ideal consistency level was reached.
       * Will be set to null if ideal CL was not configured
@@ -108,6 +126,9 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
         this.hintOnFailure = hintOnFailure;
         this.failureReasonByEndpoint = new ConcurrentHashMap<>();
         this.requestTime = requestTime;
+
+        this.slotInfo = replicaPlan.slotInfo();
+        this.slotTracker = (slotInfo != null) ? new SlotResponseTracker(slotInfo) : null;
     }
 
     public void get() throws WriteTimeoutException, WriteFailureException
@@ -219,6 +240,13 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
      */
     protected int blockFor()
     {
+        // When slot grouping is active, use base quorum without pending additions.
+        // Slot grouping treats transitioning endpoints as a single logical unit,
+        // so blockFor is based on slot count rather than being inflated by pending replicas.
+        if (slotInfo != null)
+        {
+            return replicaPlan.consistencyLevel().blockFor(replicaPlan.replicationStrategy());
+        }
         // During bootstrap, we have to include the pending endpoints or we may fail the consistency level
         // guarantees (see #833)
         return replicaPlan.writeQuorum();
@@ -248,6 +276,23 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
     protected boolean waitingFor(InetAddressAndPort from)
     {
         return true;
+    }
+
+    protected boolean isSlotGroupingActive()
+    {
+        return slotInfo != null;
+    }
+
+    protected boolean processSlotResponse(InetAddressAndPort from)
+    {
+        assert slotTracker != null;
+        int newSatisfiedSlotCount = slotTracker.recordSuccess(from);
+        return newSatisfiedSlotCount >= blockFor();
+    }
+
+    protected int satisfiedSlotCount()
+    {
+        return slotTracker != null ? slotTracker.satisfiedCount() : 0;
     }
 
     /**
@@ -292,11 +337,20 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
                 ? failuresUpdater.incrementAndGet(this)
                 : failures;
 
+        if (slotTracker != null)
+            slotTracker.recordFailure(from);
+
         failureReasonByEndpoint.put(from, failureReason);
 
         logFailureOrTimeoutToIdealCLDelegate();
 
-        if (blockFor() + n > candidateReplicaCount())
+        boolean cannotSucceed;
+        if (slotTracker != null)
+            cannotSucceed = !slotTracker.canSucceed(blockFor());
+        else
+            cannotSucceed = blockFor() + n > candidateReplicaCount();
+
+        if (cannotSucceed)
             signal();
 
         if (hintOnFailure != null && StorageProxy.shouldHint(replicaPlan.lookup(from)) && requestTime.shouldSendHints())

--- a/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
+++ b/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
@@ -87,6 +87,7 @@ public class PendingRangeCalculatorService
     public static void calculatePendingRanges(AbstractReplicationStrategy strategy, String keyspaceName)
     {
         StorageService.instance.getTokenMetadata().calculatePendingRanges(strategy, keyspaceName);
+        StorageService.instance.getTokenMetadata().calculateSlotGroups(strategy, keyspaceName);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/service/WriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/WriteResponseHandler.java
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
 
 import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.utils.FBUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,8 +59,26 @@ public class WriteResponseHandler<T> extends AbstractWriteResponseHandler<T>
 
     public void onResponse(Message<T> m)
     {
-        if (responsesUpdater.decrementAndGet(this) == 0)
-            signal();
+        // Determine the endpoint that sent this response
+        // if m is null, it means the response is from local
+        InetAddressAndPort from = (m == null) ? FBUtilities.getBroadcastAddressAndPort() : m.from();
+
+        // Use slot-aware counting when feature is enabled
+        if (isSlotGroupingActive())
+        {
+            // O(1) slot-aware response processing
+            if (processSlotResponse(from))
+            {
+                signal();
+            }
+        }
+        else
+        {
+            // Existing behavior: simple counter decrement
+            if (responsesUpdater.decrementAndGet(this) == 0)
+                signal();
+        }
+
         //Must be last after all subclass processing
         //The two current subclasses both assume logResponseToIdealCLDelegate is called
         //here.
@@ -67,6 +87,11 @@ public class WriteResponseHandler<T> extends AbstractWriteResponseHandler<T>
 
     protected int ackCount()
     {
+        // When slot grouping is active, return satisfied slot count
+        if (isSlotGroupingActive())
+        {
+            return satisfiedSlotCount();
+        }
         return blockFor() - responses;
     }
 }

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -48,6 +48,9 @@ import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.ReplicaLayout;
 import org.apache.cassandra.locator.ReplicaLayout.ForTokenWrite;
 import org.apache.cassandra.locator.ReplicaPlan.ForRead;
+import org.apache.cassandra.locator.ReplicaPlans;
+import org.apache.cassandra.locator.SlotGroupMaps;
+import org.apache.cassandra.locator.SlotResponseTracker;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -356,7 +359,10 @@ public class Paxos
          */
         final int sizeOfReadQuorum;
 
-        Participants(Keyspace keyspace, ConsistencyLevel consistencyForConsensus, ReplicaLayout.ForTokenWrite all, ReplicaLayout.ForTokenWrite electorate, EndpointsForToken live)
+        @Nullable
+        final SlotGroupMaps.SlotGroupInfo slotInfo;
+
+        Participants(Keyspace keyspace, ConsistencyLevel consistencyForConsensus, ReplicaLayout.ForTokenWrite all, ReplicaLayout.ForTokenWrite electorate, EndpointsForToken live, @Nullable SlotGroupMaps.SlotGroupInfo slotInfo)
         {
             this.keyspace = keyspace;
             this.replicationStrategy = all.replicationStrategy();
@@ -369,7 +375,10 @@ public class Paxos
             this.electorateLive = electorate.all() == live ? live : electorate.all().keep(live.endpoints());
             this.allLive = live;
             this.sizeOfReadQuorum = electorate.natural().size() / 2 + 1;
-            this.sizeOfConsensusQuorum = sizeOfReadQuorum + electorate.pending().size();
+            this.slotInfo = slotInfo;
+            this.sizeOfConsensusQuorum = (slotInfo != null)
+                                         ? sizeOfReadQuorum
+                                         : sizeOfReadQuorum + electorate.pending().size();
         }
 
         @Override
@@ -394,7 +403,8 @@ public class Paxos
 
             EndpointsForToken live = all.all().filter(FailureDetector.isReplicaAlive);
 
-            return new Participants(keyspace, consistencyForConsensus, all, electorate, live);
+            SlotGroupMaps.SlotGroupInfo slotInfo = ReplicaPlans.getValidatedSlotInfo(keyspace, all);
+            return new Participants(keyspace, consistencyForConsensus, all, electorate, live, slotInfo);
         }
 
         static Participants get(TableMetadata cfm, DecoratedKey key, ConsistencyLevel consistency)
@@ -405,6 +415,12 @@ public class Paxos
         int sizeOfPoll()
         {
             return electorateLive.size();
+        }
+
+        @Nullable
+        SlotResponseTracker newSlotTracker()
+        {
+            return slotInfo != null ? new SlotResponseTracker(slotInfo) : null;
         }
 
         InetAddressAndPort voter(int i)
@@ -434,6 +450,8 @@ public class Paxos
             if (consistency == Paxos.nonSerial(consistencyForConsensus))
                 return sizeOfConsensusQuorum;
 
+            if (slotInfo != null)
+                return consistency.blockFor(replicationStrategy());
             return consistency.blockForWrite(replicationStrategy(), pending);
         }
 

--- a/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
@@ -29,10 +29,13 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.InOurDc;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.locator.SlotResponseTracker;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -101,6 +104,9 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
     final int required;
     final OnDone onDone;
 
+    @Nullable
+    private final SlotResponseTracker slotTracker;
+
     /**
      * packs two 32-bit integers;
      * bit 00-31: accepts
@@ -120,6 +126,7 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
         this.replicas = participants.all;
         this.onDone = onDone;
         this.required = participants.requiredFor(consistencyForCommit);
+        this.slotTracker = participants.newSlotTracker();
         if (required == 0)
             onDone.accept(status());
     }
@@ -263,11 +270,33 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
         if (consistencyForCommit.isDatacenterLocal() && !InOurDc.endpoints().test(from))
             return;
 
+        int newSatisfiedSlotCount = -1;
+        int newFailedSlotCount = -1;
+        if (slotTracker != null)
+        {
+            if (success)
+                newSatisfiedSlotCount = slotTracker.recordSuccess(from);
+            else
+                newFailedSlotCount = slotTracker.recordFailure(from);
+        }
+
         long responses = responsesUpdater.addAndGet(this, success ? 0x1L : 0x100000000L);
-        // next two clauses mutually exclusive to ensure we only invoke onDone once, when either failed or succeeded
-        if (accepts(responses) == required) // if we have received _precisely_ the required accepts, we have succeeded
-            onDone.accept(status());
-        else if (replicas.size() - failures(responses) == required - 1) // if we are _unable_ to receive the required accepts, we have failed
+        // if we have received _precisely_ the required accepts, we have succeeded
+        boolean done;
+        if (slotTracker != null)
+            done = newSatisfiedSlotCount == required;
+        else
+            done = accepts(responses) == required;
+
+        // if we are _unable_ to receive the required accepts, we have failed
+        boolean failed;
+        if (slotTracker != null)
+            failed = newFailedSlotCount > 0 && !slotTracker.canSucceedWithFailed(newFailedSlotCount, required);
+        else
+            failed = replicas.size() - failures(responses) == required - 1;
+
+        // done and failed are mutually exclusive, ensuring we invoke onDone at most once
+        if (done || failed)
             onDone.accept(status());
     }
 
@@ -285,6 +314,8 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
 
     private boolean isSuccessful(long responses)
     {
+        if (slotTracker != null)
+            return slotTracker.satisfiedCount() >= required;
         return accepts(responses) >= required;
     }
 

--- a/src/java/org/apache/cassandra/service/paxos/PaxosPrepare.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosPrepare.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.SlotResponseTracker;
 import org.apache.cassandra.metrics.PaxosMetrics;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
@@ -283,6 +284,10 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
     private Committed latestCommitted; // latest actually committed proposal
 
     private final Participants participants;
+    @Nullable
+    private final SlotResponseTracker allSlotsTracker;
+    @Nullable
+    private final SlotResponseTracker withLatestSlots;
 
     private final List<Message<ReadResponse>> readResponses;
     private boolean haveReadResponseWithLatest;
@@ -310,6 +315,8 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
         this.withLatest = new ArrayList<>(participants.sizeOfConsensusQuorum);
         this.latestAccepted = this.latestCommitted = Committed.none(request.partitionKey, request.table);
         this.onDone = onDone;
+        this.allSlotsTracker = participants.newSlotTracker();
+        this.withLatestSlots = participants.newSlotTracker();
     }
 
     private boolean hasInProgressProposal()
@@ -512,8 +519,13 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
             {
                 latestCommitted = Committed.none(request.partitionKey, request.table);
                 haveReadResponseWithLatest = !readResponses.isEmpty();
-                if (needLatest != null)
+                if (needLatest != null && !needLatest.isEmpty())
                 {
+                    if (withLatestSlots != null)
+                    {
+                        for (InetAddressAndPort endpoint : needLatest)
+                            withLatestSlots.recordSuccess(endpoint);
+                    }
                     withLatest.addAll(needLatest);
                     needLatest.clear();
                 }
@@ -534,12 +546,14 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
                 case WAS_REPROPOSED_BY:
                 case SAME:
                     withLatest.add(from);
+                    recordSlotResponse(from, true);
                     haveReadResponseWithLatest |= permitted.readResponse != null;
                     break;
                 case BEFORE:
                     if (needLatest == null)
                         needLatest = new ArrayList<>(participants.sizeOfPoll() - withLatest.size());
                     needLatest.add(from);
+                    recordSlotResponse(from, false);
                     break;
                 case AFTER:
                     // move with->need
@@ -557,7 +571,9 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
                         }
                     }
 
+                    resetWithLatestSlots();
                     withLatest.add(from);
+                    recordSlotResponse(from, true);
                     haveReadResponseWithLatest = permitted.readResponse != null;
                     latestCommitted = permitted.latestCommitted;
             }
@@ -594,7 +610,7 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
             }
         }
 
-        haveQuorumOfPermissions |= withLatest() + needLatest() >= participants.sizeOfConsensusQuorum;
+        haveQuorumOfPermissions |= effectiveTotalCount() >= participants.sizeOfConsensusQuorum;
         if (haveQuorumOfPermissions)
         {
             if (request.read != null && readResponses.size() < participants.sizeOfReadQuorum)
@@ -614,7 +630,7 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
             else if (hasInProgressProposal())
                 signalDone(hasOnlyPromises ? FOUND_INCOMPLETE_ACCEPTED : SUPERSEDED);
 
-            else if (withLatest() >= participants.sizeOfConsensusQuorum)
+            else if (effectiveWithLatestCount() >= participants.sizeOfConsensusQuorum)
                 signalDone(hasOnlyPromises ? PROMISED : READ_PERMITTED);
 
             // otherwise if we have any read response with the latest commit,
@@ -799,7 +815,16 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
         super.onFailureWithMutex(from, reason);
         ++failures;
 
-        if (failures + participants.sizeOfConsensusQuorum == 1 + participants.sizeOfPoll())
+        if (allSlotsTracker != null)
+            allSlotsTracker.recordFailure(from);
+
+        boolean cannotSucceed;
+        if (allSlotsTracker != null)
+            cannotSucceed = !allSlotsTracker.canSucceed(participants.sizeOfConsensusQuorum);
+        else
+            cannotSucceed = failures + participants.sizeOfConsensusQuorum == 1 + participants.sizeOfPoll();
+
+        if (cannotSucceed)
             signalDone(MAYBE_FAILURE);
     }
 
@@ -1265,5 +1290,29 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
     {
         assert onLinearizabilityViolation == null || runnable == null;
         onLinearizabilityViolation = runnable;
+    }
+
+    private void recordSlotResponse(InetAddressAndPort from, boolean isWithLatest)
+    {
+        if (allSlotsTracker != null)
+            allSlotsTracker.recordSuccess(from);
+        if (isWithLatest && withLatestSlots != null)
+            withLatestSlots.recordSuccess(from);
+    }
+
+    private void resetWithLatestSlots()
+    {
+        if (withLatestSlots != null)
+            withLatestSlots.reset();
+    }
+
+    private int effectiveTotalCount()
+    {
+        return allSlotsTracker != null ? allSlotsTracker.satisfiedCount() : withLatest() + needLatest();
+    }
+
+    private int effectiveWithLatestCount()
+    {
+        return withLatestSlots != null ? withLatestSlots.satisfiedCount() : withLatest();
     }
 }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosPropose.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosPropose.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +35,9 @@ import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.SlotResponseTracker;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -128,6 +132,8 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
     final int required;
     /** Invoke on reaching a terminal status */
     final OnDone onDone;
+    @Nullable
+    private final SlotResponseTracker slotTracker;
 
     /**
      * bit 0-20:  accepts
@@ -145,7 +151,7 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
     /** The newest superseding ballot from a refusal; only returned to the caller if we fail to reach a quorum */
     private volatile Ballot supersededBy;
 
-    private PaxosPropose(Proposal proposal, int participants, int required, boolean waitForNoSideEffect, OnDone onDone)
+    private PaxosPropose(Proposal proposal, int participants, int required, boolean waitForNoSideEffect, OnDone onDone, @Nullable SlotResponseTracker slotTracker)
     {
         this.proposal = proposal;
         assert required > 0;
@@ -153,6 +159,7 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
         this.participants = participants;
         this.required = required;
         this.onDone = onDone;
+        this.slotTracker = slotTracker;
     }
 
     /**
@@ -169,9 +176,9 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
         // to avoid unnecessary object allocations we extend PaxosPropose to implements Paxos.Async
         class Async extends PaxosPropose<ConditionAsConsumer<Status>> implements Paxos.Async<Status>
         {
-            private Async(Proposal proposal, int participants, int required, boolean waitForNoSideEffect)
+            private Async(Proposal proposal, int participants, int required, boolean waitForNoSideEffect, @Nullable SlotResponseTracker slotTracker)
             {
-                super(proposal, participants, required, waitForNoSideEffect, newConditionAsConsumer());
+                super(proposal, participants, required, waitForNoSideEffect, newConditionAsConsumer(), slotTracker);
             }
 
             public Status awaitUntil(long deadline)
@@ -190,7 +197,7 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
             }
         }
 
-        Async propose = new Async(proposal, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, waitForNoSideEffect);
+        Async propose = new Async(proposal, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, waitForNoSideEffect, participants.newSlotTracker());
         propose.start(participants);
         return propose;
     }
@@ -200,7 +207,7 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
         if (waitForNoSideEffect && proposal.update.isEmpty())
             waitForNoSideEffect = false; // by definition this has no "side effects" (besides linearizing the operation)
 
-        PaxosPropose<?> propose = new PaxosPropose<>(proposal, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, waitForNoSideEffect, onDone);
+        PaxosPropose<?> propose = new PaxosPropose<>(proposal, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, waitForNoSideEffect, onDone, participants.newSlotTracker());
         propose.start(participants);
         return onDone;
     }
@@ -259,6 +266,9 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
                 ? ACCEPT_INCREMENT
                 : REFUSAL_INCREMENT;
 
+        if (supersededBy == null && slotTracker != null)
+            slotTracker.recordSuccess(from);
+
         update(increment);
     }
 
@@ -267,6 +277,9 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
     {
         if (logger.isTraceEnabled())
             logger.trace("{} {} failure from {}", proposal, reason, from);
+
+        if (slotTracker != null)
+            slotTracker.recordFailure(from);
 
         super.onFailure(from, reason);
         update(FAILURE_INCREMENT);
@@ -282,18 +295,24 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
     // returns true at most once for a given PaxosPropose, so we do not propagate a signal more than once
     private boolean shouldSignal(long responses)
     {
-        return shouldSignal(responses, required, participants, waitForNoSideEffect, responsesUpdater, this);
+        return shouldSignal(responses, required, participants, waitForNoSideEffect, responsesUpdater, this, slotTracker);
     }
 
     @VisibleForTesting
-    public static <T> boolean shouldSignal(long responses, int required, int participants, boolean waitForNoSideEffect, AtomicLongFieldUpdater<T> responsesUpdater, T update)
+    public static <T> boolean shouldSignal(long responses, int required, int participants, boolean waitForNoSideEffect, AtomicLongFieldUpdater<T> responsesUpdater, T update, @Nullable SlotResponseTracker slotTracker)
     {
         if (responses <= 0L) // already signalled via ambiguous signal bit
             return false;
 
-        if (!isSuccessful(responses, required))
+        boolean successful = slotTracker != null
+                             ? slotTracker.satisfiedCount() >= required
+                             : isSuccessful(responses, required);
+        if (!successful)
         {
-            if (canSucceed(responses, required, participants))
+            boolean canStillSucceed = slotTracker != null
+                                     ? slotTracker.canSucceed(required) && refusals(responses) == 0
+                                     : canSucceed(responses, required, participants);
+            if (canStillSucceed)
                 return false;
 
             if (waitForNoSideEffect && !hasPossibleSideEffects(responses))
@@ -311,7 +330,9 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
 
     private boolean isSuccessful(long responses)
     {
-        return isSuccessful(responses, required);
+        return slotTracker != null
+               ? slotTracker.satisfiedCount() >= required
+               : isSuccessful(responses, required);
     }
 
     private static boolean isSuccessful(long responses, int required)
@@ -321,7 +342,9 @@ public class PaxosPropose<OnDone extends Consumer<? super PaxosPropose.Status>> 
 
     private boolean canSucceed(long responses)
     {
-        return canSucceed(responses, required, participants);
+        return slotTracker != null
+               ? slotTracker.canSucceed(required) && refusals(responses) == 0
+               : canSucceed(responses, required, participants);
     }
 
     private static boolean canSucceed(long responses, int required, int participants)

--- a/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingAdvancedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingAdvancedTest.java
@@ -1,0 +1,714 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.MutationVerbHandler;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.IMessageFilters;
+import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.PendingRangeCalculatorService;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.service.paxos.PaxosCommit;
+import org.apache.cassandra.service.paxos.PaxosCommitAndPrepare;
+import org.apache.cassandra.service.paxos.PaxosPrepare;
+import org.apache.cassandra.service.paxos.PaxosPropose;
+import org.apache.cassandra.utils.Clock;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * Advanced slot grouping tests: ack permutations, failure reply handling, and Paxos-specific
+ * slot tracker scenarios (reset during PREPARE, lowBound reclassification).
+ */
+public class ReplicaSlotGroupingAdvancedTest extends ReplicaSlotGroupingTestBase
+{
+    /**
+     * ByteBuddy helper to inject failure responses from verb handlers.
+     * When {@link #injectFailures} is true, intercepted handlers throw RuntimeException,
+     * which InboundSink catches and converts to FAILURE_RSP (RequestFailureReason.UNKNOWN).
+     * This exercises the failure-reply code paths (SlotResponseTracker.recordFailure,
+     * canSucceed, canSucceedWithFailed) rather than the timeout-based paths.
+     */
+    public static class FailureInjectionBB
+    {
+        public static final AtomicBoolean injectFailures = new AtomicBoolean(false);
+        public static final Set<Integer> targetNodes = new HashSet<>(Arrays.asList(3, 4));
+
+        public static void resetForNodes(Integer... nodes)
+        {
+            targetNodes.clear();
+            targetNodes.addAll(Arrays.asList(nodes));
+            injectFailures.set(false);
+        }
+
+        /**
+         * Set injectFailures on each target node via runOnInstance.
+         * Each node has its own class loader and thus its own copy of static fields;
+         * setting from the test context only affects the test's copy.
+         */
+        public static void setInjectFailures(Cluster cluster, boolean value)
+        {
+            for (int nodeNum : targetNodes)
+            {
+                IInvokableInstance inst = cluster.get(nodeNum);
+                inst.runOnInstance(() -> injectFailures.set(value));
+            }
+        }
+
+        public static void install(ClassLoader cl, Integer nodeNum)
+        {
+            if (!targetNodes.contains(nodeNum))
+                return;
+
+            Class<?>[] targets = {
+                MutationVerbHandler.class,
+                PaxosPrepare.RequestHandler.class,
+                PaxosPropose.RequestHandler.class,
+                PaxosCommit.RequestHandler.class,
+                PaxosCommitAndPrepare.RequestHandler.class
+            };
+            for (Class<?> target : targets)
+            {
+                new ByteBuddy().rebase(target).method(named("doVerb")).
+                    intercept(MethodDelegation.to(FailureInjectionBB.class)).
+                    make().load(cl, ClassLoadingStrategy.Default.INJECTION);
+            }
+        }
+
+        public static void doVerb(@SuperCall Callable<Void> zuper) throws Exception
+        {
+            if (injectFailures.get())
+                throw new RuntimeException("Injected failure for slot grouping test");
+            zuper.call();
+        }
+    }
+
+    /**
+     * Test case data for permutation testing.
+     */
+    private static class PermutationTestCase
+    {
+        final boolean aResponds;
+        final boolean bResponds;
+        final boolean cResponds;
+        final boolean dResponds;
+        final boolean expectEnabledSuccess;
+        final boolean expectDisabledSuccess;
+
+        PermutationTestCase(boolean aResponds, boolean bResponds, boolean cResponds, boolean dResponds,
+                           boolean expectEnabledSuccess, boolean expectDisabledSuccess)
+        {
+            this.aResponds = aResponds;
+            this.bResponds = bResponds;
+            this.cResponds = cResponds;
+            this.dResponds = dResponds;
+            this.expectEnabledSuccess = expectEnabledSuccess;
+            this.expectDisabledSuccess = expectDisabledSuccess;
+        }
+    }
+
+    /**
+     * Get all 10 permutation test cases.
+     * 
+     * Slots: {A}, {B}, {C, D transitioning}
+     * blockFor = 2 for QUORUM with RF=3
+     */
+    private List<PermutationTestCase> getPermutationTestCases()
+    {
+        return Arrays.asList(
+            //                           A      B      C      D      enabled  disabled
+            new PermutationTestCase(true,  true,  true,  true,  true,    true),   // All respond
+            new PermutationTestCase(true,  true,  true,  false, true,    true),   // D busy
+            new PermutationTestCase(true,  true,  false, true,  true,    true),   // C busy
+            new PermutationTestCase(true,  true,  false, false, true,    false),  // C,D busy - KEY DIFFERENCE!
+            new PermutationTestCase(true,  false, true,  true,  true,    true),   // B busy
+            new PermutationTestCase(false, true,  true,  true,  true,    true),   // A busy
+            new PermutationTestCase(true,  false, true,  false, false,   false),  // B,D busy
+            new PermutationTestCase(false, true,  true,  false, false,   false),  // A,D busy
+            new PermutationTestCase(true,  false, false, true,  false,   false),  // B,C busy
+            new PermutationTestCase(false, true,  false, true,  false,   false)   // A,C busy
+        );
+    }
+
+    /**
+     * Test all 10 meaningful ack permutations for 3 slots {A}, {B}, {C, D transitioning}.
+     * For each permutation, block non-responding nodes via message filters, then verify that
+     * the write + LWT succeeds or times out as expected with feature ENABLED and DISABLED.
+     * Tests all permutations with BOTH feature enabled and disabled.
+     */
+    @Test
+    public void testSlotGroupingAckPermutations() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set("paxos_variant", "v2")).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    numStartNodes + 1, "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance nodeA = cluster.get(1);  // Slot A
+            IInvokableInstance nodeB = cluster.get(2);  // Slot B
+            IInvokableInstance nodeC = cluster.get(3);  // Slot C (natural in transitioning slot)
+            
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + 
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + 
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            long staleBefore = getStaleFallbacks(nodeA);
+            long cvBefore = getConstraintViolations(nodeA);
+
+            // Bootstrap node D (kept in pending state)
+            IInvokableInstance nodeD = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            nodeD.startup(cluster);
+
+            // Find keys in the transitioning range (T3, T4] where node D is pending
+            int basePk = pkInTransitioningRange(cluster);
+
+            // Run all permutation test cases
+            List<PermutationTestCase> testCases = getPermutationTestCases();
+            int pkCounter = 0;
+
+            for (PermutationTestCase tc : testCases)
+            {
+                // Pick a coordinator that IS responding AND is a natural replica (nodes 1,2,3).
+                // The coordinator processes its local mutation directly (not through the network),
+                // so inbound MUTATION_REQ filters do NOT block the coordinator's own ack.
+                // The coordinator must NOT be a node we want to simulate as "blocked".
+                IInvokableInstance coordinator;
+                if (tc.aResponds)
+                    coordinator = nodeA;
+                else if (tc.bResponds)
+                    coordinator = nodeB;
+                else
+                    coordinator = nodeC;
+
+                logger.info(
+                    "Testing permutation: A={} B={} C={} D={}, expectEnabled={}, expectDisabled={}, coordinator={}",
+                    tc.aResponds, tc.bResponds, tc.cResponds, tc.dResponds,
+                    tc.expectEnabledSuccess, tc.expectDisabledSuccess,
+                    coordinator == nodeA ? "A" : (coordinator == nodeB ? "B" : "C"));
+
+                // Set up message filters based on which nodes should NOT respond
+                List<IMessageFilters.Filter> filters = new ArrayList<>();
+                if (!tc.aResponds)
+                    filters.add(cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(1).drop());
+                if (!tc.bResponds)
+                    filters.add(cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(2).drop());
+                if (!tc.cResponds)
+                    filters.add(cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(3).drop());
+                if (!tc.dResponds)
+                    filters.add(cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(4).drop());
+
+                // Use the SAME PK for both enabled and disabled (A/B comparison)
+                int pk = nextPkInRange(cluster.get(3), cluster.get(4), basePk + pkCounter);
+                pkCounter++;
+
+                // TEST WITH FEATURE ENABLED
+                setSlotGroupingEnabled(cluster, true);
+                coordinator.runOnInstance(() -> {
+                    PendingRangeCalculatorService.instance.update();
+                    PendingRangeCalculatorService.instance.blockUntilFinished();
+                });
+
+                if (tc.expectEnabledSuccess)
+                {
+                    executeSuccessfulWrite(coordinator, pk, ConsistencyLevel.QUORUM);
+                    executeSuccessfulLwt(coordinator, pk);
+                    logger.info("  ENABLED: write + LWT SUCCESS as expected");
+                }
+                else
+                {
+                    executeWriteExpectingTimeout(coordinator, pk, ConsistencyLevel.QUORUM);
+                    executeLwtExpectingTimeout(coordinator, pk);
+                    logger.info("  ENABLED: write + LWT TIMEOUT as expected");
+                }
+
+                // TEST WITH FEATURE DISABLED (same PK for direct A/B comparison)
+                setSlotGroupingEnabled(cluster, false);
+
+                if (tc.expectDisabledSuccess)
+                {
+                    executeSuccessfulWrite(coordinator, pk, ConsistencyLevel.QUORUM);
+                    executeSuccessfulLwt(coordinator, pk);
+                    logger.info("  DISABLED: write + LWT SUCCESS as expected");
+                }
+                else
+                {
+                    executeWriteExpectingTimeout(coordinator, pk, ConsistencyLevel.QUORUM);
+                    executeLwtExpectingTimeout(coordinator, pk);
+                    logger.info("  DISABLED: write + LWT TIMEOUT as expected");
+                }
+
+                // Clean up filters
+                filters.forEach(IMessageFilters.Filter::off);
+            }
+
+            assertMetricsUnchanged(
+                nodeA, staleBefore, cvBefore,
+                "ack permutations");
+
+            // Clean up
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Test: Failure reply scenario - nodes reply with FAILURE_RSP instead of dropping messages.
+     *
+     * Unlike the timeout-based tests which DROP messages (causing the coordinator to wait until
+     * RPC timeout), this test uses ByteBuddy to make verb handlers on nodes 3 and 4 throw
+     * RuntimeException. InboundSink catches the exception and sends an immediate FAILURE_RSP
+     * (with RequestFailureReason.UNKNOWN) back to the coordinator.
+     *
+     * This exercises the failure-specific code paths in SlotResponseTracker:
+     * - recordFailure(from): marks a node as failed in its slot
+     * - canSucceed(required): checks if enough slots can still be satisfied
+     * - canSucceedWithFailed(failedCount, required): used in PaxosCommit
+     *
+     * Setup: 3-node cluster (RF=3), Node 4 bootstrapping (kept pending via BootstrapBB)
+     * Slots: {1}, {2}, {3+4 transitioning}
+     * Failure injection: nodes 3 and 4 (entire transitioning slot fails)
+     *
+     * - ENABLED: Slots {1} and {2} satisfied by nodes 1,2 → 2 >= blockFor=2 → SUCCESS
+     * - DISABLED: Only 2 acks from nodes 1,2. blockFor=3 → FAILURE (WriteFailureException)
+     */
+    @Test
+    public void testSlotGroupingWithFailureReplies() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+        FailureInjectionBB.resetForNodes(3, 4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set(
+                    "paxos_variant", "v2").set(
+                    "skip_paxos_repair_on_topology_change", true)).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    numStartNodes + 1, "datacenter1", "rack1")).
+                withInstanceInitializer((cl, nodeNum) -> {
+                    BootstrapBB.install(cl, nodeNum);
+                    FailureInjectionBB.install(cl, nodeNum);
+                }).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            cluster.setUncaughtExceptionsFilter((nodeNum, throwable) ->
+                throwable.getMessage() != null
+                && throwable.getMessage().contains("Injected failure for slot grouping test"));
+
+            IInvokableInstance node1 = cluster.get(1);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Enable slot grouping before bootstrap
+            setSlotGroupingEnabled(cluster, true);
+
+            // Bootstrap node 4 (kept in pending state via BootstrapBB)
+            IInvokableInstance node4 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            // Wait for slot group calculation
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            int pkTransitioning = pkInTransitioningRange(cluster);
+
+            // === Test 1: Failure injection + slot grouping ENABLED → SUCCESS ===
+            // Nodes 3 and 4 reply with FAILURE_RSP (immediate, not timeout).
+            // Slots {1} and {2} are satisfied by nodes 1 and 2 → 2 >= blockFor=2 → SUCCESS
+            FailureInjectionBB.setInjectFailures(cluster, true);
+
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + Failure injection on nodes 3,4: write + LWT succeeded");
+
+            // === Test 2: Failure injection + slot grouping DISABLED → FAILURE ===
+            // With slot grouping disabled, blockFor=3 (inflated for pending replica).
+            // Only 2 acks from nodes 1,2, with 2 failures → cannot reach quorum.
+            setSlotGroupingEnabled(cluster, false);
+
+            executeWriteExpectingFailureOrTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeLwtExpectingFailureOrTimeout(node1, pkTransitioning);
+            logger.info("DISABLED + Failure injection on nodes 3,4: write + LWT failed as expected");
+
+            // === Test 3: Disable failure injection → recovery, both modes succeed ===
+            FailureInjectionBB.setInjectFailures(cluster, false);
+
+            setSlotGroupingEnabled(cluster, true);
+            int pkRecovery = nextPkInRange(cluster.get(3), cluster.get(4), pkTransitioning + 1000);
+            executeSuccessfulWrite(node1, pkRecovery, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkRecovery);
+            logger.info("ENABLED + No injection: write + LWT succeeded after recovery");
+
+            setSlotGroupingEnabled(cluster, false);
+            executeSuccessfulWrite(node1, pkRecovery, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkRecovery);
+            logger.info("DISABLED + No injection: write + LWT succeeded after recovery");
+
+            // Clean up
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Test: Paxos PREPARE committed-state divergence triggers SlotResponseTracker.reset(),
+     * and the refresh path applies the missed committed mutation to the stale node.
+     *
+     * When a PREPARE response carries a newer latestCommitted (AFTER case), all previous
+     * "withLatest" acks are invalidated and withLatestSlots.reset() is called. With node 1
+     * blocked, only 3 nodes participate. The slot layout is:
+     *   Slot 1: Node 1 (stable, BLOCKED)
+     *   Slot 2: Node 2 (stable)
+     *   Slot 3: Node 3 + Node 4 (transitioning)
+     *
+     * With reset(): after AFTER fires, withLatestSlots has only node 4 (Slot 3: 1/2) and
+     * node 2 (Slot 2: 1/1) → satisfiedCount=1 < quorum(2) → refreshStaleParticipants()
+     * sends the missed commit to node 3 → state.commit() applies the mutation locally.
+     *
+     * Without reset(): node 3's stale ack remains → Slot 3 has 2/2 (stale node3 + node4)
+     * → satisfiedCount=2 >= quorum → fast path, no refresh → node 3 never gets the missed
+     * mutation applied to its local storage.
+     *
+     * The test asserts on node 3's local data via executeInternalWithResult (bypassing
+     * coordinator/CL). The missed LWT wrote v2=200; if reset() works, node 3 has v2=200
+     * (from refresh). If reset() is broken, node 3 still has v2=100 (stale).
+     */
+    @Test
+    public void testSlotTrackerResetDuringPaxosPrepare() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set(
+                    "paxos_variant", "v2").set(
+                    "skip_paxos_repair_on_topology_change", true)).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    numStartNodes + 1, "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+            IInvokableInstance node3 = cluster.get(3);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v1 int, v2 int, PRIMARY KEY (pk, ck))");
+
+            setSlotGroupingEnabled(cluster, true);
+
+            IInvokableInstance node4 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            int pk = pkInTransitioningRange(cluster);
+
+            // Seed the row
+            node1.coordinator().execute(
+                "INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v1, v2) VALUES (?, ?, ?, ?)",
+                ConsistencyLevel.QUORUM, pk, 1, 0, 0);
+
+            // LWT1: set v2=100 on all nodes (establishes baseline committed state)
+            node1.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v2 = 100 WHERE pk = ? AND ck = ? IF v1 = 0",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("LWT1 committed v2=100 on all nodes");
+
+            // Drop commit messages inbound to node 3
+            int[] commitVerbs = {
+                Verb.PAXOS_COMMIT_REQ.id,
+                Verb.PAXOS2_COMMIT_AND_PREPARE_REQ.id
+            };
+            IMessageFilters.Filter commitFilter = cluster.filters().inbound().to(3).
+                verbs(commitVerbs).drop();
+
+            // LWT2: set v2=200 — commits on 1,2,4 but node 3 misses it (still has v2=100)
+            node1.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v2 = 200 WHERE pk = ? AND ck = ? IF v1 = 0",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("LWT2 committed v2=200; node 3 missed the commit (has v2=100)");
+
+            commitFilter.off();
+
+            // Block node 1 so only nodes 2, 3, 4 participate in the next LWT.
+            // This makes the refresh path necessary: with reset(), only Slot 2 (node 2) is
+            // satisfied → satisfiedCount=1 < 2 → refresh fires → node 3 gets v2=200.
+            IMessageFilters.Filter blockNode1 = cluster.filters().inbound().
+                verbs(BLOCK_NODE_VERBS).to(1).drop();
+
+            // LWT3 from node 3 (stale coordinator): writes v1=1 (does NOT touch v2).
+            // PREPARE triggers AFTER → reset() → refresh applies LWT2's commit (v2=200) on node 3.
+            node3.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v1 = 1 WHERE pk = ? AND ck = ? IF v1 = 0",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("LWT3 from stale node 3 succeeded");
+
+            blockNode1.off();
+
+            // Read v2 directly from node 3's local storage (no coordinator, no read repair).
+            // If reset() worked: refresh applied LWT2's commit → v2=200.
+            // If reset() was missing: no refresh, v2 still 100 from LWT1.
+            Object[][] localResult = node3.executeInternalWithResult(
+                "SELECT v2 FROM " + KEYSPACE + ".tbl WHERE pk = ? AND ck = ?", pk, 1).
+                toObjectArrays();
+            Assert.assertEquals("Node 3 should have v2=200 from the refresh during PREPARE",
+                                200, localResult[0][0]);
+
+            // Also verify v1 was updated by LWT3
+            Object[][] result = node1.coordinator().execute(
+                "SELECT v1, v2 FROM " + KEYSPACE + ".tbl WHERE pk = ? AND ck = ?",
+                ConsistencyLevel.QUORUM, pk, 1);
+            Assert.assertEquals("v1 should be 1 from LWT3", 1, result[0][0]);
+            Assert.assertEquals("v2 should be 200 from LWT2", 200, result[0][1]);
+
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Exercises the lowBound path in PaxosPrepare.permitted() where needLatest nodes are reclassified as withLatest
+     * and the withLatestSlots tracker must be updated for the reclassified nodes.
+     *
+     * The lowBound path fires when a PREPARE response carries a paxos repair lowBound higher than the coordinator's
+     * current latestCommitted ballot. This invalidates latestCommitted (reset to none) and moves all needLatest
+     * nodes into withLatest.
+     *
+     * Scenario (3 slots, quorum=2, node 1 blocked so only 3 nodes respond):
+     *   Slot 1: Node 1 (stable, BLOCKED)
+     *   Slot 2: Node 2 (stable, has high lowBound from paxos repair)
+     *   Slot 3: Node 3 + Node 4 (transitioning)
+     *
+     * 1. LWT1 commits B1 on all nodes
+     * 2. Drop commits to node 3; LWT2 commits B2 on 1,2,4 (node 3 has B1)
+     * 3. Set paxos repair lowBound on node 2 above B2
+     * 4. Block node 1 from receiving Paxos messages
+     * 5. LWT from node 3 (coordinator): local response sets latestCommitted=B1. Node 4 (B2, no high lowBound)
+     *    responds next: AFTER fires, node 3 moves to needLatest. Then node 2 (B2, high lowBound) fires the
+     *    lowBound path, reclassifying node 3 as withLatest.
+     *    Without the fix: withLatestSlots has Slot 2 (1 satisfied) but Slot 3 is missing node 3's ack (1/2) ->
+     *    effectiveWithLatestCount=1 < 2 -> PREPARE hangs -> CAS timeout.
+     *    With the fix: Slot 3 has both node 3 + node 4 acks (2/2) -> effectiveWithLatestCount=2 -> PREPARE succeeds.
+     *
+     * A message filter delays PREPARE_REQ delivery to node 2, ensuring deterministic response ordering (node 4 before
+     * node 2) so the reclassification path is exercised on every run.
+     */
+    @Test
+    public void testSlotTrackerLowBoundReclassification() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set(
+                    "paxos_variant", "v2").set(
+                    "skip_paxos_repair_on_topology_change", true)).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    numStartNodes + 1, "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+            IInvokableInstance node2 = cluster.get(2);
+            IInvokableInstance node3 = cluster.get(3);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            setSlotGroupingEnabled(cluster, true);
+
+            IInvokableInstance node4 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            int pk = pkInTransitioningRange(cluster);
+
+            // Seed the row so IF EXISTS conditions succeed
+            node1.coordinator().execute(
+                "INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
+                ConsistencyLevel.QUORUM, pk, 1, 1);
+
+            // LWT1: establish committed state B1 on all nodes
+            node1.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v = 10 WHERE pk = ? AND ck = ? IF EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("LWT1 committed on all nodes");
+
+            // Drop commit messages to node 3
+            int[] commitVerbs = { Verb.PAXOS_COMMIT_REQ.id, Verb.PAXOS2_COMMIT_AND_PREPARE_REQ.id };
+            IMessageFilters.Filter commitFilter = cluster.filters().inbound().to(3).
+                verbs(commitVerbs).drop();
+
+            // LWT2: commits B2 on nodes 1,2,4 but node 3 still has B1
+            node1.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v = 20 WHERE pk = ? AND ck = ? IF EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("LWT2 committed; node 3 missed the commit");
+
+            commitFilter.off();
+
+            // Set paxos repair lowBound on node 2 above B2. This simulates a paxos repair having completed on
+            // node 2 but not yet on other nodes; future PREPARE responses from node 2 carry this high lowBound.
+            // The lowBound is placed on node 2 (the last responder) so that node 4's AFTER response (which
+            // populates needLatest) is processed before node 2's lowBound triggers the reclassification path.
+            node2.runOnInstance(() -> {
+                long nowMicros = TimeUnit.MILLISECONDS.toMicros(Clock.Global.currentTimeMillis());
+                Ballot highBallot = Ballot.atUnixMicrosWithLsb(nowMicros + 1_000_000L, 0, Ballot.Flag.GLOBAL);
+                Token minToken = Murmur3Partitioner.instance.getMinimumToken();
+                Token maxToken = Murmur3Partitioner.instance.getMaximumToken();
+                Collection<Range<Token>> ranges = Collections.singleton(new Range<>(minToken, maxToken));
+                Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl").onPaxosRepairComplete(ranges, highBallot);
+            });
+
+            // Block node 1 so only nodes 2, 3, 4 participate; Slot 3 (transitioning) becomes critical for quorum.
+            IMessageFilters.Filter blockNode1 = cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(1).drop();
+
+            // Delay PREPARE_REQ delivery to node 2 so node 4 responds first. This ensures node 4's B2 triggers the
+            // AFTER case (populating needLatest) before node 2's high lowBound fires the reclassification path.
+            IMessageFilters.Filter delayNode2Prepare =
+                cluster.filters().inbound().to(2).verbs(Verb.PAXOS2_PREPARE_REQ.id).messagesMatching(
+                    (from, to, msg) ->
+                    {
+                        try
+                        {
+                            Thread.sleep(200);
+                        }
+                        catch (InterruptedException e)
+                        {
+                            Thread.currentThread().interrupt();
+                        }
+                        return false;
+                    }).drop();
+
+            // Coordinate from node 3 (stale). Delay filter ensures deterministic ordering: node3 (local, B1) ->
+            // node4 (B2, AFTER creates needLatest=[node3]) -> node2 (high lowBound fires reclassification).
+            node3.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v = 30 WHERE pk = ? AND ck = ? IF EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+
+            delayNode2Prepare.off();
+            logger.info("ENABLED: LWT from stale node 3 succeeded (lowBound reclassification path exercised)");
+
+            blockNode1.off();
+
+            // Verify the final value
+            Object[][] result = node1.coordinator().execute(
+                "SELECT v FROM " + KEYSPACE + ".tbl WHERE pk = ? AND ck = ?",
+                ConsistencyLevel.QUORUM, pk, 1);
+            Assert.assertEquals("Final value should reflect the last LWT", 30, result[0][0]);
+
+            // === DISABLED: same scenario, verify LWT still succeeds via count-based quorum ===
+            // With slot grouping disabled, Paxos quorum = participants/2+1 = 4/2+1 = 3.
+            // Node 1 blocked → 3 responses from nodes 2,3,4 → meets quorum → SUCCESS.
+            setSlotGroupingEnabled(cluster, false);
+
+            // Re-create committed-state divergence: drop commits to node 3, run LWT from node 1
+            commitFilter = cluster.filters().inbound().to(3).verbs(commitVerbs).drop();
+            node1.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v = 40 WHERE pk = ? AND ck = ? IF EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("DISABLED: LWT from node 1 committed; node 3 missed the commit");
+            commitFilter.off();
+
+            // Block node 1 again
+            blockNode1 = cluster.filters().inbound().verbs(BLOCK_NODE_VERBS).to(1).drop();
+
+            // LWT from stale node 3 should succeed: 3 responses (nodes 2,3,4) >= quorum=3
+            node3.coordinator().execute(
+                "UPDATE " + KEYSPACE + ".tbl SET v = 50 WHERE pk = ? AND ck = ? IF EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+            logger.info("DISABLED: LWT from stale node 3 succeeded (count-based quorum: 3/4 >= 3)");
+
+            blockNode1.off();
+
+            result = node1.coordinator().execute(
+                "SELECT v FROM " + KEYSPACE + ".tbl WHERE pk = ? AND ck = ?",
+                ConsistencyLevel.QUORUM, pk, 1);
+            Assert.assertEquals("Final value should reflect the disabled LWT", 50, result[0][0]);
+
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingTest.java
@@ -1,0 +1,886 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.IMessageFilters;
+import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
+import org.apache.cassandra.locator.ReplicaSlotGroup;
+import org.apache.cassandra.locator.SlotGroupMaps;
+import org.apache.cassandra.service.PendingRangeCalculatorService;
+import org.apache.cassandra.service.StorageService;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.BOOTSTRAP_SKIP_SCHEMA_CHECK;
+import static org.apache.cassandra.distributed.action.GossipHelper.statusToLeaving;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.replaceHostAndStart;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.stopUnchecked;
+
+/**
+ * Topology-related tests for the replica_slot_grouping_enabled feature.
+ *
+ * Tests bootstrap, replacement, decommission, move, constraint violation fallback,
+ * and stale fallback scenarios. Each test compares behavior with feature ENABLED vs DISABLED:
+ * - ENABLED: blockFor = slot count, slot needs ALL members to ack
+ * - DISABLED: blockFor increases with pending replicas (old behavior)
+ */
+public class ReplicaSlotGroupingTest extends ReplicaSlotGroupingTestBase
+{
+    /**
+     * Validate computed SlotGroupMaps structure on a given node.
+     *
+     * @param node              the node to run the validation on
+     * @param pkTransitioning   a PK in a range expected to have at least one transitioning slot
+     * @param pkStable          a PK in a range expected to have all stable slots
+     * @param scenario          description for assertion messages (e.g. "bootstrap", "decommission")
+     */
+    private void assertSlotGroupStructure(IInvokableInstance node, int pkTransitioning, int pkStable, String scenario)
+    {
+        final int pkT = pkTransitioning;
+        final int pkS = pkStable;
+        node.runOnInstance(() -> {
+            SlotGroupMaps slotGroupMaps = StorageService.instance.getTokenMetadata().
+                getSlotGroupMaps(KEYSPACE);
+            Assert.assertNotNull("SlotGroupMaps should not be null during " + scenario, slotGroupMaps);
+            Assert.assertFalse("SlotGroupMaps should not be empty during " + scenario, slotGroupMaps.isEmpty());
+
+            Token tTransitioning = Murmur3Partitioner.instance.getToken(Int32Type.instance.decompose(pkT));
+            SlotGroupMaps.SlotGroupInfo infoTransitioning = slotGroupMaps.getSlotInfoForToken(tTransitioning);
+            Assert.assertNotNull(
+                "SlotGroupInfo should exist for transitioning range during " + scenario,
+                infoTransitioning);
+
+            boolean hasTransitioning = false;
+            for (ReplicaSlotGroup slot : infoTransitioning.endpointToSlot.values())
+            {
+                if (slot.isTransitioning())
+                {
+                    hasTransitioning = true;
+                    break;
+                }
+            }
+            Assert.assertTrue("Should have at least one transitioning slot during " + scenario, hasTransitioning);
+
+            Token tStable = Murmur3Partitioner.instance.getToken(Int32Type.instance.decompose(pkS));
+            SlotGroupMaps.SlotGroupInfo infoStable = slotGroupMaps.getSlotInfoForToken(tStable);
+            Assert.assertNotNull("SlotGroupInfo should exist for stable range during " + scenario, infoStable);
+
+            for (ReplicaSlotGroup slot : infoStable.endpointToSlot.values())
+            {
+                Assert.assertFalse(
+                    "Stable range should have no transitioning slots during " + scenario,
+                    slot.isTransitioning());
+                Assert.assertNotNull(slot.naturalEndpoint());
+            }
+        });
+    }
+
+    /**
+     * Test: Bootstrap scenario - compares enabled vs disabled behavior.
+     * 
+     * Setup: 3-node cluster (RF=3), Node 4 bootstrapping
+     * 
+     * With evenlyDistributedTokens(4) and RF=3:
+     * - When node 4 joins, it takes over a token range
+     * - For that range: before={1,2,3}, after={4,1,2}
+     * - Node 3 "loses" replica responsibility, node 4 "gains" it
+     * - Transitioning slot: {3 (losing), 4 (gaining)}
+     * 
+     * Slots (enabled): {1}, {2}, {3+4 transitioning}
+     * 
+     * Tests multiple sub-scenarios:
+     * 1. Both nodes 3,4 blocked
+     * 2. Happy path: all respond, only node 4 blocked, only node 3 blocked
+     * 3. Degraded path: node 2 DOWN, various combinations
+     */
+    @Test
+    public void testSlotGroupingDuringBootstrap() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set("paxos_variant", "v2")).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    numStartNodes + 1, "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+            
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + 
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + 
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Enable slot grouping before bootstrap so gossip-triggered calculation includes slot groups
+            setSlotGroupingEnabled(cluster, true);
+
+            // Bootstrap node 4 (kept in pending state via ByteBuddy)
+            IInvokableInstance node4 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            // Wait for gossip-triggered slot group calculation to complete on coordinator
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            int pkTransitioning = pkInTransitioningRange(cluster);
+            // Range (T4, T1] is stable: replicas={1,2,3} both before and after bootstrap
+            int pkStable = pkInRange(cluster.get(4), cluster.get(1));
+            assertSlotGroupStructure(node1, pkTransitioning, pkStable, "bootstrap");
+
+            long staleBefore = getStaleFallbacks(node1);
+            long cvBefore = getConstraintViolations(node1);
+
+            // === Sub-test 1: Both nodes 3,4 blocked ===
+            IMessageFilters.Filter blockNode3 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(3).drop();
+            IMessageFilters.Filter blockNode4 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(4).drop();
+
+            // ENABLED: blockFor=2 slots, slots {1} and {2} satisfied -> SUCCESS
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + Nodes 3,4 blocked: QUORUM write + LWT succeeded");
+
+            // DISABLED with same PK: blockFor=3, only 2 acks -> TIMEOUT
+            setSlotGroupingEnabled(cluster, false);
+            executeWriteExpectingTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeLwtExpectingTimeout(node1, pkTransitioning);
+            logger.info("DISABLED + Nodes 3,4 blocked: QUORUM + LWT timed out as expected");
+
+            blockNode3.off();
+            blockNode4.off();
+
+            // === Sub-test 2: Happy path - all respond ===
+            setSlotGroupingEnabled(cluster, true);
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + All respond: QUORUM write + LWT succeeded");
+
+            setSlotGroupingEnabled(cluster, false);
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("DISABLED + All respond: QUORUM write + LWT succeeded");
+
+            // === Sub-test 3: Happy path - only node 4 blocked, 1,2,3 respond ===
+            blockNode4 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(4).drop();
+
+            setSlotGroupingEnabled(cluster, true);
+            // ENABLED: {1} + {2} = 2 slots >= blockFor=2; {3+4} not satisfied but not needed
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + Node 4 blocked: QUORUM write + LWT succeeded");
+
+            setSlotGroupingEnabled(cluster, false);
+            // DISABLED: 3 acks >= blockFor=3 -> SUCCESS
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("DISABLED + Node 4 blocked: QUORUM write + LWT succeeded");
+
+            blockNode4.off();
+
+            // === Sub-test 4: Happy path - only node 3 blocked, 1,2,4 respond ===
+            blockNode3 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(3).drop();
+
+            setSlotGroupingEnabled(cluster, true);
+            // ENABLED: {1} + {2} = 2 slots >= blockFor=2; {3+4} not satisfied but not needed
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + Node 3 blocked: QUORUM write + LWT succeeded");
+
+            setSlotGroupingEnabled(cluster, false);
+            // DISABLED: 3 acks >= blockFor=3 -> SUCCESS
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("DISABLED + Node 3 blocked: QUORUM write + LWT succeeded");
+
+            blockNode3.off();
+
+            // === Sub-test 5: Degraded - node 2 DOWN, nodes 1+3+4 respond ===
+            IMessageFilters.Filter blockNode2 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(2).drop();
+
+            setSlotGroupingEnabled(cluster, true);
+            // ENABLED: slots {1} and {3+4} both satisfied, 2 >= blockFor=2
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("ENABLED + Node 2 blocked: QUORUM write + LWT succeeded");
+
+            setSlotGroupingEnabled(cluster, false);
+            // DISABLED: 3 acks >= blockFor=3 -> SUCCESS
+            executeSuccessfulWrite(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkTransitioning);
+            logger.info("DISABLED + Node 2 blocked: QUORUM write + LWT succeeded");
+
+            blockNode2.off();
+
+            // === Sub-test 6: Degraded - node 2 DOWN + node 4 blocked ===
+            blockNode2 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(2).drop();
+            blockNode4 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(4).drop();
+
+            setSlotGroupingEnabled(cluster, true);
+            // ENABLED: slot {3+4} needs both but only 3 acked -> 1 slot satisfied -> TIMEOUT
+            executeWriteExpectingTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            // LWT ENABLED: only slot {1} satisfied (node 1), slot {2} and {3+4} not -> 1 < 2 -> TIMEOUT
+            executeLwtExpectingTimeout(node1, pkTransitioning);
+            logger.info("ENABLED + Nodes 2,4 blocked: write + LWT both timed out");
+
+            setSlotGroupingEnabled(cluster, false);
+            // DISABLED: 2 acks < blockFor=3 -> TIMEOUT
+            executeWriteExpectingTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeLwtExpectingTimeout(node1, pkTransitioning);
+            logger.info("DISABLED + Nodes 2,4 blocked: QUORUM + LWT timed out");
+
+            blockNode2.off();
+            blockNode4.off();
+
+            // === Sub-test 7: Degraded - node 2 DOWN + node 3 blocked ===
+            blockNode2 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(2).drop();
+            blockNode3 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(3).drop();
+
+            setSlotGroupingEnabled(cluster, true);
+            // ENABLED: slot {3+4} needs both but only 4 acked -> 1 slot satisfied -> TIMEOUT
+            executeWriteExpectingTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            // LWT ENABLED: only slot {1} satisfied, slot {2} and {3+4} not -> 1 < 2 -> TIMEOUT
+            executeLwtExpectingTimeout(node1, pkTransitioning);
+            logger.info("ENABLED + Nodes 2,3 blocked: write + LWT both timed out");
+
+            setSlotGroupingEnabled(cluster, false);
+            // DISABLED: 2 acks < blockFor=3 -> TIMEOUT
+            executeWriteExpectingTimeout(node1, pkTransitioning, ConsistencyLevel.QUORUM);
+            executeLwtExpectingTimeout(node1, pkTransitioning);
+            logger.info("DISABLED + Nodes 2,3 blocked: QUORUM + LWT timed out");
+
+            blockNode2.off();
+            blockNode3.off();
+
+            // === Sub-test 8: Failure path - node 4 genuinely dead + node 3 blocked ===
+            // Unlike Sub-tests 1-7 which DROP messages (causing timeouts),
+            // this sub-test stops node 4 so that PaxosCommit.start() calls
+            // onFailure(node4, NODE_DOWN) IMMEDIATELY via participants.allDown.
+            // This exercises slotTracker.recordFailure() and the canSucceed()
+            // fast-failure detection path, not just timeout-based failures.
+            stopUnchecked(cluster.get(4));
+            java.net.InetSocketAddress node4Addr = cluster.get(4).broadcastAddress();
+
+            // Wait for node 1's failure detector to mark node 4 as dead
+            for (int attempt = 0; attempt < 60; attempt++)
+            {
+                boolean alive = node1.callOnInstance(() ->
+                    org.apache.cassandra.gms.FailureDetector.instance.isAlive(
+                        org.apache.cassandra.locator.InetAddressAndPort.getByAddress(node4Addr)));
+                if (!alive)
+                    break;
+                Thread.sleep(1000);
+            }
+            logger.info("Node 4 detected as dead by node 1");
+
+            blockNode3 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(3).drop();
+
+            // Use a fresh PK so IF NOT EXISTS triggers a full Paxos commit phase
+            int pkFailure = nextPkInRange(cluster.get(3), cluster.get(4), pkTransitioning + 1000);
+
+            // Set on living nodes only (node 4 is stopped)
+            setSlotGroupingEnabled(node1, true);
+            setSlotGroupingEnabled(cluster.get(2), true);
+            setSlotGroupingEnabled(cluster.get(3), true);
+            // ENABLED: node 4 dead -> PaxosCommit immediately fails slot {3+4}
+            // via recordFailure(). Slots {1} and {2} satisfied -> 2 >= blockFor=2 -> SUCCESS
+            executeSuccessfulWrite(node1, pkFailure, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkFailure);
+            logger.info("ENABLED + Node 4 dead + Node 3 blocked: write + LWT succeeded (failure path)");
+
+            setSlotGroupingEnabled(node1, false);
+            setSlotGroupingEnabled(cluster.get(2), false);
+            setSlotGroupingEnabled(cluster.get(3), false);
+            // DISABLED: node 4 dead (1 immediate failure) + node 3 blocked (timeout)
+            // -> only 2 acks from nodes 1,2, blockFor=3 -> TIMEOUT
+            executeWriteExpectingTimeout(node1, pkFailure + 1, ConsistencyLevel.QUORUM);
+            executeLwtExpectingTimeout(node1, pkFailure + 1);
+            logger.info("DISABLED + Node 4 dead + Node 3 blocked: write + LWT timed out");
+
+            blockNode3.off();
+
+            assertMetricsUnchanged(
+                node1, staleBefore, cvBefore, "bootstrap");
+
+            // Clean up
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Test: Replacement scenario - compares enabled vs disabled behavior.
+     * 
+     * Setup: 3-node cluster (RF=3), Node 2 DOWN, Node 4 replacing
+     * Slots (enabled): {1}, {2 DOWN, 4 transitioning}, {3}
+     * 
+     * Key difference: With ENABLED, QUORUM succeeds regardless of Node 4's response
+     * because stable slots 1 and 3 satisfy quorum.
+     */
+    @Test
+    public void testSlotGroupingDuringReplacement() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(numStartNodes);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set("paxos_variant", "v2")).
+                withDynamicPortAllocation(false).
+                withRacks(1, 3, numStartNodes).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node == (numStartNodes + 1) ? 2 : node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+            IInvokableInstance nodeToRemove = cluster.get(2);
+            IInvokableInstance node3 = cluster.get(3);
+            
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + 
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + 
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Stop node 2
+            stopUnchecked(nodeToRemove);
+
+            // Enable slot grouping on alive nodes before replacement
+            setSlotGroupingEnabled(node1, true);
+            setSlotGroupingEnabled(node3, true);
+
+            long staleBefore = getStaleFallbacks(node1);
+            long cvBefore = getConstraintViolations(node1);
+
+            // Start node 4 as replacement for node 2
+            IInvokableInstance replacingNode = replaceHostAndStart(cluster, nodeToRemove, props -> {
+                props.set(BOOTSTRAP_SKIP_SCHEMA_CHECK, true);
+            });
+
+            // Wait for gossip-triggered slot group calculation to complete on coordinator
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            // Find a pk in a range where node 4 (replacing node 2) is pending
+            int pk = pkInRange(cluster.get(1), nodeToRemove);
+
+            // Block messages to replacement node to simulate it being busy
+            IMessageFilters.Filter blockReplacement = cluster.filters().
+                inbound().
+                verbs(BLOCK_NODE_VERBS).
+                to(4).
+                drop();
+
+            // Replacement blocked → QUORUM should SUCCESS (stable slots 1, 3 satisfy)
+            executeSuccessfulWrite(node1, pk, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pk);
+            logger.info("ENABLED + Replacement blocked: QUORUM write + LWT succeeded");
+
+            // TEST WITH FEATURE DISABLED
+            setSlotGroupingEnabled(node1, false);
+            setSlotGroupingEnabled(node3, false);
+
+            // Replacement blocked → QUORUM should FAIL (blockFor=3, only 2 acks)
+            executeWriteExpectingTimeout(node1, pk, ConsistencyLevel.QUORUM);
+            // LWT DISABLED: node 2 dead + node 4 blocked -> only 2 Paxos responses, quorum(3) not met
+            executeLwtExpectingTimeout(node1, pk);
+            logger.info("DISABLED + Replacement blocked: write + LWT timed out");
+
+            assertMetricsUnchanged(
+                node1, staleBefore, cvBefore,
+                "replacement");
+
+            // Clean up
+            blockReplacement.off();
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Test: Decommission scenario - compares enabled vs disabled behavior.
+     * 
+     * Setup: 4-node cluster (RF=3), Node 2 decommissioning (in leaving state)
+     * During decommission, Node 2's ranges are being transferred to Node 4.
+     * Slots (enabled): {1}, {2 leaving + 4 gaining}, {3}
+     * 
+     * To test the difference, we block BOTH nodes in the transitioning slot (2 and 4).
+     * - ENABLED: blockFor=2 slots, slots {1} and {3} satisfied → SUCCESS
+     * - DISABLED: blockFor=3 (base quorum + pending), only 2 acks from nodes 1,3 → TIMEOUT
+     */
+    @Test
+    public void testSlotGroupingDuringDecommission() throws Exception
+    {
+        int numNodes = 4;
+        
+        try (Cluster cluster = Cluster.build(numNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set("paxos_variant", "v2")).
+                withRacks(1, 1, numNodes).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+            IInvokableInstance node2 = cluster.get(2);  // Will be set to "leaving" state
+            
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + 
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + 
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Enable slot grouping before topology change
+            setSlotGroupingEnabled(cluster, true);
+
+            long staleBefore = getStaleFallbacks(node1);
+            long cvBefore = getConstraintViolations(node1);
+
+            // Set node 2 to "leaving" state via gossip
+            cluster.forEach(statusToLeaving(node2));
+
+            // Wait for gossip-triggered slot group calculation to complete on coordinator
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " completed");
+
+            // Use a key in range (T4, T1] where node 4 is the pending replica
+            // gaining from node 2 leaving.  Before={1,2,3}, after={1,3,4}.
+            // Blocking nodes 2 and 4 leaves nodes 1 and 3 to ack.
+            int pkDecom = pkInRange(cluster.get(4), cluster.get(1));
+
+            IMessageFilters.Filter blockNode2 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(2).drop();
+            IMessageFilters.Filter blockNode4 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(4).drop();
+
+            // Range (T2, T3] is stable: replicas={3,4,1}, node 2 is not a replica so leaving has no effect
+            int pkStable = pkInRange(cluster.get(2), cluster.get(3));
+            assertSlotGroupStructure(node1, pkDecom, pkStable, "decommission");
+
+            executeSuccessfulWrite(node1, pkDecom, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, pkDecom);
+            logger.info("ENABLED + Nodes 2,4 blocked: QUORUM write + LWT succeeded");
+
+            // TEST WITH FEATURE DISABLED (same PK)
+            setSlotGroupingEnabled(cluster, false);
+
+            executeWriteExpectingTimeout(node1, pkDecom, ConsistencyLevel.QUORUM);
+            // LWT DISABLED: only 2 Paxos responses from nodes 1,3. Quorum(3) not met
+            executeLwtExpectingTimeout(node1, pkDecom);
+            logger.info("DISABLED + Nodes 2,4 blocked: write + LWT timed out");
+
+            // Clean up filters and test with all nodes responding
+            blockNode2.off();
+            blockNode4.off();
+
+            // TEST WITH ALL RESPONDING - should succeed in both modes
+            setSlotGroupingEnabled(cluster, true);
+            executeSuccessfulWrite(node1, 300, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, 300);
+            logger.info("ENABLED + All respond: QUORUM write + LWT succeeded");
+            
+            setSlotGroupingEnabled(cluster, false);
+            executeSuccessfulWrite(node1, 400, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node1, 400);
+            logger.info("DISABLED + All respond: QUORUM write + LWT succeeded");
+
+            assertMetricsUnchanged(
+                node1, staleBefore, cvBefore,
+                "decommission");
+        }
+    }
+
+    /**
+     * Test: Move scenario - compares enabled vs disabled behavior.
+     *
+     * Setup: 4-node cluster (RF=3), Node 2 moving to a new token between T3 and T4.
+     * During move, node 2 gains replica responsibility for range (T2, T3]:
+     *   Before={3,4,1}, After={3,2,4}. Node 2 is pending (gaining), node 1 is losing.
+     * Slots (enabled): {3}, {4}, {1 losing + 2 gaining}
+     *
+     * To test the difference, we block BOTH nodes in the transitioning slot (1 and 2).
+     * Use node 3 as coordinator (natural replica, avoids local ack bypassing filters on blocked nodes).
+     * - ENABLED: blockFor=2 slots, slots {3} and {4} satisfied → SUCCESS
+     * - DISABLED: blockFor=3, only 2 acks from nodes 3,4 → TIMEOUT
+     */
+    @Test
+    public void testSlotGroupingDuringMove() throws Exception
+    {
+        int numNodes = 4;
+
+        try (Cluster cluster = Cluster.build(numNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set("paxos_variant", "v2")).
+                withRacks(1, 1, numNodes).
+                start())
+        {
+            IInvokableInstance node3 = cluster.get(3);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Enable slot grouping before topology change
+            setSlotGroupingEnabled(cluster, true);
+
+            long staleBefore = getStaleFallbacks(node3);
+            long cvBefore = getConstraintViolations(node3);
+
+            // Set node 2 to MOVING state
+            // We add the moving endpoint directly on the coordinator's (node 3) TokenMetadata
+            // so it computes pending ranges and slot groups correctly.
+            node3.runOnInstance(() -> {
+                java.util.List<Token> sorted = new java.util.ArrayList<>(
+                    StorageService.instance.getTokenMetadata().
+                        sortedTokens());
+                Token node2Token = sorted.get(1);
+                org.apache.cassandra.locator.InetAddressAndPort node2Ep =
+                    StorageService.instance.getTokenMetadata().getEndpoint(node2Token);
+
+                long t3Val = Long.parseLong(sorted.get(2).toString());
+                long t4Val = Long.parseLong(sorted.get(3).toString());
+                long midVal = t3Val + (t4Val - t3Val) / 2;
+                Token newToken = Murmur3Partitioner.instance.getTokenFactory().
+                    fromString(Long.toString(midVal));
+
+                StorageService.instance.getTokenMetadata().
+                    addMovingEndpoint(newToken, node2Ep);
+            });
+
+            // Moving state is added directly to TokenMetadata (not via gossip),
+            // so we must trigger pending range calculation manually.
+            node3.runOnInstance(() -> {
+                PendingRangeCalculatorService.instance.update();
+                PendingRangeCalculatorService.instance.blockUntilFinished();
+            });
+
+            // Use key in range (T2, T3] where node 2 becomes pending (replacing node 1).
+            // Before: replicas={3,4,1}. After (node 2 at new position): replicas={3,2,4}.
+            int pkMove = pkInRange(cluster.get(2), cluster.get(3));
+
+            // Block BOTH nodes in the transitioning slot: node 1 (losing) and node 2 (gaining).
+            IMessageFilters.Filter blockNode1 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(1).drop();
+            IMessageFilters.Filter blockNode2 = cluster.filters().
+                inbound().verbs(BLOCK_NODE_VERBS).to(2).drop();
+
+            // Range (T4, T1] is stable: replicas={1,2,3}, unaffected by node 2's move
+            int pkStable = pkInRange(cluster.get(4), cluster.get(1));
+            assertSlotGroupStructure(node3, pkMove, pkStable, "move");
+
+            // Nodes 1,2 blocked -> QUORUM should SUCCESS
+            // Slots {3} and {4} satisfied by coordinator (node 3) and node 4, meeting blockFor=2
+            executeSuccessfulWrite(node3, pkMove, ConsistencyLevel.QUORUM);
+            executeSuccessfulLwt(node3, pkMove);
+            logger.info("ENABLED + Nodes 1,2 blocked: QUORUM write + LWT succeeded");
+
+            // TEST WITH FEATURE DISABLED (same PK)
+            setSlotGroupingEnabled(cluster, false);
+
+            // Nodes 1,2 blocked -> QUORUM should FAIL
+            // blockFor=3 (base quorum 2 + 1 pending), only 2 acks from nodes 3,4
+            executeWriteExpectingTimeout(node3, pkMove, ConsistencyLevel.QUORUM);
+            // LWT DISABLED: only 2 Paxos responses from nodes 3,4. Quorum(3) not met
+            executeLwtExpectingTimeout(node3, pkMove);
+            logger.info("DISABLED + Nodes 1,2 blocked: write + LWT timed out");
+
+            assertMetricsUnchanged(
+                node3, staleBefore, cvBefore, "move");
+            
+            // Clean up
+            blockNode1.off();
+            blockNode2.off();
+        }
+    }
+
+    /**
+     * Test: Constraint violation fallback when two nodes bootstrap simultaneously.
+     *
+     * Setup: 3-node cluster (RF=3), Node 4 and Node 5 both bootstrapping (kept in pending
+     * state via BootstrapBB with targetNodes={4,5}).
+     *
+     * With evenlyDistributedTokens(5) and RF=3, before = 3-node ring (all ranges → {1,2,3}):
+     * - Node 4 bootstrap at T4: for token T2, replicas change from {1,2,3} to {3,4,1},
+     *   so node 4 is pending (replacing node 2).
+     * - Node 5 bootstrap at T5: for token T2, replicas change from {1,2,3} to {3,5,1},
+     *   so node 5 is pending (also replacing node 2).
+     * - Token T2 now has two pending operations → CONSTRAINT VIOLATION.
+     *
+     * Expected: Slot group calculation detects the violation, falls back to existing behavior
+     * (no slot groups computed). Writes still succeed when all natural replicas respond.
+     */
+    @Test
+    public void testSlotGroupingConstraintViolationFallback() throws Exception
+    {
+        int numStartNodes = 3;
+        int totalNodes = 5;
+        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(totalNodes);
+
+        BootstrapBB.resetForNodes(4, 5);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set(
+                    "paxos_variant", "v2").set(
+                    "skip_paxos_repair_on_topology_change", true)).
+                withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(
+                    totalNodes, "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            // Create keyspace and table
+            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+            // Enable slot grouping before bootstraps
+            setSlotGroupingEnabled(cluster, true);
+
+            long staleBefore = getStaleFallbacks(node1);
+            long cvBefore = getConstraintViolations(node1);
+
+            // Bootstrap node 4 (kept in pending state via BootstrapBB)
+            IInvokableInstance node4 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            // Bootstrap node 5 (also kept in pending state via BootstrapBB)
+            // With both nodes 4 and 5 bootstrapping, their pending ranges overlap at
+            // the same token boundary (e.g., T2), triggering the constraint violation.
+            IInvokableInstance node5 = cluster.bootstrap(cluster.newInstanceConfig().
+                set("auto_bootstrap", true));
+            node5.startup(cluster);
+
+            // Wait for constraint violation to be detected on coordinator
+            node1.logs().watchFor("Slot group calculation for " + KEYSPACE + " failed due to constraint violation");
+
+            // Verify: slot groups should be null due to constraint violation.
+            // getSlotInfoForToken returns null when slotGroupMaps has no entry for
+            // this keyspace (removed by the constraint violation fallback path).
+            node1.runOnInstance(() -> {
+                Token t = Murmur3Partitioner.instance.getToken(Int32Type.instance.decompose(1));
+                if (StorageService.instance.getTokenMetadata().
+                        getSlotInfoForToken(t, "replica_slot_grouping_test") != null)
+                {
+                    throw new RuntimeException(
+                        "Slot groups should be null due to constraint violation, but slot info was found");
+                }
+            });
+            logger.info(
+                "Constraint violation correctly detected:" +
+                " slot groups cleared (fallback to standard behavior)");
+
+            // Verify ConstraintViolations incremented and
+            // StaleFallbacks unchanged
+            long cvAfter = getConstraintViolations(node1);
+            Assert.assertTrue(
+                "ConstraintViolations should increment," +
+                " before=" + cvBefore + " after=" + cvAfter,
+                cvAfter > cvBefore);
+            Assert.assertEquals(
+                "StaleFallbacks should not change during" +
+                " constraint violation fallback",
+                staleBefore, getStaleFallbacks(node1));
+            logger.info(
+                "Metrics verified: ConstraintViolations" +
+                " {}->{}; StaleFallbacks unchanged={}",
+                cvBefore, cvAfter, staleBefore);
+
+            // Sanity check: writes still succeed with all natural replicas
+            executeSuccessfulWrite(node1, 1, ConsistencyLevel.QUORUM);
+            logger.info(
+                "Constraint violation fallback + all responding:" +
+                " QUORUM succeeded");
+
+            // Clean up
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+
+    /**
+     * Test: Stale fallback when slot groups don't cover all contacts.
+     *
+     * Setup: 3-node cluster (RF=3), node 4 bootstrapping (kept in pending state).
+     * After slot groups are computed for the 4-node topology, a fake 5th bootstrap
+     * endpoint is added to TokenMetadata and pending ranges are recalculated (without
+     * recalculating slot groups). This creates a stale condition: the write contacts
+     * include the fake node 5 (as a pending replica), but the slot groups only know
+     * about nodes {1,2,3,4}.
+     *
+     * Expected: The stale detection in getValidatedSlotInfo finds node 5 not in
+     * endpointToSlot, increments StaleFallbacks, and falls back to standard write
+     * behavior. The write succeeds because enough real nodes respond.
+     */
+    @Test
+    public void testSlotGroupingStaleFallback() throws Exception
+    {
+        int numStartNodes = 3;
+        TokenSupplier even =
+            TokenSupplier.evenlyDistributedTokens(numStartNodes + 1);
+
+        BootstrapBB.resetForNodes(4);
+
+        try (Cluster cluster = Cluster.build(numStartNodes).
+                withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK).set(
+                    "paxos_variant", "v2").set(
+                    "skip_paxos_repair_on_topology_change", true)).
+                withNodeIdTopology(NetworkTopology.
+                    singleDcNetworkTopology(
+                        numStartNodes + 1,
+                        "datacenter1", "rack1")).
+                withInstanceInitializer(BootstrapBB::install).
+                withTokenSupplier(node -> even.token(node)).
+                start())
+        {
+            IInvokableInstance node1 = cluster.get(1);
+
+            fixDistributedSchemas(cluster);
+            init(cluster);
+
+            cluster.schemaChange(
+                "CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                " WITH replication = {'class':" +
+                " 'SimpleStrategy'," +
+                " 'replication_factor': 3};");
+            cluster.schemaChange(
+                "CREATE TABLE IF NOT EXISTS " + KEYSPACE +
+                ".tbl (pk int, ck int, v int," +
+                " PRIMARY KEY (pk, ck))");
+
+            setSlotGroupingEnabled(cluster, true);
+
+            // Bootstrap node 4 (kept in pending state)
+            IInvokableInstance node4 =
+                cluster.bootstrap(cluster.newInstanceConfig().
+                    set("auto_bootstrap", true));
+            node4.startup(cluster);
+
+            node1.logs().watchFor(
+                "Slot group calculation for " +
+                KEYSPACE + " completed");
+
+            long staleBefore = getStaleFallbacks(node1);
+            long cvBefore = getConstraintViolations(node1);
+
+            // Add a fake 5th bootstrap endpoint to the coordinator's TokenMetadata, then recalculate
+            // only pending ranges (NOT slot groups). We call TokenMetadata.calculatePendingRanges()
+            // directly instead of PendingRangeCalculatorService.update(), because the latter also
+            // recalculates slot groups — which would include the fake node and defeat the stale test.
+            // Returns a pk guaranteed to be in the fake node's pending range.
+            int stalePk = node1.callOnInstance(() -> {
+                org.apache.cassandra.locator.TokenMetadata tm =
+                    StorageService.instance.getTokenMetadata();
+                java.util.List<Token> sorted = new java.util.ArrayList<>(tm.sortedTokens());
+
+                long t1Val = Long.parseLong(sorted.get(0).toString());
+                long t2Val = Long.parseLong(sorted.get(1).toString());
+                long midVal = t1Val + (t2Val - t1Val) / 2;
+                Token fakeToken = Murmur3Partitioner.instance.getTokenFactory().fromString(Long.toString(midVal));
+
+                org.apache.cassandra.locator.InetAddressAndPort fakeEp;
+                try
+                {
+                    fakeEp = org.apache.cassandra.locator.InetAddressAndPort.getByNameOverrideDefaults(
+                        "127.0.0.100", 7012);
+                }
+                catch (java.net.UnknownHostException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                tm.addBootstrapToken(fakeToken, fakeEp);
+
+                // Recalculate ONLY pending ranges, not slot groups
+                org.apache.cassandra.locator.AbstractReplicationStrategy strategy =
+                    org.apache.cassandra.db.Keyspace.open(KEYSPACE).getReplicationStrategy();
+                tm.calculatePendingRanges(strategy, KEYSPACE);
+
+                // Find a pk whose token falls in (sorted[0], fakeToken] — the fake node is the
+                // primary replica for this range in the "after" topology, so it will be a pending
+                // replica and trigger the stale detection in getValidatedSlotInfo.
+                Token lbToken = sorted.get(0);
+                for (int pk = 0; pk < 2_000_000; pk++)
+                {
+                    Token pkt = Murmur3Partitioner.instance.getToken(
+                        org.apache.cassandra.db.marshal.Int32Type.instance.decompose(pk));
+                    if (lbToken.compareTo(pkt) < 0 && fakeToken.compareTo(pkt) >= 0)
+                        return pk;
+                }
+                throw new RuntimeException("Could not find pk in fake node's pending range");
+            });
+
+            // Write should succeed: stale detection falls back to standard behavior
+            executeSuccessfulWrite(node1, stalePk, ConsistencyLevel.QUORUM);
+            logger.info("ENABLED + Stale slot groups: write succeeded via fallback");
+
+            // Verify StaleFallbacks incremented
+            long staleAfter = getStaleFallbacks(node1);
+            Assert.assertTrue(
+                "StaleFallbacks should increment, before=" +
+                staleBefore + " after=" + staleAfter,
+                staleAfter > staleBefore);
+            Assert.assertEquals(
+                "ConstraintViolations should not change" +
+                " during stale fallback",
+                cvBefore, getConstraintViolations(node1));
+            logger.info(
+                "Metrics: StaleFallbacks {}->{};" +
+                " ConstraintViolations unchanged={}",
+                staleBefore, staleAfter, cvBefore);
+
+            // Clean up
+            BootstrapBB.keepNodeInPendingState.set(false);
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ReplicaSlotGroupingTestBase.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.IInstance;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.metrics.SlotGroupingMetrics;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.StorageService;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.junit.Assert.fail;
+
+/**
+ * Base class for replica slot grouping tests.
+ *
+ * Provides shared constants, ByteBuddy helpers, and utility methods used by both
+ * {@link ReplicaSlotGroupingTest} (topology scenarios) and
+ * {@link ReplicaSlotGroupingAdvancedTest} (ack permutations, failure handling, Paxos).
+ */
+public abstract class ReplicaSlotGroupingTestBase extends TestBaseImpl
+{
+    protected static final Logger logger = LoggerFactory.getLogger(ReplicaSlotGroupingTestBase.class);
+    protected static final String KEYSPACE = "replica_slot_grouping_test";
+
+    /** Verbs to block when simulating a node being unreachable (mutations + Paxos V2 phases). */
+    protected static final int[] BLOCK_NODE_VERBS = {
+        Verb.MUTATION_REQ.id,
+        Verb.PAXOS2_PREPARE_REQ.id, Verb.PAXOS2_PROPOSE_REQ.id,
+        Verb.PAXOS2_COMMIT_AND_PREPARE_REQ.id, Verb.PAXOS_COMMIT_REQ.id
+    };
+
+    /**
+     * ByteBuddy helper to keep bootstrapping nodes in PENDING/JOINING state.
+     * Configure which nodes to intercept via {@link #targetNodes} before building the cluster.
+     */
+    public static class BootstrapBB
+    {
+        public static final AtomicBoolean keepNodeInPendingState = new AtomicBoolean(true);
+        public static final Set<Integer> targetNodes = new HashSet<>(Arrays.asList(4));
+
+        public static void resetForNodes(Integer... nodes)
+        {
+            targetNodes.clear();
+            targetNodes.addAll(Arrays.asList(nodes));
+            keepNodeInPendingState.set(true);
+        }
+
+        public static void install(ClassLoader cl, Integer nodeNum)
+        {
+            if (!targetNodes.contains(nodeNum))
+                return;
+            new ByteBuddy().
+                rebase(StorageService.class).
+                method(named("bootstrapFinished")).
+                intercept(MethodDelegation.to(BootstrapBB.class)).
+                make().
+                load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        public static void bootstrapFinished(@SuperCall Callable<Boolean> zuper) throws Exception
+        {
+            while (keepNodeInPendingState.get())
+            {
+                logger.info("Keeping node in pending state by throwing error");
+                throw new RuntimeException("Keep node in joining state");
+            }
+            logger.info("Done keeping node in pending state. Node will finish join soon.");
+            zuper.call();
+        }
+    }
+
+    protected void setSlotGroupingEnabled(Cluster cluster, boolean enabled)
+    {
+        cluster.forEach(instance ->
+            instance.runOnInstance(() ->
+                DatabaseDescriptor.setReplicaSlotGroupingEnabled(enabled)));
+    }
+
+    protected void setSlotGroupingEnabled(IInvokableInstance node, boolean enabled)
+    {
+        node.runOnInstance(() -> DatabaseDescriptor.setReplicaSlotGroupingEnabled(enabled));
+    }
+
+    protected static long getStaleFallbacks(IInvokableInstance node)
+    {
+        return node.callOnInstance(() -> SlotGroupingMetrics.staleFallbacks.getCount());
+    }
+
+    protected static long getConstraintViolations(IInvokableInstance node)
+    {
+        return node.callOnInstance(() -> SlotGroupingMetrics.constraintViolations.getCount());
+    }
+
+    protected void assertMetricsUnchanged(IInvokableInstance node, long staleBefore, long cvBefore, String scenario)
+    {
+        long staleAfter = getStaleFallbacks(node);
+        long cvAfter = getConstraintViolations(node);
+        Assert.assertEquals("StaleFallbacks should not change during " + scenario, staleBefore, staleAfter);
+        Assert.assertEquals("ConstraintViolations should not change during " + scenario, cvBefore, cvAfter);
+        logger.info("Metrics unchanged during {}: stale={}, cv={}", scenario, staleAfter, cvAfter);
+    }
+
+    protected static int pkInTransitioningRange(Cluster cluster)
+    {
+        return pkInRange(cluster.get(3), cluster.get(4));
+    }
+
+    protected static int pkInRange(IInstance lb, IInstance ub)
+    {
+        return nextPkInRange(lb, ub, 0);
+    }
+
+    protected static int nextPkInRange(IInstance lb, IInstance ub, int startPk)
+    {
+        Token lbToken = Murmur3Partitioner.instance.getTokenFactory().
+            fromString(lb.config().getString("initial_token"));
+        Token ubToken = Murmur3Partitioner.instance.getTokenFactory().
+            fromString(ub.config().getString("initial_token"));
+        boolean wrapping = lbToken.compareTo(ubToken) > 0;
+        int pk = startPk;
+        int maxIterations = 2_000_000;
+        for (int i = 0; i < maxIterations; i++, pk++)
+        {
+            Token pkt = Murmur3Partitioner.instance.getToken(Int32Type.instance.decompose(pk));
+            boolean inRange;
+            if (wrapping)
+                inRange = lbToken.compareTo(pkt) < 0 || ubToken.compareTo(pkt) >= 0;
+            else
+                inRange = lbToken.compareTo(pkt) < 0 && ubToken.compareTo(pkt) >= 0;
+            if (inRange)
+                return pk;
+        }
+        throw new AssertionError("Could not find pk in range after " + maxIterations + " iterations");
+    }
+
+    protected void executeSuccessfulWrite(IInvokableInstance node, int pk, ConsistencyLevel cl) throws Exception
+    {
+        node.coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
+                                   cl, pk, 1, 1);
+    }
+
+    protected void executeWriteExpectingTimeout(IInvokableInstance node, int pk, ConsistencyLevel cl) throws Exception
+    {
+        try
+        {
+            node.coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
+                                       cl, pk, 1, 1);
+            fail("Expected write to timeout but it succeeded");
+        }
+        catch (Exception e)
+        {
+            String name = e.getClass().getName();
+            if (!name.contains("WriteTimeout") && !name.contains("WriteFailure"))
+            {
+                throw new AssertionError("Expected WriteTimeout or WriteFailure but got " + name, e);
+            }
+        }
+    }
+
+    protected void executeSuccessfulLwt(IInvokableInstance node, int pk) throws Exception
+    {
+        node.coordinator().execute(
+            "INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS",
+            ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1, 1);
+        node.coordinator().execute(
+            "DELETE FROM " + KEYSPACE + ".tbl WHERE pk = ? AND ck = ? IF EXISTS",
+            ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1);
+    }
+
+    protected void executeLwtExpectingTimeout(IInvokableInstance node, int pk) throws Exception
+    {
+        try
+        {
+            node.coordinator().execute(
+                "INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1, 1);
+            fail("Expected LWT to timeout but it succeeded");
+        }
+        catch (Exception e)
+        {
+            String name = e.getClass().getName();
+            if (!name.contains("CasWriteTimeout") &&
+                !name.contains("WriteTimeout") &&
+                !name.contains("WriteFailure"))
+            {
+                throw new AssertionError("Expected CAS/WriteTimeout or WriteFailure but got " + name, e);
+            }
+        }
+    }
+
+    protected void executeWriteExpectingFailureOrTimeout(IInvokableInstance node, int pk,
+                                                         ConsistencyLevel cl) throws Exception
+    {
+        try
+        {
+            node.coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
+                                       cl, pk, 1, 1);
+            fail("Expected write to fail but it succeeded");
+        }
+        catch (Exception e)
+        {
+            String name = e.getClass().getName();
+            if (!name.contains("WriteFailure") && !name.contains("WriteTimeout"))
+            {
+                throw new AssertionError("Expected WriteFailure or WriteTimeout but got " + name, e);
+            }
+        }
+    }
+
+    protected void executeLwtExpectingFailureOrTimeout(IInvokableInstance node, int pk) throws Exception
+    {
+        try
+        {
+            node.coordinator().execute(
+                "INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS",
+                ConsistencyLevel.SERIAL, ConsistencyLevel.QUORUM, pk, 1, 1);
+            fail("Expected LWT to fail but it succeeded");
+        }
+        catch (Exception e)
+        {
+            String name = e.getClass().getName();
+            if (!name.contains("WriteFailure") && !name.contains("WriteTimeout") &&
+                !name.contains("CasWriteTimeout"))
+            {
+                throw new AssertionError("Expected WriteFailure or WriteTimeout but got " + name, e);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/locator/ReplicaSlotGroupTest.java
+++ b/test/unit/org/apache/cassandra/locator/ReplicaSlotGroupTest.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.utils.Pair;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for ReplicaSlotGroup and SlotGroupMaps classes.
+ */
+public class ReplicaSlotGroupTest
+{
+    private static InetAddressAndPort ep(String addr) throws UnknownHostException
+    {
+        return InetAddressAndPort.getByName(addr);
+    }
+
+    private static Token token(long value)
+    {
+        return new Murmur3Partitioner.LongToken(value);
+    }
+
+    // ==================== ReplicaSlotGroup Tests ====================
+
+    @Test
+    public void testStableSlot() throws UnknownHostException
+    {
+        InetAddressAndPort natural = ep("127.0.0.1");
+        ReplicaSlotGroup slot = ReplicaSlotGroup.stableSlot(natural);
+
+        assertFalse("Stable slot should not be transitioning", slot.isTransitioning());
+        assertEquals(natural, slot.naturalEndpoint());
+        assertNull("Stable slot should have null pending endpoint", slot.pendingEndpoint());
+        assertEquals(1, slot.requiredAcks());
+        assertEquals(1, slot.members().size());
+        assertTrue(slot.members().contains(natural));
+    }
+
+    @Test
+    public void testTransitioningSlot() throws UnknownHostException
+    {
+        InetAddressAndPort natural = ep("127.0.0.1");
+        InetAddressAndPort pending = ep("127.0.0.2");
+        ReplicaSlotGroup slot = ReplicaSlotGroup.transitioningSlot(natural, pending);
+
+        assertTrue("Transitioning slot should be transitioning", slot.isTransitioning());
+        assertEquals(natural, slot.naturalEndpoint());
+        assertEquals(pending, slot.pendingEndpoint());
+        assertEquals(2, slot.requiredAcks());
+        assertEquals(2, slot.members().size());
+        assertTrue(slot.members().contains(natural));
+        assertTrue(slot.members().contains(pending));
+    }
+
+    @Test
+    public void testStableSlotSatisfaction() throws UnknownHostException
+    {
+        InetAddressAndPort natural = ep("127.0.0.1");
+        InetAddressAndPort other = ep("127.0.0.2");
+        ReplicaSlotGroup slot = ReplicaSlotGroup.stableSlot(natural);
+
+        // Empty set should not satisfy
+        assertFalse(slot.isSatisfied(Collections.emptySet()));
+
+        // Wrong endpoint should not satisfy
+        assertFalse(slot.isSatisfied(Collections.singleton(other)));
+
+        // Correct endpoint should satisfy
+        assertTrue(slot.isSatisfied(Collections.singleton(natural)));
+
+        // Multiple endpoints including natural should satisfy
+        Set<InetAddressAndPort> both = new HashSet<>(Arrays.asList(natural, other));
+        assertTrue(slot.isSatisfied(both));
+    }
+
+    @Test
+    public void testTransitioningSlotSatisfaction() throws UnknownHostException
+    {
+        InetAddressAndPort natural = ep("127.0.0.1");
+        InetAddressAndPort pending = ep("127.0.0.2");
+        InetAddressAndPort other = ep("127.0.0.3");
+        ReplicaSlotGroup slot = ReplicaSlotGroup.transitioningSlot(natural, pending);
+
+        // Empty set should not satisfy
+        assertFalse(slot.isSatisfied(Collections.emptySet()));
+
+        // Only natural should not satisfy
+        assertFalse(slot.isSatisfied(Collections.singleton(natural)));
+
+        // Only pending should not satisfy
+        assertFalse(slot.isSatisfied(Collections.singleton(pending)));
+
+        // Both natural and pending should satisfy
+        Set<InetAddressAndPort> both = new HashSet<>(Arrays.asList(natural, pending));
+        assertTrue(slot.isSatisfied(both));
+
+        // Natural, pending, and others should satisfy
+        Set<InetAddressAndPort> all = new HashSet<>(Arrays.asList(natural, pending, other));
+        assertTrue(slot.isSatisfied(all));
+    }
+
+    @Test
+    public void testEquality() throws UnknownHostException
+    {
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+
+        ReplicaSlotGroup stable1 = ReplicaSlotGroup.stableSlot(ep1);
+        ReplicaSlotGroup stable2 = ReplicaSlotGroup.stableSlot(ep1);
+        ReplicaSlotGroup stable3 = ReplicaSlotGroup.stableSlot(ep2);
+
+        assertEquals(stable1, stable2);
+        assertNotEquals(stable1, stable3);
+
+        ReplicaSlotGroup trans1 = ReplicaSlotGroup.transitioningSlot(ep1, ep2);
+        ReplicaSlotGroup trans2 = ReplicaSlotGroup.transitioningSlot(ep1, ep2);
+        ReplicaSlotGroup trans3 = ReplicaSlotGroup.transitioningSlot(ep2, ep1);
+
+        assertEquals(trans1, trans2);
+        assertNotEquals(trans1, trans3);
+        assertNotEquals(stable1, trans1);
+    }
+
+    // ==================== SlotGroupMaps Tests ====================
+
+    @Test
+    public void testSlotGroupMapsEmpty()
+    {
+        SlotGroupMaps maps = new SlotGroupMaps();
+        assertTrue(maps.isEmpty());
+        assertEquals(0, maps.size());
+        assertNull(maps.getSlotInfoForToken(token(100)));
+    }
+
+    @Test
+    public void testSlotGroupMapsLookup() throws UnknownHostException
+    {
+        SlotGroupMaps maps = new SlotGroupMaps();
+
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+        InetAddressAndPort ep3 = ep("127.0.0.3");
+
+        // Add slot groups for token 100
+        List<ReplicaSlotGroup> slots100 = Arrays.asList(
+            ReplicaSlotGroup.stableSlot(ep1),
+            ReplicaSlotGroup.stableSlot(ep2),
+            ReplicaSlotGroup.stableSlot(ep3)
+        );
+        maps.addSlotGroups(token(100), slots100);
+
+        // Add slot groups for token 200
+        List<ReplicaSlotGroup> slots200 = Arrays.asList(
+            ReplicaSlotGroup.stableSlot(ep2),
+            ReplicaSlotGroup.stableSlot(ep3),
+            ReplicaSlotGroup.stableSlot(ep1)
+        );
+        maps.addSlotGroups(token(200), slots200);
+
+        assertFalse(maps.isEmpty());
+        assertEquals(2, maps.size());
+
+        // Lookup should find the ceiling entry
+        SlotGroupMaps.SlotGroupInfo info50 = maps.getSlotInfoForToken(token(50));
+        assertNotNull(info50);
+        assertEquals(3, info50.endpointToSlot.size());  // 3 stable slots = 3 endpoints
+
+        // Lookup exact token
+        SlotGroupMaps.SlotGroupInfo info100 = maps.getSlotInfoForToken(token(100));
+        assertNotNull(info100);
+        assertEquals(3, info100.endpointToSlot.size());
+
+        // Lookup between tokens
+        SlotGroupMaps.SlotGroupInfo info150 = maps.getSlotInfoForToken(token(150));
+        assertNotNull(info150);
+        assertEquals(3, info150.endpointToSlot.size());
+    }
+
+    @Test
+    public void testSlotGroupInfoPrecomputed() throws UnknownHostException
+    {
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+        InetAddressAndPort ep3 = ep("127.0.0.3");
+        InetAddressAndPort ep4 = ep("127.0.0.4");
+
+        // Create slots: one stable, one transitioning
+        List<ReplicaSlotGroup> slots = Arrays.asList(
+            ReplicaSlotGroup.stableSlot(ep1),                    // Stable: needs 1 ack
+            ReplicaSlotGroup.transitioningSlot(ep2, ep3),        // Transitioning: needs 2 acks
+            ReplicaSlotGroup.stableSlot(ep4)                     // Stable: needs 1 ack
+        );
+
+        SlotGroupMaps.SlotGroupInfo info = new SlotGroupMaps.SlotGroupInfo(slots);
+
+        // 4 endpoints mapped: ep1, ep2, ep3 (both in transitioning slot with ep2), ep4
+        assertEquals(4, info.endpointToSlot.size());
+
+        // Check endpoint-to-slot mapping
+        ReplicaSlotGroup ep1Slot = info.endpointToSlot.get(ep1);
+        assertNotNull(ep1Slot);
+        assertFalse(ep1Slot.isTransitioning());
+        assertEquals(ep1, ep1Slot.naturalEndpoint());
+        assertEquals(1, ep1Slot.requiredAcks());
+
+        // ep2 and ep3 should map to the same transitioning slot
+        ReplicaSlotGroup ep2Slot = info.endpointToSlot.get(ep2);
+        ReplicaSlotGroup ep3Slot = info.endpointToSlot.get(ep3);
+        assertNotNull(ep2Slot);
+        assertTrue(ep2Slot.isTransitioning());
+        assertSame(ep2Slot, ep3Slot);  // Same slot object
+        assertEquals(ep2, ep2Slot.naturalEndpoint());
+        assertEquals(ep3, ep2Slot.pendingEndpoint());
+        assertEquals(2, ep2Slot.requiredAcks());
+
+        ReplicaSlotGroup ep4Slot = info.endpointToSlot.get(ep4);
+        assertNotNull(ep4Slot);
+        assertFalse(ep4Slot.isTransitioning());
+        assertEquals(ep4, ep4Slot.naturalEndpoint());
+        assertEquals(1, ep4Slot.requiredAcks());
+    }
+
+    @Test
+    public void testSlotGroupInfoNoTransitioning() throws UnknownHostException
+    {
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+
+        // All stable slots
+        List<ReplicaSlotGroup> slots = Arrays.asList(
+            ReplicaSlotGroup.stableSlot(ep1),
+            ReplicaSlotGroup.stableSlot(ep2)
+        );
+
+        SlotGroupMaps.SlotGroupInfo info = new SlotGroupMaps.SlotGroupInfo(slots);
+
+        // 2 stable slots = 2 endpoints
+        assertEquals(2, info.endpointToSlot.size());
+
+        // All slots should be stable (no transitioning)
+        for (ReplicaSlotGroup slot : info.endpointToSlot.values())
+        {
+            assertFalse(slot.isTransitioning());
+            assertEquals(1, slot.requiredAcks());
+        }
+    }
+
+    @Test
+    public void testSlotGroupMapsWrapAround() throws UnknownHostException
+    {
+        SlotGroupMaps maps = new SlotGroupMaps();
+
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+
+        // Add only one slot group at token 100
+        maps.addSlotGroups(token(100), Collections.singletonList(ReplicaSlotGroup.stableSlot(ep1)));
+
+        // Lookup for token > 100 should wrap around to first entry
+        SlotGroupMaps.SlotGroupInfo info500 = maps.getSlotInfoForToken(token(500));
+        assertNotNull(info500);
+        assertEquals(1, info500.endpointToSlot.size());
+    }
+
+    // ==================== SlotGroupMaps.Builder Tests ====================
+
+    @Test
+    public void testSlotGroupMapsBuilderAllStable() throws UnknownHostException
+    {
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+        InetAddressAndPort ep3 = ep("127.0.0.3");
+
+        Set<Token> allTokens = new TreeSet<>(Arrays.asList(token(100), token(200), token(300)));
+        Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot = new HashMap<>();
+
+        // Simulated natural replicas: same 3 endpoints for all tokens
+        EndpointsForRange stableReplicas = EndpointsForRange.of(
+            new Replica(ep1, token(0), token(100), true),
+            new Replica(ep2, token(0), token(100), true),
+            new Replica(ep3, token(0), token(100), true)
+        );
+
+        SlotGroupMaps result = SlotGroupMaps.Builder.build(allTokens, tokenToPendingSlot, t -> stableReplicas);
+
+        assertFalse(result.isEmpty());
+        assertEquals(3, result.size());
+
+        // All slots should be stable
+        for (Token t : allTokens)
+        {
+            SlotGroupMaps.SlotGroupInfo info = result.getSlotInfoForToken(t);
+            assertNotNull(info);
+            assertEquals(3, info.endpointToSlot.size());
+            for (ReplicaSlotGroup slot : info.endpointToSlot.values())
+            {
+                assertFalse(slot.isTransitioning());
+            }
+        }
+    }
+
+    @Test
+    public void testSlotGroupMapsBuilderWithTransitioning() throws UnknownHostException
+    {
+        InetAddressAndPort ep1 = ep("127.0.0.1");
+        InetAddressAndPort ep2 = ep("127.0.0.2");
+        InetAddressAndPort ep3 = ep("127.0.0.3");
+        InetAddressAndPort ep4 = ep("127.0.0.4");
+
+        Set<Token> allTokens = new TreeSet<>(Arrays.asList(token(100), token(200)));
+
+        // Token 100 has a pending: ep4 is replacing ep3
+        Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot = new HashMap<>();
+        tokenToPendingSlot.put(token(100), Pair.create(ep4, ep3));
+
+        // Natural replicas for all tokens: ep1, ep2, ep3
+        EndpointsForRange naturalReplicas = EndpointsForRange.of(
+            new Replica(ep1, token(0), token(100), true),
+            new Replica(ep2, token(0), token(100), true),
+            new Replica(ep3, token(0), token(100), true)
+        );
+
+        SlotGroupMaps result = SlotGroupMaps.Builder.build(allTokens, tokenToPendingSlot, t -> naturalReplicas);
+
+        // Token 100: ep1 stable, ep2 stable, ep3->ep4 transitioning
+        SlotGroupMaps.SlotGroupInfo info100 = result.getSlotInfoForToken(token(100));
+        assertNotNull(info100);
+        // 4 endpoints mapped: ep1, ep2, ep3 (natural of transitioning), ep4 (pending of transitioning)
+        assertEquals(4, info100.endpointToSlot.size());
+
+        ReplicaSlotGroup ep3Slot = info100.endpointToSlot.get(ep3);
+        assertNotNull(ep3Slot);
+        assertTrue(ep3Slot.isTransitioning());
+        assertEquals(ep3, ep3Slot.naturalEndpoint());
+        assertEquals(ep4, ep3Slot.pendingEndpoint());
+
+        // ep4 should map to the same transitioning slot as ep3
+        assertSame(ep3Slot, info100.endpointToSlot.get(ep4));
+
+        // ep1 and ep2 should be stable
+        assertFalse(info100.endpointToSlot.get(ep1).isTransitioning());
+        assertFalse(info100.endpointToSlot.get(ep2).isTransitioning());
+
+        // Token 200: no pending, all stable
+        SlotGroupMaps.SlotGroupInfo info200 = result.getSlotInfoForToken(token(200));
+        assertNotNull(info200);
+        assertEquals(3, info200.endpointToSlot.size());
+        for (ReplicaSlotGroup slot : info200.endpointToSlot.values())
+        {
+            assertFalse(slot.isTransitioning());
+        }
+    }
+
+    @Test
+    public void testSlotGroupMapsBuilderEmptyTokens()
+    {
+        Set<Token> allTokens = new TreeSet<>();
+        Map<Token, Pair<InetAddressAndPort, InetAddressAndPort>> tokenToPendingSlot = new HashMap<>();
+
+        SlotGroupMaps result = SlotGroupMaps.Builder.build(allTokens, tokenToPendingSlot, t -> null);
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
…ogy changes

During topology changes (bootstrap, decommission, replace, move), endpoints transitioning the same replica position are treated as a single logical "slot". This keeps blockFor at base quorum instead of inflating it by pending replicas, maintaining write availability when the feature is enabled via the replica_slot_grouping_enabled configuration flag.

The feature integrates with both the normal write path and all three Paxos V2 phases (Prepare, Propose, Commit).

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21200)

