### PR TITLE
CASSANDRA-19985: Enhance CQLSH to support machine-readable output formatting

### DIFF
--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -37,6 +37,9 @@
 ; version = None
 
 [ui]
+;; The format of the output. Valid values are tabular, csv, and json.
+; mode = tabular
+
 ;; Whether or not to display query results with colors
 ; color = on
 

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -98,6 +98,8 @@ Options:
   Collect coverage data
 `--encoding=ENCODING`::
   Specify a non-default encoding for output. (Default: utf-8)
+`--mode=MODE`::
+  Specify the output display format. Valid values are `tabular` (default), `csv`, and `json`.
 `--cqlshrc=CQLSHRC`::
   Specify an alternative cqlshrc file location.
 `--credentials=CREDENTIALS`::

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -100,6 +100,12 @@ Options:
   Specify a non-default encoding for output. (Default: utf-8)
 `--mode=MODE`::
   Specify the output display format. Valid values are `tabular` (default), `csv`, and `json`.
+  +
+  * `tabular` - Human-readable table format with aligned columns (default)
+  * `csv` - Machine-readable CSV format. Null values are represented as empty fields (matching `COPY TO` behavior).
+  * `json` - Machine-readable JSON array format. Each row is a JSON object with column names as keys.
+  +
+  NOTE: When using `json` mode, if a query returns multiple columns with the same name (e.g., `SELECT id, id FROM table`), only the last value will be included in the output JSON object. This is a known limitation of the JSON object format. CSV mode does not have this limitation.
 `--cqlshrc=CQLSHRC`::
   Specify an alternative cqlshrc file location.
 `--credentials=CREDENTIALS`::

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -50,7 +50,7 @@ from cqlshlib.displaying import (ANSI_RESET, BLUE, COLUMN_NAME_COLORS, CYAN,
                                  TablePrinter, TabularTablePrinter, CsvTablePrinter, JsonTablePrinter)
 from cqlshlib.formatting import (DEFAULT_DATE_FORMAT, DEFAULT_NANOTIME_FORMAT,
                                  DEFAULT_TIMESTAMP_FORMAT, CqlType, DateTimeFormat,
-                                 format_by_type)
+                                 format_by_type, format_json_value)
 from cqlshlib.helptopics import get_html_anchor, get_html_topics
 from cqlshlib.tracing import print_trace, print_trace_session
 from cqlshlib.util import get_file_encoding_bomsize, is_file_secure
@@ -1044,6 +1044,28 @@ class Shell(cmd.Cmd):
             ks_name = table_meta.keyspace_name if table_meta else self.current_keyspace
             ks_meta = self.conn.metadata.keyspaces.get(ks_name, None)
             cql_types = [CqlType(cql_typename(t), ks_meta) for t in result.column_types]
+
+        if isinstance(printer, JsonTablePrinter):
+            dtformats = DateTimeFormat(timestamp_format=self.display_timestamp_format,
+                                       date_format=self.display_date_format,
+                                       nanotime_format=self.display_nanotime_format,
+                                       timezone=self.display_timezone)
+            json_rows = []
+            for row in result.current_rows:
+                json_row = []
+                for i, c in enumerate(column_names):
+                    cqltype = cql_types[i] if i < len(cql_types) else None
+                    precision = self.display_double_precision if cqltype and cqltype.type_name == 'double' \
+                        else self.display_float_precision
+                    json_row.append(format_json_value(row[c], cqltype=cqltype,
+                                                      encoding=self.output_codec.name,
+                                                      date_time_format=dtformats,
+                                                      float_precision=precision))
+                json_rows.append(json_row)
+            if with_header:
+                printer.print_header(formatted_names)
+            printer.print_rows(formatted_names, json_rows)
+            return
 
         formatted_values = [list(map(self.myformat_value, [row[c] for c in column_names], cql_types)) for row in result.current_rows]
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -208,6 +208,27 @@ class SwitchState(Enum):
     ON = True
     OFF = False
 
+class OutputMode(str, Enum):
+    TABULAR = 'tabular'
+    CSV = 'csv'
+    JSON = 'json'
+
+    __str__ = str.__str__
+
+    @property
+    def is_machine_readable(self):
+        return self is not OutputMode.TABULAR
+
+    @classmethod
+    def parse(cls, value):
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value).strip().lower())
+        except ValueError:
+            raise ValueError("Invalid output mode %r; expected one of: %s"
+                             % (value, ', '.join(m.value for m in cls)))
+
 
 def format_value(val, cqltype, encoding, addcolor=False, date_time_format=None,
                  float_precision=None, colormap=None, nullval=None):
@@ -293,7 +314,7 @@ class Shell(cmd.Cmd):
         self.auth_provider = auth_provider
         self.username = username
         self.config_file = config_file
-        self.mode = mode.lower()
+        self.mode = OutputMode.parse(mode)
 
         if isinstance(auth_provider, PlainTextAuthProvider):
             self.username = auth_provider.username

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -46,7 +46,8 @@ from cassandra.util import datetime_from_timestamp
 from cqlshlib import cql3handling, pylexotron, sslhandling, cqlshhandling, authproviderhandling
 from cqlshlib.copyutil import ExportTask, ImportTask
 from cqlshlib.displaying import (ANSI_RESET, BLUE, COLUMN_NAME_COLORS, CYAN,
-                                 RED, WHITE, FormattedValue, colorme)
+                                 RED, WHITE, FormattedValue, colorme,
+                                 TablePrinter, TabularTablePrinter, CsvTablePrinter, JsonTablePrinter)
 from cqlshlib.formatting import (DEFAULT_DATE_FORMAT, DEFAULT_NANOTIME_FORMAT,
                                  DEFAULT_TIMESTAMP_FORMAT, CqlType, DateTimeFormat,
                                  format_by_type)
@@ -284,13 +285,15 @@ class Shell(cmd.Cmd):
                  connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
                  is_subshell=False,
                  auth_provider=None,
-                 disable_history=False):
+                 disable_history=False,
+                 mode='tabular'):
         cmd.Cmd.__init__(self, completekey=completekey)
         self.hostname = hostname
         self.port = port
         self.auth_provider = auth_provider
         self.username = username
         self.config_file = config_file
+        self.mode = mode.lower()
 
         if isinstance(auth_provider, PlainTextAuthProvider):
             self.username = auth_provider.username
@@ -329,6 +332,8 @@ class Shell(cmd.Cmd):
         self.browser = browser
         self.docspath = docspath
         self.color = color
+        if self.mode in ('csv', 'json'):
+            self.color = False
 
         self.display_nanotime_format = display_nanotime_format
         self.display_timestamp_format = display_timestamp_format
@@ -965,42 +970,55 @@ class Shell(cmd.Cmd):
             self.print_result(result, self.get_table_meta('system_auth', 'generated_values'))
         elif result:
             # CAS INSERT/UPDATE
-            self.writeresult("")
-            self.print_static_result(result, self.parse_for_update_meta(statement.query_string), with_header=True, tty=self.tty)
+            if self.mode not in ('csv', 'json'):
+                self.writeresult("")
+            cas_printer = TablePrinter.factory(self.mode, self)
+            self.print_static_result(result, self.parse_for_update_meta(statement.query_string),
+                                     with_header=True, tty=self.tty,
+                                     printer=cas_printer)
+            cas_printer.finish()
         if self.elapsed_enabled:
