### PR TITLE
IndexSummaryRedistribution should unmark compacting SSTables in batch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.1.12
+ * IndexSummaryRedistribution should unmark compacting SSTables in batch (CASSANDRA-20159)
  * Harden data resurrection startup check with atomic heartbeat file write with fallback (CASSANDRA-21290)
 
 4.1.11


### PR DESCRIPTION
Details in JIRA ticket: https://issues.apache.org/jira/browse/CASSANDRA-20159

```
IndexSummaryRedistribution should unmark compacting SSTables in batch

patch by Yuqi Yan; reviewed by <Reviewers> for CASSANDRA-20159
```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

