### PR TITLE
CASSANDRA-21320: add rows mutated per write request histogram

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ClientRequestSizeMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestSizeMetrics.java
@@ -19,6 +19,8 @@
 package org.apache.cassandra.metrics;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.codahale.metrics.Counter;
 
@@ -28,6 +30,7 @@ import org.apache.cassandra.cql3.selection.Selection;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
@@ -66,18 +69,22 @@ public class ClientRequestSizeMetrics
 
         int rowCount = 0;
         int columnCount = 0;
+        Map<TableId, Integer> rowsMutatedPerRequest = new HashMap<>();
 
         for (IMutation mutation : mutations)
         {
             for (PartitionUpdate update : mutation.getPartitionUpdates())
             {
                 columnCount += update.affectedColumnCount();
-                rowCount += update.affectedRowCount();
+                int affectedRows = update.affectedRowCount();
+                rowCount += affectedRows;
+                rowsMutatedPerRequest.merge(update.metadata().id, affectedRows, Integer::sum);
             }
         }
 
         ClientRequestSizeMetrics.totalColumnsWritten.inc(columnCount);
         ClientRequestSizeMetrics.totalRowsWritten.inc(rowCount);
+        incrementRowsMutatedPerWriteRequest(rowsMutatedPerRequest);
     }
 
     public static void recordRowAndColumnCountMetrics(PartitionUpdate update)
@@ -86,6 +93,20 @@ public class ClientRequestSizeMetrics
             return;
 
         ClientRequestSizeMetrics.totalColumnsWritten.inc(update.affectedColumnCount());
-        ClientRequestSizeMetrics.totalRowsWritten.inc(update.affectedRowCount());
+        int affectedRows = update.affectedRowCount();
+        ClientRequestSizeMetrics.totalRowsWritten.inc(affectedRows);
+        ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(update.metadata().id);
+        if (cfs != null)
+            cfs.metric.rowsMutatedPerWriteHistogram.update(affectedRows);
+    }
+
+    private static void incrementRowsMutatedPerWriteRequest(Map<TableId, Integer> rowsMutatedPerRequest)
+    {
+        for (Map.Entry<TableId, Integer> entry : rowsMutatedPerRequest.entrySet())
+        {
+            ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(entry.getKey());
+            if (cfs != null)
+                cfs.metric.rowsMutatedPerWriteHistogram.update(entry.getValue());
+        }
     }
 }

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -83,6 +83,8 @@ public class KeyspaceMetrics
     public final Histogram sstablesPerReadHistogram;
     /** Histogram of the number of sstable data files accessed per partition range read */
     public final Histogram sstablesPerRangeReadHistogram;
+    /** Histogram of rows mutated per write request in this keyspace. */
+    public final Histogram rowsMutatedPerWriteHistogram;
     /** Tombstones scanned in queries on this Keyspace */
     public final Histogram tombstoneScannedHistogram;
     /** Purgeable tombstones scanned in queries on this Keyspace */
@@ -255,6 +257,7 @@ public class KeyspaceMetrics
         // create histograms for TableMetrics to replicate updates to
         sstablesPerReadHistogram = createKeyspaceHistogram("SSTablesPerReadHistogram", true);
         sstablesPerRangeReadHistogram = createKeyspaceHistogram("SSTablesPerRangeReadHistogram", true);
+        rowsMutatedPerWriteHistogram = createKeyspaceHistogram("RowsMutatedPerWriteHistogram", false);
         tombstoneScannedHistogram = createKeyspaceHistogram("TombstoneScannedHistogram", false);
         purgeableTombstoneScannedHistogram = createKeyspaceHistogram("PurgeableTombstoneScannedHistogram", false);
         liveScannedHistogram = createKeyspaceHistogram("LiveScannedHistogram", false);

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -238,6 +238,8 @@ public class TableMetrics
     public final SnapshottingTimer coordinatorReadLatency;
     public final Timer coordinatorScanLatency;
     public final SnapshottingTimer coordinatorWriteLatency;
+    /** Histogram of rows mutated per write request on this table. */
+    public final TableHistogram rowsMutatedPerWriteHistogram;
 
     private final TableMetricNameFactory factory;
     private final TableMetricNameFactory aliasFactory;
@@ -816,6 +818,7 @@ public class TableMetrics
         coordinatorReadLatency = createTableTimer("CoordinatorReadLatency");
         coordinatorScanLatency = createTableTimer("CoordinatorScanLatency");
         coordinatorWriteLatency = createTableTimer("CoordinatorWriteLatency");
+        rowsMutatedPerWriteHistogram = createTableHistogram("RowsMutatedPerWriteHistogram", cfs.keyspace.metric.rowsMutatedPerWriteHistogram, false);
 
         // We do not want to capture view mutation specific metrics for a view
         // They only makes sense to capture on the base table

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestRowAndColumnMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestRowAndColumnMetricsTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.config.Config;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.paxos.Paxos;
@@ -219,11 +220,13 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
     public void shouldRecordWriteMetricsForSingleValueRow()
     {
         createTable("CREATE TABLE %s (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = currentTableStore();
 
         executeNet(CURRENT, "INSERT INTO %s (pk, ck, v) VALUES (1, 1, 1)");
 
         assertEquals(1, ClientRequestSizeMetrics.totalRowsWritten.getCount());
         assertEquals(1, ClientRequestSizeMetrics.totalColumnsWritten.getCount());
+        assertEquals(1, cfs.metric.rowsMutatedPerWriteHistogram.cf.getCount());
     }
 
     @Test
@@ -254,6 +257,7 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
     public void shouldRecordWriteMetricsForBatch() throws Exception
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v1 int, v2 int)");
+        ColumnFamilyStore cfs = currentTableStore();
 
         try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, CURRENT))
         {
@@ -269,7 +273,13 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
             // The metrics should reflect the batch as a single write operation with multiple rows and columns.
             assertEquals(2, ClientRequestSizeMetrics.totalRowsWritten.getCount());
             assertEquals(4, ClientRequestSizeMetrics.totalColumnsWritten.getCount());
+            assertEquals(1, cfs.metric.rowsMutatedPerWriteHistogram.cf.getCount());
         }
+    }
+
+    private ColumnFamilyStore currentTableStore()
+    {
+        return ColumnFamilyStore.getIfExists(KEYSPACE, currentTable());
     }
 
     @Test


### PR DESCRIPTION
## What is this
Implements a table-level histogram for write request size in rows.

## JIRA
- CASSANDRA-21320

## Changes
- Added `RowsMutatedPerWriteHistogram` to `TableMetrics`.
- Added matching keyspace histogram `RowsMutatedPerWriteHistogram` in `KeyspaceMetrics`.
- Updated write request metric recording to update this histogram once per write request per table.
  - For multi-mutation requests (e.g., batches), rows are aggregated per table and recorded once.
  - For single `PartitionUpdate`, one histogram update is recorded for that request.
- Extended `ClientRequestRowAndColumnMetricsTest` with assertions for the new table histogram.

## Testing
- Unable to run unit tests in this environment because `ant` is not installed (`ant: command not found` on Windows shell).
- Verified changed call paths and metric wiring via code inspection and diff checks.
