### PR TITLE
CASSANDRA-21369 Consider first token of SSTable when calculating SSTable intersection in LeveledScanner

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -48,7 +48,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
-import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -466,8 +465,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
             {
                 for (SSTableReader sstable : sstables)
                 {
-                    Bounds<Token> sstableRange = new Bounds<>(sstable.getFirst().getToken(), sstable.getLast().getToken());
-                    if (range == null || range.intersects(sstableRange))
+                    if (range == null || range.intersects(sstable.getBounds()))
                         filtered.add(sstable);
                 }
             }

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -465,8 +466,8 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
             {
                 for (SSTableReader sstable : sstables)
                 {
-                    Range<Token> sstableRange = new Range<>(sstable.getFirst().getToken(), sstable.getLast().getToken());
-                    if (range == null || sstableRange.intersects(range) || (sstable.getFirst().getToken().compareTo(range.right) == 0))
+                    Bounds<Token> sstableRange = new Bounds<>(sstable.getFirst().getToken(), sstable.getLast().getToken());
+                    if (range == null || range.intersects(sstableRange))
                         filtered.add(sstable);
                 }
             }

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -466,7 +466,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
                 for (SSTableReader sstable : sstables)
                 {
                     Range<Token> sstableRange = new Range<>(sstable.getFirst().getToken(), sstable.getLast().getToken());
-                    if (range == null || sstableRange.intersects(range))
+                    if (range == null || sstableRange.intersects(range) || (sstable.getFirst().getToken().compareTo(range.right) == 0))
                         filtered.add(sstable);
                 }
             }

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -405,7 +405,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
 
     // Lazily creates SSTableBoundedScanner for sstable that are assumed to be from the
     // same level (e.g. non overlapping) - see #4142
-    private static class LeveledScanner extends AbstractIterator<UnfilteredRowIterator> implements ISSTableScanner
+    protected static class LeveledScanner extends AbstractIterator<UnfilteredRowIterator> implements ISSTableScanner
     {
         private final TableMetadata metadata;
         private final Collection<Range<Token>> ranges;

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -76,6 +76,7 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.TimeUUID;
 
 import static java.util.Collections.singleton;
+import static org.apache.cassandra.schema.MockSchema.readerBounds;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -1059,6 +1060,14 @@ public class LeveledCompactionStrategyTest
             assertFalse(task.reduceScopeForLimitedSpace(Sets.newHashSet(sstables), 0));
             assertEquals(Sets.newHashSet(sstables), txn.originals());
         }
+    }
+
+    @Test
+    public void testLevelScannerIntersection()
+    {
+        Collection<SSTableReader> sstable = Collections.singleton(MockSchema.sstableWithLevel(1, 10, 20, 1, cfs));
+        Range<Token> range = new Range<>(readerBounds(1).getToken(), readerBounds(10).getToken());
+        assertEquals(1, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
     }
 
     private Pair<Set<SSTableReader>, Set<SSTableReader>> groupByLevel(Iterable<SSTableReader> sstables)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -1066,8 +1066,26 @@ public class LeveledCompactionStrategyTest
     public void testLevelScannerIntersection()
     {
         Collection<SSTableReader> sstable = Collections.singleton(MockSchema.sstableWithLevel(1, 10, 20, 1, cfs));
-        Range<Token> range = new Range<>(readerBounds(1).getToken(), readerBounds(10).getToken());
+
+        // SSTable range - [10, 20]
+        // range - (1, 9]
+        Range<Token> range = new Range<>(readerBounds(1).getToken(), readerBounds(9).getToken());
+        assertEquals(0, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (1, 10]
+        range = new Range<>(readerBounds(1).getToken(), readerBounds(10).getToken());
         assertEquals(1, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (1, 15]
+        range = new Range<>(readerBounds(1).getToken(), readerBounds(15).getToken());
+        assertEquals(1, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (20, 25]
+        range = new Range<>(readerBounds(20).getToken(), readerBounds(25).getToken());
+        assertEquals(0, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
     }
 
     private Pair<Set<SSTableReader>, Set<SSTableReader>> groupByLevel(Iterable<SSTableReader> sstables)


### PR DESCRIPTION
Ranges in Cassandra are exclusive for the first token, but in this case we want it to be inclusive since a SSTable contains the first token. 

patch by Alan Wang;

reviewed by for [CASSANDRA-21369](https://issues.apache.org/jira/browse/CASSANDRA-21369)

Co-authored-by: Name1
Co-authored-by: Name2