### PR TITLE
Migrate index status propagation from gossip to table polling

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -957,6 +957,9 @@ index_summary_capacity:
 # Min unit: m
 index_summary_resize_interval: 60m
 
+# How frequently (in seconds) to poll the index_events table for peer index status changes.
+# index_status_poll_interval_in_seconds: 30
+
 # Whether to, when doing sequential writing, fsync() at intervals in
 # order to force the operating system to flush the dirty
 # buffers. Enable this to avoid sudden dirty buffer flushing from

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1004,6 +1004,9 @@ index_summary_capacity:
 # Min unit: m
 index_summary_resize_interval: 60m
 
+# How frequently (in seconds) to poll the index_events table for peer index status changes.
+# index_status_poll_interval_in_seconds: 30
+
 # Whether to, when doing sequential writing, fsync() at intervals in
 # order to force the operating system to flush the dirty
 # buffers. Enable this to avoid sudden dirty buffer flushing from

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -944,6 +944,7 @@ public class Config
 
     public volatile String default_secondary_index = CassandraIndex.NAME;
     public volatile boolean default_secondary_index_enabled = true;
+    public volatile int index_status_poll_interval_in_seconds = 30;
 
     public volatile boolean uncompressed_tables_enabled = true;
     public volatile boolean compact_tables_enabled = true;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -1011,6 +1011,7 @@ public class Config
 
     public volatile String default_secondary_index = CassandraIndex.NAME;
     public volatile boolean default_secondary_index_enabled = true;
+    public volatile int index_status_poll_interval_in_seconds = 30;
 
     public volatile boolean uncompressed_tables_enabled = true;
     public volatile boolean compact_tables_enabled = true;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4710,6 +4710,16 @@ public class DatabaseDescriptor
         conf.default_secondary_index_enabled = enabled;
     }
 
+    public static int getIndexStatusPollInterval()
+    {
+        return conf.index_status_poll_interval_in_seconds;
+    }
+
+    public static void setIndexStatusPollInterval(int seconds)
+    {
+        conf.index_status_poll_interval_in_seconds = seconds;
+    }
+
     public static boolean isTransientReplicationEnabled()
     {
         return conf.transient_replication_enabled;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4926,6 +4926,16 @@ public class DatabaseDescriptor
         conf.default_secondary_index_enabled = enabled;
     }
 
+    public static int getIndexStatusPollInterval()
+    {
+        return conf.index_status_poll_interval_in_seconds;
+    }
+
+    public static void setIndexStatusPollInterval(int seconds)
+    {
+        conf.index_status_poll_interval_in_seconds = seconds;
+    }
+
     public static boolean isTransientReplicationEnabled()
     {
         return conf.transient_replication_enabled;

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -18,12 +18,18 @@
 
 package org.apache.cassandra.index;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -36,6 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ExecutorPlus;
+import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.exceptions.ReadFailureException;
@@ -46,10 +55,12 @@ import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.locator.Endpoints;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.utils.CassandraVersion;
+import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JsonUtils;
@@ -69,6 +80,14 @@ public class IndexStatusManager
     private static final Logger logger = LoggerFactory.getLogger(IndexStatusManager.class);
 
     public static final IndexStatusManager instance = new IndexStatusManager();
+
+    private static final int MAX_GOSSIP_VALUE_SIZE = 65535;
+
+    public static final String TABLE_FALLBACK_MARKER = "TABLE_FALLBACK";
+
+    private volatile long lastPollTimestampMillis = 0;
+
+    private ScheduledFuture<?> pollFuture;
 
     // executes index status propagation task asynchronously to avoid potential deadlock on SIM
     private final ExecutorPlus statusPropagationExecutor = executorFactory().withJmxInternal()
@@ -163,7 +182,16 @@ public class IndexStatusManager
             if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
                 return;
 
-            Map<String, Index.Status> indexStatusMap = statusMapFromString(versionedValue);
+            Map<String, Index.Status> indexStatusMap;
+
+            if (versionedValue.value.equals(TABLE_FALLBACK_MARKER))
+            {
+                indexStatusMap = SystemDistributedKeyspace.allIndexStatusesForHost(StorageService.instance.getHostIdForEndpoint(endpoint));
+            }
+            else
+            {
+                indexStatusMap = statusMapFromString(versionedValue);
+            }
 
             Map<String, Index.Status> oldStatus = peerIndexStatus.put(endpoint, indexStatusMap);
             Map<String, Index.Status> updated = updatedIndexStatuses(oldStatus, indexStatusMap);
@@ -229,29 +257,65 @@ public class IndexStatusManager
             Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(),
                                                                                k -> new HashMap<>());
             String keyspaceIndex = identifier(keyspace, index);
+            UUID localHostId = StorageService.instance.getLocalHostUUID();
+            CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
 
             if (status == Index.Status.DROPPED)
+            {
                 statusMap.remove(keyspaceIndex);
+                if (localHostId != null)
+                    statusPropagationExecutor.submit(() -> {
+                        if (shouldWriteToIndexTables(minVersion))
+                        {
+                            SystemDistributedKeyspace.setIndexRemoved(localHostId, keyspace, index);
+                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
+                        }
+                    });
+            }
             else
+            {
                 statusMap.put(keyspaceIndex, status);
+                if (localHostId != null)
+                    statusPropagationExecutor.submit(() -> {
+                        if (shouldWriteToIndexTables(minVersion))
+                        {
+                            SystemDistributedKeyspace.updateIndexStatus(localHostId, keyspace, index, status);
+                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
+                        }
+                    });
+            }
 
-            // Don't try and propagate if the gossiper isn't enabled. This is primarily for tests where the
-            // Gossiper has not been started. If we attempt to propagate when not started an exception is
-            // logged and this causes a number of dtests to fail.
-            if (Gossiper.instance.isEnabled())
+            // Only propagate via gossip when the gossiper is enabled and the cluster is not fully on 6.0+.
+            // Once all nodes are on 6.0+, index status is propagated via table polling instead.
+            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables(minVersion))
             {
                 // Versions 5.0.0 through 5.0.2 use a much more bloated format that duplicates keyspace names
                 // and writes full status names instead of their numeric codes. If the minimum cluster version is
                 // unknown or one of those 3 versions, continue to propagate the old format.
-                CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
-
-                String newSerializedStatusMap = shouldWriteLegacyStatusFormat(minVersion) ? JsonUtils.writeAsJsonString(statusMap) 
+                String newSerializedStatusMap = shouldWriteLegacyStatusFormat(minVersion) ? JsonUtils.writeAsJsonString(statusMap)
                                                                                           : toSerializedFormat(statusMap);
+
+                byte[] utf8Bytes = newSerializedStatusMap.getBytes(StandardCharsets.UTF_8);
+                String gossipPayload;
+
+                if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE)
+                {
+                    logger.error("Index status gossip payload size ({} bytes) exceeds limit ({} bytes), please consider removing unwanted indexes.",
+                                 utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
+                    gossipPayload = TABLE_FALLBACK_MARKER;
+                }
+                else
+                {
+                    if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
+                        logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
+                                    utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
+                    gossipPayload = newSerializedStatusMap;
+                }
 
                 statusPropagationExecutor.submit(() -> {
                     // schedule gossiper update asynchronously to avoid potential deadlock when another thread is holding
                     // gossiper taskLock.
-                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(newSerializedStatusMap);
+                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(gossipPayload);
                     Gossiper.instance.addLocalApplicationState(ApplicationState.INDEX_STATUS, value);
                 });
             }
