### PR TITLE
CASSANDRA-21342: Fix broken Antora xref/anchor targets in cassandra docs

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 ifndef::local-build[]
 ** xref:master@_:ROOT:glossary.adoc[Glossary]
 ** xref:master@_:ROOT:bugs.adoc[How to report bugs]
-** xref:master@_:ROOT:contactus.adoc[Contact us]
+** xref:master@_:ROOT:community.adoc[Contact us]
 ** xref:master@_:ROOT:development/index.adoc[Development]
 *** xref:master@_:ROOT:development/gettingstarted.adoc[Getting started]
 *** xref:master@_:ROOT:development/ide.adoc[Building and IDE integration]

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -48,7 +48,7 @@ If you would like to contribute to this documentation, you are welcome to do so 
 
 ifndef::local-build[]
 * xref:master@_:ROOT:bugs.adoc[Reporting bugs]
-* xref:master@_:ROOT:contactus.adoc[Contact us]
+* xref:master@_:ROOT:community.adoc[Contact us]
 * xref:master@_:ROOT:development/index.adoc[Contributing code]
 * xref:master@_:ROOT:docdev/index.adoc[Contributing to the docs]
 * xref:master@_:ROOT:community.adoc[Community]

--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -128,7 +128,7 @@
 
 ** xref:reference/index.adoc[]
 *** xref:reference/cql-commands/commands-toc.adoc[CQL commands]
-*** xref:developing/cql/cql_singlefile.html[CQL specification]
+*** xref:cassandra:developing/cql/cql_singlefile.adoc[CQL specification]
 *** xref:reference/java17.adoc[Java 17]
 *** xref:reference/native-protocol.adoc[Native Protocol specification]
 *** xref:reference/sai-virtual-table-indexes.adoc[SAI virtual table]

--- a/doc/modules/cassandra/pages/developing/cql/batch/batch-good-example.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/batch/batch-good-example.adoc
@@ -24,7 +24,7 @@ All the `INSERT` and `UPDATE` statements in this batch write to the same partiti
 include::cassandra:example$CQL/cyclist_expenses-table.cql[tag=batch_Vera]
 ----
 +
-This batching example includes conditional updates combined with using xref:reference:static.adoc[static columns].
+This batching example includes conditional updates combined with using xref:cassandra:developing/cql/ddl.adoc#static-column[static columns].
 Recall that single partition batches are not logged.
 +
 [NOTE]

--- a/doc/modules/cassandra/pages/developing/cql/collections/list.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/collections/list.adoc
@@ -9,7 +9,7 @@ Use the `list` data type to store data that has a possible many-to-many relation
 
 == Prerequisite
 
-* xref:developing/cql/keyspace-check.adoc[Keyspace] must exist
+* xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[Keyspace] must exist
 
 In the following example, a `list` called `events` stores all the race events on an upcoming calendar.
 The table is called `upcoming_calendar`. Each event listed in the `list` will have a `text` data type.

--- a/doc/modules/cassandra/pages/developing/cql/collections/map.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/collections/map.adoc
@@ -11,7 +11,7 @@ Each element can have an individual time-to-live and expire when the TTL ends.
 
 == Prerequisite
 
-* xref:developing/cql/keyspace-check.adoc[Keyspace] must exist
+* xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[Keyspace] must exist
 
 In the following example, each team listed in the `map` called `teams` will have a `year` of integer type and a `team name` of text type.
 The table is named `cyclist_teams`.

--- a/doc/modules/cassandra/pages/developing/cql/collections/set.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/collections/set.adoc
@@ -8,7 +8,7 @@ Use the `set` data type to store data that has a many-to-one relationship with a
 
 == Prerequisite
 
-* xref:developing/cql/keyspace-check.adoc[Keyspace] must exist
+* xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[Keyspace] must exist
 
 In the following example, a `set` called `teams` stores all the teams that a cyclist has been a member of during their career.
 The table is `cyclist_career_teams`.

--- a/doc/modules/cassandra/pages/developing/cql/create-custom-index.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/create-custom-index.adoc
@@ -55,7 +55,7 @@ SAI allows only alphanumeric characters and underscores in names.
 SAI returns `InvalidRequestException` if you try to define an index on a column name that contains other characters, and does not create the index.
 
 map_name::
-Used with xref:cassandra:developing/collections/collection-create.adoc[collections], identifier of the `map_name` specified in `CREATE TABLE` ...
+Used with xref:cassandra:developing/cql/collections/collection-create.adoc[collections], identifier of the `map_name` specified in `CREATE TABLE` ...
 `map(<map_name>)`.
 The regular column syntax applies for collection types `list` and `set`.
 
