### PR TITLE
CASSANDRA-21342: Long-tail xref follow-up (trunk)

### DIFF
--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -117,7 +117,7 @@
 **** xref:cassandra:managing/tools/cqlsh.adoc[cqlsh: the CQL shell]
 **** xref:cassandra:managing/tools/nodetool/nodetool.adoc[nodetool]
 **** xref:cassandra:managing/tools/sstable/index.adoc[SSTable tools]
-**** xref:cassandra:managing/tools/cassandra_stress.adoc[cassandra-stress]
+**** xref:cassandra:tooling/cassandra-stress.adoc[cassandra-stress]
 
 
 ** xref:cassandra:troubleshooting/index.adoc[Troubleshooting]

--- a/doc/modules/cassandra/pages/architecture/index.adoc
+++ b/doc/modules/cassandra/pages/architecture/index.adoc
@@ -6,5 +6,5 @@ This section describes the general architecture of Apache Cassandra.
 * xref:architecture/dynamo.adoc[Dynamo]
 * xref:architecture/storage-engine.adoc[Storage Engine]
 * xref:architecture/guarantees.adoc[Guarantees]
-* xref:architecture/snitch.adoc[Snitches]
+* xref:cassandra:managing/operating/snitch.adoc[Snitches]
 * xref:architecture/accord.adoc[Accord]

--- a/doc/modules/cassandra/pages/architecture/storage-engine.adoc
+++ b/doc/modules/cassandra/pages/architecture/storage-engine.adoc
@@ -30,7 +30,7 @@ Once the defined size is reached, a new commit log segment is created.
 Commit log segments can be archived, deleted, or recycled once all the data is flushed to
 https://cassandra.apache.org/_/glossary.html#sstable[SSTables].
 Commit log segments are truncated when Cassandra has written data older than a certain point to the SSTables.
-Running xref:managing:tools/nodetool/drain.adoc[`nodetool drain`] before stopping Cassandra will write everything in the memtables
+Running xref:cassandra:managing/tools/nodetool/drain.adoc[`nodetool drain`] before stopping Cassandra will write everything in the memtables
 to SSTables and remove the need to sync with the commit logs on startup.
 
 * xref:cassandra:managing/configuration/cass_yaml_file.adoc#commitlog_segment_size [`commitlog_segment_size`]: The default size is 32MiB, which is almost always fine, but if you are archiving commitlog segments (see commitlog_archiving.properties), then you probably want a finer granularity of archiving; 8 or 16 MiB is reasonable.
@@ -105,7 +105,7 @@ A partition index is also created on the disk that maps the tokens to a location
 
 The queue can be configured with either the xref:cassandra:managing/configuration/cass_yaml_file.adoc#memtable_heap_space[`memtable_heap_space`] or xref:cassandra:managing/configuration/cass_yaml_file.adoc#memtable_offheap_space[`memtable_offheap_space`] setting in the `cassandra.yaml` file.
 If the data to be flushed exceeds the `memtable_cleanup_threshold`, Cassandra blocks writes until the next flush succeeds.
-You can manually flush a table using xref:managing:tools/nodetool/flush.adoc[`nodetool flush`] or `nodetool drain` (flushes memtables without listening for connections to other nodes). 
+You can manually flush a table using xref:cassandra:managing/tools/nodetool/flush.adoc[`nodetool flush`] or `nodetool drain` (flushes memtables without listening for connections to other nodes).
 To reduce the commit log replay time, the recommended best practice is to flush the memtable before you restart the nodes. 
 If a node stops working, replaying the commit log restores writes to the memtable that were there before it stopped.
 