@@ -265,6 +329,29 @@ public class IndexStatusManager
     private static boolean shouldWriteLegacyStatusFormat(CassandraVersion minVersion)
     {
         return minVersion == null || (minVersion.major == 5 && minVersion.minor == 0 && minVersion.patch < 3);
+    }
+
+    private static boolean shouldWriteToIndexTables(CassandraVersion minVersion)
+    {
+        return minVersion != null && (minVersion.major >= 6);
+    }
+
+    @VisibleForTesting
+    static boolean shouldWriteToIndexTablesForTesting(CassandraVersion minVersion)
+    {
+        return shouldWriteToIndexTables(minVersion);
+    }
+
+    @VisibleForTesting
+    void processEventsForTesting(UntypedResultSet results)
+    {
+        processEvents(results);
+    }
+
+    @VisibleForTesting
+    void resetLastPollTimestamp()
+    {
+        lastPollTimestampMillis = 0;
     }
 
     /**
@@ -340,8 +427,136 @@ public class IndexStatusManager
         return keyspace + '.' + index;
     }
 
+    /**
+     * Load index statuses from the system_distributed.index_build_status table on startup
+     * so that index statuses are known before gossip starts.
+     */
+    public synchronized void loadIndexStatusesFromTable()
+    {
+        try
+        {
+            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            {
+                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
+                if (endpoint == null)
+                    continue;
+
+                peerIndexStatus.putIfAbsent(endpoint, entry.getValue());
+            }
+            logger.info("Loaded index statuses from system table for {} peers", allStatuses.size());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Refresh index statuses from the full table, overwriting any existing data.
+     */
+    public synchronized void refreshFromFullTable()
+    {
+        try
+        {
+            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            {
+                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
+                if (endpoint == null)
+                    continue;
+
+                peerIndexStatus.put(endpoint, entry.getValue());
+            }
+            logger.info("Refreshed index statuses from system table for {} peers", allStatuses.size());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to refresh index statuses from system table: {}", e.getMessage());
+        }
+    }
+
     public void shutdownAndWait(long interval, TimeUnit unit) throws InterruptedException, TimeoutException
     {
+        if (pollFuture != null)
+            pollFuture.cancel(false);
+
         ExecutorUtils.shutdownAndWait(interval, unit, statusPropagationExecutor);
+    }
+
+    public void startPolling()
+    {
+        int intervalSeconds = DatabaseDescriptor.getIndexStatusPollInterval();
+        if (intervalSeconds <= 0)
+            return;
+
+        pollFuture = ScheduledExecutors.scheduledTasks.scheduleWithFixedDelay(
+            this::pollIndexEvents,
+            intervalSeconds,
+            intervalSeconds,
+            TimeUnit.SECONDS);
+    }
+
+    private synchronized void pollIndexEvents()
+    {
+        if (lastPollTimestampMillis == 0)
+        {
+            refreshFromFullTable();
+            lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+        }
+        else
+        {
+            try
+            {
+                String today = LocalDate.now(ZoneOffset.UTC).toString();
+                String lastPollDate = Instant.ofEpochMilli(lastPollTimestampMillis).atZone(ZoneOffset.UTC).toLocalDate().toString();
+
+                if (!today.equals(lastPollDate))
+                {
+                    // midnight crossed so get remaining events from last day.
+                    UntypedResultSet yesterdayResults = SystemDistributedKeyspace.queryIndexEvents(lastPollDate, lastPollTimestampMillis);
+                    if (yesterdayResults != null)
+                        processEvents(yesterdayResults);
+                }
+
+                UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, lastPollTimestampMillis);
+                if (todayResults != null)
+                    processEvents(todayResults);
+
+                lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+            }
+            catch (Exception e)
+            {
+                logger.warn("Unable to load index events from system table: {}", e.getMessage());
+            }
+        }
+    }
+
+    private void processEvents(UntypedResultSet results)
+    {
+        for (UntypedResultSet.Row row : results)
+        {
+            UUID hostId = row.getUUID("host_id");
+            if ((hostId == null) || hostId.equals(StorageService.instance.getLocalHostUUID()))
+                continue;
+
+            InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(hostId);
+            if (endpoint == null)
+                continue;
+
+            String indexName = row.getString("index_name");
+            Index.Status status = Index.Status.valueOf(row.getString("event"));
+
+            if (status == Index.Status.DROPPED)
+            {
+                Map<String, Index.Status> statusMap = peerIndexStatus.get(endpoint);
+                if (statusMap != null)
+                    statusMap.remove(indexName);
+            }
+            else
+            {
+                peerIndexStatus.computeIfAbsent(endpoint, k -> new HashMap<>()).put(indexName, status);
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -59,6 +58,7 @@ import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.ExecutorUtils;
@@ -83,8 +83,6 @@ public class IndexStatusManager
 
     private static final int MAX_GOSSIP_VALUE_SIZE = 65535;
 
-    public static final String TABLE_FALLBACK_MARKER = "TABLE_FALLBACK";
-
     private volatile long lastPollTimestampMillis = 0;
 
     private ScheduledFuture<?> pollFuture;
@@ -96,7 +94,7 @@ public class IndexStatusManager
     /**
      * A map of per-endpoint index statuses: the key of inner map is the identifier "keyspace.index"
      */
-    public final Map<InetAddressAndPort, Map<String, Index.Status>> peerIndexStatus = new HashMap<>();
+    public final Map<NodeId, Map<String, Index.Status>> peerIndexStatus = new HashMap<>();
 
     private IndexStatusManager() {}
 
@@ -182,18 +180,18 @@ public class IndexStatusManager
             if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
                 return;
 
+            NodeId nodeId = ClusterMetadata.current().directory.peerId(endpoint);
+
+            if (nodeId == null)
+            {
+                logger.warn("Ignoring index status from unknown endpoint {}",  endpoint);
+                return;
+            }
+
             Map<String, Index.Status> indexStatusMap;
 
-            if (versionedValue.value.equals(TABLE_FALLBACK_MARKER))
-            {
-                indexStatusMap = SystemDistributedKeyspace.allIndexStatusesForHost(StorageService.instance.getHostIdForEndpoint(endpoint));
-            }
-            else
-            {
-                indexStatusMap = statusMapFromString(versionedValue);
-            }
-
-            Map<String, Index.Status> oldStatus = peerIndexStatus.put(endpoint, indexStatusMap);
+            indexStatusMap = statusMapFromString(versionedValue);
+            Map<String, Index.Status> oldStatus = peerIndexStatus.put(nodeId, indexStatusMap);
             Map<String, Index.Status> updated = updatedIndexStatuses(oldStatus, indexStatusMap);
             Set<String> removed = removedIndexStatuses(oldStatus, indexStatusMap);
             if (!updated.isEmpty() || !removed.isEmpty())
@@ -254,40 +252,36 @@ public class IndexStatusManager
     {
         try
         {
-            Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(),
-                                                                               k -> new HashMap<>());
+            NodeId localNodeId = ClusterMetadata.current().myNodeId();
+            if (localNodeId == null)
+                return;
+            Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(localNodeId, k -> new HashMap<>());
             String keyspaceIndex = identifier(keyspace, index);
-            UUID localHostId = StorageService.instance.getLocalHostUUID();
             CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
+            boolean shouldWriteToIndexTables = shouldWriteToIndexTables(minVersion);
 
             if (status == Index.Status.DROPPED)
             {
                 statusMap.remove(keyspaceIndex);
-                if (localHostId != null)
-                    statusPropagationExecutor.submit(() -> {
-                        if (shouldWriteToIndexTables(minVersion))
-                        {
-                            SystemDistributedKeyspace.setIndexRemoved(localHostId, keyspace, index);
-                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
-                        }
-                    });
+                if (shouldWriteToIndexTables)
+                {
+                    SystemDistributedKeyspace.setIndexRemoved(localNodeId, keyspace, index);
+                    SystemDistributedKeyspace.recordIndexEvent(localNodeId, keyspace, index, status);
+                }
             }
             else
             {
                 statusMap.put(keyspaceIndex, status);
-                if (localHostId != null)
-                    statusPropagationExecutor.submit(() -> {
-                        if (shouldWriteToIndexTables(minVersion))
-                        {
-                            SystemDistributedKeyspace.updateIndexStatus(localHostId, keyspace, index, status);
-                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
-                        }
-                    });
+                if (shouldWriteToIndexTables)
+                {
+                    SystemDistributedKeyspace.updateIndexStatus(localNodeId, keyspace, index, status);
+                    SystemDistributedKeyspace.recordIndexEvent(localNodeId, keyspace, index, status);
+                }
             }
 
             // Only propagate via gossip when the gossiper is enabled and the cluster is not fully on 6.0+.
             // Once all nodes are on 6.0+, index status is propagated via table polling instead.
-            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables(minVersion))
+            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables)
             {
                 // Versions 5.0.0 through 5.0.2 use a much more bloated format that duplicates keyspace names
                 // and writes full status names instead of their numeric codes. If the minimum cluster version is
@@ -296,26 +290,21 @@ public class IndexStatusManager
                                                                                           : toSerializedFormat(statusMap);
 
                 byte[] utf8Bytes = newSerializedStatusMap.getBytes(StandardCharsets.UTF_8);
-                String gossipPayload;
-
                 if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE)
                 {
                     logger.error("Index status gossip payload size ({} bytes) exceeds limit ({} bytes), please consider removing unwanted indexes.",
                                  utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
-                    gossipPayload = TABLE_FALLBACK_MARKER;
+                    return;
                 }
-                else
-                {
-                    if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
-                        logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
-                                    utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
-                    gossipPayload = newSerializedStatusMap;
-                }
+
+                if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
+                    logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
+                                utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
 
                 statusPropagationExecutor.submit(() -> {
                     // schedule gossiper update asynchronously to avoid potential deadlock when another thread is holding
                     // gossiper taskLock.
-                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(gossipPayload);
+                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(newSerializedStatusMap);
                     Gossiper.instance.addLocalApplicationState(ApplicationState.INDEX_STATUS, value);
                 });
             }
@@ -340,18 +329,6 @@ public class IndexStatusManager
     static boolean shouldWriteToIndexTablesForTesting(CassandraVersion minVersion)
     {
         return shouldWriteToIndexTables(minVersion);
-    }
-
-    @VisibleForTesting
-    void processEventsForTesting(UntypedResultSet results)
-    {
-        processEvents(results);
-    }
-
-    @VisibleForTesting
-    void resetLastPollTimestamp()
-    {
-        lastPollTimestampMillis = 0;
     }
 
     /**
@@ -390,7 +367,10 @@ public class IndexStatusManager
     @VisibleForTesting
     public synchronized Index.Status getIndexStatus(InetAddressAndPort peer, String keyspace, String index)
     {
-        return peerIndexStatus.getOrDefault(peer, Collections.emptyMap())
+        NodeId nodeId = ClusterMetadata.current().directory.peerId(peer);
+        if (nodeId == null)
+            return Index.Status.UNKNOWN;
+        return peerIndexStatus.getOrDefault(nodeId, Collections.emptyMap())
                               .getOrDefault(identifier(keyspace, index), Index.Status.UNKNOWN);
     }
 
@@ -435,14 +415,10 @@ public class IndexStatusManager
     {
         try
         {
-            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
-            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<NodeId, Map<String, Index.Status>> entry : allStatuses.entrySet())
             {
-                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
-                if (endpoint == null)
-                    continue;
-
-                peerIndexStatus.putIfAbsent(endpoint, entry.getValue());
+                peerIndexStatus.putIfAbsent(entry.getKey(), entry.getValue());
             }
             logger.info("Loaded index statuses from system table for {} peers", allStatuses.size());
         }
@@ -459,14 +435,10 @@ public class IndexStatusManager
     {
         try
         {
-            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
-            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<NodeId, Map<String, Index.Status>> entry : allStatuses.entrySet())
             {
-                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
-                if (endpoint == null)
-                    continue;
-
-                peerIndexStatus.put(endpoint, entry.getValue());
+                peerIndexStatus.put(entry.getKey(), entry.getValue());
             }
             logger.info("Refreshed index statuses from system table for {} peers", allStatuses.size());
         }
@@ -499,15 +471,19 @@ public class IndexStatusManager
 
     private synchronized void pollIndexEvents()
     {
-        if (lastPollTimestampMillis == 0)
+        try
         {
-            refreshFromFullTable();
-            lastPollTimestampMillis = Clock.Global.currentTimeMillis();
-        }
-        else
-        {
-            try
+            if (lastPollTimestampMillis == 0)
             {
+                refreshFromFullTable();
+                String today = LocalDate.now(ZoneOffset.UTC).toString();
+                UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, 0);
+                long newestEventTime = todayResults != null ? processEvents(todayResults) : 0;
+                lastPollTimestampMillis = newestEventTime != 0 ? newestEventTime : Clock.Global.currentTimeMillis();
+            }
+            else
+            {
+                long newestPollTimestampMillis = 0;
                 String today = LocalDate.now(ZoneOffset.UTC).toString();
                 String lastPollDate = Instant.ofEpochMilli(lastPollTimestampMillis).atZone(ZoneOffset.UTC).toLocalDate().toString();
 
@@ -516,32 +492,32 @@ public class IndexStatusManager
                     // midnight crossed so get remaining events from last day.
                     UntypedResultSet yesterdayResults = SystemDistributedKeyspace.queryIndexEvents(lastPollDate, lastPollTimestampMillis);
                     if (yesterdayResults != null)
-                        processEvents(yesterdayResults);
+                        newestPollTimestampMillis = processEvents(yesterdayResults);
                 }
 
                 UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, lastPollTimestampMillis);
                 if (todayResults != null)
-                    processEvents(todayResults);
+                    newestPollTimestampMillis = processEvents(todayResults);
 
-                lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+                if (newestPollTimestampMillis != 0)
+                    lastPollTimestampMillis = newestPollTimestampMillis;
             }
-            catch (Exception e)
-            {
-                logger.warn("Unable to load index events from system table: {}", e.getMessage());
-            }
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index events from system table: {}", e.getMessage());
         }
     }
 
-    private void processEvents(UntypedResultSet results)
+    private long processEvents(UntypedResultSet results)
     {
+        NodeId localNodeId = ClusterMetadata.current().myNodeId();
+        long newestEventTime = 0;
         for (UntypedResultSet.Row row : results)
         {
-            UUID hostId = row.getUUID("host_id");
-            if ((hostId == null) || hostId.equals(StorageService.instance.getLocalHostUUID()))
-                continue;
-
-            InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(hostId);
-            if (endpoint == null)
+            newestEventTime = row.getTimestamp("event_time").getTime();
+            NodeId nodeId = new NodeId(row.getInt("node_id"));
+            if (nodeId.equals(localNodeId))
                 continue;
 
             String indexName = row.getString("index_name");
@@ -549,14 +525,15 @@ public class IndexStatusManager
 
             if (status == Index.Status.DROPPED)
             {
-                Map<String, Index.Status> statusMap = peerIndexStatus.get(endpoint);
+                Map<String, Index.Status> statusMap = peerIndexStatus.get(nodeId);
                 if (statusMap != null)
                     statusMap.remove(indexName);
             }
             else
             {
-                peerIndexStatus.computeIfAbsent(endpoint, k -> new HashMap<>()).put(indexName, status);
+                peerIndexStatus.computeIfAbsent(nodeId, k -> new HashMap<>()).put(indexName, status);
             }
         }
+        return newestEventTime;
     }
 }

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -59,6 +58,7 @@ import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.ExecutorUtils;
@@ -83,8 +83,6 @@ public class IndexStatusManager
 
     private static final int MAX_GOSSIP_VALUE_SIZE = 65535;
 
-    public static final String TABLE_FALLBACK_MARKER = "TABLE_FALLBACK";
-
     private volatile long lastPollTimestampMillis = 0;
 
     private ScheduledFuture<?> pollFuture;
@@ -96,7 +94,7 @@ public class IndexStatusManager
     /**
      * A map of per-endpoint index statuses: the key of inner map is the identifier "keyspace.index"
      */
-    public final Map<InetAddressAndPort, Map<String, Index.Status>> peerIndexStatus = new HashMap<>();
+    public final Map<NodeId, Map<String, Index.Status>> peerIndexStatus = new HashMap<>();
 
     private IndexStatusManager() {}
 
@@ -182,18 +180,18 @@ public class IndexStatusManager
             if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
                 return;
 
+            NodeId nodeId = ClusterMetadata.current().directory.peerId(endpoint);
+
+            if (nodeId == null)
+            {
+                logger.warn("Ignoring index status from unknown endpoint {}",  endpoint);
+                return;
+            }
+
             Map<String, Index.Status> indexStatusMap;
 
-            if (versionedValue.value.equals(TABLE_FALLBACK_MARKER))
-            {
-                indexStatusMap = SystemDistributedKeyspace.allIndexStatusesForHost(StorageService.instance.getHostIdForEndpoint(endpoint));
-            }
-            else
-            {
-                indexStatusMap = statusMapFromString(versionedValue);
-            }
-
-            Map<String, Index.Status> oldStatus = peerIndexStatus.put(endpoint, indexStatusMap);
+            indexStatusMap = statusMapFromString(versionedValue);
+            Map<String, Index.Status> oldStatus = peerIndexStatus.put(nodeId, indexStatusMap);
             Map<String, Index.Status> updated = updatedIndexStatuses(oldStatus, indexStatusMap);
             Set<String> removed = removedIndexStatuses(oldStatus, indexStatusMap);
             if (!updated.isEmpty() || !removed.isEmpty())
@@ -254,40 +252,36 @@ public class IndexStatusManager
     {
         try
         {
-            Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(),
-                                                                               k -> new HashMap<>());
+            NodeId localNodeId = ClusterMetadata.current().myNodeId();
+            if (localNodeId == null)
+                return;
+            Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(localNodeId, k -> new HashMap<>());
             String keyspaceIndex = identifier(keyspace, index);
-            UUID localHostId = StorageService.instance.getLocalHostUUID();
             CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
+            boolean shouldWriteToIndexTables = shouldWriteToIndexTables(minVersion);
 
             if (status == Index.Status.DROPPED)
             {
                 statusMap.remove(keyspaceIndex);
-                if (localHostId != null)
-                    statusPropagationExecutor.submit(() -> {
-                        if (shouldWriteToIndexTables(minVersion))
-                        {
-                            SystemDistributedKeyspace.setIndexRemoved(localHostId, keyspace, index);
-                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
-                        }
-                    });
+                if (shouldWriteToIndexTables)
+                {
+                    SystemDistributedKeyspace.setIndexRemoved(localNodeId, keyspace, index);
+                    SystemDistributedKeyspace.recordIndexEvent(localNodeId, keyspace, index, status);
+                }
             }
             else
             {
                 statusMap.put(keyspaceIndex, status);
-                if (localHostId != null)
-                    statusPropagationExecutor.submit(() -> {
-                        if (shouldWriteToIndexTables(minVersion))
-                        {
-                            SystemDistributedKeyspace.updateIndexStatus(localHostId, keyspace, index, status);
-                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
-                        }
-                    });
+                if (shouldWriteToIndexTables)
+                {
+                    SystemDistributedKeyspace.updateIndexStatus(localNodeId, keyspace, index, status);
+                    SystemDistributedKeyspace.recordIndexEvent(localNodeId, keyspace, index, status);
+                }
             }
 
             // Only propagate via gossip when the gossiper is enabled and the cluster is not fully on 6.0+.
             // Once all nodes are on 6.0+, index status is propagated via table polling instead.
-            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables(minVersion))
+            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables)
             {
                 // Versions 5.0.0 through 5.0.2 use a much more bloated format that duplicates keyspace names
                 // and writes full status names instead of their numeric codes. If the minimum cluster version is
@@ -296,26 +290,21 @@ public class IndexStatusManager
                                                                                           : toSerializedFormat(statusMap);
 
                 byte[] utf8Bytes = newSerializedStatusMap.getBytes(StandardCharsets.UTF_8);
-                String gossipPayload;
-
                 if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE)
                 {
                     logger.error("Index status gossip payload size ({} bytes) exceeds limit ({} bytes), please consider removing unwanted indexes.",
                                  utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
-                    gossipPayload = TABLE_FALLBACK_MARKER;
+                    return;
                 }
-                else
-                {
-                    if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
-                        logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
-                                    utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
-                    gossipPayload = newSerializedStatusMap;
-                }
+
+                if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
+                    logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
+                                utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
 
                 statusPropagationExecutor.submit(() -> {
                     // schedule gossiper update asynchronously to avoid potential deadlock when another thread is holding
                     // gossiper taskLock.
-                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(gossipPayload);
+                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(newSerializedStatusMap);
                     Gossiper.instance.addLocalApplicationState(ApplicationState.INDEX_STATUS, value);
                 });
             }
@@ -343,18 +332,6 @@ public class IndexStatusManager
     static boolean shouldWriteToIndexTablesForTesting(CassandraVersion minVersion)
     {
         return shouldWriteToIndexTables(minVersion);
-    }
-
-    @VisibleForTesting
-    void processEventsForTesting(UntypedResultSet results)
-    {
-        processEvents(results);
-    }
-
-    @VisibleForTesting
-    void resetLastPollTimestamp()
-    {
-        lastPollTimestampMillis = 0;
     }
 
     /**
@@ -393,7 +370,10 @@ public class IndexStatusManager
     @VisibleForTesting
     public synchronized Index.Status getIndexStatus(InetAddressAndPort peer, String keyspace, String index)
     {
-        return peerIndexStatus.getOrDefault(peer, Collections.emptyMap())
+        NodeId nodeId = ClusterMetadata.current().directory.peerId(peer);
+        if (nodeId == null)
+            return Index.Status.UNKNOWN;
+        return peerIndexStatus.getOrDefault(nodeId, Collections.emptyMap())
                               .getOrDefault(identifier(keyspace, index), Index.Status.UNKNOWN);
     }
 
@@ -438,14 +418,10 @@ public class IndexStatusManager
     {
         try
         {
-            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
-            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<NodeId, Map<String, Index.Status>> entry : allStatuses.entrySet())
             {
-                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
-                if (endpoint == null)
-                    continue;
-
-                peerIndexStatus.putIfAbsent(endpoint, entry.getValue());
+                peerIndexStatus.putIfAbsent(entry.getKey(), entry.getValue());
             }
             logger.info("Loaded index statuses from system table for {} peers", allStatuses.size());
         }
@@ -462,14 +438,10 @@ public class IndexStatusManager
     {
         try
         {
-            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
-            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<NodeId, Map<String, Index.Status>> entry : allStatuses.entrySet())
             {
-                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
-                if (endpoint == null)
-                    continue;
-
-                peerIndexStatus.put(endpoint, entry.getValue());
+                peerIndexStatus.put(entry.getKey(), entry.getValue());
             }
             logger.info("Refreshed index statuses from system table for {} peers", allStatuses.size());
         }
@@ -502,15 +474,19 @@ public class IndexStatusManager
 
     private synchronized void pollIndexEvents()
     {
-        if (lastPollTimestampMillis == 0)
+        try
         {
-            refreshFromFullTable();
-            lastPollTimestampMillis = Clock.Global.currentTimeMillis();
-        }
-        else
-        {
-            try
+            if (lastPollTimestampMillis == 0)
             {
+                refreshFromFullTable();
+                String today = LocalDate.now(ZoneOffset.UTC).toString();
+                UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, 0);
+                long newestEventTime = todayResults != null ? processEvents(todayResults) : 0;
+                lastPollTimestampMillis = newestEventTime != 0 ? newestEventTime : Clock.Global.currentTimeMillis();
+            }
+            else
+            {
+                long newestPollTimestampMillis = 0;
                 String today = LocalDate.now(ZoneOffset.UTC).toString();
                 String lastPollDate = Instant.ofEpochMilli(lastPollTimestampMillis).atZone(ZoneOffset.UTC).toLocalDate().toString();
 
@@ -519,32 +495,32 @@ public class IndexStatusManager
                     // midnight crossed so get remaining events from last day.
                     UntypedResultSet yesterdayResults = SystemDistributedKeyspace.queryIndexEvents(lastPollDate, lastPollTimestampMillis);
                     if (yesterdayResults != null)
-                        processEvents(yesterdayResults);
+                        newestPollTimestampMillis = processEvents(yesterdayResults);
                 }
 
                 UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, lastPollTimestampMillis);
                 if (todayResults != null)
-                    processEvents(todayResults);
+                    newestPollTimestampMillis = processEvents(todayResults);
 
-                lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+                if (newestPollTimestampMillis != 0)
+                    lastPollTimestampMillis = newestPollTimestampMillis;
             }
-            catch (Exception e)
-            {
-                logger.warn("Unable to load index events from system table: {}", e.getMessage());
-            }
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index events from system table: {}", e.getMessage());
         }
     }
 
-    private void processEvents(UntypedResultSet results)
+    private long processEvents(UntypedResultSet results)
     {
+        NodeId localNodeId = ClusterMetadata.current().myNodeId();
+        long newestEventTime = 0;
         for (UntypedResultSet.Row row : results)
         {
-            UUID hostId = row.getUUID("host_id");
-            if ((hostId == null) || hostId.equals(StorageService.instance.getLocalHostUUID()))
-                continue;
-
-            InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(hostId);
-            if (endpoint == null)
+            newestEventTime = row.getTimestamp("event_time").getTime();
+            NodeId nodeId = new NodeId(row.getInt("node_id"));
+            if (nodeId.equals(localNodeId))
                 continue;
 
             String indexName = row.getString("index_name");
@@ -552,14 +528,15 @@ public class IndexStatusManager
 
             if (status == Index.Status.DROPPED)
             {
-                Map<String, Index.Status> statusMap = peerIndexStatus.get(endpoint);
+                Map<String, Index.Status> statusMap = peerIndexStatus.get(nodeId);
                 if (statusMap != null)
                     statusMap.remove(indexName);
             }
             else
             {
-                peerIndexStatus.computeIfAbsent(endpoint, k -> new HashMap<>()).put(indexName, status);
+                peerIndexStatus.computeIfAbsent(nodeId, k -> new HashMap<>()).put(indexName, status);
             }
         }
+        return newestEventTime;
     }
 }

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -18,12 +18,18 @@
 
 package org.apache.cassandra.index;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -36,7 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ExecutorPlus;
+import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.exceptions.ReadFailureException;
@@ -47,10 +55,12 @@ import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.locator.Endpoints;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.utils.CassandraVersion;
+import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JsonUtils;
@@ -70,6 +80,14 @@ public class IndexStatusManager
     private static final Logger logger = LoggerFactory.getLogger(IndexStatusManager.class);
 
     public static final IndexStatusManager instance = new IndexStatusManager();
+
+    private static final int MAX_GOSSIP_VALUE_SIZE = 65535;
+
+    public static final String TABLE_FALLBACK_MARKER = "TABLE_FALLBACK";
+
+    private volatile long lastPollTimestampMillis = 0;
+
+    private ScheduledFuture<?> pollFuture;
 
     // executes index status propagation task asynchronously to avoid potential deadlock on SIM
     private final ExecutorPlus statusPropagationExecutor = executorFactory().withJmxInternal()
@@ -164,7 +182,16 @@ public class IndexStatusManager
             if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
                 return;
 
-            Map<String, Index.Status> indexStatusMap = statusMapFromString(versionedValue);
+            Map<String, Index.Status> indexStatusMap;
+
+            if (versionedValue.value.equals(TABLE_FALLBACK_MARKER))
+            {
+                indexStatusMap = SystemDistributedKeyspace.allIndexStatusesForHost(StorageService.instance.getHostIdForEndpoint(endpoint));
+            }
+            else
+            {
+                indexStatusMap = statusMapFromString(versionedValue);
+            }
 
             Map<String, Index.Status> oldStatus = peerIndexStatus.put(endpoint, indexStatusMap);
             Map<String, Index.Status> updated = updatedIndexStatuses(oldStatus, indexStatusMap);
@@ -230,29 +257,65 @@ public class IndexStatusManager
             Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(),
                                                                                k -> new HashMap<>());
             String keyspaceIndex = identifier(keyspace, index);
+            UUID localHostId = StorageService.instance.getLocalHostUUID();
+            CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
 
             if (status == Index.Status.DROPPED)
+            {
                 statusMap.remove(keyspaceIndex);
+                if (localHostId != null)
+                    statusPropagationExecutor.submit(() -> {
+                        if (shouldWriteToIndexTables(minVersion))
+                        {
+                            SystemDistributedKeyspace.setIndexRemoved(localHostId, keyspace, index);
+                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
+                        }
+                    });
+            }
             else
+            {
                 statusMap.put(keyspaceIndex, status);
+                if (localHostId != null)
+                    statusPropagationExecutor.submit(() -> {
+                        if (shouldWriteToIndexTables(minVersion))
+                        {
+                            SystemDistributedKeyspace.updateIndexStatus(localHostId, keyspace, index, status);
+                            SystemDistributedKeyspace.recordIndexEvent(localHostId, keyspace, index, status);
+                        }
+                    });
+            }
 
-            // Don't try and propagate if the gossiper isn't enabled. This is primarily for tests where the
-            // Gossiper has not been started. If we attempt to propagate when not started an exception is
-            // logged and this causes a number of dtests to fail.
-            if (Gossiper.instance.isEnabled())
+            // Only propagate via gossip when the gossiper is enabled and the cluster is not fully on 6.0+.
+            // Once all nodes are on 6.0+, index status is propagated via table polling instead.
+            if (Gossiper.instance.isEnabled() && !shouldWriteToIndexTables(minVersion))
             {
                 // Versions 5.0.0 through 5.0.2 use a much more bloated format that duplicates keyspace names
                 // and writes full status names instead of their numeric codes. If the minimum cluster version is
                 // unknown or one of those 3 versions, continue to propagate the old format.
-                CassandraVersion minVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion;
-
-                String newSerializedStatusMap = shouldWriteLegacyStatusFormat(minVersion) ? JsonUtils.writeAsJsonString(statusMap) 
+                String newSerializedStatusMap = shouldWriteLegacyStatusFormat(minVersion) ? JsonUtils.writeAsJsonString(statusMap)
                                                                                           : toSerializedFormat(statusMap);
+
+                byte[] utf8Bytes = newSerializedStatusMap.getBytes(StandardCharsets.UTF_8);
+                String gossipPayload;
+
+                if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE)
+                {
+                    logger.error("Index status gossip payload size ({} bytes) exceeds limit ({} bytes), please consider removing unwanted indexes.",
+                                 utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
+                    gossipPayload = TABLE_FALLBACK_MARKER;
+                }
+                else
+                {
+                    if (utf8Bytes.length > MAX_GOSSIP_VALUE_SIZE * 0.8)
+                        logger.warn("Index status gossip payload size ({} bytes) approaching the limit ({} bytes), please consider removing unwanted indexes.",
+                                    utf8Bytes.length, MAX_GOSSIP_VALUE_SIZE);
+                    gossipPayload = newSerializedStatusMap;
+                }
 
                 statusPropagationExecutor.submit(() -> {
                     // schedule gossiper update asynchronously to avoid potential deadlock when another thread is holding
                     // gossiper taskLock.
-                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(newSerializedStatusMap);
+                    VersionedValue value = StorageService.instance.valueFactory.indexStatus(gossipPayload);
                     Gossiper.instance.addLocalApplicationState(ApplicationState.INDEX_STATUS, value);
                 });
             }
@@ -269,6 +332,29 @@ public class IndexStatusManager
             return false;
 
         return minVersion == null || (minVersion.major == 5 && minVersion.minor == 0 && minVersion.patch < 3);
+    }
+
+    private static boolean shouldWriteToIndexTables(CassandraVersion minVersion)
+    {
+        return minVersion != null && (minVersion.major >= 6);
+    }
+
+    @VisibleForTesting
+    static boolean shouldWriteToIndexTablesForTesting(CassandraVersion minVersion)
+    {
+        return shouldWriteToIndexTables(minVersion);
+    }
+
+    @VisibleForTesting
+    void processEventsForTesting(UntypedResultSet results)
+    {
+        processEvents(results);
+    }
+
+    @VisibleForTesting
+    void resetLastPollTimestamp()
+    {
+        lastPollTimestampMillis = 0;
     }
 
     /**
@@ -344,8 +430,136 @@ public class IndexStatusManager
         return keyspace + '.' + index;
     }
 
+    /**
+     * Load index statuses from the system_distributed.index_build_status table on startup
+     * so that index statuses are known before gossip starts.
+     */
+    public synchronized void loadIndexStatusesFromTable()
+    {
+        try
+        {
+            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            {
+                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
+                if (endpoint == null)
+                    continue;
+
+                peerIndexStatus.putIfAbsent(endpoint, entry.getValue());
+            }
+            logger.info("Loaded index statuses from system table for {} peers", allStatuses.size());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Refresh index statuses from the full table, overwriting any existing data.
+     */
+    public synchronized void refreshFromFullTable()
+    {
+        try
+        {
+            Map<UUID, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
+            for (Map.Entry<UUID, Map<String, Index.Status>> entry : allStatuses.entrySet())
+            {
+                InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(entry.getKey());
+                if (endpoint == null)
+                    continue;
+
+                peerIndexStatus.put(endpoint, entry.getValue());
+            }
+            logger.info("Refreshed index statuses from system table for {} peers", allStatuses.size());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to refresh index statuses from system table: {}", e.getMessage());
+        }
+    }
+
     public void shutdownAndWait(long interval, TimeUnit unit) throws InterruptedException, TimeoutException
     {
+        if (pollFuture != null)
+            pollFuture.cancel(false);
+
         ExecutorUtils.shutdownAndWait(interval, unit, statusPropagationExecutor);
+    }
+
+    public void startPolling()
+    {
+        int intervalSeconds = DatabaseDescriptor.getIndexStatusPollInterval();
+        if (intervalSeconds <= 0)
+            return;
+
+        pollFuture = ScheduledExecutors.scheduledTasks.scheduleWithFixedDelay(
+            this::pollIndexEvents,
+            intervalSeconds,
+            intervalSeconds,
+            TimeUnit.SECONDS);
+    }
+
+    private synchronized void pollIndexEvents()
+    {
+        if (lastPollTimestampMillis == 0)
+        {
+            refreshFromFullTable();
+            lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+        }
+        else
+        {
+            try
+            {
+                String today = LocalDate.now(ZoneOffset.UTC).toString();
+                String lastPollDate = Instant.ofEpochMilli(lastPollTimestampMillis).atZone(ZoneOffset.UTC).toLocalDate().toString();
+
+                if (!today.equals(lastPollDate))
+                {
+                    // midnight crossed so get remaining events from last day.
+                    UntypedResultSet yesterdayResults = SystemDistributedKeyspace.queryIndexEvents(lastPollDate, lastPollTimestampMillis);
+                    if (yesterdayResults != null)
+                        processEvents(yesterdayResults);
+                }
+
+                UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, lastPollTimestampMillis);
+                if (todayResults != null)
+                    processEvents(todayResults);
+
+                lastPollTimestampMillis = Clock.Global.currentTimeMillis();
+            }
+            catch (Exception e)
+            {
+                logger.warn("Unable to load index events from system table: {}", e.getMessage());
+            }
+        }
+    }
+
+    private void processEvents(UntypedResultSet results)
+    {
+        for (UntypedResultSet.Row row : results)
+        {
+            UUID hostId = row.getUUID("host_id");
+            if ((hostId == null) || hostId.equals(StorageService.instance.getLocalHostUUID()))
+                continue;
+
+            InetAddressAndPort endpoint = StorageService.instance.getEndpointForHostId(hostId);
+            if (endpoint == null)
+                continue;
+
+            String indexName = row.getString("index_name");
+            Index.Status status = Index.Status.valueOf(row.getString("event"));
+
+            if (status == Index.Status.DROPPED)
+            {
+                Map<String, Index.Status> statusMap = peerIndexStatus.get(endpoint);
+                if (statusMap != null)
+                    statusMap.remove(indexName);
+            }
+            else
+            {
+                peerIndexStatus.computeIfAbsent(endpoint, k -> new HashMap<>()).put(indexName, status);
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -60,7 +60,6 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.CassandraVersion;
-import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JsonUtils;
@@ -314,7 +313,7 @@ public class IndexStatusManager
         }
         catch (Exception e)
         {
-            logger.warn("Unable to propagate index status: {}", e.getMessage());
+            logger.warn("Unable to propagate index status", e);
         }
     }
 
@@ -376,6 +375,10 @@ public class IndexStatusManager
         NodeId nodeId = ClusterMetadata.current().directory.peerId(peer);
         if (nodeId == null)
             return Index.Status.UNKNOWN;
+        Index.Status status = peerIndexStatus.getOrDefault(nodeId, Collections.emptyMap())
+                                             .getOrDefault(identifier(keyspace, index), Index.Status.UNKNOWN);
+        if (status == Index.Status.UNKNOWN)
+            pollIndexEvents();
         return peerIndexStatus.getOrDefault(nodeId, Collections.emptyMap())
                               .getOrDefault(identifier(keyspace, index), Index.Status.UNKNOWN);
     }
@@ -485,8 +488,7 @@ public class IndexStatusManager
                 refreshFromFullTable();
                 String today = LocalDate.now(ZoneOffset.UTC).toString();
                 UntypedResultSet todayResults = SystemDistributedKeyspace.queryIndexEvents(today, 0);
-                long newestEventTime = todayResults != null ? processEvents(todayResults) : 0;
-                lastPollTimestampMillis = newestEventTime != 0 ? newestEventTime : Clock.Global.currentTimeMillis();
+                lastPollTimestampMillis = todayResults != null ? processEvents(todayResults) : 0;
             }
             else
             {

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -253,7 +253,7 @@ public class IndexStatusManager
         try
         {
             NodeId localNodeId = ClusterMetadata.current().myNodeId();
-            if (localNodeId == null)
+            if (localNodeId == NodeId.UNREGISTERED)
                 return;
             Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(localNodeId, k -> new HashMap<>());
             String keyspaceIndex = identifier(keyspace, index);
@@ -439,10 +439,7 @@ public class IndexStatusManager
         try
         {
             Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
-            for (Map.Entry<NodeId, Map<String, Index.Status>> entry : allStatuses.entrySet())
-            {
-                peerIndexStatus.put(entry.getKey(), entry.getValue());
-            }
+            peerIndexStatus.putAll(allStatuses);
             logger.info("Refreshed index statuses from system table for {} peers", allStatuses.size());
         }
         catch (Exception e)

--- a/src/java/org/apache/cassandra/index/IndexStatusManager.java
+++ b/src/java/org/apache/cassandra/index/IndexStatusManager.java
@@ -252,7 +252,10 @@ public class IndexStatusManager
     {
         try
         {
-            NodeId localNodeId = ClusterMetadata.current().myNodeId();
+            ClusterMetadata metadata = ClusterMetadata.currentNullable();
+            if (metadata == null)
+                return;
+            NodeId localNodeId = metadata.myNodeId();
             if (localNodeId == NodeId.UNREGISTERED)
                 return;
             Map<String, Index.Status> statusMap = peerIndexStatus.computeIfAbsent(localNodeId, k -> new HashMap<>());
@@ -416,6 +419,8 @@ public class IndexStatusManager
      */
     public synchronized void loadIndexStatusesFromTable()
     {
+        if (!shouldWriteToIndexTables(ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion))
+            return;
         try
         {
             Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
@@ -471,6 +476,8 @@ public class IndexStatusManager
 
     private synchronized void pollIndexEvents()
     {
+        if (!shouldWriteToIndexTables(ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion))
+            return;
         try
         {
             if (lastPollTimestampMillis == 0)

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.schema;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,6 +57,7 @@ import org.apache.cassandra.db.compression.CompressionDictionary;
 import org.apache.cassandra.db.compression.CompressionDictionary.LightweightCompressionDictionary;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.CommonRange;
 import org.apache.cassandra.repair.messages.RepairOption;
@@ -89,10 +92,11 @@ public final class SystemDistributedKeyspace
      * gen 6: add denylist table
      * gen 7: add auto_repair_history and auto_repair_priority tables for AutoRepair feature
      * gen 8: add compression_dictionaries for dictionary-based compression algorithms (e.g. zstd)
+     * gen 9: add index_build_status and index_events tables for CASSANDRA-21264
      *
      * // TODO: TCM - how do we evolve these tables?
      */
-    public static final long GENERATION = 8;
+    public static final long GENERATION = 9;
 
     public static final String REPAIR_HISTORY = "repair_history";
 
@@ -108,10 +112,15 @@ public final class SystemDistributedKeyspace
 
     public static final String COMPRESSION_DICTIONARIES = "compression_dictionaries";
 
+    public static final String INDEX_BUILD_STATUS = "index_build_status";
+
+    public static final String INDEX_EVENTS = "index_events";
+
     public static final Set<String> TABLE_NAMES = ImmutableSet.of(REPAIR_HISTORY, PARENT_REPAIR_HISTORY,
                                                                   VIEW_BUILD_STATUS, PARTITION_DENYLIST_TABLE,
                                                                   AUTO_REPAIR_HISTORY, AUTO_REPAIR_PRIORITY,
-                                                                  COMPRESSION_DICTIONARIES);
+                                                                  COMPRESSION_DICTIONARIES, INDEX_BUILD_STATUS,
+                                                                  INDEX_EVENTS);
 
     public static final String REPAIR_HISTORY_CQL = "CREATE TABLE IF NOT EXISTS %s ("
                                                      + "keyspace_name text,"
@@ -210,6 +219,30 @@ public final class SystemDistributedKeyspace
     private static final TableMetadata CompressionDictionariesTable =
         parse(COMPRESSION_DICTIONARIES, "Compression dictionaries for applicable tables", COMPRESSION_DICTIONARIES_CQL).build();
 
+    public static final String INDEX_BUILD_STATUS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
+                                                        "host_id uuid," +
+                                                        "keyspace_name text," +
+                                                        "index_name text," +
+                                                        "status text," +
+                                                        "PRIMARY KEY (host_id, keyspace_name, index_name))";
+    private static final TableMetadata IndexBuildStatus =
+            parse(INDEX_BUILD_STATUS, "Index build status", INDEX_BUILD_STATUS_CQL).build();
+
+    private static final String INDEX_EVENTS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
+                                                   "date text," +
+                                                   "event_time timestamp," +
+                                                   "index_name text," +
+                                                   "host_id UUID," +
+                                                   "event text," +
+                                                   "PRIMARY KEY (date, event_time, index_name, host_id)) " +
+                                                   "WITH CLUSTERING ORDER BY (event_time DESC)";
+
+    private static final TableMetadata IndexEventsTable =
+        parse(INDEX_EVENTS, "Index events for applicable tables", INDEX_EVENTS_CQL)
+        .defaultTimeToLive((int) TimeUnit.DAYS.toSeconds(7))
+        .compaction(CompactionParams.twcs(ImmutableMap.of("compaction_window_unit","DAYS",
+                                                          "compaction_window_size","1"))).build();
+
     private static TableMetadata.Builder parse(String table, String description, String cql)
     {
         return CreateTableStatement.parse(format(cql, table), SchemaConstants.DISTRIBUTED_KEYSPACE_NAME)
@@ -223,9 +256,9 @@ public final class SystemDistributedKeyspace
         return KeyspaceMetadata.create(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
                                        KeyspaceParams.simple(Math.max(DEFAULT_RF, DatabaseDescriptor.getDefaultKeyspaceRF())),
                                        Tables.of(RepairHistory, ParentRepairHistory,
-                                                 ViewBuildStatus, PartitionDenylistTable,
+                                                 ViewBuildStatus, IndexBuildStatus, PartitionDenylistTable,
                                                  AutoRepairHistoryTable, AutoRepairPriorityTable,
-                                                 CompressionDictionariesTable));
+                                                 CompressionDictionariesTable, IndexEventsTable));
     }
 
     public static void startParentRepair(TimeUUID parent_id, String keyspaceName, String[] cfnames, RepairOption options)
@@ -408,6 +441,110 @@ public final class SystemDistributedKeyspace
         String buildReq = "DELETE FROM %s.%s WHERE keyspace_name = ? AND view_name = ?";
         QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, VIEW_BUILD_STATUS), keyspaceName, viewName);
         forceBlockingFlush(VIEW_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
+    }
+
+    public static void updateIndexStatus(UUID hostId, String keyspace, String index, Index.Status status)
+    {
+        String query = "INSERT INTO %s.%s (host_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
+        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                               ConsistencyLevel.ONE,
+                               Lists.newArrayList(bytes(hostId),
+                                                  bytes(keyspace),
+                                                  bytes(index),
+                                                  bytes(status.toString())));
+    }
+
+    public static void setIndexRemoved(UUID hostId, String keyspaceName, String indexName)
+    {
+        String buildReq = "DELETE FROM %s.%s WHERE host_id = ? AND keyspace_name = ? AND index_name = ?";
+        QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                       hostId, keyspaceName, indexName);
+        forceBlockingFlush(INDEX_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
+    }
+
+    public static Map<UUID, Map<String, Index.Status>> allIndexStatuses()
+    {
+        String query = "SELECT host_id, keyspace_name, index_name, status FROM %s.%s";
+        UntypedResultSet results;
+
+        try
+        {
+            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                             ConsistencyLevel.ONE);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+
+        Map<UUID, Map<String, Index.Status>> allStatuses = new HashMap<>();
+        for (UntypedResultSet.Row row : results)
+        {
+            UUID hostId = row.getUUID("host_id");
+            String identifier = row.getString("keyspace_name") + '.' + row.getString("index_name");
+            Index.Status status = Index.Status.valueOf(row.getString("status"));
+            allStatuses.computeIfAbsent(hostId, k -> new HashMap<>()).put(identifier, status);
+        }
+
+        return allStatuses;
+    }
+
+    public static Map<String, Index.Status> allIndexStatusesForHost(UUID hostId)
+    {
+        String query = "SELECT keyspace_name, index_name, status FROM %s.%s WHERE host_id = ?";
+        UntypedResultSet results;
+
+        try
+        {
+            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                             ConsistencyLevel.ONE,
+                                             hostId);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table for host {}: {}", hostId, e.getMessage());
+            return Collections.emptyMap();
+        }
+
+        Map<String, Index.Status> statuses = new HashMap<>();
+        for (UntypedResultSet.Row row : results)
+        {
+            statuses.put(row.getString("keyspace_name") + '.' + row.getString("index_name"),
+                         Index.Status.valueOf(row.getString("status")));
+        }
+
+        return statuses;
+    }
+
+    public static void recordIndexEvent(UUID hostId, String keyspace, String index, Index.Status status)
+    {
+        String query = "INSERT INTO %s.%s (date, event_time, index_name, host_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)";
+        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
+                               ConsistencyLevel.ONE,
+                               Lists.newArrayList(bytes(LocalDate.now(ZoneOffset.UTC).toString()),
+                                                  bytes(keyspace + '.' + index),
+                                                  bytes(hostId),
+                                                  bytes(status.toString())));
+    }
+
+    public static UntypedResultSet queryIndexEvents(String date, long sinceTimestampMillis)
+    {
+        String query = "SELECT index_name, host_id, event FROM %s.%s WHERE date = ? AND event_time > ? ";
+        UntypedResultSet status;
+        try
+        {
+            status = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
+                                             ConsistencyLevel.ONE,
+                                             date,
+                                             new java.util.Date(sinceTimestampMillis));
+        }
+        catch (Exception e)
+        {
+            return null;
+        }
+
+        return status;
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -61,6 +61,7 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.CommonRange;
 import org.apache.cassandra.repair.messages.RepairOption;
+import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
 
@@ -220,11 +221,11 @@ public final class SystemDistributedKeyspace
         parse(COMPRESSION_DICTIONARIES, "Compression dictionaries for applicable tables", COMPRESSION_DICTIONARIES_CQL).build();
 
     public static final String INDEX_BUILD_STATUS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
-                                                        "host_id uuid," +
+                                                        "node_id int," +
                                                         "keyspace_name text," +
                                                         "index_name text," +
                                                         "status text," +
-                                                        "PRIMARY KEY (host_id, keyspace_name, index_name))";
+                                                        "PRIMARY KEY (node_id, keyspace_name, index_name))";
     private static final TableMetadata IndexBuildStatus =
             parse(INDEX_BUILD_STATUS, "Index build status", INDEX_BUILD_STATUS_CQL).build();
 
@@ -232,10 +233,10 @@ public final class SystemDistributedKeyspace
                                                    "date text," +
                                                    "event_time timestamp," +
                                                    "index_name text," +
-                                                   "host_id UUID," +
+                                                   "node_id int," +
                                                    "event text," +
-                                                   "PRIMARY KEY (date, event_time, index_name, host_id)) " +
-                                                   "WITH CLUSTERING ORDER BY (event_time DESC)";
+                                                   "PRIMARY KEY (date, event_time, index_name, node_id)) " +
+                                                   "WITH CLUSTERING ORDER BY (event_time ASC)";
 
     private static final TableMetadata IndexEventsTable =
         parse(INDEX_EVENTS, "Index events for applicable tables", INDEX_EVENTS_CQL)
@@ -443,34 +444,55 @@ public final class SystemDistributedKeyspace
         forceBlockingFlush(VIEW_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
     }
 
-    public static void updateIndexStatus(UUID hostId, String keyspace, String index, Index.Status status)
+    public static void updateIndexStatus(NodeId nodeId, String keyspace, String index, Index.Status status)
     {
-        String query = "INSERT INTO %s.%s (host_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
-        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                               ConsistencyLevel.ONE,
-                               Lists.newArrayList(bytes(hostId),
-                                                  bytes(keyspace),
-                                                  bytes(index),
-                                                  bytes(status.toString())));
+        String query = "INSERT INTO %s.%s (node_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
+        try
+        {
+            QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                   ConsistencyLevel.QUORUM, nodeId.id(), keyspace, index, status.toString());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to update index status with QUORUM for {}.{}, retrying with ONE", keyspace, index);
+            QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                   ConsistencyLevel.ONE, nodeId.id(), keyspace, index, status.toString());
+        }
     }
 