-            self.writeresult("(%dms elapsed)" % elapsed)
+            elapsed_msg = "(%dms elapsed)" % elapsed
+            if self.mode in ('csv', 'json'):
+                self.printerr(elapsed_msg)
+            else:
+                self.writeresult(elapsed_msg)
         self.flush_output()
         return True, future
 
     def print_result(self, result, table_meta):
         self.decoding_errors = []
 
-        self.writeresult("")
+        if self.mode not in ('csv', 'json'):
+            self.writeresult("")
+        printer = TablePrinter.factory(self.mode, self)
 
-        def print_all(result, table_meta, tty):
-            # Return the number of rows in total
+        def print_all(result, table_meta, tty, printer):
+            machine_mode = self.mode in ('csv', 'json')
+            effective_tty = tty and not machine_mode
             num_rows = 0
             is_first = True
             while True:
-                # Always print for the first page even it is empty
                 if result.current_rows or is_first:
-                    with_header = is_first or tty
-                    self.print_static_result(result, table_meta, with_header, tty, num_rows)
+                    with_header = is_first or effective_tty
+                    self.print_static_result(result, table_meta, with_header, effective_tty,
+                                             num_rows, printer)
                     num_rows += len(result.current_rows)
                 if result.has_more_pages:
-                    if self.shunted_query_out is None and tty:
-                        # Only pause when not capturing.
+                    if self.shunted_query_out is None and effective_tty:
                         input("---MORE---")
                     result.fetch_next_page()
                 else:
-                    if not tty:
+                    if not effective_tty and not machine_mode:
                         self.writeresult("")
                     break
                 is_first = False
             return num_rows
 
-        num_rows = print_all(result, table_meta, self.tty)
-        self.writeresult("(%d rows)" % num_rows)
+        num_rows = print_all(result, table_meta, self.tty, printer)
+        printer.finish()
+        if self.mode not in ('csv', 'json'):
+            self.writeresult("(%d rows)" % num_rows)
 
         if self.decoding_errors:
             for err in self.decoding_errors[:2]:
@@ -1009,15 +1027,16 @@ class Shell(cmd.Cmd):
                 self.writeresult('%d more decoding errors suppressed.'
                                  % (len(self.decoding_errors) - 2), color=RED)
 
-    def print_static_result(self, result, table_meta, with_header, tty, row_count_offset=0):
+    def print_static_result(self, result, table_meta, with_header, tty, row_count_offset=0, printer=None):
         if not result.column_names and not table_meta:
             return
 
         column_names = result.column_names or list(table_meta.columns.keys())
         formatted_names = [self.myformat_colname(name, table_meta) for name in column_names]
+
         if not result.current_rows:
-            # print header only
-            self.print_formatted_result(formatted_names, None, with_header=True, tty=tty)
+            if with_header:
+                printer.print_header(formatted_names)
             return
 
         cql_types = []
@@ -1028,10 +1047,9 @@ class Shell(cmd.Cmd):
 
         formatted_values = [list(map(self.myformat_value, [row[c] for c in column_names], cql_types)) for row in result.current_rows]
 
-        if self.expand_enabled:
-            self.print_formatted_result_vertically(formatted_names, formatted_values, row_count_offset)
-        else:
-            self.print_formatted_result(formatted_names, formatted_values, with_header, tty)
+        if with_header:
+            printer.print_header(formatted_names)
+        printer.print_rows(formatted_names, formatted_values)
 
     def print_formatted_result(self, formatted_names, formatted_values, with_header, tty):
         # determine column widths
@@ -2045,6 +2063,7 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
     argvalues.completekey = option_with_default(configs.get, 'ui', 'completekey',
                                                 DEFAULT_COMPLETEKEY)
     argvalues.color = option_with_default(configs.getboolean, 'ui', 'color')
+    argvalues.mode = option_with_default(configs.get, 'ui', 'mode', 'tabular')
     argvalues.time_format = raw_option_with_default(configs, 'ui', 'time_format',
                                                     DEFAULT_TIMESTAMP_FORMAT)
     argvalues.nanotime_format = raw_option_with_default(configs, 'ui', 'nanotime_format',
@@ -2249,6 +2268,8 @@ def main(cmdline, pkgpath):
                         help='Force tty mode (command prompt).')
     parser.add_argument('--disable-history', default=False, action='store_true',
                         help='Disable saving of history (existing history will still be loaded)')
+    parser.add_argument('--mode', choices=['tabular', 'csv', 'json'],
+                        help='Specify the output format (tabular, csv, json). Default is tabular.')
 
     # This is a hidden option to suppress the warning when the -p/--password command line option is used.
     # Power users may use this option if they know no other people has access to the system where cqlsh is run or don't care about security.
@@ -2376,6 +2397,7 @@ def main(cmdline, pkgpath):
                       display_double_precision=options.double_precision,
                       display_timezone=timezone,
                       max_trace_wait=options.max_trace_wait,
+                      mode=options.mode,
                       ssl=options.ssl,
                       single_statement=options.execute,
                       request_timeout=options.request_timeout,

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -46,7 +46,7 @@ from cassandra.util import datetime_from_timestamp
 from cqlshlib import cql3handling, pylexotron, sslhandling, cqlshhandling, authproviderhandling
 from cqlshlib.copyutil import ExportTask, ImportTask
 from cqlshlib.displaying import (ANSI_RESET, BLUE, COLUMN_NAME_COLORS, CYAN,
-                                 RED, WHITE, FormattedValue, colorme,
+                                 RED, WHITE, FormattedValue, colorme, get_str,
                                  TablePrinter, TabularTablePrinter, CsvTablePrinter, JsonTablePrinter)
 from cqlshlib.formatting import (DEFAULT_DATE_FORMAT, DEFAULT_NANOTIME_FORMAT,
                                  DEFAULT_TIMESTAMP_FORMAT, CqlType, DateTimeFormat,
@@ -314,7 +314,11 @@ class Shell(cmd.Cmd):
         self.auth_provider = auth_provider
         self.username = username
         self.config_file = config_file
-        self.mode = OutputMode.parse(mode)
+        try:
+            self.mode = OutputMode.parse(mode)
+        except ValueError as e:
+            sys.stderr.write("cqlsh: error: %s\n" % e)
+            sys.exit(1)
 
         if isinstance(auth_provider, PlainTextAuthProvider):
             self.username = auth_provider.username
@@ -353,7 +357,7 @@ class Shell(cmd.Cmd):
         self.browser = browser
         self.docspath = docspath
         self.color = color
-        if self.mode in ('csv', 'json'):
+        if self.mode.is_machine_readable:
             self.color = False
 
         self.display_nanotime_format = display_nanotime_format
@@ -991,16 +995,16 @@ class Shell(cmd.Cmd):
             self.print_result(result, self.get_table_meta('system_auth', 'generated_values'))
         elif result:
             # CAS INSERT/UPDATE
-            if self.mode not in ('csv', 'json'):
+            if not self.mode.is_machine_readable:
                 self.writeresult("")
-            cas_printer = TablePrinter.factory(self.mode, self)
+            cas_printer = TablePrinter.factory(self.mode.value, self)
             self.print_static_result(result, self.parse_for_update_meta(statement.query_string),
                                      with_header=True, tty=self.tty,
                                      printer=cas_printer)
             cas_printer.finish()
         if self.elapsed_enabled:
             elapsed_msg = "(%dms elapsed)" % elapsed
-            if self.mode in ('csv', 'json'):
+            if self.mode.is_machine_readable:
                 self.printerr(elapsed_msg)
             else:
                 self.writeresult(elapsed_msg)
@@ -1010,12 +1014,12 @@ class Shell(cmd.Cmd):
     def print_result(self, result, table_meta):
         self.decoding_errors = []
 
-        if self.mode not in ('csv', 'json'):
+        if not self.mode.is_machine_readable:
             self.writeresult("")
-        printer = TablePrinter.factory(self.mode, self)
+        printer = TablePrinter.factory(self.mode.value, self)
 
         def print_all(result, table_meta, tty, printer):
-            machine_mode = self.mode in ('csv', 'json')
+            machine_mode = self.mode.is_machine_readable
             effective_tty = tty and not machine_mode
             num_rows = 0
             is_first = True
@@ -1023,7 +1027,7 @@ class Shell(cmd.Cmd):
                 if result.current_rows or is_first:
                     with_header = is_first or effective_tty
                     self.print_static_result(result, table_meta, with_header, effective_tty,
-                                             num_rows, printer)
+                                             printer)
                     num_rows += len(result.current_rows)
                 if result.has_more_pages:
                     if self.shunted_query_out is None and effective_tty:
