### PR TITLE
CASSANDRA-18282: Exception for RTBoundValidator [5.0]

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -801,6 +801,7 @@ public abstract class ReadCommand extends AbstractReadQuery
     /**
      *  A transformation used for simulating slow queries by tests.
      */
+    @VisibleForTesting
     private static class DelayInjector extends Transformation<UnfilteredRowIterator>
     {
         @Override

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.db;
 
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +117,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         {
             logger.debug("Query cancelled (timeout)", e);
             response = null;
-            assert !command.isCompleted() : "Read marked as completed despite being aborted by timeout to table " + command.metadata();
+            Preconditions.checkState(!command.isCompleted(), "Read marked as completed despite being aborted by timeout to table %s", command.metadata());
         }
 
         if (command.complete())

--- a/src/java/org/apache/cassandra/db/transform/RTBoundValidator.java
+++ b/src/java/org/apache/cassandra/db/transform/RTBoundValidator.java
@@ -25,7 +25,8 @@ import org.apache.cassandra.db.rows.RangeTombstoneMarker;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 
 /**
- * A validating transformation that sanity-checks the sequence of RT bounds and boundaries in every partition.
+ * A validating transformation that sanity-checks the sequence of Range Tombstone bounds and boundaries in every
+ * partition.
  *
  * What we validate, specifically:
  * - that open markers are only followed by close markers
@@ -109,7 +110,7 @@ public final class RTBoundValidator extends Transformation<UnfilteredRowIterator
         public void onPartitionClose()
         {
             if (enforceIsClosed && null != openMarkerDeletionTime)
-                throw ise("expected all RTs to be closed, but the last one is open");
+                throw ise("expected all Range Tombstones to be closed, but the last one is open");
         }
 
         private IllegalStateException ise(String why)
@@ -119,7 +120,7 @@ public final class RTBoundValidator extends Transformation<UnfilteredRowIterator
 
         private String message(String why)
         {
-            return String.format("%s UnfilteredRowIterator for %s (key: %s omdt: [%s]) has an illegal RT bounds sequence: %s",
+            return String.format("%s UnfilteredRowIterator for %s (key: %s omdt: [%s]) has an illegal Range Tombstone bounds sequence: %s",
                                  stage,
                                  partition.metadata(),
                                  partition.metadata().partitionKeyType.getString(partition.partitionKey().getKey()),

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2222,7 +2222,7 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     logger.debug("Query cancelled (timeout)", e);
                     response = null;
-                    assert !command.isCompleted() : "Local read marked as completed despite being aborted by timeout to table " + command.metadata();
+                    Preconditions.checkState(!command.isCompleted(), "Local read marked as completed despite being aborted by timeout to table %s", command.metadata());
                 }
 
                 if (command.complete())


### PR DESCRIPTION
Ticket: https://issues.apache.org/jira/browse/CASSANDRA-18282

Wording-only change: spells out "RT" as "Range Tombstone" in RTBoundValidator error messages, for clarity. CASSANDRA-17810 already addressed the root cause on this branch.

## Test plan

- Targeted tests green: ReadCommandTest, RTTransformationsTest, TimeoutAbortTest