-    public static void setIndexRemoved(UUID hostId, String keyspaceName, String indexName)
+    public static void setIndexRemoved(NodeId nodeId, String keyspaceName, String indexName)
     {
-        String buildReq = "DELETE FROM %s.%s WHERE host_id = ? AND keyspace_name = ? AND index_name = ?";
-        QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                       hostId, keyspaceName, indexName);
+        String buildReq = format("DELETE FROM %s.%s WHERE node_id = ? AND keyspace_name = ? AND index_name = ?",
+                                 SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
+        try
+        {
+            QueryProcessor.execute(buildReq, ConsistencyLevel.QUORUM, nodeId.id(), keyspaceName, indexName);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to remove index status with QUORUM for {}.{}, retrying with ONE", keyspaceName, indexName);
+            QueryProcessor.execute(buildReq, ConsistencyLevel.ONE, nodeId.id(), keyspaceName, indexName);
+        }
         forceBlockingFlush(INDEX_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
     }
 
-    public static Map<UUID, Map<String, Index.Status>> allIndexStatuses()
+    public static Map<NodeId, Map<String, Index.Status>> allIndexStatuses()
     {
-        String query = "SELECT host_id, keyspace_name, index_name, status FROM %s.%s";
+        String query = format("SELECT node_id, keyspace_name, index_name, status FROM %s.%s",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
         UntypedResultSet results;
 
         try
         {
-            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                             ConsistencyLevel.ONE);
+            try
+            {
+                results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to load index statuses with QUORUM, retrying with ONE");
+                results = QueryProcessor.execute(query, ConsistencyLevel.ONE);
+            }
         }
         catch (Exception e)
         {
@@ -478,32 +500,39 @@ public final class SystemDistributedKeyspace
             return Collections.emptyMap();
         }
 
-        Map<UUID, Map<String, Index.Status>> allStatuses = new HashMap<>();
+        Map<NodeId, Map<String, Index.Status>> allStatuses = new HashMap<>();
         for (UntypedResultSet.Row row : results)
         {
-            UUID hostId = row.getUUID("host_id");
+            NodeId nodeId = new NodeId(row.getInt("node_id"));
             String identifier = row.getString("keyspace_name") + '.' + row.getString("index_name");
             Index.Status status = Index.Status.valueOf(row.getString("status"));
-            allStatuses.computeIfAbsent(hostId, k -> new HashMap<>()).put(identifier, status);
+            allStatuses.computeIfAbsent(nodeId, k -> new HashMap<>()).put(identifier, status);
         }
 
         return allStatuses;
     }
 
-    public static Map<String, Index.Status> allIndexStatusesForHost(UUID hostId)
+    public static Map<String, Index.Status> allIndexStatusesForHost(NodeId nodeId)
     {
-        String query = "SELECT keyspace_name, index_name, status FROM %s.%s WHERE host_id = ?";
+        String query = format("SELECT keyspace_name, index_name, status FROM %s.%s WHERE node_id = ?",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
         UntypedResultSet results;
 
         try
         {
-            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                             ConsistencyLevel.ONE,
-                                             hostId);
+            try
+            {
+                results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM, nodeId.id());
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to load index statuses with QUORUM for host {}, retrying with ONE", nodeId);
+                results = QueryProcessor.execute(query, ConsistencyLevel.ONE, nodeId.id());
+            }
         }
         catch (Exception e)
         {
-            logger.warn("Unable to load index statuses from system table for host {}: {}", hostId, e.getMessage());
+            logger.warn("Unable to load index statuses from system table for host {}: {}", nodeId, e.getMessage());
             return Collections.emptyMap();
         }
 
@@ -517,34 +546,33 @@ public final class SystemDistributedKeyspace
         return statuses;
     }
 
