### PR TITLE
service: fix 'occured' -> 'occurred' in DiskErrorsHandlerService messages

### DIFF
--- a/src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java
+++ b/src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java
@@ -54,12 +54,12 @@ public class DiskErrorsHandlerService
             }
             catch (Throwable t)
             {
-                logger.warn("Exception occured while closing disk error handler of class " + oldInstance.getClass().getName(), t);
+                logger.warn("Exception occurred while closing disk error handler of class " + oldInstance.getClass().getName(), t);
             }
         }
         catch (Throwable t)
         {
-            throw new ConfigurationException("Exception occured while initializing disk error handler of class " + newInstance.getClass().getName(), t);
+            throw new ConfigurationException("Exception occurred while initializing disk error handler of class " + newInstance.getClass().getName(), t);
         }
     }
 


### PR DESCRIPTION
Two messages in `src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java` (lines 57, 62) read `Exception occured while`. Fixed to `occurred`. One is a logger.warn string, the other a ConfigurationException message. String-literal-only change.