### PR TITLE
CASSANDRA-21247: [6.0] Enable check_data_resurrection by default in cassandra_latest.yaml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha2
+ * Enable check_data_resurrection by default in cassandra_latest.yaml (CASSANDRA-21247)
  * Introduce minimum_threshold for data resurrection startup check (CASSANDRA-21293)
  * Synchronously publish changes to local gossip state following metadata updates (CASSANDRA-21239)
  * Change default for cassandra.set_sep_thread_name to false to reduce CPU usage (CASSANDRA-21089)

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2503,25 +2503,25 @@ default_secondary_index_enabled: true
 # It is possible to implement custom startup checks by implementing StatupCheck interface
 # and placing JAR on a classpath, using SPI mechanism.
 #
-#startup_checks:
+startup_checks:
+# Enable this property to fail startup if the node is down for longer than max(gc_grace_seconds, minimum_threshold),
+# to potentially prevent data resurrection on tables with deletes.
+# By default, this will run against all keyspaces and tables except the
+# ones specified on excluded_keyspaces and excluded_tables.
+  check_data_resurrection:
+    enabled: true
+#    # Minimum grace period for the check, defaults to 0. Useful when gc_grace_seconds is very
+#    # small (e.g. 0) to avoid blocking startup immediately.
+    minimum_threshold: 3h
+#    #file where Cassandra periodically writes the last time it was known to run
+#    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
+#    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
+#    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
 #  check_filesystem_ownership:
 #    enabled: false
 #    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
 #    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
-# Enable this property to fail startup if the node is down for longer than max(gc_grace_seconds, minimum_threshold),
-# to potentially prevent data resurrection on tables with deletes.
-# By default, this will run against all keyspaces and tables except the
-# ones specified on excluded_keyspaces and excluded_tables.
-#  check_data_resurrection:
-#    enabled: false
-#    # Minimum grace period for the check, defaults to 0. Useful when gc_grace_seconds is very
-#    # small (e.g. 0) to avoid blocking startup immediately.
-#    minimum_threshold: 3h
-#    #file where Cassandra periodically writes the last time it was known to run
-#    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
-#    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
-#    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
 
 # This property indicates with what Cassandra major version the storage format will be compatible with.
 #

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.locator.NetworkTopologyProximity;
 import org.apache.cassandra.locator.SimpleSeedProvider;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DTEST_ACCORD_ENABLED;
+import static org.apache.cassandra.config.StartupChecksConfiguration.ENABLED_PROPERTY;
 
 public class InstanceConfig implements IInstanceConfig
 {
@@ -129,7 +130,8 @@ public class InstanceConfig implements IInstanceConfig
                 .set("index_summary_capacity", "50MiB")
                 .set("counter_cache_size", "50MiB")
                 .set("key_cache_size", "50MiB")
-                .set("commitlog_disk_access_mode", "legacy");
+                .set("commitlog_disk_access_mode", "legacy")
+                .set("startup_checks", Map.of("check_data_resurrection", Map.of(ENABLED_PROPERTY, false)));
         if (CassandraRelevantProperties.DTEST_JVM_DTESTS_USE_LATEST.getBoolean())
         {
             // TODO: make this load latest_diff.yaml or cassandra_latest.yaml


### PR DESCRIPTION
From discussion on https://issues.apache.org/jira/browse/CASSANDRA-21221, it was clear that users may not know that this feature exists. This PR updates the cassandra_latest.yaml so that users who take advantage of the recommended production settings can get this feature automatically in the next release.