@@ -1038,7 +1042,7 @@ class Shell(cmd.Cmd):
 
         num_rows = print_all(result, table_meta, self.tty, printer)
         printer.finish()
-        if self.mode not in ('csv', 'json'):
+        if not self.mode.is_machine_readable:
             self.writeresult("(%d rows)" % num_rows)
 
         if self.decoding_errors:
@@ -1048,7 +1052,7 @@ class Shell(cmd.Cmd):
                 self.writeresult('%d more decoding errors suppressed.'
                                  % (len(self.decoding_errors) - 2), color=RED)
 
-    def print_static_result(self, result, table_meta, with_header, tty, row_count_offset=0, printer=None):
+    def print_static_result(self, result, table_meta, with_header, tty, printer=None):
         if not result.column_names and not table_meta:
             return
 
@@ -1066,26 +1070,41 @@ class Shell(cmd.Cmd):
             ks_meta = self.conn.metadata.keyspaces.get(ks_name, None)
             cql_types = [CqlType(cql_typename(t), ks_meta) for t in result.column_types]
 
-        if isinstance(printer, JsonTablePrinter):
+        if isinstance(printer, (JsonTablePrinter, CsvTablePrinter)):
             dtformats = DateTimeFormat(timestamp_format=self.display_timestamp_format,
                                        date_format=self.display_date_format,
                                        nanotime_format=self.display_nanotime_format,
                                        timezone=self.display_timezone)
-            json_rows = []
+            raw_rows = []
             for row in result.current_rows:
-                json_row = []
+                raw_row = []
                 for i, c in enumerate(column_names):
                     cqltype = cql_types[i] if i < len(cql_types) else None
-                    precision = self.display_double_precision if cqltype and cqltype.type_name == 'double' \
-                        else self.display_float_precision
-                    json_row.append(format_json_value(row[c], cqltype=cqltype,
+                    val = row[c]
+                    if isinstance(printer, JsonTablePrinter):
+                        # JSON output uses full precision for machine readability;
+                        # display precision settings are intentionally ignored.
+                        formatted = format_json_value(val, cqltype=cqltype,
                                                       encoding=self.output_codec.name,
                                                       date_time_format=dtformats,
-                                                      float_precision=precision))
-                json_rows.append(json_row)
+                                                      float_precision=None)
+                    else:  # CsvTablePrinter
+                        # For CSV, use empty string for nulls (matching COPY TO default behavior)
+                        if val is None:
+                            formatted = ''
+                        else:
+                            # Format the value without color, preserving display precision for CSV
+                            precision = self.display_double_precision if cqltype and cqltype.type_name == 'double' \
+                                else self.display_float_precision
+                            formatted_val = format_value(val, cqltype=cqltype, encoding=self.output_codec.name,
+                                                         addcolor=False, date_time_format=dtformats,
+                                                         float_precision=precision)
+                            formatted = get_str(formatted_val)
+                    raw_row.append(formatted)
+                raw_rows.append(raw_row)
             if with_header:
                 printer.print_header(formatted_names)
-            printer.print_rows(formatted_names, json_rows)
+            printer.print_rows(formatted_names, raw_rows)
             return
 
         formatted_values = [list(map(self.myformat_value, [row[c] for c in column_names], cql_types)) for row in result.current_rows]

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -1571,7 +1571,8 @@ class Shell(cmd.Cmd):
                          request_timeout=self.session.default_timeout,
                          connect_timeout=self.conn.connect_timeout,
                          is_subshell=True,
-                         auth_provider=self.auth_provider)
+                         auth_provider=self.auth_provider,
+                         mode=self.mode)
         # duplicate coverage related settings in subshell
         if self.coverage:
             subshell.coverage = True

--- a/pylib/cqlshlib/displaying.py
+++ b/pylib/cqlshlib/displaying.py
@@ -180,41 +180,44 @@ class CsvTablePrinter(TablePrinter):
         import csv
         self._writer = csv.writer(shell.query_out)
         self._header_written = False
-        self._colnames = None
+        self._pending_header = None
 
     def print_header(self, formatted_names):
-        self._colnames = [n.strval for n in formatted_names]
+        self._pending_header = formatted_names
 
     def print_rows(self, formatted_names, formatted_values):
         if not self._header_written:
-            self._writer.writerow(self._colnames)
+            self._writer.writerow([n.strval for n in formatted_names])
             self._header_written = True
         if formatted_values is None:
             return
         for row in formatted_values:
-            self._writer.writerow([col.strval for col in row])
+            # Rows now contain plain strings (not FormattedValue), with empty strings for nulls
+            self._writer.writerow(row)
 
     def finish(self):
-        if self._colnames is not None and not self._header_written:
-            self._writer.writerow(self._colnames)
+        if self._pending_header is not None and not self._header_written:
+            self._writer.writerow([n.strval for n in self._pending_header])
             self._header_written = True
 
 class JsonTablePrinter(TablePrinter):
     def __init__(self, shell):
         self._shell = shell
-        self._colnames = None
         self._first_row = True
 
     def print_header(self, formatted_names):
-        self._colnames = [n.strval for n in formatted_names]
         self._shell.writeresult('[')
 
     def print_rows(self, formatted_names, formatted_values):
         import json
         if formatted_values is None:
             return
+        colnames = [n.strval for n in formatted_names]
         for row in formatted_values:
-            row_dict = {self._colnames[i]: val for i, val in enumerate(row)}
+            # Note: Duplicate column names will silently collapse to the last value
+            # in the dict comprehension. This is a known limitation when SELECT
+            # returns multiple columns with the same name (e.g., SELECT id, id FROM t).
+            row_dict = {colnames[i]: val for i, val in enumerate(row)}
             serialized = json.dumps(row_dict, ensure_ascii=False)
             if self._first_row:
                 self._shell.writeresult('  ' + serialized, newline=False)

--- a/pylib/cqlshlib/displaying.py
+++ b/pylib/cqlshlib/displaying.py
@@ -214,8 +214,8 @@ class JsonTablePrinter(TablePrinter):
         if formatted_values is None:
             return
         for row in formatted_values:
-            row_dict = {self._colnames[i]: col.strval for i, col in enumerate(row)}
-            serialized = json.dumps(row_dict)
+            row_dict = {self._colnames[i]: val for i, val in enumerate(row)}
+            serialized = json.dumps(row_dict, ensure_ascii=False)
             if self._first_row:
                 self._shell.writeresult('  ' + serialized, newline=False)
                 self._first_row = False

