### PR TITLE
CASSANDRA-21276: fix s390x unit tests

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/ViewPKTest.java
+++ b/test/unit/org/apache/cassandra/cql3/ViewPKTest.java
@@ -466,16 +466,16 @@ public class ViewPKTest extends ViewAbstractTest
                    "  PRIMARY KEY (id1, v1, id2)" +
                    "  WITH CLUSTERING ORDER BY (v1 DESC, id2 ASC)");
 
-        execute("INSERT INTO %s (id1, id2, v1, v2) VALUES (?, ?, ?, ?)", 0, 1, "foo", "bar");
+        updateView("INSERT INTO %s (id1, id2, v1, v2) VALUES (?, ?, ?, ?)", 0, 1, "foo", "bar");
 
         assertRowsNet(executeNet("SELECT * FROM %s"), row(0, 1, "foo", "bar"));
         assertRowsNet(executeViewNet("SELECT * FROM %s"), row(0, "foo", 1, "bar"));
 
-        executeNet("UPDATE %s SET v1=? WHERE id1=? AND id2=?", null, 0, 1);
+        updateView("UPDATE %s SET v1=? WHERE id1=? AND id2=?", null, 0, 1);
         assertRowsNet(executeNet("SELECT * FROM %s"), row(0, 1, null, "bar"));
         assertRowsNet(executeViewNet("SELECT * FROM %s"));
 
-        executeNet("UPDATE %s SET v2=? WHERE id1=? AND id2=?", "rab", 0, 1);
+        updateView("UPDATE %s SET v2=? WHERE id1=? AND id2=?", "rab", 0, 1);
         assertRowsNet(executeNet("SELECT * FROM %s"), row(0, 1, null, "rab"));
         assertRowsNet(executeViewNet("SELECT * FROM %s"));
     }

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -68,6 +68,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.OS_ARCH;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -81,6 +82,9 @@ public class PartitionIndexTest
 
     private final static long SEED = System.nanoTime();
     private final static Random random = new Random(SEED);
+    private static final String S390X = "s390x";
+    private static final long DEFAULT_TEST_THREAD_STACK_SIZE = 32L * 1024;
+    private static final long S390X_TEST_THREAD_STACK_SIZE = 256L * 1024;
 
     static final ByteComparable.Version VERSION = Walker.BYTE_COMPARABLE_VERSION;
 
@@ -535,10 +539,15 @@ public class PartitionIndexTest
             {
                 future.completeExceptionally(err);
             }
-        }, "testThread", 32 * 1024);
+        }, "testThread", testThreadStackSize());
 
         t.start();
         future.join();
+    }
+
+    private static long testThreadStackSize()
+    {
+        return S390X.equals(OS_ARCH.getString()) ? S390X_TEST_THREAD_STACK_SIZE : DEFAULT_TEST_THREAD_STACK_SIZE;
     }
 
     class JumpingFile extends SequentialWriter
@@ -887,3 +896,4 @@ public class PartitionIndexTest
         return PartitionIndex.load(fhBuilder, partitioner, false);
     }
 }
+

--- a/test/unit/org/apache/cassandra/io/util/MemoryTest.java
+++ b/test/unit/org/apache/cassandra/io/util/MemoryTest.java
@@ -44,7 +44,7 @@ public class MemoryTest
         ThreadLocalRandom.current().nextBytes(bytes);
         final Memory memory = Memory.allocate(bytes.length);
         memory.setBytes(0, bytes, 0, bytes.length);
-        ByteBuffer canon = ByteBuffer.wrap(bytes).order(ByteOrder.nativeOrder());
+        ByteBuffer canon = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
         test(canon, memory);
         memory.setBytes(0, new byte[1000], 0, 1000);
         memory.setBytes(0, canon.duplicate());
@@ -84,7 +84,7 @@ public class MemoryTest
 
     private static void test(ByteBuffer canon, Memory memory)
     {
-        ByteBuffer hollow = MemoryUtil.getHollowDirectByteBuffer();
+        ByteBuffer hollow = MemoryUtil.getHollowDirectByteBuffer(ByteOrder.LITTLE_ENDIAN);
         test(canon, hollow, memory, 0, 1000);
         test(canon, hollow, memory, 33, 100);
         test(canon, hollow, memory, 77, 77);
@@ -95,7 +95,7 @@ public class MemoryTest
     {
         canon = canon.duplicate();
         canon.position(offset).limit(offset + length);
-        canon = canon.slice().order(ByteOrder.nativeOrder());
+        canon = canon.slice().order(ByteOrder.LITTLE_ENDIAN);
         test(canon, memory.asByteBuffer(offset, length));
         memory.setByteBuffer(hollow, offset, length);
         test(canon, hollow);


### PR DESCRIPTION
Fix s390x-specific test issues:

Use updateView() in ViewPKTest to wait for asynchronous materialized view updates and avoid race failures.
Increase PartitionIndexTest helper thread stack from 32 KB to 256 KB for stability on s390x.
Use explicit little-endian buffers in MemoryTest to match Memory semantics on big-endian systems.