### PR TITLE
doc: fix typo in native protocol doc script error message

### DIFF
--- a/doc/scripts/process-native-protocol-specs-in-docker.sh
+++ b/doc/scripts/process-native-protocol-specs-in-docker.sh
@@ -52,7 +52,7 @@ rm -rf "${TMPDIR}/cassandra-website"
 git clone -n --depth=1 --filter=tree:0 https://github.com/apache/cassandra-website
 
 if [ $? != "0" ]; then
-  echo "Error occured while cloning https://github.com/apache/cassandra-website"
+  echo "Error occurred while cloning https://github.com/apache/cassandra-website"
   exit 1
 fi
 


### PR DESCRIPTION
This is a small docs/script cleanup.

Change:
- fix typo in `doc/scripts/process-native-protocol-specs-in-docker.sh`
- `Error occured while cloning ...` -> `Error occurred while cloning ...`