--- a/pylib/cqlshlib/displaying.py
+++ b/pylib/cqlshlib/displaying.py
@@ -126,3 +126,101 @@ COLUMN_NAME_COLORS = defaultdict(lambda: MAGENTA,
                                  )
 
 NO_COLOR_MAP = dict()
+
+class TablePrinter:
+    def print_header(self, formatted_names):
+        raise NotImplementedError
+
+    def print_rows(self, formatted_names, formatted_values):
+        raise NotImplementedError
+
+    def finish(self):
+        pass
+
+    @staticmethod
+    def factory(format_type, shell):
+        format_map = {'csv': CsvTablePrinter, 'json': JsonTablePrinter, 'tabular': TabularTablePrinter}
+        printer_cls = format_map.get(format_type.lower(), TabularTablePrinter)
+        return printer_cls(shell) if format_type.lower() != 'tabular' else printer_cls(shell, shell.tty)
+
+class TabularTablePrinter(TablePrinter):
+    def __init__(self, shell, tty, row_count_offset=0):
+        self._shell = shell
+        self._tty = tty
+        self._row_count_offset = row_count_offset
+        self._pending_header = None
+
+    def print_header(self, formatted_names):
+        # Store only — cannot render yet because column widths depend on
+        # data values. print_rows will render header+data together.
+        # Empty-result case is handled in finish().
+        self._pending_header = formatted_names
+
+    def print_rows(self, formatted_names, formatted_values):
+        # with_header=True only when print_header was called for this page.
+        with_header = self._pending_header is not None
+        self._pending_header = None
+        if self._shell.expand_enabled:
+            self._shell.print_formatted_result_vertically(
+                formatted_names, formatted_values, self._row_count_offset)
+        else:
+            self._shell.print_formatted_result(
+                formatted_names, formatted_values, with_header, self._tty)
+        if formatted_values:
+            self._row_count_offset += len(formatted_values)
+
+    def finish(self):
+        if self._pending_header is not None:
+            self._shell.print_formatted_result(
+                self._pending_header, None, with_header=True, tty=self._tty)
+            self._pending_header = None
+
+class CsvTablePrinter(TablePrinter):
+    def __init__(self, shell):
+        import csv
+        self._writer = csv.writer(shell.query_out)
+        self._header_written = False
+        self._colnames = None
+
+    def print_header(self, formatted_names):
+        self._colnames = [n.strval for n in formatted_names]
+
+    def print_rows(self, formatted_names, formatted_values):
+        if not self._header_written:
+            self._writer.writerow(self._colnames)
+            self._header_written = True
+        if formatted_values is None:
+            return
+        for row in formatted_values:
+            self._writer.writerow([col.strval for col in row])
+
+    def finish(self):
+        if self._colnames is not None and not self._header_written:
+            self._writer.writerow(self._colnames)
+            self._header_written = True
+
+class JsonTablePrinter(TablePrinter):
+    def __init__(self, shell):
+        self._shell = shell
+        self._colnames = None
+        self._first_row = True
+
+    def print_header(self, formatted_names):
+        self._colnames = [n.strval for n in formatted_names]
+        self._shell.writeresult('[')
+
+    def print_rows(self, formatted_names, formatted_values):
+        import json
+        if formatted_values is None:
+            return
+        for row in formatted_values:
+            row_dict = {self._colnames[i]: col.strval for i, col in enumerate(row)}
+            serialized = json.dumps(row_dict)
+            if self._first_row:
+                self._shell.writeresult('  ' + serialized, newline=False)
+                self._first_row = False
+            else:
+                self._shell.writeresult(',\n  ' + serialized, newline=False)
+
+    def finish(self):
+        self._shell.writeresult('\n]')

--- a/pylib/cqlshlib/formatting.py
+++ b/pylib/cqlshlib/formatting.py
@@ -605,3 +605,164 @@ NANOS_PER_SECOND = 1000 * NANOS_PER_MILLI
 NANOS_PER_MINUTE = 60 * NANOS_PER_SECOND
 NANOS_PER_HOUR = 60 * NANOS_PER_MINUTE
 MONTHS_PER_YEAR = 12
+
+
+# ---- JSON formatter registry ----
+# Parallel to _formatters, but each function returns a native Python object
+# suitable for json.dumps rather than a display string.
+# Types with no native JSON equivalent fall back to the display formatter.
+
+_json_formatters = {}
+
+
+def json_formatter_for(typname):
+    def registrator(f):
+        _json_formatters[typname.lower()] = f
+        return f
+    return registrator
+
+
+def get_json_formatter(val, cqltype):
+    if cqltype:
+        fmt = _json_formatters.get(cqltype.type_name.lower())
+        if fmt is not None:
+            return fmt
+    return _json_formatters.get(type(val).__name__.lower())
+
+
+def format_json_value(val, cqltype, encoding, date_time_format=None, float_precision=None,
+                      decimal_sep=None, thousands_sep=None, boolean_styles=None, nullval=None, **_):
+    """Return a native Python value for JSON serialization.
+
+    Integer, float, bool, str, list, and dict types are returned as their
+    Python equivalents.  Other types (UUID, timestamp, decimal, inet, blob,
+    duration, …) fall back to the display formatter and return a plain string.
+    None and EMPTY both become None (JSON null).
+    """
+    if val is None or val == EMPTY:
+        return None
+    fmt = get_json_formatter(val, cqltype)
+    if fmt is None:
+        return _json_fallback(val, cqltype=cqltype, encoding=encoding,
+                               date_time_format=date_time_format,
+                               float_precision=float_precision,
+                               decimal_sep=decimal_sep, thousands_sep=thousands_sep,
+                               boolean_styles=boolean_styles)
+    return fmt(val, cqltype=cqltype, encoding=encoding,
+                date_time_format=date_time_format, float_precision=float_precision,
+                decimal_sep=decimal_sep, thousands_sep=thousands_sep,
+                boolean_styles=boolean_styles)
+
+
+def _json_fallback(val, cqltype, encoding, date_time_format=None, float_precision=None,
+                   decimal_sep=None, thousands_sep=None, boolean_styles=None, **_):
+    """Use the display formatter with no color and return a plain string."""
+    if date_time_format is None:
+        date_time_format = DateTimeFormat()
+    if float_precision is None:
+        float_precision = default_float_precision
+    result = format_value(val, cqltype=cqltype, encoding=encoding, colormap=NO_COLOR_MAP,
+                           date_time_format=date_time_format, float_precision=float_precision,
+                           decimal_sep=decimal_sep, thousands_sep=thousands_sep,
+                           boolean_styles=boolean_styles)
+    if isinstance(result, FormattedValue):
+        return result.strval
+    return str(result)
+
+
+# Integer types → native int
+def _json_format_integer(val, **_):
+    return int(val)
+
+
+json_formatter_for('int')(_json_format_integer)
+json_formatter_for('long')(_json_format_integer)
+json_formatter_for('bigint')(_json_format_integer)
+json_formatter_for('varint')(_json_format_integer)
+json_formatter_for('smallint')(_json_format_integer)
+json_formatter_for('tinyint')(_json_format_integer)
+json_formatter_for('counter')(_json_format_integer)
+
+
+# Float/double → native float; NaN and Infinity are not valid JSON values,
+# so they fall back to their display string representation.
+def _json_format_float(val, **_):
+    if math.isnan(val):
+        return 'NaN'
+    if math.isinf(val):
+        return 'Infinity' if val > 0 else '-Infinity'
+    return float(val)
+
+
+json_formatter_for('float')(_json_format_float)
+json_formatter_for('double')(_json_format_float)
+
+
+# Boolean → native bool; boolean_styles are intentionally ignored so JSON
+# always uses the canonical true / false literals.
+def _json_format_boolean(val, **_):
+    return bool(val)
+
+
+json_formatter_for('bool')(_json_format_boolean)
+json_formatter_for('boolean')(_json_format_boolean)
+
+
+# Text → raw Python str; CQL quoting/escaping is intentionally omitted so
+# the value round-trips cleanly through json.dumps / json.loads.
+def _json_format_text(val, **_):
+    return str(val)
+
+
+json_formatter_for('str')(_json_format_text)
+json_formatter_for('unicode')(_json_format_text)
+json_formatter_for('text')(_json_format_text)
+json_formatter_for('ascii')(_json_format_text)
+json_formatter_for('varchar')(_json_format_text)
+
+
+# Sequences (list, tuple, set, frozenset, vector) → Python list with
+# recursively formatted elements.  Sets have no JSON equivalent.
+def _json_format_sequence(val, cqltype, encoding, date_time_format=None,
+                           float_precision=None, **kwargs):
+    val_list = list(val)
+    if not cqltype or not cqltype.sub_types:
+        return [format_json_value(v, None, encoding, date_time_format, float_precision, **kwargs)
+                for v in val_list]
+    try:
+        sub_types = cqltype.get_n_sub_types(len(val_list))
+    except Exception:
+        sub_types = [cqltype.sub_types[0]] * len(val_list)
+    return [format_json_value(v, st, encoding, date_time_format, float_precision, **kwargs)
+            for v, st in zip(val_list, sub_types)]
+
+
+json_formatter_for('list')(_json_format_sequence)
+json_formatter_for('tuple')(_json_format_sequence)
+json_formatter_for('set')(_json_format_sequence)
+json_formatter_for('frozenset')(_json_format_sequence)
+json_formatter_for('sortedset')(_json_format_sequence)
+
+
+# Map → Python dict; JSON only supports string keys, so non-string keys are
+# converted via format_json_value and then cast to str if needed.
+def _json_format_map(val, cqltype, encoding, date_time_format=None,
+                      float_precision=None, **kwargs):
+    if not cqltype or len(cqltype.sub_types) < 2:
+        return {str(k): format_json_value(v, None, encoding, date_time_format, float_precision, **kwargs)
+                for k, v in val.items()}
+    ktype, vtype = cqltype.sub_types[0], cqltype.sub_types[1]
+    result = {}
+    for k, v in val.items():
+        json_k = format_json_value(k, ktype, encoding, date_time_format, float_precision, **kwargs)
+        if not isinstance(json_k, str):
+            json_k = str(json_k)
+        result[json_k] = format_json_value(v, vtype, encoding, date_time_format, float_precision, **kwargs)
+    return result
+
+
+json_formatter_for('dict')(_json_format_map)
+json_formatter_for('OrderedDict')(_json_format_map)
+json_formatter_for('OrderedMap')(_json_format_map)
+json_formatter_for('OrderedMapSerializedKey')(_json_format_map)
+json_formatter_for('map')(_json_format_map)

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -1266,3 +1266,49 @@ class TestCqlshOutput(BaseTestCase):
             cleanup_q2 = "DELETE FROM %s.has_all_types WHERE num = 9999;" % ks
             cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
                            tty=False, input=cleanup_q2 + '\n')