--- a/doc/modules/cassandra/pages/developing/cql/create-custom-index.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/create-custom-index.adoc
@@ -119,7 +119,7 @@ Also refer xref:cassandra:developing/cql/indexing/sai/sai-query.adoc[Examine SAI
 === SAI collection map examples with keys, values, and entries
 
 The following examples demonstrate using collection maps of multiple types (`keys`, `values`, `entries`) in SAI indexes.
-For related information, see xref:cassandra:developing/cql/collections/collection-create.adoc[Creating collections] and xref:cassandra:developing/collections/map.adoc[Using map type].
+For related information, see xref:cassandra:developing/cql/collections/collection-create.adoc[Creating collections] and xref:cassandra:developing/cql/collections/map.adoc[Using map type].
 
 Also refer to the SAI collection examples of type xref:#saiCreateCustomIndexCollectionsListAndSetExamples[list and set] in this topic.
 
@@ -294,8 +294,8 @@ These examples demonstrate using collections with the `list` and `set` types in 
 For related information, see:
 
 * xref:cassandra:developing/cql/collections/collection-create.adoc[Creating collections]
-* xref:cassandra:developing/collections/list.adoc[Using list type]
-* xref:cassandra:developing/collections/set.adoc[Using set type]
+* xref:cassandra:developing/cql/collections/list.adoc[Using list type]
+* xref:cassandra:developing/cql/collections/set.adoc[Using set type]
 
 [source,language-cql]
 ----

--- a/doc/modules/cassandra/pages/developing/cql/create-index.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/create-index.adoc
@@ -8,7 +8,7 @@ After an index has been created, it is automatically updated when data in the co
 Indexing via this `CREATE INDEX` command can impact performance.
 Before creating an index, be aware of when and xref:cassandra:developing/cql/indexing/2i/2i-when-to-use.adoc#when-no-index[when not to create an index].
 
-Use xref:cassandra:developing/cql/indexing/create-custom-index.adoc[CREATE CUSTOM INDEX] for Storage-Attached Indexes (SAI).
+Use xref:cassandra:developing/cql/create-custom-index.adoc[CREATE CUSTOM INDEX] for Storage-Attached Indexes (SAI).
 
 *Restriction:* Indexing counter columns is not supported.
 For maps, index the key, value, or entries.

--- a/doc/modules/cassandra/pages/developing/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/ddl.adoc
@@ -166,7 +166,7 @@ will result in:
 include::cassandra:example$RESULTS/autoexpand_exclude_dc.result[]
 ----
 
-If xref:new/transientreplication.adoc[transient replication] has been enabled, transient replicas can be
+If xref:cassandra:managing/operating/transientreplication.adoc[transient replication] has been enabled, transient replicas can be
 configured for both `SimpleStrategy` and `NetworkTopologyStrategy` by
 defining replication factors in the format
 `'<total_replicas>/<transient_replicas>'`

--- a/doc/modules/cassandra/pages/developing/cql/definitions.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/definitions.adoc
@@ -118,7 +118,7 @@ include::cassandra:example$BNF/term.bnf[]
 
 A term is thus one of:
 
-* A xref:cassandra:developing/cql/defintions.adoc#constants[constant]
+* A xref:cassandra:developing/cql/definitions.adoc#constants[constant]
 * A literal for either a xref:cassandra:developing/cql/types.adoc#collections[collection], a xref:cassandra:developing/cql/types.adoc#vectors[vector],
 a xref:cassandra:developing/cql/types.adoc#udts[user-defined type] or a xref:cassandra:developing/cql/types.adoc#tuples[tuple]
 * A xref:cassandra:developing/cql/functions.adoc#cql-functions[function] call, either a xref:cassandra:developing/cql/functions.adoc#scalar-native-functions[native function]

--- a/doc/modules/cassandra/pages/developing/cql/indexing/2i/operations/2i-build.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/2i/operations/2i-build.adoc
@@ -7,4 +7,4 @@ Indexes are built in the background automatically, without blocking reads or wri
 Client-maintained _tables as indexes_ must be created manually;
 for example, if the artists column had been indexed by creating a table such as `songs_by_artist`, your client application would have to populate the table with data from the songs table.
 
-To perform a hot rebuild of an index, use the xref:cassandra:tools/nodetool/rebuild_index.adoc[nodetool rebuild_index] command.
+To perform a hot rebuild of an index, use the xref:cassandra:managing/tools/nodetool/rebuild_index.adoc[nodetool rebuild_index] command.

--- a/doc/modules/cassandra/pages/developing/cql/indexing/sai/_sai-create.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/sai/_sai-create.adoc
@@ -76,4 +76,4 @@ include::cassandra:example$CQL/sai/index-sai-similarity-function.cql[]
 '''
 Other resources
 
-See xref:developing/cql/indexing/create-custom-index.adoc[CREATE CUSTOM INDEX] for more information about creating SAI indexes.
+See xref:cassandra:developing/cql/create-custom-index.adoc[CREATE CUSTOM INDEX] for more information about creating SAI indexes.

--- a/doc/modules/cassandra/pages/developing/cql/indexing/sai/operations/configuring.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/indexing/sai/operations/configuring.adoc
@@ -3,8 +3,9 @@
 
 // LLP: *NOT DONE*
 
-Configuring your {product} environment for Storage-Attached Indexing (SAI) may require some customization of the `cassandra.yaml` file. 
+Configuring your {product} environment for Storage-Attached Indexing (SAI) may require some customization of the `cassandra.yaml` file.
 
+[[saiConfigure__saiCompactionStrategies]]
 == Compaction strategies
 
 Read queries perform better with compaction strategies that produce fewer SSTables.
@@ -20,13 +21,13 @@ While in a time window, TWCS compacts all SSTables flushed from memory into larg
 At the end of the time window, all of these SSTables are compacted into a single SSTable.
 Then the next time window starts and the process repeats.
 The duration of the time window is the only setting required.
-See xref:reference:cql-commands/create-table.adoc#compactSubprop__TWCS[TimeWindowCompactionStrategy].
+See xref:cassandra:reference/cql-commands/compact-subproperties.adoc#TWCS[TimeWindowCompactionStrategy].
 For more information about TWCS, see xref:cassandra:managing/operating/compaction/twcs.adoc[Time Window Compaction Strategy].
 
 In general, do not use `LeveledCompactionStrategy` (LCS) unless your index queries restrict the token range, either directly or by providing a restriction on the partition key.
 However, if you decide to use LCS, use the following guidelines:
 
-* The `160` MB default for the `CREATE TABLE` command's `sstable_size_in_mb` option, described in this xref:reference:cql-commands/create-table.adoc#compactSubprop__LCS[topic], may result in suboptimal performance for index queries that do not restrict on token range or partition key.
+* The `160` MB default for the `CREATE TABLE` command's `sstable_size_in_mb` option, described in this xref:cassandra:reference/cql-commands/compact-subproperties.adoc#LCS[topic], may result in suboptimal performance for index queries that do not restrict on token range or partition key.
 * While even higher values may be appropriate, depending on your hardware, we recommend at least doubling the default value of `sstable_size_in_mb`. 
 
 Example:

--- a/doc/modules/cassandra/pages/getting-started/production.adoc
+++ b/doc/modules/cassandra/pages/getting-started/production.adoc
@@ -118,7 +118,7 @@ https://thelastpickle.com/blog/2018/08/08/compression_performance.html[The Last 
 
 == Compaction
 
-There are different xref:compaction/index.adoc[compaction] strategies available
+There are different xref:cassandra:managing/operating/compaction/index.adoc[compaction] strategies available
 for different workloads.
 We recommend reading about the different strategies to understand which is the
 best for your environment.

--- a/doc/modules/cassandra/pages/getting-started/querying.adoc
+++ b/doc/modules/cassandra/pages/getting-started/querying.adoc
@@ -22,7 +22,7 @@ include::cassandra:example$BASH/cqlsh_localhost.sh[]
 ----
 include::cassandra:example$RESULTS/cqlsh_localhost.result[]
 ----
-If the command is used without specifying a node, `localhost` is the default. See the xref:tools/cqlsh.adoc[`cqlsh` section] for full documentation.
+If the command is used without specifying a node, `localhost` is the default. See the xref:cassandra:managing/tools/cqlsh.adoc[`cqlsh` section] for full documentation.
 
 == Client drivers
 

--- a/doc/modules/cassandra/pages/installing/installing.adoc
+++ b/doc/modules/cassandra/pages/installing/installing.adoc
@@ -279,4 +279,4 @@ include::cassandra:partial$nodetool_and_cqlsh_nobin.adoc[]
 
 == Further installation info
 
-For help with installation issues, see the xref:cassandra:troubleshooting/index.html[Troubleshooting] section.
+For help with installation issues, see the xref:cassandra:troubleshooting/index.adoc[Troubleshooting] section.

--- a/doc/modules/cassandra/pages/managing/operating/bulk_loading.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/bulk_loading.adoc
@@ -25,7 +25,7 @@ The `sstableloader` and `nodetool import` are accessible if the
 Cassandra installation `bin` directory is in the `PATH` environment
 variable.
 Or these may be accessed directly from the `bin` directory.
-The examples use the keyspaces and tables created in xref:cassandra:developing/cql/operating/backups.adoc[Backups].
+The examples use the keyspaces and tables created in xref:cassandra:managing/operating/backups.adoc[Backups].
 
 == Using sstableloader
 

--- a/doc/modules/cassandra/pages/managing/operating/security.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/security.adoc
@@ -465,7 +465,7 @@ If enabling remote connections, it is recommended to also use
 xref:cassandra:managing/operating/security.adoc#jmx-with-ssl[`SSL`] connections.
 
 Finally, after enabling auth and/or SSL, ensure that tools which use
-JMX, such as xref:tools/nodetool/nodetools.adoc[`nodetool`] are correctly configured and working
+JMX, such as xref:cassandra:managing/tools/nodetool/nodetool.adoc[`nodetool`] are correctly configured and working
 as expected.
 
 === Standard JMX Auth

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -22,7 +22,7 @@ of `cqlsh`.
 
 By default, `cqlsh` displays all timestamps with a UTC timezone.
 For Python 3.9 or higher, timestamps can be displayed in different timezones by modifying the
-`timezone` option in xref:cassandra:developing/cql/tools/cqlsh.adoc#cqlshrc[cqlshrc] or by setting the environment
+`timezone` option in xref:cassandra:managing/tools/cqlsh.adoc#cqlshrc[cqlshrc] or by setting the environment
 variable `TZ`.
 Python 3.8 or lower, however, will also require the installation of http://pytz.sourceforge.net/[pytz] library.
 

--- a/doc/modules/cassandra/pages/new/index.adoc
+++ b/doc/modules/cassandra/pages/new/index.adoc
@@ -19,7 +19,7 @@ This section covers the new features in Apache Cassandra 5.0.
 * Trie SSTables: https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-25%3A+Trie-indexed+SSTable+format[CEP-25], https://issues.apache.org/jira/browse/CASSANDRA-18398[JIRA ticket]
 * JDK 17: xref:cassandra:reference/java17.adoc[Docs], https://issues.apache.org/jira/browse/CASSANDRA-16895[JIRA ticket]
 * More guardrails: https://github.com/apache/cassandra/blob/trunk/NEWS.txt[NEWS.txt]
-* TTL and writetime on collections and UDTs: xref:cassandra:developing/cql/dml.html#writetime-and-ttl-function[Docs], https://issues.apache.org/jira/browse/CASSANDRA-8877[JIRA ticket]
+* TTL and writetime on collections and UDTs: xref:cassandra:developing/cql/functions.adoc#writetime-and-ttl-functions[Docs], https://issues.apache.org/jira/browse/CASSANDRA-8877[JIRA ticket]
 * New vector data type: xref:cassandra:reference/vector-data-type.adoc[Docs], https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-30%3A+Approximate+Nearest+Neighbor%28ANN%29+Vector+Search+via+Storage-Attached+Indexes[CEP-30], https://issues.apache.org/jira/browse/CASSANDRA-18504[JIRA ticket]
 * New vector similarity functions: xref:cassandra:vector-search/overview.adoc[Docs], https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-30%3A+Approximate+Nearest+Neighbor%28ANN%29+Vector+Search+via+Storage-Attached+Indexes[CEP-30], https://issues.apache.org/jira/browse/CASSANDRA-18640[JIRA ticket]
 * Unified Compaction Strategy: xref:cassandra:managing/operating/compaction/ucs.adoc[Docs], https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-26%3A+Unified+Compaction+Strategy[CEP-26], https://issues.apache.org/jira/browse/CASSANDRA-18397[JIRA ticket]

--- a/doc/modules/cassandra/pages/reference/cql-commands/alter-table.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/alter-table.adoc
@@ -98,7 +98,7 @@ Enclose the value for a string property in single quotation marks.
 +
 Other table properties are set using a JSON map: `+option_name = { <subproperty_name> : <value> [ , ... ] }+`
 +
-See xref:reference:cql-commands/create-table.adoc#table_options[table_options] for more details.
+See xref:cassandra:reference/cql-commands/create-table.adoc#table_options[table_options] for more details.
 
 == Usage notes
 
@@ -190,7 +190,7 @@ To change an existing table's properties, use `ALTER TABLE` and `WITH`.
 You can specify a:
 
 * Single property name and value.
-* Property map to set the names and values, as shown in the xref:cql-commands/alter-table.adoc#alter-compression[next section on compression and compaction].
+* Property map to set the names and values, as shown in the xref:cassandra:reference/cql-commands/alter-table.adoc#alter-compression[next section on compression and compaction].
 
 For example, to add a comment to the xref:cassandra:cyclist_base-table.adoc[cyclist_base] table using WITH:
 

--- a/doc/modules/cassandra/pages/reference/cql-commands/compact-subproperties.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/compact-subproperties.adoc
@@ -235,7 +235,7 @@ Default: `160`
 ==== 
 The default value, 160 MB, may be inefficient and negatively impact database indexing and the queries that rely on indexes.
 For example, consider the benefit of using higher values for sstable_size_in_mb in tables that use (SAI) indexes.
-For related information, see xref:developing:indexing/sai/configuring.adoc#saiConfigure__saiCompactionStrategies[Compaction strategies].
+For related information, see xref:cassandra:developing/cql/indexing/sai/operations/configuring.adoc#saiConfigure__saiCompactionStrategies[Compaction strategies].
 ====
 
 fanout_size::

--- a/doc/modules/cassandra/pages/reference/cql-commands/create-table.adoc
+++ b/doc/modules/cassandra/pages/reference/cql-commands/create-table.adoc
@@ -67,6 +67,7 @@ include::cassandra:partial$compress-subproperties.adoc[]
 
 include::cassandra:partial$compact-subproperties.adoc[]
 
+[[table_options]]
 == Optional parameters
 
 // Table Keywords
@@ -88,7 +89,7 @@ If the column already contains data, it is indexed during the execution of this 
 After an index has been created, it is automatically updated when data in the column changes.
 
 Indexing with the `CREATE INDEX` command can impact performance.
-Before creating an index, be aware of when and xref:cassandra:developing/indexing/2i/2i-when-to-use.adoc#when-no-index[when not to create an index].
+Before creating an index, be aware of when and xref:cassandra:developing/cql/indexing/2i/2i-when-to-use.adoc#when-no-index[when not to create an index].
 
 *Restriction:* Indexing counter columns is not supported.
 

--- a/doc/modules/cassandra/pages/reference/static.adoc
+++ b/doc/modules/cassandra/pages/reference/static.adoc
@@ -48,7 +48,7 @@ The table that does not have clustering columns has a one-row partition in which
 * A column designated to be the partition key cannot be static.
 ====
 
-You can do xref:developing/batch/batch-good-example.adoc[batch conditional updates to a static column].
+You can do xref:cassandra:developing/cql/batch/batch-good-example.adoc[batch conditional updates to a static column].
 
 Use the `DISTINCT` keyword to select static columns.
 In this case, the database retrieves only the beginning (static column) of the partition.

--- a/doc/modules/cassandra/pages/troubleshooting/finding_nodes.adoc
+++ b/doc/modules/cassandra/pages/troubleshooting/finding_nodes.adoc
@@ -128,6 +128,6 @@ exhaust significant CPU capacitity with a "single" query.
 
 Once you have narrowed down the problem as much as possible (datacenter,
 rack , node), login to one of the nodes using SSH and proceed to debug
-using xref:reading_logs.adoc[`logs`], xref:use_nodetooladoc[`nodetool`], and
-xref:use_tools.adoc[`os tools`].
+using xref:cassandra:troubleshooting/reading_logs.adoc[`logs`], xref:cassandra:troubleshooting/use_nodetool.adoc[`nodetool`], and
+xref:cassandra:troubleshooting/use_tools.adoc[`os tools`].
 If you are not able to login you may still have access to `logs` and `nodetool` remotely.

--- a/doc/modules/cassandra/pages/troubleshooting/reading_logs.adoc
+++ b/doc/modules/cassandra/pages/troubleshooting/reading_logs.adoc
@@ -244,4 +244,4 @@ index b2c5b10..71b0a49 100644
 
 Note that if you want more information than this tool provides, there
 are other live capture options available such as
-xref:cassandra:developing/cql/troubleshooting/use_tools.adoc#packet-capture[`packet-capture`].
+xref:cassandra:troubleshooting/use_tools.adoc#packet-capture[`packet-capture`].

--- a/doc/modules/cassandra/pages/troubleshooting/use_tools.adoc
+++ b/doc/modules/cassandra/pages/troubleshooting/use_tools.adoc
@@ -208,7 +208,7 @@ when it syncs the commit log. This typically enters into the very high
 percentiles of write latency.
 
 Note that to get detailed latency breakdowns you will need a more
-advanced tool such as xref:use_tools.adoc#bcc-tools[`bcc-tools`].
+advanced tool such as xref:cassandra:troubleshooting/use_tools.adoc#use-bcc-tools[`bcc-tools`].
 
 === OS page Cache Usage
 
@@ -232,8 +232,8 @@ Cassandra performance can suffer significantly. This is why Cassandra
 starts with a reasonably small amount of memory reserved for the heap.
 
 If you suspect that you are missing the OS page cache frequently you can
-use advanced tools like xref:use_tools.adoc#use-bcc-tools[cachestat] or
-xref:use_tools.adoc#use-vmtouch[vmtouch] to dive deeper.
+use advanced tools like xref:cassandra:troubleshooting/use_tools.adoc#use-bcc-tools[cachestat] or
+xref:cassandra:troubleshooting/use_tools.adoc#use-vmtouch[vmtouch] to dive deeper.
 
 === Network Latency and Reliability
 
@@ -483,7 +483,7 @@ $ ./vmtouch /var/lib/cassandra/data/
 
 In this case almost the entire dataset is hot in OS page Cache.
 Generally speaking the percentage doesn't really matter unless reads are
-missing the cache (per e.g. xref:cassandra:developing/cql/troubleshooting/use_tools.adoc#use-bcc-tools[cachestat] in which case
+missing the cache (per e.g. xref:cassandra:troubleshooting/use_tools.adoc#use-bcc-tools[cachestat] in which case
 having additional memory may help read performance.
 
 === CPU Flamegraphs
@@ -544,6 +544,7 @@ $ cat cassandra_stacks | ./stackcollapse-perf.pl | grep -v cpu_idle | \
 The resulting SVG is searchable, zoomable, and generally easy to
 introspect using a browser.
 
+[[packet-capture]]
 === Packet Capture
 
 Sometimes you have to understand what queries a Cassandra node is

--- a/doc/modules/cassandra/pages/vector-search/concepts.adoc
+++ b/doc/modules/cassandra/pages/vector-search/concepts.adoc
@@ -4,7 +4,7 @@
 
 Vector Search is a new feature added to {cass-50}.
 It is a powerful technique for finding relevant content within large datasets and is particularly useful for AI applications. 
-Vector Search also makes use of xref:cassandra:developing/cql/indexing/sai/overview.adoc[Storage-Attached Indexes(SAI)], leveraging the new modularity of the latter feature.
+Vector Search also makes use of xref:cassandra:developing/cql/indexing/sai/sai-overview.adoc[Storage-Attached Indexes(SAI)], leveraging the new modularity of the latter feature.
 Vector Search is the first instance of validating the extensibility of SAI.
 
 Data stored in a database is useful, but the context of that data is critical to applications.

--- a/doc/modules/cassandra/partials/compact-subproperties.adoc
+++ b/doc/modules/cassandra/partials/compact-subproperties.adoc
@@ -162,7 +162,7 @@ TWCS creates a new time window within each successive time period.
 During the active time window, TWCS compacts all SSTables flushed from memory into larger SSTables using STCS.
 At the end of the time period, all of these SSTables are compacted into a single SSTable.
 Then the next time window starts and the process repeats.
-See xref:operating/compaction/twcs.adoc#twcs_options[TimeWindowCompactionStrategy (TWCS)].
+See xref:cassandra:managing/operating/compaction/twcs.adoc#twcs_options[TimeWindowCompactionStrategy (TWCS)].
 
 [NOTE]
 ====
@@ -228,7 +228,7 @@ Default: `160`
 ====
 The default value, 160 MB, may be inefficient and negatively impact database indexing and the queries that rely on indexes.
 For example, consider the benefit of using higher values for sstable_size_in_mb in tables that use (SAI) indexes.
-For related information, see xref:developing/cql/indexing/sai/configuring.adoc#saiConfigure__saiCompactionStrategies[Compaction strategies].
+For related information, see xref:cassandra:developing/cql/indexing/sai/operations/configuring.adoc#saiConfigure__saiCompactionStrategies[Compaction strategies].
 ====
 
 ==== DateTieredCompactionStrategy (deprecated)


### PR DESCRIPTION
## Summary

Follow-up to the umbrella patch for CASSANDRA-21342 (merged 2026-05-14). Closes the long-tail of broken xref errors that remained on `trunk` after the first wave landed.

Mechanical retargets only — no prose was rewritten and no pages were added or removed. Anchors that did not exist are added with the project's existing `[[anchor]]` convention.

## Edit classes

| Class | Files | Sites |
|---|---:|---:|
| Module-prefix xrefs (bare/partial paths -> `cassandra:`-qualified) | 9 | 11 |
| Moved-page xrefs (page renamed/relocated; retarget to current home) | 9 | 11 |
| Filename typo (`defintions.adoc` -> `definitions.adoc`) | 1 | 1 |
| `.html` -> `.adoc`; writetime retargeted to `functions.adoc` | 2 | 2 |
| `nodetool` xrefs qualified to `cassandra:managing/tools/nodetool/` (generated targets) | 3 | 4 |
| Anchors: add 3 missing `[[anchor]]` targets and retarget the xrefs that point at them | 7 | 7 + 3 anchor adds |

26 files changed total, +40 / -37.

## Verification

For every still-existing anchor target, the destination page and explicit `[[anchor]]` (or auto-generated section id) were grep-verified on `upstream/trunk` before the edit. Triage was driven by the 2026-04-21 Antora 3 baseline (Jenkins #2752); patterns where no source file on `trunk` still references the old target were treated as already-closed and not touched.

### Build evidence

cassandra-website built locally with Antora 3 against this branch as the cassandra source:

- Baseline (Jenkins #2752, 2026-04-21): **161** trunk-level error log lines
- After this patch: **3** error log lines

The 3 remaining errors are all in **cassandra-website** source (two blog posts referencing `Cassandra:cassandra:architecture/overview.adoc`, and `main-nav.adoc` referencing `Cassandra::index.adoc`) — out of scope for this patch on the cassandra repo.

## Not included

About ten additional broken xrefs require content decisions and are deferred to a separate workstream alongside the `master@_:ROOT:bugs.adoc` / `contactus.adoc` decision (Accord index stub, compression-options retarget, `_2i-*` partial-prefix resolution, the `cyclist_*-table.adoc` example references, drop-materialized-view stub, the `_/download.adoc` cross-component xref). They are mechanically distinct: they need either a new page, an external link, or a prose rewrite — not a retarget.

## Generated-page caveat

The four `nodetool` xrefs included point at generated pages that `gen-asciidoc` emits at Antora build time, so they cannot be grep-verified from a static checkout. The form matches existing `nav.adoc` xrefs (e.g. `cassandra:managing/tools/nodetool/nodetool.adoc`) that have shipped without complaint. If any do not resolve at the next build, will fix in a follow-up.

## Forward-merge

`cassandra-5.0`, `cassandra-4.1`, and `cassandra-4.0` will receive applicable subsets after merge here, following the same convention as the previous CASSANDRA-21342 PR's forward-merges (committer push, no per-branch PR). Pattern-presence will be re-checked per branch.

## AI disclosure

Drafting and triage were performed with AI assistance (Anthropic Claude). The change set is reviewable as straightforward xref retargets and anchor additions. Source provenance per ASF generative tooling guidance.