@@ -119,7 +119,7 @@ Also refer xref:cassandra:developing/cql/indexing/sai/sai-query.adoc[Examine SAI
 === SAI collection map examples with keys, values, and entries
 
 The following examples demonstrate using collection maps of multiple types (`keys`, `values`, `entries`) in SAI indexes.
-For related information, see xref:cassandra:developing/collections/collection-create.adoc[Creating collections] and xref:cassandra:developing/collections/map.adoc[Using map type].
+For related information, see xref:cassandra:developing/cql/collections/collection-create.adoc[Creating collections] and xref:cassandra:developing/collections/map.adoc[Using map type].
 
 Also refer to the SAI collection examples of type xref:#saiCreateCustomIndexCollectionsListAndSetExamples[list and set] in this topic.
 
@@ -293,7 +293,7 @@ Remember that in CQL queries using SAI indexes, the `CONTAINS` clauses are suppo
 These examples demonstrate using collections with the `list` and `set` types in SAI indexes.
 For related information, see:
 
-* xref:cassandra:developing/collections/collection-create.adoc[Creating collections]
+* xref:cassandra:developing/cql/collections/collection-create.adoc[Creating collections]
 * xref:cassandra:developing/collections/list.adoc[Using list type]
 * xref:cassandra:developing/collections/set.adoc[Using set type]
 

--- a/doc/modules/cassandra/pages/developing/cql/create-index.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/create-index.adoc
@@ -90,7 +90,7 @@ To index map keys, use the `KEYS` keyword and map name in nested parentheses:
 include::cassandra:example$CQL/sai/cyclist_teams-table.cql[tag=keysidx]
 ----
 
-To query the table, you can use xref:cassandra:reference/cql-commands/select.adoc#filtering-on-collections[CONTAINS KEY] in `WHERE` clauses.
+To query the table, you can use xref:cassandra:developing/cql/dml.adoc#allow-filtering[CONTAINS KEY] in `WHERE` clauses.
 
 [source,language-cql]
 ----

--- a/doc/modules/cassandra/pages/developing/cql/indexing/2i/2i-working-with.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/2i/2i-working-with.adoc
@@ -4,8 +4,8 @@
 
 == Prerequisites
 
-* xref:developing/keyspace-create.adoc[Keyspace created]
-* xref:developing/table-create.adoc[Table created]
+* xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[Keyspace created]
+* xref:cassandra:developing/cql/ddl.adoc#create-table-statement[Table created]
 
 include::_2i-create.adoc[leveloffset=+1]
 

--- a/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-faq.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-faq.adoc
@@ -314,7 +314,7 @@ the post filtering on `col2` is carried out on the replicas themselves.
 Another case were post-filtering comes into play is when constructing a query that involves more than two SAI indexes.
 Refer to this xref:#saiAndQueriesFaq[related FAQ] about `AND` queries.
 
-== Can I create an SAI index based on a xref:reference:static.adoc[static column]?
+== Can I create an SAI index based on a xref:cassandra:developing/cql/ddl.adoc#static-column[static column]?
 
 Yes.
 For example, consider a `transaction_by_customer` table where you have a primary key `customer_id`, plus static columns to contain each customer's `address`, `phone_number`, and `date_of_birth`.

--- a/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-read-write-paths.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-read-write-paths.adoc
@@ -27,7 +27,7 @@ SAI calculates an estimate of the incremental heap consumption of the new entry.
 This estimate counts against the heap usage of the underlying Memtable.
 This feature also means that as more columns are indexed on a table, the Memtable flush rate will increase, and the size of flushed SSTables will decrease.
 The number of total writes and the estimated heap usage of all live Memtable indexes are exposed as metrics.
-See xref:cassandra:developing/cql/indexing/sai/monitoring.adoc#saiMonitorMetrics[SAI metrics].
+See xref:cassandra:developing/cql/indexing/sai/operations/monitoring.adoc#saiMonitorMetrics[SAI metrics].
 
 === Memtable flush
  
@@ -94,7 +94,7 @@ image::sai/saiOnDiskStructureWithOffsets.png[alt=SAI on-disk layout as described
 The actual segment flushing process is very similar to a Memtable flush.
 However, buffered terms are sorted before they can be written with their postings to their respective type-specific on-disk structures.
 At the end of compaction for a given index, a special empty marker file is flagged to indicate success, and the number of segments is recorded in SAI metrics.
-See xref:developing:indexing/sai/monitoring.adoc#saiGlobalIndexingMetrics[Global indexing metrics].
+See xref:cassandra:developing/cql/indexing/sai/operations/monitoring.adoc#saiGlobalIndexingMetrics[Global indexing metrics].
 
 When the entire compaction task finishes, SAI receives an SSTable List Changed Notification that contains the SSTables added and removed during the transaction.
 SSTable Context Manager and Index View Manager are responsible for replacing old SSTable indexes with new ones atomically.

--- a/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-working-with.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/sai/sai-working-with.adoc
@@ -4,8 +4,8 @@
 
 == Prerequisites
 
-* xref:developing/keyspace-create.adoc[Keyspace created]
-* xref:developing/table-create.adoc[Table created]
+* xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[Keyspace created]
+* xref:cassandra:developing/cql/ddl.adoc#create-table-statement[Table created]
 
 include::_sai-create.adoc[leveloffset=+1]
 

--- a/doc/modules/cassandra/pages/developing/cql/security.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/security.adoc
@@ -167,11 +167,11 @@ used and the role does not exist the statement is a no-op.
 DROP ROLE intentionally does not terminate any open user sessions.
 Currently connected sessions will remain connected and will retain the
 ability to perform any database actions which do not require
-xref:cassandra:managing/operating/authorization/security.adoc#authorization[authorization].
+xref:cassandra:managing/operating/security.adoc#authorization[authorization].
 However, if authorization is enabled, xref:cassandra:developing/cql/security.adoc#cql-permissions[permissions] of the dropped role are also revoked,
-subject to the xref:cassandra:managing/operating/security.adoc#auth-caching[caching options] configured in xref:cassandra:developing/cql/configuring.adoc#cassandra.yaml[cassandra-yaml] file.
-Should a dropped role be subsequently recreated and have new xref:security.adoc#grant-permission-statement[permissions] or
-xref:security.adoc#grant-role-statement[roles] granted to it, any client sessions still
+subject to the xref:cassandra:managing/operating/security.adoc#auth-caching[caching options] configured in xref:cassandra:managing/configuration/cass_yaml_file.adoc[cassandra-yaml] file.
+Should a dropped role be subsequently recreated and have new xref:cassandra:developing/cql/security.adoc#grant-permission-statement[permissions] or
+xref:cassandra:developing/cql/security.adoc#grant-role-statement[roles] granted to it, any client sessions still
 connected will acquire the newly granted permissions and roles.
 ====
 
@@ -344,7 +344,7 @@ Existing users can be listed using the `LIST USERS` statement:
 include::cassandra:example$BNF/list_users_statement.bnf[]
 ----
 
-Note that this statement is equivalent to xref:security.adoc#list-roles-statement[LIST ROLES], but only roles with the `LOGIN` privilege are included in the output.
+Note that this statement is equivalent to xref:cassandra:developing/cql/security.adoc#list-roles-statement[LIST ROLES], but only roles with the `LOGIN` privilege are included in the output.
 
 [[databaseIdentity]]
 === Database Identities

--- a/doc/modules/cassandra/pages/managing/operating/security.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/security.adoc
@@ -323,7 +323,7 @@ xref:cassandra:developing/cql/security.adoc#operation-roles[`CassandraRoleManage
 See also: `setting-credentials-for-internal-authentication`,
 xref:cassandra:developing/cql/security.adoc#create-role[`CREATE ROLE`],
 xref:cassandra:developing/cql/security.adoc#alter-role[`ALTER ROLE`],
-xref:xref:cassandra:developing/cql/security.adoc#alter-keyspace[`ALTER KEYSPACE`] and
+xref:cassandra:developing/cql/ddl.adoc#alter-keyspace-statement[`ALTER KEYSPACE`] and
 xref:cassandra:developing/cql/security.adoc#grant-permission[`GRANT PERMISSION`].
 
 == Authorization

--- a/doc/modules/cassandra/pages/reference/cql-commands/alter-table.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/alter-table.adoc
@@ -204,7 +204,7 @@ Enclose a text property value in single quotation marks.
 [[alter-compression]]
 === Modifying compression and compaction
 
-Use a property map to alter the xref:cassandra:comments-table.adoc[comments] table's compression or compaction setting:
+Use a property map to alter the comments table's compression or compaction setting:
 
 [source,language-cql]
 ----
@@ -223,7 +223,7 @@ For strategies to minimize this disruption, see http://blog.alteroot.org/article
 
 === Changing caching
 
-Set the number of rows per partition to store in the row cache for the xref:cassandra:comments-table.adoc[comments] table to 10 rows:
+Set the number of rows per partition to store in the row cache for the comments table to 10 rows:
 
 [source,language-cql]
 ----
@@ -338,7 +338,7 @@ Lists the number of pending tasks for a compaction strategy.
 
 == Alter a table with memtable
 
-To alter a table with memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:architecture/storage-engine/memtable.adoc[Memtable] for more information.
+To alter a table with memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:cassandra:architecture/storage-engine.adoc#memtables[Memtable] for more information.
 
 To alter a table with a default memtable:
 

--- a/doc/modules/cassandra/pages/reference/cql-commands/commands-toc.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/commands-toc.adoc
@@ -4,126 +4,114 @@
 This section describes the Cassandra Query Language (CQL) commands supported by the {product} database.
 
 '''
-xref:reference/cql-commands/alter-keyspace.adoc[ALTER KEYSPACE] ::
+xref:cassandra:developing/cql/ddl.adoc#alter-keyspace-statement[ALTER KEYSPACE] ::
 Changes keyspace replication strategy and enables or disables commit log.
 
-xref:reference/cql-commands/alter-materialized-view.adoc[ALTER MATERIALIZED VIEW] ::
+xref:cassandra:developing/cql/mvs.adoc#alter-materialized-view-statement[ALTER MATERIALIZED VIEW] ::
 Changes the table properties of a materialized view.
 
-xref:reference/cql-commands/alter-role.adoc[ALTER ROLE] ::
+xref:cassandra:developing/cql/security.adoc#alter-role-statement[ALTER ROLE] ::
 Changes password and sets superuser or login options.
 
-xref:reference/cql-commands/alter-table.adoc[ALTER TABLE] ::
+xref:cassandra:reference/cql-commands/alter-table.adoc[ALTER TABLE] ::
 Modifies the columns and properties of a table, or modify
 
-xref:reference/cql-commands/alter-type.adoc[ALTER TYPE] ::
+xref:cassandra:developing/cql/types.adoc#udts[ALTER TYPE] ::
 Modifies an existing user-defined type (UDT).
 
-xref:reference/cql-commands/alter-user.adoc[ALTER USER (Deprecated)] ::
+xref:cassandra:developing/cql/security.adoc#alter-user-statement[ALTER USER (Deprecated)] ::
 Deprecated. Alter existing user options.
 
-xref:reference/cql-commands/batch.adoc[BATCH] ::
+xref:cassandra:developing/cql/dml.adoc#batch_statement[BATCH] ::
 Applies multiple data modification language (DML) statements with atomicity and/or in isolation.
 
-xref:reference/cql-commands/create-aggregate.adoc[CREATE AGGREGATE] ::
+xref:cassandra:developing/cql/functions.adoc#create-aggregate-statement[CREATE AGGREGATE] ::
 Defines a user-defined aggregate.
-xref:reference/cql-commands/create-custom-index.adoc[CREATE CUSTOM INDEX] ::
+xref:cassandra:reference/cql-commands/create-custom-index.adoc[CREATE CUSTOM INDEX] ::
 Creates a storage-attached index.
 
-xref:reference/cql-commands/create-function.adoc[CREATE FUNCTION] ::
+xref:cassandra:developing/cql/functions.adoc#create-function-statement[CREATE FUNCTION] ::
 Creates custom function to execute user provided code.
 
-xref:reference/cql-commands/create-index.adoc[CREATE INDEX] ::
+xref:cassandra:reference/cql-commands/create-index.adoc[CREATE INDEX] ::
 Defines a new index for a single column of a table.
 
-xref:reference/cql-commands/create-keyspace.adoc[CREATE KEYSPACE] ::
+xref:cassandra:developing/cql/ddl.adoc#create-keyspace-statement[CREATE KEYSPACE] ::
 
-xref:reference/cql-commands/create-materialized-view.adoc[CREATE MATERIALIZED VIEW] ::
+xref:cassandra:developing/cql/mvs.adoc#create-materialized-view-statement[CREATE MATERIALIZED VIEW] ::
 Optimizes read requests and eliminates the need for multiple write requests by duplicating data from a base table.
 
-xref:reference/cql-commands/create-role.adoc[CREATE ROLE] ::
+xref:cassandra:developing/cql/security.adoc#create-role-statement[CREATE ROLE] ::
 Creates a cluster wide database object used for access control.
 
-xref:reference/cql-commands/create-table.adoc[CREATE TABLE] ::
+xref:cassandra:reference/cql-commands/create-table.adoc[CREATE TABLE] ::
 Creates a new table.
 
-xref:reference/cql-commands/create-type.adoc[CREATE TYPE] ::
+xref:cassandra:developing/cql/types.adoc#udts[CREATE TYPE] ::
 Creates a custom data type in the keyspace that contains one or more fields of related information.
 
-xref:reference/cql-commands/create-user.adoc[CREATE USER (Deprecated)] ::
+xref:cassandra:developing/cql/security.adoc#create-user-statement[CREATE USER (Deprecated)] ::
 Deprecated. Creates a new user.
 
-xref:reference/cql-commands/delete.adoc[DELETE] ::
+xref:cassandra:developing/cql/dml.adoc#delete_statement[DELETE] ::
 Removes data from one or more columns or removes the entire row
 
-xref:reference/cql-commands/drop-aggregate.adoc[DROP AGGREGATE] ::
+xref:cassandra:developing/cql/functions.adoc#drop-aggregate-statement[DROP AGGREGATE] ::
 Deletes a user-defined aggregate from a keyspace.
 
-xref:reference/cql-commands/drop-function.adoc[DROP FUNCTION] ::
+xref:cassandra:developing/cql/functions.adoc#drop-function-statement[DROP FUNCTION] ::
 Deletes a user-defined function (UDF) from a keyspace.
 
-xref:reference/cql-commands/drop-index.adoc[DROP INDEX] ::
+xref:cassandra:reference/cql-commands/drop-index.adoc[DROP INDEX] ::
 Removes an index from a table.
 
-xref:reference/cql-commands/drop-keyspace.adoc[DROP KEYSPACE] ::
+xref:cassandra:developing/cql/ddl.adoc#drop-keyspace-statement[DROP KEYSPACE] ::
 Removes the keyspace.
 
-xref:reference/cql-commands/drop-materialized-view.adoc[DROP MATERIALIZED VIEW] ::
+xref:cassandra:developing/cql/mvs.adoc#drop-materialized-view-statement[DROP MATERIALIZED VIEW] ::
 Removes the named materialized view.
 
-xref:reference/cql-commands/drop-role.adoc[DROP ROLE] ::
+xref:cassandra:developing/cql/security.adoc#drop-role-statement[DROP ROLE] ::
 Removes a role.
 
-xref:reference/cql-commands/drop-table.adoc[DROP TABLE] ::
+xref:cassandra:reference/cql-commands/drop-table.adoc[DROP TABLE] ::
 Removes the table.
 
-xref:reference/cql-commands/drop-type.adoc[DROP TYPE] ::
+xref:cassandra:developing/cql/types.adoc#udts[DROP TYPE] ::
 Drop a user-defined type.
 
-xref:reference/cql-commands/drop-user.adoc[DROP USER (Deprecated)] ::
+xref:cassandra:developing/cql/security.adoc#drop-user-statement[DROP USER (Deprecated)] ::
 Removes a user.
 
-xref:reference/cql-commands/grant.adoc[GRANT] ::
+xref:cassandra:developing/cql/security.adoc#grant-permission-statement[GRANT] ::
 Allow access to database resources.
 
-xref:reference/cql-commands/insert.adoc[INSERT] ::
+xref:cassandra:developing/cql/dml.adoc#insert-statement[INSERT] ::
 Inserts an entire row or upserts data into existing rows.
 
-xref:reference/cql-commands/list-permissions.adoc[LIST PERMISSIONS] ::
+xref:cassandra:developing/cql/security.adoc#list-permissions-statement[LIST PERMISSIONS] ::
 Lists permissions on resources.
 
-xref:reference/cql-commands/list-roles.adoc[LIST ROLES] ::
+xref:cassandra:developing/cql/security.adoc#list-roles-statement[LIST ROLES] ::
 Lists roles and shows superuser and login status.
 
-xref:reference/cql-commands/list-superusers.adoc[LIST SUPERUSERS] ::
+xref:cassandra:developing/cql/security.adoc#list-superusers-statement[LIST SUPERUSERS] ::
 Lists roles with the superuser privilege.
 
-xref:reference/cql-commands/list-users.adoc[LIST USERS (Deprecated)] ::
+xref:cassandra:developing/cql/security.adoc#list-users-statement[LIST USERS (Deprecated)] ::
 Lists existing internal authentication users and their superuser status.
 
-xref:reference/cql-commands/restrict.adoc[RESTRICT] ::
-Denies the permission on a resource, even if the role is directly granted or inherits permissions.
-
-xref:reference/cql-commands/restrict-rows.adoc[RESTRICT ROWS] ::
-Configures the column used for row-level access control.
-
-xref:reference/cql-commands/revoke.adoc[REVOKE] ::
+xref:cassandra:developing/cql/security.adoc#revoke-permission-statement[REVOKE] ::
 Removes privileges on database objects from roles.
 
-xref:reference/cql-commands/select.adoc[SELECT] ::
+xref:cassandra:developing/cql/dml.adoc#select-statement[SELECT] ::
 Returns data from a table.
 
-xref:reference/cql-commands/truncate.adoc[TRUNCATE] ::
+xref:cassandra:developing/cql/ddl.adoc#truncate-statement[TRUNCATE] ::
 Removes all data from a table.
 
-xref:reference/cql-commands/unrestrict.adoc[UNRESTRICT] ::
-Removes a restriction from a role. 
-
-xref:reference/cql-commands/unrestrict-rows.adoc[UNRESTRICT ROWS] ::
-Removes the column definition for row-level access control. 
-
-xref:reference/cql-commands/update.adoc[UPDATE] ::
+xref:cassandra:developing/cql/dml.adoc#update-statement[UPDATE] ::
 Modifies one or more column values to a row in a table.
 
-xref:reference/cql-commands/use.adoc[USE] ::
+xref:cassandra:developing/cql/ddl.adoc#use-statement[USE] ::
 Selects the keyspace for the current client session.

--- a/doc/modules/cassandra/pages/reference/cql-commands/create-index.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/create-index.adoc
@@ -250,7 +250,7 @@ Assume a cyclist table contains this map data where `nation` is the map key and 
 ----
 
 To index map keys, use the `KEYS` keyword and map name in nested parentheses in the CREATE INDEX statement.
-To run a `SELECT` query on the table, use xref:cassandra:reference/cql-commands/select.adoc#filtering-on-collections[CONTAINS KEY] in `WHERE` clauses.
+To run a `SELECT` query on the table, use xref:cassandra:developing/cql/dml.adoc#allow-filtering[CONTAINS KEY] in `WHERE` clauses.
 This query returns cyclist teams that have an entry for the year 2015.
 
 [tabs]

--- a/doc/modules/cassandra/pages/reference/cql-commands/create-table-examples.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/create-table-examples.adoc
@@ -46,9 +46,9 @@ Create the `race_winners` table that has a frozen user-defined type (UDT):
 include::cassandra:example$CQL/race_winners-table.cql[tag=usetype]
 ----
 
-See xref:developing/user-defined-type-create.adoc[Create a user-defined type] for information on Create UDTs.
+See xref:cassandra:developing/cql/types.adoc#udts[Create a user-defined type] for information on Create UDTs.
 UDTs can be created unfrozen if only non-collection fields are used in the user-defined type creation.
-If the table is created with an unfrozen UDT, then xref:developing/inserting/insert-user-defined-type.adoc[individual field values can be updated and deleted].
+If the table is created with an unfrozen UDT, then xref:cassandra:developing/cql/dml.adoc#update-statement[individual field values can be updated and deleted].
 
 == Create a table with a CDC log
 
@@ -70,7 +70,7 @@ See https://docs.datastax.com/en/dse/6.8/dse-admin/datastax_enterprise/config/co
 
 == Create a table with a trie memtable
 
-To create a table with a trie memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:architecture/storage-engine/memtable.adoc[Memtable] for more information.
+To create a table with a trie memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:cassandra:architecture/storage-engine.adoc#memtables[Memtable] for more information.
 
 To create a table with a trie memtable:
 
@@ -81,7 +81,7 @@ include::cassandra:example$CQL/cyclist_id-table.cql[tag=trie-memtable]
 
 == Create a table with a skiplist memtable
 
-To create a table with a skiplist memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:architecture/storage-engine/memtable.adoc[Memtable] for more information.
+To create a table with a skiplist memtable, a memtable configuration must be enabled in `cassandra.yaml`. See xref:cassandra:architecture/storage-engine.adoc#memtables[Memtable] for more information.
 
 To create a table with a skiplist memtable:
 

--- a/doc/modules/cassandra/pages/reference/index.adoc
+++ b/doc/modules/cassandra/pages/reference/index.adoc
@@ -1,7 +1,7 @@
 = Reference
 
 * xref:reference/cql-commands/commands-toc.adoc[CQL commands]
-* xref:developing/cql/cql_singlefile.html[CQL specification]
+* xref:cassandra:developing/cql/cql_singlefile.adoc[CQL specification]
 * xref:reference/java17.adoc[Java 17]
 * xref:reference/native-protocol.adoc[Native Protocol specification]
 * xref:reference/sai-virtual-table-indexes.adoc[SAI virtual table]

--- a/doc/modules/cassandra/partials/compact-subproperties.adoc
+++ b/doc/modules/cassandra/partials/compact-subproperties.adoc
@@ -108,7 +108,7 @@ Default: `32`
 The compaction class `SizeTieredCompactionStrategy` (STCS) triggers a minor compaction when table meets the `min_threshold`.
 Minor compactions do not involve all the tables in a keyspace.
 See
-xref:operating/compaction/stcs.adoc#stcs_options[SizeTieredCompactionStrategy (STCS)].
+xref:cassandra:managing/operating/compaction/stcs.adoc#stcs_options[SizeTieredCompactionStrategy (STCS)].
 
 [NOTE]
 ====
@@ -151,7 +151,7 @@ Default: `50` (MB)
 [NOTE]
 ====
 The `cold_reads_to_omit` property for
-xref:operating/compaction/stcs.adoc#stcs_options[SizeTieredCompactionStrategy (STCS)] is no longer supported.
+xref:cassandra:managing/operating/compaction/stcs.adoc#stcs_options[SizeTieredCompactionStrategy (STCS)] is no longer supported.
 ====
 
 [[TWCS]]

--- a/doc/modules/cassandra/partials/primary-key-column.adoc
+++ b/doc/modules/cassandra/partials/primary-key-column.adoc
@@ -17,7 +17,7 @@ Use a unique name for each column in a table.
 To preserve case or use special characters, enclose the name in double-quotes.
 cql_type_definition ::
 Defines the type of data allowed in the column.
-See xref:reference:data-types.adoc[CQL data type] or a xref:reference:user-defined-type.adoc[user-defined type].
+See xref:cassandra:developing/cql/types.adoc#native-types[CQL data type] or a xref:cassandra:developing/cql/types.adoc#udts[user-defined type].
 *STATIC* ::
 Optional, the column has a single value.
 *PRIMARY KEY* ::

--- a/doc/modules/cassandra/partials/table-column-definitions.adoc
+++ b/doc/modules/cassandra/partials/table-column-definitions.adoc
@@ -17,7 +17,7 @@ Use a unique name for each column in a table.
 To preserve case or use special characters, enclose the name in double-quotes.
 cql_type_definition ::
 Defines the type of data allowed in the column.
-See xref:reference:data-types.adoc[CQL data type] or a xref:reference:user-defined-type.adoc[user-defined type].
+See xref:cassandra:developing/cql/types.adoc#native-types[CQL data type] or a xref:cassandra:developing/cql/types.adoc#udts[user-defined type].
 *STATIC* ::
 Optional, the column has a single value.
 *PRIMARY KEY* ::

--- a/doc/modules/cassandra/partials/table-properties.adoc
+++ b/doc/modules/cassandra/partials/table-properties.adoc
@@ -96,8 +96,8 @@ However, if you lower the `gc_grace_seconds` value, consider its interaction wit
 
 * *hint replays*: When a node goes down and then comes back up, other nodes replay the write operations (called xref:managing/operating/hints.adoc[hints]) that are queued for that node while it was unresponsive.
 The database does not replay hints older than gc_grace_seconds after creation.
-The xref:managing/configuration/configuration/cass_yaml_file.adoc#max_hint_window[max_hint_window] setting in the
-xref:managing/configuration/configuration/cass_yaml_file.adoc[cassandra.yaml] file sets the time limit (3 hours by default) for collecting hints for the unresponsive node.
+The xref:cassandra:managing/configuration/cass_yaml_file.adoc#max_hint_window[max_hint_window] setting in the
+xref:cassandra:managing/configuration/cass_yaml_file.adoc[cassandra.yaml] file sets the time limit (3 hours by default) for collecting hints for the unresponsive node.
 
 * *batch replays*: Like hint queues, xref:developing/cql/ddl.adoc#batch_statement[batch operations] store database mutations that are replayed in sequence.
 As with hints, the database does not replay a batched mutation older than gc_grace_seconds after creation.


### PR DESCRIPTION
This is the second PR under [CASSANDRA-21342](https://issues.apache.org/jira/browse/CASSANDRA-21342) "Fix broken Antora xref/include/image targets." The first PR ([apache/cassandra-website#319](https://github.com/apache/cassandra-website/pull/319)) covered the cassandra-website source tree (merged 2026-05-13). This PR covers the docs under `doc/modules/` in `apache/cassandra` and addresses 76+ xref errors against the website's Jenkins-build fixture.

Each commit is a single logical fix class. Per project convention they stay separate during review and squash on +1 (target: 3 final commits, one per JIRA logical group).

## Phase 3 — High-leverage cross-module patterns

These fix patterns that recur across multiple includes or branches, so one edit cascades:

- **B:** `reference:user-defined-type.adoc` / `reference:data-types.adoc` → `cassandra:developing/cql/types.adoc#{udts,native-types}`. Two partials are included by 3 CQL command pages (alter-table, create-table, create-custom-index), so one edit resolves 24 errors.
- **C:** Collections — `keyspace-check.adoc` (never existed) → `developing/cql/ddl.adoc#create-keyspace-statement`; `collection-create.adoc` xrefs missing the `/cql/` segment. 4 pages, 24 errors.
- **A2:** `master@_:ROOT:contactus.adoc` (lost in CASSANDRA-16066 Jekyll→Antora migration) → `community.adoc`. Affects `nav.adoc` and `pages/index.adoc` across 7 build branches.

Plus two reviewer-driven follow-up commits:
- A2 fix: Antora version slot `_@_` → `master@_` (cassandra-website's `antora.yml` declares `version: master`)
- C1 fix: anchor `#create-keyspace` → `#create-keyspace-statement` (explicit id wins over heading auto-id)

## Phase 4 — Trunk-lane long-tail cleanup

Targeted fixes for `apache/cassandra` trunk-only errors:

- Memtable xrefs → `storage-engine.adoc#memtables` (memtable.adoc was consolidated)
- Legacy `developing/*` paths → current `developing/cql/{ddl,types,dml}.adoc#anchor`
- Component-qualify in-page `security.adoc` anchors (two `security.adoc` files exist on trunk; unqualified xrefs are ambiguous)
- Drop duplicated `configuration/configuration/` segment in `cass_yaml_file.adoc` xrefs
- `cql_singlefile.html` → `.adoc` (Antora resolves extension at render time)
- Rewrite `commands-toc.adoc` to point at consolidated CQL anchors
- Three more broken xrefs across the two `security.adoc` pages
- `static.adoc` and `select.adoc#filtering` retargets to existing pages
- Correct paths for `monitoring.adoc` and `stcs.adoc` xrefs
- Remove dead xref to `comments-table.adoc` (kept "comments" as plain text; include directives unaffected)

## Out of scope

- **`master@_:ROOT:bugs.adoc`** in `nav.adoc:4` and `index.adoc:50` — also lost in CASSANDRA-16066. No equivalent page exists in cassandra-website. Three options (create new page, replace with external JIRA link, drop nav entry) need a `[DISCUSS]` thread before commit. Tracked separately.
- **Forward-merges to `cassandra-5.0`** for Phase 3 commits B + C (and A2 across `cassandra-5.0`, `cassandra-4.1`, `cassandra-4.0`) are committer follow-ups per the standard cherry-pick chain. `cassandra-3.11` (EOL) skipped unless reviewer requests.

## Verification

Local Antora full build (`-g`) of the cassandra-website container is impractical (≥10 min, requires Java/ant inside the container and an `accord` submodule clone; repeatedly timed out at 8 min in the ant init phase). Local minimal build (`-g`-less) can't import the cassandra component, so it can't exercise these `cassandra:` xrefs.

**Verification path is Jenkins** (the `cassandra-website` job on ci-cassandra.apache.org), same constraint PR #319 hit for its `Cassandra:` xrefs. Pre-flight structural confidence is high:

- Target file paths confirmed via grep against `upstream/trunk` working tree
- Anchor ids (`#udts`, `#native-types`, `#create-keyspace-statement`, `#memtables`) confirmed present at expected source lines
- Component-qualified prefixes match cassandra-website's `antora.yml` declarations

## AI-assistance disclosure

Per [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html): this PR was developed with material AI assistance. LLM-driven subagents mapped the broken-xref patterns to source files and per-branch presence on the local working tree, drafted the per-commit edits across non-overlapping scopes, and drafted the commit messages and this PR description. All target paths, anchor ids, and prose have been reviewed by Patrick McFadin (committer), who accepts provenance and licensing responsibility per the contributor agreements. No third-party content was incorporated — every change is grounded in the existing `apache/cassandra` source tree.

## Commit-message attribution

All 15 commits currently carry `reviewed by TBD for CASSANDRA-21342`. The TBD placeholder gets amended to the reviewer's name pre-merge (same pattern as PR #319).