-    public static void recordIndexEvent(UUID hostId, String keyspace, String index, Index.Status status)
+    public static void recordIndexEvent(NodeId nodeId, String keyspace, String index, Index.Status status)
     {
-        String query = "INSERT INTO %s.%s (date, event_time, index_name, host_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)";
-        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
-                               ConsistencyLevel.ONE,
-                               Lists.newArrayList(bytes(LocalDate.now(ZoneOffset.UTC).toString()),
-                                                  bytes(keyspace + '.' + index),
-                                                  bytes(hostId),
-                                                  bytes(status.toString())));
+        String query = format("INSERT INTO %s.%s (date, event_time, index_name, node_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS);
+        QueryProcessor.execute(query, ConsistencyLevel.QUORUM,
+                               LocalDate.now(ZoneOffset.UTC).toString(), keyspace + '.' + index, nodeId.id(), status.toString());
     }
 
     public static UntypedResultSet queryIndexEvents(String date, long sinceTimestampMillis)
     {
-        String query = "SELECT index_name, host_id, event FROM %s.%s WHERE date = ? AND event_time > ? ";
-        UntypedResultSet status;
+        String query = format("SELECT index_name, node_id, event, event_time FROM %s.%s WHERE date = ? AND event_time > ?",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS);
         try
         {
-            status = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
-                                             ConsistencyLevel.ONE,
-                                             date,
-                                             new java.util.Date(sinceTimestampMillis));
+            return QueryProcessor.execute(query, ConsistencyLevel.QUORUM, date, new java.util.Date(sinceTimestampMillis));
         }
         catch (Exception e)
         {
-            return null;
+            try
+            {
+                return QueryProcessor.execute(query, ConsistencyLevel.ONE, date, new java.util.Date(sinceTimestampMillis));
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
         }
-
-        return status;
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -66,6 +66,7 @@ import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
@@ -492,11 +493,20 @@ public final class SystemDistributedKeyspace
             {
                 results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM);
             }