+
+    def test_source_inherits_mode(self):
+        """SOURCE subshell must inherit --mode from the parent shell (not revert to tabular)."""
+        import json
+        import tempfile
+        import os
+
+        ks = get_keyspace()
+        query = "SELECT a, b FROM twenty_rows_table WHERE a IN ('1', '2');\n"
+
+        # Write the query to a temporary SOURCE file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.cql', delete=False) as f:
+            f.write(query)
+            source_file = f.name
+
+        try:
+            # Run cqlsh --mode json and SOURCE the file
+            source_cmd = "SOURCE '%s';\n" % source_file
+            output, result = cqlsh_testcall(args=('--mode', 'json'), prompt=None,
+                                            env=self.default_env, tty=False,
+                                            input=source_cmd)
+            self.assertEqual(0, result)
+            try:
+                rows = json.loads(output)
+                self.assertIsInstance(rows, list,
+                                      msg='SOURCE with --mode json must produce a JSON array')
+                self.assertEqual(len(rows), 2)
+                results = {(item['a'], item['b']) for item in rows}
+                self.assertIn(('1', '1'), results)
+                self.assertIn(('2', '2'), results)
+            except ValueError as e:
+                self.fail("SOURCE output is not valid JSON (mode not inherited): %s\nOutput: %r"
+                          % (e, output))
+
+            # Also verify CSV mode is inherited
+            output_csv, result_csv = cqlsh_testcall(args=('--mode', 'csv'), prompt=None,
+                                                    env=self.default_env, tty=False,
+                                                    input=source_cmd)
+            self.assertEqual(0, result_csv)
+            import csv, io
+            reader = csv.reader(io.StringIO(output_csv.strip()))
+            csv_rows = list(reader)
+            self.assertGreater(len(csv_rows), 1, msg='SOURCE with --mode csv must produce CSV rows')
+            self.assertIn('a', csv_rows[0], msg='First CSV row must be a header')
+        finally:
+            os.unlink(source_file)

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -1312,3 +1312,80 @@ class TestCqlshOutput(BaseTestCase):
             self.assertIn('a', csv_rows[0], msg='First CSV row must be a header')
         finally:
             os.unlink(source_file)
