### PR TITLE
[CASSANDRA-21351][trunk] Reduce memory allocations in SelectStatement.getQuery

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -131,8 +131,10 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
     public Slices slices(QueryOptions options) throws InvalidRequestException
     {
         MultiCBuilder builder = new MultiCBuilder(comparator);
-        int keyPosition = 0;
+        if (restrictions.isEmpty()) // to avoid an iterator allocation for restrictions
+            return builder.buildSlices();
 
+        int keyPosition = 0;
         for (SingleRestriction r : restrictions)
         {
             if (handleInFilter(r, keyPosition))

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -131,7 +131,6 @@ import org.apache.cassandra.service.pager.QueryPager;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
-import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NoSpamLogger;
 
@@ -802,7 +801,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
     private ReadQuery getSliceCommands(QueryOptions options, ClientState state, ColumnFilter columnFilter,
                                        RowFilter rowFilter, DataLimits limit, long nowInSec, PotentialTxnConflicts potentialTxnConflicts)
     {
-        Collection<ByteBuffer> keys = restrictions.getPartitionKeys(options, state);
+        List<ByteBuffer> keys = restrictions.getPartitionKeys(options, state);
         if (keys.isEmpty())
             return ReadQuery.empty(table);
 
@@ -815,11 +814,21 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
         if (filter == null || filter.isEmpty(table.comparator))
             return ReadQuery.empty(table);
 
-        List<DecoratedKey> decoratedKeys = new ArrayList<>(keys.size());
-        for (ByteBuffer key : keys)
+        List<DecoratedKey> decoratedKeys;
+        if (keys.size() == 1) // reduce allocations in collections for keys
         {
+            ByteBuffer key = keys.get(0);
             QueryProcessor.validateKey(key);
-            decoratedKeys.add(table.partitioner.decorateKey(ByteBufferUtil.clone(key)));
+            decoratedKeys = Collections.singletonList(table.partitioner.decorateKey(key));
+        }
+        else
+        {
+            decoratedKeys = new ArrayList<>(keys.size());
+            for (ByteBuffer key : keys)
+            {
+                QueryProcessor.validateKey(key);
+                decoratedKeys.add(table.partitioner.decorateKey(key));
+            }
         }
 
         SinglePartitionReadQuery.Group<? extends SinglePartitionReadQuery> group =

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -1388,6 +1388,17 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
                                    ClusteringIndexFilter clusteringIndexFilter,
                                    PotentialTxnConflicts potentialTxnConflicts)
         {
+            if (partitionKeys.size() == 1)
+            {
+                return one(SinglePartitionReadCommand.create(metadata,
+                                                             nowInSec,
+                                                             columnFilter,
+                                                             rowFilter,
+                                                             limits,
+                                                             partitionKeys.get(0),
+                                                             clusteringIndexFilter,
+                                                             potentialTxnConflicts));
+            }
             List<SinglePartitionReadCommand> commands = new ArrayList<>(partitionKeys.size());
             for (DecoratedKey partitionKey : partitionKeys)
             {


### PR DESCRIPTION
- SinglePartitionReadCommand.Group#create - typical single partition select, use singletonList instead of ArrayList + Object[]
- SelectStatement#getSliceCommands - remove unnecessary cloning of partition key, it is a part of a very old patch, now we copy all values from Netty buffers 
- SelectStatement#getSliceCommands - typical single partition select, use singletonList instead of ArrayList + Object[] SinglePartitionReadQuery.Group#maybeValidateIndex, avoid iterators for restrictionSet if a full partition is selected

patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21351