+            catch (UncheckedInterruptedException e)
+            {
+                throw e;
+            }
             catch (Exception e)
             {
                 logger.warn("Failed to load index statuses with QUORUM, retrying with ONE");
                 results = QueryProcessor.execute(query, ConsistencyLevel.ONE);
             }
+        }
+        catch (UncheckedInterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return Collections.emptyMap();
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -62,6 +62,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.CommonRange;
 import org.apache.cassandra.repair.messages.RepairOption;
 import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
@@ -224,11 +225,11 @@ public final class SystemDistributedKeyspace
         parse(COMPRESSION_DICTIONARIES, "Compression dictionaries for applicable tables", COMPRESSION_DICTIONARIES_CQL).build();
 
     public static final String INDEX_BUILD_STATUS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
-                                                        "host_id uuid," +
+                                                        "node_id int," +
                                                         "keyspace_name text," +
                                                         "index_name text," +
                                                         "status text," +
-                                                        "PRIMARY KEY (host_id, keyspace_name, index_name))";
+                                                        "PRIMARY KEY (node_id, keyspace_name, index_name))";
     private static final TableMetadata IndexBuildStatus =
             parse(INDEX_BUILD_STATUS, "Index build status", INDEX_BUILD_STATUS_CQL).build();
 
@@ -236,10 +237,10 @@ public final class SystemDistributedKeyspace
                                                    "date text," +
                                                    "event_time timestamp," +
                                                    "index_name text," +
-                                                   "host_id UUID," +
+                                                   "node_id int," +
                                                    "event text," +
-                                                   "PRIMARY KEY (date, event_time, index_name, host_id)) " +
-                                                   "WITH CLUSTERING ORDER BY (event_time DESC)";
+                                                   "PRIMARY KEY (date, event_time, index_name, node_id)) " +
+                                                   "WITH CLUSTERING ORDER BY (event_time ASC)";
 
     private static final TableMetadata IndexEventsTable =
         parse(INDEX_EVENTS, "Index events for applicable tables", INDEX_EVENTS_CQL)
@@ -447,34 +448,55 @@ public final class SystemDistributedKeyspace
         forceBlockingFlush(VIEW_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
     }
 
-    public static void updateIndexStatus(UUID hostId, String keyspace, String index, Index.Status status)
+    public static void updateIndexStatus(NodeId nodeId, String keyspace, String index, Index.Status status)
     {
-        String query = "INSERT INTO %s.%s (host_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
-        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                               ConsistencyLevel.ONE,
-                               Lists.newArrayList(bytes(hostId),
-                                                  bytes(keyspace),
-                                                  bytes(index),
-                                                  bytes(status.toString())));
+        String query = "INSERT INTO %s.%s (node_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
+        try
+        {
+            QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                   ConsistencyLevel.QUORUM, nodeId.id(), keyspace, index, status.toString());
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to update index status with QUORUM for {}.{}, retrying with ONE", keyspace, index);
+            QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                   ConsistencyLevel.ONE, nodeId.id(), keyspace, index, status.toString());
+        }
     }
 
