### PR TITLE
Atomic heartbeat file write with fallback (4.1)

### DIFF
--- a/src/java/org/apache/cassandra/service/DataResurrectionCheck.java
+++ b/src/java/org/apache/cassandra/service/DataResurrectionCheck.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.service;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.utils.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +55,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.cassandra.exceptions.StartupException.ERR_WRONG_DISK_STATE;
 import static org.apache.cassandra.exceptions.StartupException.ERR_WRONG_MACHINE_STATE;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 
@@ -86,12 +87,24 @@ public class DataResurrectionCheck implements StartupCheck
 
         public void serializeToJsonFile(File outputFile) throws IOException
         {
-            FBUtilities.serializeToJsonFile(this, outputFile);
+            FBUtilities.serializeToJsonFileAtomic(this, outputFile);
         }
 
         public static Heartbeat deserializeFromJsonFile(File file) throws IOException
         {
-            return FBUtilities.deserializeFromJsonFile(Heartbeat.class, file);
+            byte[] bytes = Files.readAllBytes(file.toPath());
+            try
+            {
+                return FBUtilities.deserializeFromJsonBytes(Heartbeat.class, bytes);
+            }
+            catch (IOException ex)
+            {
+                int maxLogBytes = Math.min(bytes.length, 1024);
+                String hexContent = bytes.length > 0 ? Hex.bytesToHex(bytes, 0, maxLogBytes) : "(empty)";
+                LOGGER.error("Failed to deserialize heartbeat file {} (length: {} bytes, first {} bytes hex: {})",
+                        file, bytes.length, maxLogBytes, hexContent, ex);
+                throw ex;
+            }
         }
 
         @Override
@@ -173,7 +186,11 @@ public class DataResurrectionCheck implements StartupCheck
         }
         catch (IOException ex)
         {
-            throw new StartupException(ERR_WRONG_DISK_STATE, "Failed to deserialize heartbeat file " + heartbeatFile);
+            LOGGER.warn("Failed to deserialize heartbeat file "
+                    + heartbeatFile
+                    + ". Falling back to file last modified time.", ex);
+            Instant lastModified = Instant.ofEpochMilli(heartbeatFile.lastModified());
+            heartbeat = new Heartbeat(lastModified);
         }
 
         if (heartbeat.lastHeartbeat == null)

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -856,12 +856,49 @@ public class FBUtilities
         }
     }
 
+    public static void serializeToJsonFileAtomic(Object object, File outputFile) throws IOException
+    {
+        // Try to write then perform atomic move so that file can't be corrupted
+        // by process crash in the middle of the write.
+        File tempFile = new File(outputFile.path() + ".tmp");
+        try
+        {
+            // Serialize to bytes first so we can flush and fsync before close.
+            // Jackson's writeValue(OutputStream, ...) auto-closes the stream,
+            // which would prevent us from calling sync() afterwards.
+            byte[] data = jsonMapper.writeValueAsBytes(object);
+            try (FileOutputStreamPlus out = tempFile.newOutputStream(OVERWRITE))
+            {
+                out.write(data);
+                // Force data to disk before rename to ensure durability.
+                // Without this, a crash after rename but before OS flushes to disk
+                // can leave the file with zero-filled or corrupted blocks.
+                out.sync();
+            }
+            tempFile.move(outputFile);
+            // Fsync the parent directory to ensure the rename is durable.
+            // Without this, a crash after rename can revert to the old directory entry.
+            // See: https://transactional.blog/how-to-learn/disk-io
+            SyncUtil.trySyncDir(outputFile.parent());
+        }
+        catch (IOException ex)
+        {
+            tempFile.deleteIfExists();
+            throw ex;
+        }
+    }
+
     public static <T> T deserializeFromJsonFile(Class<T> tClass, File file) throws IOException
     {
         try (FileInputStreamPlus in = file.newInputStream())
         {
             return jsonMapper.readValue((InputStream) in, tClass);
         }
+    }
+
+    public static <T> T deserializeFromJsonBytes(Class<T> tClass, byte[] bytes) throws IOException
+    {
+        return jsonMapper.readValue(bytes, tClass);
     }
 
     public static String prettyPrintMemory(long size)

--- a/test/unit/org/apache/cassandra/service/StartupChecksTest.java
+++ b/test/unit/org/apache/cassandra/service/StartupChecksTest.java
@@ -18,9 +18,11 @@
 package org.apache.cassandra.service;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.List;
 
@@ -194,6 +196,43 @@ public class StartupChecksTest
         startupChecks.withTest(check);
 
         verifyFailure(startupChecks, "Invalid tables: abc.def");
+    }
+
+    @Test
+    public void testDataResurrectionCheckLastModifiedFallback() throws Exception
+    {
+        DataResurrectionCheck check = new DataResurrectionCheck() {
+            @Override
+            List<String> getKeyspaces()
+            {
+                return singletonList("test_ks");
+            }
+
+            @Override
+            List<TableGCPeriod> getTablesGcPeriods(String userKeyspace)
+            {
+                return singletonList(new TableGCPeriod("test_table", 10));
+            }
+        };
+
+        // Empty file
+        Files.write(heartbeatFile.toPath(), "".getBytes(StandardCharsets.UTF_8));
+        Instant recentTimestamp = Instant.ofEpochMilli(Clock.Global.currentTimeMillis());
+        Files.setLastModifiedTime(heartbeatFile.toPath(), FileTime.from(recentTimestamp));
+
+        startupChecks.withTest(check);
+        verifySuccess(startupChecks);
+    }
+
+    private void verifySuccess(StartupChecks tests) {
+        try
+        {
+            tests.verify(options);
+        }
+        catch (StartupException e)
+        {
+            fail("Failed startup check with error: " + e.getMessage());
+        }
     }
 
     private void copyInvalidLegacySSTables(Path targetDir) throws IOException


### PR DESCRIPTION
4.1 backport of https://github.com/apache/cassandra/pull/4717
_____

Atomically write to the heartbeat file by writing to a temp file and then performing an atomic move. Also, if an empty heartbeat file is somehow written, add logic to fall back to the last modified time of the heartbeat file

[CASSANDRA-21290](https://issues.apache.org/jira/browse/CASSANDRA-21290)