+
+    def test_csv_null_handling(self):
+        """CSV output should use empty string for nulls, not literal 'null'."""
+        ks = get_keyspace()
+        # Insert a row with null and a row with string 'null'
+        setup = (
+            "INSERT INTO %s.has_all_types (num, textcol) VALUES (9990, null);"
+            "INSERT INTO %s.has_all_types (num, textcol) VALUES (9991, 'null');" % (ks, ks)
+        )
+        cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                       tty=False, input=setup + '\n')
+        try:
+            query = "SELECT num, textcol FROM %s.has_all_types WHERE num IN (9990, 9991);" % ks
+            output, result = cqlsh_testcall(args=('--mode', 'csv'), prompt=None,
+                                            env=self.default_env, tty=False, input=query + '\n')
+            self.assertEqual(0, result)
+            import csv, io
+            reader = csv.reader(io.StringIO(output.strip()))
+            rows = list(reader)
+            self.assertEqual(rows[0], ['num', 'textcol'])
+
+            # Find the rows
+            data_rows = {int(r[0]): r[1] for r in rows[1:] if r[0] in ('9990', '9991')}
+
+            # Row with null should have empty string
+            self.assertEqual(data_rows[9990], '',
+                             msg='CSV null should be empty string, not literal "null"')
+            # Row with string 'null' should have 'null'
+            self.assertEqual(data_rows[9991], 'null',
+                             msg='CSV string "null" should remain as "null"')
+        finally:
+            cleanup = "DELETE FROM %s.has_all_types WHERE num IN (9990, 9991);" % ks
+            cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                           tty=False, input=cleanup + '\n')
+
+    def test_json_float_precision(self):
+        """JSON output should preserve full float precision, not truncate to display precision."""
+        ks = get_keyspace()
+        # Insert a double with high precision
+        setup = "INSERT INTO %s.has_all_types (num, doublecol) VALUES (9992, 3.141592653589793);" % ks
+        cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                       tty=False, input=setup + '\n')
+        try:
+            query = "SELECT num, doublecol FROM %s.has_all_types WHERE num = 9992;" % ks
+            output, result = cqlsh_testcall(args=('--mode', 'json'), prompt=None,
+                                            env=self.default_env, tty=False, input=query + '\n')
+            self.assertEqual(0, result)
+            import json
+            rows = json.loads(output.strip())
+            self.assertEqual(len(rows), 1)
+            double_val = rows[0]['doublecol']
+            # Should preserve more than 5 digits (default display precision)
+            self.assertIsInstance(double_val, float)
+            # Check that we have more precision than 5 significant figures
+            self.assertAlmostEqual(double_val, 3.141592653589793, places=10,
+                                   msg='JSON should preserve full float precision')
+        finally:
+            cleanup = "DELETE FROM %s.has_all_types WHERE num = 9992;" % ks
+            cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                           tty=False, input=cleanup + '\n')
+
+    def test_json_duplicate_columns(self):
+        """JSON output with duplicate column names silently keeps only the last value."""
+        ks = get_keyspace()
+        # Select the same column multiple times
+        query = "SELECT num, num FROM %s.has_all_types WHERE num = 0;" % ks
+        output, result = cqlsh_testcall(args=('--mode', 'json'), prompt=None,
+                                        env=self.default_env, tty=False, input=query + '\n')
+        self.assertEqual(0, result)
+        import json
+        rows = json.loads(output.strip())
+        self.assertGreater(len(rows), 0)
+        # Dict comprehension silently collapses duplicate keys
+        # This is a known limitation documented in the code
+        self.assertIn('num', rows[0])
+        # Only one 'num' key should exist in the dict
+        self.assertEqual(len([k for k in rows[0].keys() if k == 'num']), 1)

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -1083,3 +1083,155 @@ class TestCqlshOutput(BaseTestCase):
                                         tty=False, input=query)
         self.assertEqual(0, result)
         self.assertEqual(output.splitlines()[3].strip(), "{data: 'I''m newb'}")
+
+    def test_csv_output(self):
+        ks = get_keyspace()
+        query = "SELECT a, b FROM twenty_rows_table WHERE a IN ('1', '2');"
+
+        output, result = cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                                        tty=False, input=query + '\n')
+        self.assertEqual(0, result)
+
+        lines = output.strip().splitlines()
+        self.assertEqual(lines[0].strip(), 'a,b')
+        self.assertIn('1,1', [l.strip() for l in lines])
+        self.assertIn('2,2', [l.strip() for l in lines])
+
+        query2 = "SELECT num, setcol FROM has_all_types WHERE num = 0;"
+        output2, result2 = cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                                          tty=False, input=query2 + '\n')
+        self.assertEqual(0, result2)
+        import csv, io
+        reader = csv.reader(io.StringIO(output2.strip()))
+        rows = list(reader)
+        self.assertEqual(rows[0], ['num', 'setcol'])
+        for row in rows[1:]:
+            self.assertEqual(len(row), 2,
+                             msg='CSV row has wrong field count (commas inside setcol not quoted?): %r' % row)
+
+        query3 = "SELECT num, varintcol FROM has_all_types WHERE num = 0;"
+        output3, result3 = cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                                          tty=False, input=query3 + '\n')
+        self.assertEqual(0, result3)
+        reader3 = csv.reader(io.StringIO(output3.strip()))
+        rows3 = list(reader3)
+        varint_val = rows3[1][1]
+        self.assertNotIn(',', varint_val,
+                         msg='Large varint should not contain thousands separator in CSV: %r' % varint_val)
+
+        ks = get_keyspace()
+        setup_q = ("INSERT INTO %s.has_all_types (num, textcol) VALUES (9998, 'Smith, Joe');" % ks)
+        cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                       tty=False, input=setup_q + '\n')
+        try:
+            q4 = "SELECT num, textcol FROM %s.has_all_types WHERE num = 9998;" % ks
+            output4, result4 = cqlsh_testcall(args=('--mode', 'csv'), prompt=None,
+                                              env=self.default_env, tty=False, input=q4 + '\n')
+            self.assertEqual(0, result4)
+            reader4 = csv.reader(io.StringIO(output4.strip()))
+            rows4 = list(reader4)
+            self.assertEqual(rows4[0], ['num', 'textcol'])
+            for row in rows4[1:]:
+                self.assertEqual(len(row), 2,
+                                 msg='Comma inside textcol must be quoted in CSV: %r' % row)
+            data_rows4 = [r for r in rows4[1:] if r[0] == '9998']
+            self.assertEqual(len(data_rows4), 1)
+            self.assertEqual(data_rows4[0][1], 'Smith, Joe')
+        finally:
+            cleanup_q = "DELETE FROM %s.has_all_types WHERE num = 9998;" % ks
+            cqlsh_testcall(args=('--mode', 'csv'), prompt=None, env=self.default_env,
+                           tty=False, input=cleanup_q + '\n')
+
+    def test_json_output(self):
+        ks = get_keyspace()
+        query = "SELECT a, b FROM twenty_rows_table WHERE a IN ('1', '2');"
+
+        output, result = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                                        tty=False, input=query + '\n')
+        self.assertEqual(0, result)
+
+        import json
+        try:
+            parsed_json = json.loads(output)
+            self.assertEqual(len(parsed_json), 2)
+
+            results = { (item['a'], item['b']) for item in parsed_json }
+            self.assertIn(('1', '1'), results)
+            self.assertIn(('2', '2'), results)
+        except ValueError as e:
+            self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output))
+
+        query2 = "SELECT num, setcol, listcol, mapcol FROM has_all_types WHERE num = 0;"
+        output2, result2 = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                                          tty=False, input=query2 + '\n')
+        self.assertEqual(0, result2)
+        try:
+            rows2 = json.loads(output2)
+            self.assertEqual(len(rows2), 1)
+            row = rows2[0]
+            self.assertIsInstance(row['setcol'], str,
+                                  msg='setcol should be a JSON string, got: %r' % type(row['setcol']))
+            self.assertIsInstance(row['listcol'], str,
+                                  msg='listcol should be a JSON string, got: %r' % type(row['listcol']))
+            self.assertIsInstance(row['mapcol'], str,
+                                  msg='mapcol should be a JSON string, got: %r' % type(row['mapcol']))
+        except ValueError as e:
+            self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output2))
+
+        query3 = "SELECT num, varintcol FROM has_all_types WHERE num = 0;"
+        output3, result3 = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                                          tty=False, input=query3 + '\n')
+        self.assertEqual(0, result3)
+        try:
+            rows3 = json.loads(output3)
+            self.assertEqual(rows3[0]['varintcol'], '10000000000000000000000000')
+        except ValueError as e:
+            self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output3))
+
+        q4 = "SELECT num, uuidcol, decimalcol, timestampcol FROM has_all_types WHERE num = 0;"
+        output4, result4 = cqlsh_testcall(args=('--mode', 'json'), prompt=None,
+                                          env=self.default_env, tty=False, input=q4 + '\n')
+        self.assertEqual(0, result4)
+        try:
+            rows4 = json.loads(output4)
+            self.assertEqual(len(rows4), 1)
+            row4 = rows4[0]
+            import re
+            uuid_val = row4.get('uuidcol', '')
+            self.assertRegex(uuid_val,
+                             r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+                             msg='uuidcol must be a UUID-formatted string: %r' % uuid_val)
+            from decimal import Decimal as PyDecimal, InvalidOperation
+            decimal_val = row4.get('decimalcol', '')
+            self.assertIsInstance(decimal_val, str, msg='decimalcol must be a string in JSON')
+            try:
+                PyDecimal(decimal_val)
+            except InvalidOperation:
+                self.fail('decimalcol value %r is not a valid decimal string' % decimal_val)
+            ts_val = row4.get('timestampcol', '')
+            self.assertIsInstance(ts_val, str)
+            self.assertTrue(len(ts_val) > 0, msg='timestampcol must be a non-empty string')
+        except ValueError as e:
+            self.fail("UUID/Decimal/Timestamp JSON output invalid: %s\nOutput: %s" % (e, output4))
+
+        ks = get_keyspace()
+        setup_q2 = r"INSERT INTO " + ks + r".has_all_types (num, textcol) VALUES (9999, 'say \"hello\" \\ world');"
+        cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                       tty=False, input=setup_q2 + '\n')
+        try:
+            q5 = "SELECT num, textcol FROM %s.has_all_types WHERE num = 9999;" % ks
+            output5, result5 = cqlsh_testcall(args=('--mode', 'json'), prompt=None,
+                                              env=self.default_env, tty=False, input=q5 + '\n')
+            self.assertEqual(0, result5)
+            try:
+                rows5 = json.loads(output5)
+                self.assertEqual(len(rows5), 1)
+                text_val = rows5[0]['textcol']
+                self.assertIsInstance(text_val, str)
+                self.assertIn('"', text_val, msg='Double-quote must survive JSON round-trip')
+            except ValueError as e:
+                self.fail("Special-char JSON output is not valid JSON: %s\nOutput: %s" % (e, output5))
+        finally:
+            cleanup_q2 = "DELETE FROM %s.has_all_types WHERE num = 9999;" % ks
+            cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                           tty=False, input=cleanup_q2 + '\n')

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -1161,6 +1161,7 @@ class TestCqlshOutput(BaseTestCase):
         except ValueError as e:
             self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output))
 
