### PR TITLE
Fix 'occured' -> 'occurred' typos

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/OperationExecutionException.java
+++ b/src/java/org/apache/cassandra/exceptions/OperationExecutionException.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.cql3.functions.OperationFcts;
 import org.apache.cassandra.db.marshal.AbstractType;
 
 /**
- * Thrown when an operation problem has occured (e.g. division by zero with integer).
+ * Thrown when an operation problem has occurred (e.g. division by zero with integer).
  */
 public final class OperationExecutionException extends FunctionExecutionException
 {

--- a/src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java
+++ b/src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java
@@ -54,12 +54,12 @@ public class DiskErrorsHandlerService
             }
             catch (Throwable t)
             {
-                logger.warn("Exception occured while closing disk error handler of class " + oldInstance.getClass().getName(), t);
+                logger.warn("Exception occurred while closing disk error handler of class " + oldInstance.getClass().getName(), t);
             }
         }
         catch (Throwable t)
         {
-            throw new ConfigurationException("Exception occured while initializing disk error handler of class " + newInstance.getClass().getName(), t);
+            throw new ConfigurationException("Exception occurred while initializing disk error handler of class " + newInstance.getClass().getName(), t);
         }
     }
 


### PR DESCRIPTION
Trivial spelling fix — `occured` → `occurred`.

- `src/java/org/apache/cassandra/service/DiskErrorsHandlerService.java` — two user-visible messages emitted when a disk error handler fails to close (`logger.warn`) or initialize (`ConfigurationException`).
- `src/java/org/apache/cassandra/exceptions/OperationExecutionException.java` — class Javadoc.

No functional changes.