### PR TITLE
virtual: fix 'recieved' -> 'received' in AccordVirtualTables comment

### DIFF
--- a/src/java/org/apache/cassandra/db/virtual/AccordVirtualTables.java
+++ b/src/java/org/apache/cassandra/db/virtual/AccordVirtualTables.java
@@ -85,7 +85,7 @@ public class AccordVirtualTables
                                   "  ready boolean,\n" +
                                   ")")
                   .partitioner(new LocalPartitioner(ReversedType.getInstance(LongType.instance)))
-                  .comment("Exposes the epoch ready state for recieved epochs in Accord")
+                  .comment("Exposes the epoch ready state for received epochs in Accord")
                   .build());
         }
 


### PR DESCRIPTION
Comment string in `src/java/org/apache/cassandra/db/virtual/AccordVirtualTables.java` line 88 reads `recieved epochs`. This string is visible in the virtual table description. Fixed to `received`. String-literal-only change.