+        # Collections and maps should be native JSON types, not strings
         query2 = "SELECT num, setcol, listcol, mapcol FROM has_all_types WHERE num = 0;"
         output2, result2 = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
                                           tty=False, input=query2 + '\n')
@@ -1169,24 +1170,54 @@ class TestCqlshOutput(BaseTestCase):
             rows2 = json.loads(output2)
             self.assertEqual(len(rows2), 1)
             row = rows2[0]
-            self.assertIsInstance(row['setcol'], str,
-                                  msg='setcol should be a JSON string, got: %r' % type(row['setcol']))
-            self.assertIsInstance(row['listcol'], str,
-                                  msg='listcol should be a JSON string, got: %r' % type(row['listcol']))
-            self.assertIsInstance(row['mapcol'], str,
-                                  msg='mapcol should be a JSON string, got: %r' % type(row['mapcol']))
+            self.assertIsInstance(row['setcol'], list,
+                                  msg='setcol (set<text>) should be a JSON array, got: %r' % type(row['setcol']))
+            self.assertIsInstance(row['listcol'], list,
+                                  msg='listcol (list<text>) should be a JSON array, got: %r' % type(row['listcol']))
+            self.assertIsInstance(row['mapcol'], dict,
+                                  msg='mapcol (map<text, int>) should be a JSON object, got: %r' % type(row['mapcol']))
+            # map values should be native ints, not strings
+            for v in row['mapcol'].values():
+                self.assertIsInstance(v, int,
+                                      msg='mapcol values should be int, got: %r' % type(v))
         except ValueError as e:
             self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output2))
 
-        query3 = "SELECT num, varintcol FROM has_all_types WHERE num = 0;"
+        # Integer types should be native JSON numbers, not quoted strings
+        query3 = "SELECT num, varintcol, bigintcol, intcol FROM has_all_types WHERE num = 0;"
         output3, result3 = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
                                           tty=False, input=query3 + '\n')
         self.assertEqual(0, result3)
         try:
             rows3 = json.loads(output3)
-            self.assertEqual(rows3[0]['varintcol'], '10000000000000000000000000')
+            self.assertEqual(rows3[0]['varintcol'], 10000000000000000000000000)
+            self.assertIsInstance(rows3[0]['varintcol'], int,
+                                  msg='varintcol should be int, got: %r' % type(rows3[0]['varintcol']))
+            self.assertIsInstance(rows3[0]['bigintcol'], int,
+                                  msg='bigintcol should be int, got: %r' % type(rows3[0]['bigintcol']))
+            self.assertIsInstance(rows3[0]['intcol'], int,
+                                  msg='intcol should be int, got: %r' % type(rows3[0]['intcol']))
         except ValueError as e:
             self.fail("Output is not valid JSON: %s\nOutput was:\n%s" % (e, output3))