-    public static void setIndexRemoved(UUID hostId, String keyspaceName, String indexName)
+    public static void setIndexRemoved(NodeId nodeId, String keyspaceName, String indexName)
     {
-        String buildReq = "DELETE FROM %s.%s WHERE host_id = ? AND keyspace_name = ? AND index_name = ?";
-        QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                       hostId, keyspaceName, indexName);
+        String buildReq = format("DELETE FROM %s.%s WHERE node_id = ? AND keyspace_name = ? AND index_name = ?",
+                                 SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
+        try
+        {
+            QueryProcessor.execute(buildReq, ConsistencyLevel.QUORUM, nodeId.id(), keyspaceName, indexName);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to remove index status with QUORUM for {}.{}, retrying with ONE", keyspaceName, indexName);
+            QueryProcessor.execute(buildReq, ConsistencyLevel.ONE, nodeId.id(), keyspaceName, indexName);
+        }
         forceBlockingFlush(INDEX_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
     }
 
-    public static Map<UUID, Map<String, Index.Status>> allIndexStatuses()
+    public static Map<NodeId, Map<String, Index.Status>> allIndexStatuses()
     {
-        String query = "SELECT host_id, keyspace_name, index_name, status FROM %s.%s";
+        String query = format("SELECT node_id, keyspace_name, index_name, status FROM %s.%s",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
         UntypedResultSet results;
 
         try
         {
-            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                             ConsistencyLevel.ONE);
+            try
+            {
+                results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to load index statuses with QUORUM, retrying with ONE");
+                results = QueryProcessor.execute(query, ConsistencyLevel.ONE);
+            }
         }
         catch (Exception e)
         {
@@ -482,32 +504,39 @@ public final class SystemDistributedKeyspace
             return Collections.emptyMap();
         }
 
-        Map<UUID, Map<String, Index.Status>> allStatuses = new HashMap<>();
+        Map<NodeId, Map<String, Index.Status>> allStatuses = new HashMap<>();
         for (UntypedResultSet.Row row : results)
         {
-            UUID hostId = row.getUUID("host_id");
+            NodeId nodeId = new NodeId(row.getInt("node_id"));
             String identifier = row.getString("keyspace_name") + '.' + row.getString("index_name");
             Index.Status status = Index.Status.valueOf(row.getString("status"));
-            allStatuses.computeIfAbsent(hostId, k -> new HashMap<>()).put(identifier, status);
+            allStatuses.computeIfAbsent(nodeId, k -> new HashMap<>()).put(identifier, status);
         }
 
         return allStatuses;
     }
 
-    public static Map<String, Index.Status> allIndexStatusesForHost(UUID hostId)
+    public static Map<String, Index.Status> allIndexStatusesForHost(NodeId nodeId)
     {
-        String query = "SELECT keyspace_name, index_name, status FROM %s.%s WHERE host_id = ?";
+        String query = format("SELECT keyspace_name, index_name, status FROM %s.%s WHERE node_id = ?",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
         UntypedResultSet results;
 
         try
         {
-            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
-                                             ConsistencyLevel.ONE,
-                                             hostId);
+            try
+            {
+                results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM, nodeId.id());
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to load index statuses with QUORUM for host {}, retrying with ONE", nodeId);
+                results = QueryProcessor.execute(query, ConsistencyLevel.ONE, nodeId.id());
+            }
         }
         catch (Exception e)
         {
-            logger.warn("Unable to load index statuses from system table for host {}: {}", hostId, e.getMessage());
+            logger.warn("Unable to load index statuses from system table for host {}: {}", nodeId, e.getMessage());
             return Collections.emptyMap();
         }
 
@@ -521,34 +550,33 @@ public final class SystemDistributedKeyspace
         return statuses;
     }
 
-    public static void recordIndexEvent(UUID hostId, String keyspace, String index, Index.Status status)
+    public static void recordIndexEvent(NodeId nodeId, String keyspace, String index, Index.Status status)
     {
-        String query = "INSERT INTO %s.%s (date, event_time, index_name, host_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)";
-        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
-                               ConsistencyLevel.ONE,
-                               Lists.newArrayList(bytes(LocalDate.now(ZoneOffset.UTC).toString()),
-                                                  bytes(keyspace + '.' + index),
-                                                  bytes(hostId),
-                                                  bytes(status.toString())));
+        String query = format("INSERT INTO %s.%s (date, event_time, index_name, node_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS);
+        QueryProcessor.execute(query, ConsistencyLevel.QUORUM,
+                               LocalDate.now(ZoneOffset.UTC).toString(), keyspace + '.' + index, nodeId.id(), status.toString());
     }
 
     public static UntypedResultSet queryIndexEvents(String date, long sinceTimestampMillis)
     {
-        String query = "SELECT index_name, host_id, event FROM %s.%s WHERE date = ? AND event_time > ? ";
-        UntypedResultSet status;
+        String query = format("SELECT index_name, node_id, event, event_time FROM %s.%s WHERE date = ? AND event_time > ?",
+                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS);
         try
         {
-            status = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
-                                             ConsistencyLevel.ONE,
-                                             date,
-                                             new java.util.Date(sinceTimestampMillis));
+            return QueryProcessor.execute(query, ConsistencyLevel.QUORUM, date, new java.util.Date(sinceTimestampMillis));
         }
         catch (Exception e)
         {
-            return null;
+            try
+            {
+                return QueryProcessor.execute(query, ConsistencyLevel.ONE, date, new java.util.Date(sinceTimestampMillis));
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
         }
-
-        return status;
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.schema;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,6 +57,7 @@ import org.apache.cassandra.db.compression.CompressionDictionary;
 import org.apache.cassandra.db.compression.CompressionDictionary.LightweightCompressionDictionary;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.CommonRange;
 import org.apache.cassandra.repair.messages.RepairOption;
@@ -91,10 +94,11 @@ public final class SystemDistributedKeyspace
      * gen 6: add denylist table
      * gen 7: add auto_repair_history and auto_repair_priority tables for AutoRepair feature
      * gen 8: add compression_dictionaries for dictionary-based compression algorithms (e.g. zstd)
+     * gen 9: add index_build_status and index_events tables for CASSANDRA-21264
      *
      * // TODO: TCM - how do we evolve these tables?
      */
-    public static final long GENERATION = 8;
+    public static final long GENERATION = 9;
 
     public static final String REPAIR_HISTORY = "repair_history";
 
@@ -110,10 +114,15 @@ public final class SystemDistributedKeyspace
 
     public static final String COMPRESSION_DICTIONARIES = "compression_dictionaries";
 
+    public static final String INDEX_BUILD_STATUS = "index_build_status";
+
+    public static final String INDEX_EVENTS = "index_events";
+
     public static final Set<String> TABLE_NAMES = ImmutableSet.of(REPAIR_HISTORY, PARENT_REPAIR_HISTORY,
                                                                   VIEW_BUILD_STATUS, PARTITION_DENYLIST_TABLE,
                                                                   AUTO_REPAIR_HISTORY, AUTO_REPAIR_PRIORITY,
-                                                                  COMPRESSION_DICTIONARIES);
+                                                                  COMPRESSION_DICTIONARIES, INDEX_BUILD_STATUS,
+                                                                  INDEX_EVENTS);
 
     public static final String REPAIR_HISTORY_CQL = "CREATE TABLE IF NOT EXISTS %s ("
                                                      + "keyspace_name text,"
@@ -214,6 +223,30 @@ public final class SystemDistributedKeyspace
     private static final TableMetadata CompressionDictionariesTable =
         parse(COMPRESSION_DICTIONARIES, "Compression dictionaries for applicable tables", COMPRESSION_DICTIONARIES_CQL).build();
 
+    public static final String INDEX_BUILD_STATUS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
+                                                        "host_id uuid," +
+                                                        "keyspace_name text," +
+                                                        "index_name text," +
+                                                        "status text," +
+                                                        "PRIMARY KEY (host_id, keyspace_name, index_name))";
+    private static final TableMetadata IndexBuildStatus =
+            parse(INDEX_BUILD_STATUS, "Index build status", INDEX_BUILD_STATUS_CQL).build();
+
+    private static final String INDEX_EVENTS_CQL = "CREATE TABLE IF NOT EXISTS %s (" +
+                                                   "date text," +
+                                                   "event_time timestamp," +
+                                                   "index_name text," +
+                                                   "host_id UUID," +
+                                                   "event text," +
+                                                   "PRIMARY KEY (date, event_time, index_name, host_id)) " +
+                                                   "WITH CLUSTERING ORDER BY (event_time DESC)";
+
+    private static final TableMetadata IndexEventsTable =
+        parse(INDEX_EVENTS, "Index events for applicable tables", INDEX_EVENTS_CQL)
+        .defaultTimeToLive((int) TimeUnit.DAYS.toSeconds(7))
+        .compaction(CompactionParams.twcs(ImmutableMap.of("compaction_window_unit","DAYS",
+                                                          "compaction_window_size","1"))).build();
+
     private static TableMetadata.Builder parse(String table, String description, String cql)
     {
         return CreateTableStatement.parse(format(cql, table), SchemaConstants.DISTRIBUTED_KEYSPACE_NAME)
@@ -227,9 +260,9 @@ public final class SystemDistributedKeyspace
         return KeyspaceMetadata.create(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
                                        KeyspaceParams.simple(Math.max(DEFAULT_RF, DatabaseDescriptor.getDefaultKeyspaceRF())),
                                        Tables.of(RepairHistory, ParentRepairHistory,
-                                                 ViewBuildStatus, PartitionDenylistTable,
+                                                 ViewBuildStatus, IndexBuildStatus, PartitionDenylistTable,
                                                  AutoRepairHistoryTable, AutoRepairPriorityTable,
-                                                 CompressionDictionariesTable));
+                                                 CompressionDictionariesTable, IndexEventsTable));
     }
 
     public static void startParentRepair(TimeUUID parent_id, String keyspaceName, String[] cfnames, RepairOption options)
