### PR TITLE
doc: fix README grammar in getting started walkthrough

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -58,7 +58,7 @@ cqlsh>
 ----
 
 As the banner says, you can use 'help;' or '?' to see what CQL has to
-offer, and 'quit;' or 'exit;' when you've had enough fun. But lets try
+offer, and 'quit;' or 'exit;' when you've had enough fun. But let's try
 something slightly more interesting:
 
 ----


### PR DESCRIPTION
Small docs wording fix in `README.asc`.

Change:
- `But lets try` -> `But let's try`

This keeps the getting-started text grammatically correct for new users.