+
+        # null values should be JSON null (Python None), not the string "null"
+        q3b = "SELECT num, setcol, listcol, mapcol, bigintcol FROM has_all_types WHERE num = 999;"
+        output3b, result3b = cqlsh_testcall(args=('--mode', 'json'), prompt=None, env=self.default_env,
+                                            tty=False, input=q3b + '\n')
+        self.assertEqual(0, result3b)
+        try:
+            rows3b = json.loads(output3b)
+            if rows3b:
+                row3b = rows3b[0]
+                for col in ('setcol', 'listcol', 'mapcol', 'bigintcol'):
+                    if col in row3b and row3b[col] is None:
+                        # None is correctly JSON null
+                        pass
+                    elif col in row3b:
+                        self.assertNotEqual(row3b[col], 'null',
+                                            msg='%s null should be JSON null, not the string "null"' % col)
+        except ValueError as e:
+            self.fail("Null-value JSON output is not valid JSON: %s\nOutput: %s" % (e, output3b))
 
         q4 = "SELECT num, uuidcol, decimalcol, timestampcol FROM has_all_types WHERE num = 0;"
         output4, result4 = cqlsh_testcall(args=('--mode', 'json'), prompt=None,

--- a/pylib/cqlshlib/test/test_json_formatting.py
+++ b/pylib/cqlshlib/test/test_json_formatting.py
@@ -1,0 +1,243 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for format_json_value — no live Cassandra connection required."""
+
+import math
+import unittest
+from decimal import Decimal
+from uuid import UUID
+
+from cqlshlib.formatting import CqlType, DateTimeFormat, format_json_value
+
+
+class TestFormatJsonValue(unittest.TestCase):
+    """Tests that format_json_value returns native Python types for JSON output."""
+
+    def setUp(self):
+        self.enc = 'utf-8'
+        self.dtf = DateTimeFormat()
+        self.fp = 3
+
+    def _fmt(self, val, type_str):
+        cqltype = CqlType(type_str) if type_str else None
+        return format_json_value(val, cqltype, self.enc,
+                                  date_time_format=self.dtf,
+                                  float_precision=self.fp)
+
+    # ---- null ----
+
+    def test_none_is_json_null(self):
+        self.assertIsNone(self._fmt(None, 'bigint'))
+        self.assertIsNone(self._fmt(None, 'text'))
+        self.assertIsNone(self._fmt(None, 'int'))
+        self.assertIsNone(self._fmt(None, 'boolean'))
+
+    # ---- integer types → int ----
+
+    def test_bigint_is_int(self):
+        result = self._fmt(14413, 'bigint')
+        self.assertEqual(result, 14413)
+        self.assertIsInstance(result, int)
+
+    def test_int_is_int(self):
+        result = self._fmt(42, 'int')
+        self.assertEqual(result, 42)
+        self.assertIsInstance(result, int)
+
+    def test_varint_is_int(self):
+        big = 10000000000000000000000000
+        result = self._fmt(big, 'varint')
+        self.assertEqual(result, big)
+        self.assertIsInstance(result, int)
+
+    def test_smallint_is_int(self):
+        result = self._fmt(32767, 'smallint')
+        self.assertIsInstance(result, int)
+
+    def test_tinyint_is_int(self):
+        result = self._fmt(127, 'tinyint')
+        self.assertIsInstance(result, int)
+
+    def test_negative_int(self):
+        result = self._fmt(-12, 'int')
+        self.assertEqual(result, -12)
+
+    # ---- float types → float ----
+
+    def test_float_is_float(self):
+        result = self._fmt(1.5, 'float')
+        self.assertIsInstance(result, float)
+
+    def test_double_is_float(self):
+        result = self._fmt(1.0, 'double')
+        self.assertIsInstance(result, float)
+
+    def test_nan_becomes_string(self):
+        self.assertEqual(self._fmt(float('nan'), 'float'), 'NaN')
+
+    def test_positive_inf_becomes_string(self):
+        self.assertEqual(self._fmt(float('inf'), 'float'), 'Infinity')
+
+    def test_negative_inf_becomes_string(self):
+        self.assertEqual(self._fmt(float('-inf'), 'float'), '-Infinity')
+
+    # ---- boolean → bool ----
+
+    def test_true_is_bool(self):
+        result = self._fmt(True, 'boolean')
+        self.assertIs(result, True)
+        self.assertIsInstance(result, bool)
+
+    def test_false_is_bool(self):
+        result = self._fmt(False, 'boolean')
+        self.assertIs(result, False)
+
+    # ---- text types → str ----
+
+    def test_text_is_str(self):
+        result = self._fmt('hello', 'text')
+        self.assertEqual(result, 'hello')
+        self.assertIsInstance(result, str)
+
+    def test_ascii_is_str(self):
+        result = self._fmt('abc', 'ascii')
+        self.assertIsInstance(result, str)
+
+    def test_text_with_double_quotes(self):
+        result = self._fmt('say "hi"', 'text')
+        self.assertIn('"', result)
+        self.assertIsInstance(result, str)
+
+    def test_text_no_cql_quoting(self):
+        # Raw string must not be wrapped in single-quotes (CQL literal style)
+        result = self._fmt('hello', 'text')
+        self.assertFalse(result.startswith("'"))
+
+    # ---- list → list ----
+
+    def test_list_is_list(self):
+        result = self._fmt(['a', 'b', 'c'], 'list<text>')
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, ['a', 'b', 'c'])
+
+    def test_list_elements_are_native(self):
+        result = self._fmt([1, 2, 3], 'list<int>')
+        for v in result:
+            self.assertIsInstance(v, int)
+
+    def test_empty_list(self):
+        result = self._fmt([], 'list<text>')
+        self.assertEqual(result, [])
+
+    # ---- set → list ----
+
+    def test_set_is_list(self):
+        result = self._fmt({'a', 'b', 'c'}, 'set<text>')
+        self.assertIsInstance(result, list)
+        self.assertEqual(set(result), {'a', 'b', 'c'})
+
+    def test_empty_set(self):
+        result = self._fmt(set(), 'set<text>')
+        self.assertEqual(result, [])
+
+    # ---- map → dict ----
+
+    def test_map_is_dict(self):
+        result = self._fmt({'a': 1, 'b': 2}, 'map<text, int>')
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result, {'a': 1, 'b': 2})
+
+    def test_map_values_are_int(self):
+        result = self._fmt({'x': 42}, 'map<text, int>')
+        self.assertIsInstance(result['x'], int)
+
+    def test_map_int_keys_become_strings(self):
+        result = self._fmt({4: 3, 5: 2}, 'map<int, int>')
+        self.assertIsInstance(result, dict)
+        self.assertIn('4', result)
+        self.assertEqual(result['4'], 3)
+        self.assertIn('5', result)
+        self.assertEqual(result['5'], 2)
+
+    def test_empty_map(self):
+        result = self._fmt({}, 'map<text, int>')
+        self.assertEqual(result, {})
+
+    def test_map_null_value(self):
+        result = self._fmt({'k': None}, 'map<text, int>')
+        self.assertIsNone(result['k'])
+
+    # ---- fallback types → str ----
+
+    def test_uuid_is_string(self):
+        u = UUID('bd1924e1-6af8-44ae-b5e1-f24131dbd460')
+        result = self._fmt(u, 'uuid')
+        self.assertIsInstance(result, str)
+        self.assertRegex(result,
+                         r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+
+    def test_decimal_is_string(self):
+        d = Decimal('19952.11882')
+        result = self._fmt(d, 'decimal')
+        self.assertIsInstance(result, str)
+        self.assertEqual(Decimal(result), d)
+
+    # ---- json.dumps round-trip ----
+
+    def test_json_roundtrip_integers(self):
+        import json
+        row = {
+            'bigintcol': self._fmt(14413, 'bigint'),
+            'intcol': self._fmt(-12, 'int'),
+            'varintcol': self._fmt(10000000000000000000000000, 'varint'),
+        }
+        s = json.dumps(row)
+        parsed = json.loads(s)
+        self.assertEqual(parsed['bigintcol'], 14413)
+        self.assertEqual(parsed['intcol'], -12)
+        self.assertEqual(parsed['varintcol'], 10000000000000000000000000)
+
+    def test_json_roundtrip_collections(self):
+        import json
+        row = {
+            'listcol': self._fmt(['a', 'b'], 'list<text>'),
+            'mapcol': self._fmt({'k': 1}, 'map<text, int>'),
+            'nullcol': self._fmt(None, 'bigint'),
+        }
+        s = json.dumps(row)
+        parsed = json.loads(s)
+        self.assertEqual(parsed['listcol'], ['a', 'b'])
+        self.assertEqual(parsed['mapcol'], {'k': 1})
+        self.assertIsNone(parsed['nullcol'])
+
+    def test_null_serializes_as_json_null_not_string(self):
+        import json
+        row = {'val': self._fmt(None, 'bigint')}
+        s = json.dumps(row)
+        self.assertIn('null', s)
+        self.assertNotIn('"null"', s)
+
+    def test_int_serializes_without_quotes(self):
+        import json
+        row = {'val': self._fmt(14413, 'bigint')}
+        s = json.dumps(row)
+        self.assertIn('14413', s)
+        self.assertNotIn('"14413"', s)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enhance CQLSH to support machine-readable output formatting (csv, json)

Currently, `cqlsh` output formatting provides tabular formatting designed for human readability, which complicates machine processing in automated pipelines. This patch introduces a `--mode` argument to switch between output formats.

Changes included in this patch:
* Added `--mode` argument supporting `tabular`, `csv`, and `json` formats.
* Retained `tabular` as the default mode to ensure no breaking changes for existing users.
* Disabled ANSI color codes and extra footer text (like `(X rows)`) when `csv` or `json` mode is selected to ensure purely machine-readable output.
* [cite_start]Updated `cqlsh.adoc` documentation and `cqlshrc.sample` configuration file[cite: 1, 2].
* [cite_start]Added unit tests in `test_cqlsh_output.py` to verify both CSV and JSON formats[cite: 1, 2].

patch by Arvind Kandpal; reviewed by <Reviewers> for CASSANDRA-19985

The [Cassandra Jira](CASSANDRA-19985)