@@ -412,6 +445,110 @@ public final class SystemDistributedKeyspace
         String buildReq = "DELETE FROM %s.%s WHERE keyspace_name = ? AND view_name = ?";
         QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, VIEW_BUILD_STATUS), keyspaceName, viewName);
         forceBlockingFlush(VIEW_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
+    }
+
+    public static void updateIndexStatus(UUID hostId, String keyspace, String index, Index.Status status)
+    {
+        String query = "INSERT INTO %s.%s (host_id, keyspace_name, index_name, status) VALUES (?, ?, ?, ?)";
+        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                               ConsistencyLevel.ONE,
+                               Lists.newArrayList(bytes(hostId),
+                                                  bytes(keyspace),
+                                                  bytes(index),
+                                                  bytes(status.toString())));
+    }
+
+    public static void setIndexRemoved(UUID hostId, String keyspaceName, String indexName)
+    {
+        String buildReq = "DELETE FROM %s.%s WHERE host_id = ? AND keyspace_name = ? AND index_name = ?";
+        QueryProcessor.executeInternal(format(buildReq, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                       hostId, keyspaceName, indexName);
+        forceBlockingFlush(INDEX_BUILD_STATUS, ColumnFamilyStore.FlushReason.INTERNALLY_FORCED);
+    }
+
+    public static Map<UUID, Map<String, Index.Status>> allIndexStatuses()
+    {
+        String query = "SELECT host_id, keyspace_name, index_name, status FROM %s.%s";
+        UntypedResultSet results;
+
+        try
+        {
+            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                             ConsistencyLevel.ONE);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+
+        Map<UUID, Map<String, Index.Status>> allStatuses = new HashMap<>();
+        for (UntypedResultSet.Row row : results)
+        {
+            UUID hostId = row.getUUID("host_id");
+            String identifier = row.getString("keyspace_name") + '.' + row.getString("index_name");
+            Index.Status status = Index.Status.valueOf(row.getString("status"));
+            allStatuses.computeIfAbsent(hostId, k -> new HashMap<>()).put(identifier, status);
+        }
+
+        return allStatuses;
+    }
+
+    public static Map<String, Index.Status> allIndexStatusesForHost(UUID hostId)
+    {
+        String query = "SELECT keyspace_name, index_name, status FROM %s.%s WHERE host_id = ?";
+        UntypedResultSet results;
+
+        try
+        {
+            results = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS),
+                                             ConsistencyLevel.ONE,
+                                             hostId);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Unable to load index statuses from system table for host {}: {}", hostId, e.getMessage());
+            return Collections.emptyMap();
+        }
+
+        Map<String, Index.Status> statuses = new HashMap<>();
+        for (UntypedResultSet.Row row : results)
+        {
+            statuses.put(row.getString("keyspace_name") + '.' + row.getString("index_name"),
+                         Index.Status.valueOf(row.getString("status")));
+        }
+
+        return statuses;
+    }
+
+    public static void recordIndexEvent(UUID hostId, String keyspace, String index, Index.Status status)
+    {
+        String query = "INSERT INTO %s.%s (date, event_time, index_name, host_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)";
+        QueryProcessor.process(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
+                               ConsistencyLevel.ONE,
+                               Lists.newArrayList(bytes(LocalDate.now(ZoneOffset.UTC).toString()),
+                                                  bytes(keyspace + '.' + index),
+                                                  bytes(hostId),
+                                                  bytes(status.toString())));
+    }
+
+    public static UntypedResultSet queryIndexEvents(String date, long sinceTimestampMillis)
+    {
+        String query = "SELECT index_name, host_id, event FROM %s.%s WHERE date = ? AND event_time > ? ";
+        UntypedResultSet status;
+        try
+        {
+            status = QueryProcessor.execute(format(query, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS),
+                                             ConsistencyLevel.ONE,
+                                             date,
+                                             new java.util.Date(sinceTimestampMillis));
+        }
+        catch (Exception e)
+        {
+            return null;
+        }
+
+        return status;
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -516,40 +516,6 @@ public final class SystemDistributedKeyspace
         return allStatuses;
     }
 
