### PR TITLE
doc: fix grammar in cast function description

### DIFF
--- a/doc/modules/cassandra/pages/developing/cql/functions.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/functions.adoc
@@ -32,7 +32,7 @@ include::cassandra:example$BNF/function.bnf[]
 
 ==== Cast
 
-The `cast` function can be used to converts one native datatype to
+The `cast` function can be used to convert one native datatype to
 another.
 
 The following table describes the conversions supported by the `cast`


### PR DESCRIPTION
## What is this
Fixes a grammar typo in the CQL functions documentation.

## Why
The sentence currently says "can be used to converts", which is grammatically incorrect.

## Testing
- [x] Built-in docs text review
- [x] Verified diff only updates wording