-    public static Map<String, Index.Status> allIndexStatusesForHost(NodeId nodeId)
-    {
-        String query = format("SELECT keyspace_name, index_name, status FROM %s.%s WHERE node_id = ?",
-                              SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_BUILD_STATUS);
-        UntypedResultSet results;
-
-        try
-        {
-            try
-            {
-                results = QueryProcessor.execute(query, ConsistencyLevel.QUORUM, nodeId.id());
-            }
-            catch (Exception e)
-            {
-                logger.warn("Failed to load index statuses with QUORUM for host {}, retrying with ONE", nodeId);
-                results = QueryProcessor.execute(query, ConsistencyLevel.ONE, nodeId.id());
-            }
-        }
-        catch (Exception e)
-        {
-            logger.warn("Unable to load index statuses from system table for host {}: {}", nodeId, e.getMessage());
-            return Collections.emptyMap();
-        }
-
-        Map<String, Index.Status> statuses = new HashMap<>();
-        for (UntypedResultSet.Row row : results)
-        {
-            statuses.put(row.getString("keyspace_name") + '.' + row.getString("index_name"),
-                         Index.Status.valueOf(row.getString("status")));
-        }
-
-        return statuses;
-    }
-
     public static void recordIndexEvent(NodeId nodeId, String keyspace, String index, Index.Status status)
     {
         String query = format("INSERT INTO %s.%s (date, event_time, index_name, node_id, event) VALUES (?, to_timestamp(now()), ?, ?, ?)",
@@ -564,13 +530,13 @@ public final class SystemDistributedKeyspace
                               SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, INDEX_EVENTS);
         try
         {
-            return QueryProcessor.execute(query, ConsistencyLevel.QUORUM, date, new java.util.Date(sinceTimestampMillis));
+            return QueryProcessor.execute(query, ConsistencyLevel.QUORUM, date, sinceTimestampMillis);
         }
         catch (Exception e)
         {
             try
             {
-                return QueryProcessor.execute(query, ConsistencyLevel.ONE, date, new java.util.Date(sinceTimestampMillis));
+                return QueryProcessor.execute(query, ConsistencyLevel.ONE, date, sinceTimestampMillis);
             }
             catch (Exception ex)
             {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -848,6 +848,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
         Gossiper.waitToSettle();
 
+        IndexStatusManager.instance.loadIndexStatusesFromTable();
+        IndexStatusManager.instance.startPolling();
+
         NodeId self = Register.maybeRegister();
         if (!AccordService.isSetupOrStarting())
             AccordService.localStartup(self);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -850,6 +850,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
         Gossiper.waitToSettle();
 
+        IndexStatusManager.instance.loadIndexStatusesFromTable();
+        IndexStatusManager.instance.startPolling();
+
         NodeId self = Register.maybeRegister();
         if (!AccordService.isSetupOrStarting())
             AccordService.localStartup(self);

--- a/src/java/org/apache/cassandra/tcm/ClusterMetadata.java
+++ b/src/java/org/apache/cassandra/tcm/ClusterMetadata.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -1318,6 +1320,7 @@ public class ClusterMetadata
         return service.metadata();
     }
 
+    @Nonnull
     public NodeId myNodeId()
     {
         return localNodeId;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -48,6 +48,8 @@ import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -75,7 +77,8 @@ public class IndexAvailabilityTest extends TestBaseImpl
     public void verifyIndexStatusPropagation() throws Exception
     {
         try (Cluster cluster = init(Cluster.build(2)
-                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK)
+                                                                       .set("index_status_poll_interval_in_seconds", "1"))
                                            .start()))
         {
             verifyIndexStatusPropagation(cluster);
@@ -202,7 +205,8 @@ public class IndexAvailabilityTest extends TestBaseImpl
     {
         try (Cluster cluster = init(Cluster.build(3)
                 .withConfig(config -> config.with(GOSSIP)
-                                                          .with(NETWORK))
+                                            .with(NETWORK)
+                                            .set("index_status_poll_interval_in_seconds", "1"))
                 .start()))
         {
             String ks2 = "ks2";
@@ -447,7 +451,7 @@ public class IndexAvailabilityTest extends TestBaseImpl
             cluster.get(1).runOnInstance(() -> {
                 Map<String, Index.Status> localStatusMap =
                         IndexStatusManager.instance.peerIndexStatus
-                                .computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(), k -> new HashMap<>());
+                                .computeIfAbsent(ClusterMetadata.current().myNodeId(), k -> new HashMap<>());
 
                 for (int ks = 0; ks < 100; ks++)
                     for (int idx = 0; idx < 200; idx++)
@@ -481,8 +485,7 @@ public class IndexAvailabilityTest extends TestBaseImpl
             waitForIndexingStatus(cluster.get(2), ks, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
 
             cluster.get(1).runOnInstance(() -> {
-                java.util.Map<java.util.UUID, java.util.Map<String, Index.Status>> allStatuses =
-                        SystemDistributedKeyspace.allIndexStatuses();
+                Map<NodeId, Map<String, Index.Status>> allStatuses = SystemDistributedKeyspace.allIndexStatuses();
                 assertTrue("index_build_status table should be empty in mixed-version cluster, but has " + allStatuses.size() + " entries",
                            allStatuses.isEmpty());
             });
@@ -491,8 +494,8 @@ public class IndexAvailabilityTest extends TestBaseImpl
             waitForIndexingStatus(cluster.get(2), ks, index1, cluster.get(1), Index.Status.BUILD_FAILED);
 
             cluster.get(1).runOnInstance(() -> {
-                java.util.Map<java.util.UUID, java.util.Map<String, Index.Status>> allStatuses =
-                        SystemDistributedKeyspace.allIndexStatuses();
+                Map<NodeId, Map<String, Index.Status>> allStatuses =
+                SystemDistributedKeyspace.allIndexStatuses();
                 assertTrue("index_build_status table should still be empty in mixed-version cluster",
                            allStatuses.isEmpty());
             });

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.distributed.test.sai;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.LogAction;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexStatusManager;
@@ -44,6 +46,7 @@ import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -54,6 +57,8 @@ import static org.apache.cassandra.distributed.test.sai.SAIUtil.waitForIndexQuer
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IndexAvailabilityTest extends TestBaseImpl
 {
@@ -398,6 +403,102 @@ public class IndexAvailabilityTest extends TestBaseImpl
         public int hashCode()
         {
             return Objects.hashCode(keyspace, index, node);
+        }
+    }
+
+    @Test
+    public void verifyIndexStatusPropagationViaTablePolling() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(2)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK)
+                                                                       .set("index_status_poll_interval_in_seconds", 5)).start()))
+        {
+            String ks = "poll_test_ks";
+            String cf = "cf1";
+            String index = "cf1_poll_idx";
+
+            cluster.schemaChange(String.format(CREATE_KEYSPACE, ks, 2));
+            cluster.schemaChange(String.format(CREATE_TABLE, ks, cf));
+            cluster.schemaChange(String.format(CREATE_INDEX, index, ks, cf, "v1"));
+            waitForIndexQueryable(cluster, ks);
+
+            await().atMost(15, TimeUnit.SECONDS)
+                   .until(() -> cluster.get(2).callOnInstance(() -> {
+                       InetAddressAndPort node1Address = InetAddressAndPort.getByNameUnchecked("127.0.0.1");
+                       int port = FBUtilities.getBroadcastAddressAndPort().getPort();
+                       InetAddressAndPort node1 = InetAddressAndPort.getByAddressOverrideDefaults(node1Address.getAddress(), port);
+                       return IndexStatusManager.instance.getIndexStatus(node1, ks, index) == Index.Status.BUILD_SUCCEEDED;
+                   }));
+        }
+    }
+
+
+    @Test
+    public void verifyMaxSizeIndexTest() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(1)
+                .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                .withInstanceInitializer(MixedPatchVersionHelper::setVersions)
+                .start()))
+        {
+            LogAction logs = cluster.get(1).logs();
+            long mark = logs.mark();
+
+            cluster.get(1).runOnInstance(() -> {
+                Map<String, Index.Status> localStatusMap =
+                        IndexStatusManager.instance.peerIndexStatus
+                                .computeIfAbsent(FBUtilities.getBroadcastAddressAndPort(), k -> new HashMap<>());
+
+                for (int ks = 0; ks < 100; ks++)
+                    for (int idx = 0; idx < 200; idx++)
+                        localStatusMap.put("keyspace_" + ks + ".my_table_index_name" + idx, Index.Status.BUILD_SUCCEEDED);
+
+                IndexStatusManager.instance.propagateLocalIndexStatus("keyspace_trigger", "trigger_idx", Index.Status.BUILD_SUCCEEDED);
+            });
+
+            assertFalse(logs.watchFor(mark, "exceeds limit").getResult().isEmpty());
+        }
+    }
+
+
+    @Test
+    public void verifyMixedVersionSkipsTableWritesAndUsesGossip() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(2)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .withInstanceInitializer(MixedMajorVersionHelper::setVersions)
+                                           .start()))
+        {
+            String ks = "mixed_ks";
+            String cf = "cf1";
+            String index1 = "cf1_idx1";
+
+            cluster.schemaChange(String.format(CREATE_KEYSPACE, ks, 2));
+            cluster.schemaChange(String.format(CREATE_TABLE, ks, cf));
+            cluster.schemaChange(String.format(CREATE_INDEX, index1, ks, cf, "v1"));
+            waitForIndexQueryable(cluster, ks);
+
+            waitForIndexingStatus(cluster.get(2), ks, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
+
+            cluster.get(1).runOnInstance(() -> {
+                java.util.Map<java.util.UUID, java.util.Map<String, Index.Status>> allStatuses =
+                        SystemDistributedKeyspace.allIndexStatuses();
+                assertTrue("index_build_status table should be empty in mixed-version cluster, but has " + allStatuses.size() + " entries",
+                           allStatuses.isEmpty());
+            });
+
+            markIndexNonQueryable(cluster.get(1), ks, cf, index1);
+            waitForIndexingStatus(cluster.get(2), ks, index1, cluster.get(1), Index.Status.BUILD_FAILED);
+
+            cluster.get(1).runOnInstance(() -> {
+                java.util.Map<java.util.UUID, java.util.Map<String, Index.Status>> allStatuses =
+                        SystemDistributedKeyspace.allIndexStatuses();
+                assertTrue("index_build_status table should still be empty in mixed-version cluster",
+                           allStatuses.isEmpty());
+            });
+
+            markIndexQueryable(cluster.get(1), ks, cf, index1);
+            waitForIndexingStatus(cluster.get(2), ks, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -505,6 +505,27 @@ public class IndexAvailabilityTest extends TestBaseImpl
         }
     }
 
+    @Test
+    public void allIndexStatusesQuietWhenInterrupted() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(1)
+                .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                .start()))
+        {
+            LogAction logs = cluster.get(1).logs();
+            long mark = logs.mark();
+
+            cluster.get(1).runOnInstance(() -> {
+                Thread.currentThread().interrupt();
+                SystemDistributedKeyspace.allIndexStatuses();
+                Thread.interrupted();
+            });
+
+            assertTrue("index-status read must not WARN when interrupted",
+                    logs.grep(mark, "Unable to load index statuses from system table").getResult().isEmpty());
+        }
+    }
+
     public static class MixedMajorVersionHelper
     {
         @SuppressWarnings({ "unused", "resource" })

--- a/test/unit/org/apache/cassandra/index/IndexStatusManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/IndexStatusManagerTest.java
@@ -18,7 +18,10 @@
 
 package org.apache.cassandra.index;
 
+import java.io.UTFDataFormatException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +37,7 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.EndpointsForRange;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -41,11 +45,15 @@ import org.apache.cassandra.locator.NetworkTopologyStrategy;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.ReplicaUtils;
 import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.JsonUtils;
 
 import static org.apache.cassandra.locator.ReplicaUtils.full;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class IndexStatusManagerTest
@@ -437,5 +445,84 @@ public class IndexStatusManagerTest
         ConsistencyLevel mock = Mockito.mock(ConsistencyLevel.class);
         Mockito.when(mock.blockFor(Mockito.any())).thenReturn(required);
         return mock;
+    }
+
+    @Test
+    public void shouldFailWhenTooManyIndexesExceedGossipLimit()
+    {
+        Map<String, Index.Status> statusMap = new HashMap<>();
+        for (int ks = 0; ks < 100; ks++)
+        {
+            for (int idx = 0; idx < 200; idx++)
+            {
+                statusMap.put("keyspace_" + ks + ".my_table_index_name" + idx, Index.Status.BUILD_SUCCEEDED);
+            }
+        }
+
+        String serialized = IndexStatusManager.toSerializedFormat(statusMap);
+        byte[] utf8Bytes = serialized.getBytes(StandardCharsets.UTF_8);
+
+        assertTrue("Serialized size " + utf8Bytes.length + " should exceed 65535",
+                   utf8Bytes.length > 65535);
+
+        VersionedValue value = VersionedValue.unsafeMakeVersionedValue(serialized, 1);
+        DataOutputBuffer out = new DataOutputBuffer();
+
+        assertThatThrownBy(() -> VersionedValue.serializer.serialize(value, out, 0))
+                .isInstanceOf(UTFDataFormatException.class);
+    }
+
+    @Test
+    public void testVersionGatingAllowsWriteFor6x()
+    {
+        assertTrue(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("6.0.0")));
+        assertTrue(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("6.1.0")));
+        assertTrue(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("7.0.0")));
+    }
+
+    @Test
+    public void testVersionGatingBlocksWriteForPre6x()
+    {
+        assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("5.0.0")));
+        assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("5.0.2")));
+        assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("4.1.0")));
+    }
+
+    @Test
+    public void testProcessEventsUpdatesPeerIndexStatus()
+    {
+        IndexStatusManager manager = IndexStatusManager.instance;
+        InetAddressAndPort peer = InetAddressAndPort.getByNameUnchecked("127.0.0.100");
+
+        Map<String, Index.Status> peerStatuses = new HashMap<>();
+        manager.peerIndexStatus.put(peer, peerStatuses);
+
+        assertEquals(Index.Status.UNKNOWN, manager.getIndexStatus(peer, "ks1", "idx1"));
+        peerStatuses.put("ks1.idx1", Index.Status.BUILD_SUCCEEDED);
+        assertEquals(Index.Status.BUILD_SUCCEEDED, manager.getIndexStatus(peer, "ks1", "idx1"));
+    }
+
+    @Test
+    public void testProcessEventsHandlesDropped()
+    {
+        IndexStatusManager manager = IndexStatusManager.instance;
+        InetAddressAndPort peer = InetAddressAndPort.getByNameUnchecked("127.0.0.101");
+
+        Map<String, Index.Status> peerStatuses = new HashMap<>();
+        peerStatuses.put("ks1.idx1", Index.Status.BUILD_SUCCEEDED);
+        manager.peerIndexStatus.put(peer, peerStatuses);
+
+        assertEquals(Index.Status.BUILD_SUCCEEDED, manager.getIndexStatus(peer, "ks1", "idx1"));
+
+        peerStatuses.remove("ks1.idx1");
+
+        assertEquals(Index.Status.UNKNOWN, manager.getIndexStatus(peer, "ks1", "idx1"));
+    }
+
+    @Test
+    public void testResetLastPollTimestamp()
+    {
+        IndexStatusManager manager = IndexStatusManager.instance;
+        manager.resetLastPollTimestamp();
     }
 }

--- a/test/unit/org/apache/cassandra/index/IndexStatusManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/IndexStatusManagerTest.java
@@ -28,13 +28,16 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.test.log.ClusterMetadataTestHelper;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -51,7 +54,6 @@ import org.apache.cassandra.utils.JsonUtils;
 import static org.apache.cassandra.locator.ReplicaUtils.full;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -130,6 +132,15 @@ public class IndexStatusManagerTest
                 return new Testcase(this);
             }
         }
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        ClusterMetadataTestHelper.setInstanceForTest();
+        for (int i = 251; i <= 255; i++)
+            ClusterMetadataTestHelper.register(InetAddressAndPort.getByNameUnchecked("127.0.0." + i));
     }
 
     @Test
@@ -290,6 +301,7 @@ public class IndexStatusManagerTest
     @Test
     public void shouldThrowWhenNotEnoughQueryableEndpoints()
     {
+        int port = DatabaseDescriptor.getStoragePort();
         assertThatThrownBy(() ->
                 runTest(new Testcase.Builder()
                         .keyspace("ks1")
@@ -330,13 +342,14 @@ public class IndexStatusManagerTest
                         .build()))
                 .isInstanceOf(ReadFailureException.class)
                 .hasMessageStartingWith("Operation failed")
-                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.252:7000")
-                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.254:7000");
+                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.252:" + port)
+                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.254:" + port);
     }
 
     @Test
     public void shouldThrowWhenNoQueryableEndpoints()
     {
+        int port = DatabaseDescriptor.getStoragePort();
         assertThatThrownBy(() ->
                 runTest(new Testcase.Builder()
                         .keyspace("ks1")
@@ -365,9 +378,9 @@ public class IndexStatusManagerTest
                         .build()))
                 .isInstanceOf(ReadFailureException.class)
                 .hasMessageStartingWith("Operation failed")
-                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.253:7000")
-                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.254:7000")
-                .hasMessageContaining("INDEX_BUILD_IN_PROGRESS from /127.0.0.255:7000");
+                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.253:" + port)
+                .hasMessageContaining("INDEX_NOT_AVAILABLE from /127.0.0.254:" + port)
+                .hasMessageContaining("INDEX_BUILD_IN_PROGRESS from /127.0.0.255:" + port);
     }
 
     void runTest(Testcase testcase)
@@ -486,43 +499,5 @@ public class IndexStatusManagerTest
         assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("5.0.0")));
         assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("5.0.2")));
         assertFalse(IndexStatusManager.shouldWriteToIndexTablesForTesting(new CassandraVersion("4.1.0")));
-    }
-
-    @Test
-    public void testProcessEventsUpdatesPeerIndexStatus()
-    {
-        IndexStatusManager manager = IndexStatusManager.instance;
-        InetAddressAndPort peer = InetAddressAndPort.getByNameUnchecked("127.0.0.100");
-
-        Map<String, Index.Status> peerStatuses = new HashMap<>();
-        manager.peerIndexStatus.put(peer, peerStatuses);
-
-        assertEquals(Index.Status.UNKNOWN, manager.getIndexStatus(peer, "ks1", "idx1"));
-        peerStatuses.put("ks1.idx1", Index.Status.BUILD_SUCCEEDED);
-        assertEquals(Index.Status.BUILD_SUCCEEDED, manager.getIndexStatus(peer, "ks1", "idx1"));
-    }
-
-    @Test
-    public void testProcessEventsHandlesDropped()
-    {
-        IndexStatusManager manager = IndexStatusManager.instance;
-        InetAddressAndPort peer = InetAddressAndPort.getByNameUnchecked("127.0.0.101");
-
-        Map<String, Index.Status> peerStatuses = new HashMap<>();
-        peerStatuses.put("ks1.idx1", Index.Status.BUILD_SUCCEEDED);
-        manager.peerIndexStatus.put(peer, peerStatuses);
-
-        assertEquals(Index.Status.BUILD_SUCCEEDED, manager.getIndexStatus(peer, "ks1", "idx1"));
-
-        peerStatuses.remove("ks1.idx1");
-
-        assertEquals(Index.Status.UNKNOWN, manager.getIndexStatus(peer, "ks1", "idx1"));
-    }
-
-    @Test
-    public void testResetLastPollTimestamp()
-    {
-        IndexStatusManager manager = IndexStatusManager.instance;
-        manager.resetLastPollTimestamp();
     }
 }


### PR DESCRIPTION
Cassandra-21264

1. Migrates index status propagation from gossip to table polling to avoid the 65KB writeUTF() serialization limit. 
2. Adds two new system_distributed tables (index_build_status, index_events) with periodic polling
3. version-gated so pre-6.0 clusters continue using gossip.

patch by Sunil Ramchadnra Pawar; reviewed by Caleb Rackliffe for CASSANDRA-21264

Co-authored-by: Caleb Rackliffe
