### PR TITLE
CASSANDRA-21134: Direct I/O for background SSTable writes

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -693,6 +693,25 @@ commitlog_disk_access_mode: legacy
 # - direct: use direct I/O for compaction reads, bypassing the OS page cache
 # compaction_read_disk_access_mode: auto
 
+# Set the disk access mode for writing compressed SSTables during background operations
+# (compaction, streaming, cleanup, repair, etc.). The allowed values are:
+# - standard: use buffered I/O (default)
+# - direct: use direct I/O, bypassing the OS page cache
+# Only applies to compressed tables. Uncompressed tables always use buffered I/O.
+# Memtable flushes always use buffered I/O regardless of this setting, as flushed
+# data typically benefits from page cache for subsequent reads (workloads that
+# rarely read recently-flushed data, e.g. write-heavy time series, may see less
+# benefit from caching flush output).
+# background_write_disk_access_mode: standard
+
+# Size of the in-memory staging buffer for Direct IO background writes. Trades off syscall
+# frequency against per-flush blocking latency on the compaction thread.
+# Aligned up to filesystem block size; auto-expands to fit a single compressed chunk + CRC
+# + one block when chunk_length exceeds this value.
+# Allocated per concurrent background writer (e.g. one per active compaction thread,
+# streaming session, etc.), so total off-heap usage scales with concurrency.
+# direct_write_buffer_size: 1MiB
+
 # Compression to apply to SSTables as they flush for compressed tables.
 # Note that tables without compression enabled do not respect this flag.
 #

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -700,6 +700,21 @@ commitlog_disk_access_mode: auto
 # - direct: use direct I/O for compaction reads, bypassing the OS page cache
 # compaction_read_disk_access_mode: auto
 
+# Set the disk access mode for writing compressed SSTables during background operations
+# (compaction, streaming, cleanup, repair, etc.). The allowed values are:
+# - standard: use buffered I/O (default)
+# - direct: use direct I/O, bypassing the OS page cache
+# Only applies to compressed tables. Uncompressed tables always use buffered I/O.
+# Memtable flushes always use buffered I/O regardless of this setting, as flushed
+# data benefits from page cache for subsequent reads.
+background_write_disk_access_mode: direct
+
+# Size of the in-memory staging buffer for Direct IO background writes. Trades off syscall
+# frequency against per-flush blocking latency on the compaction thread.
+# Aligned up to filesystem block size; auto-expands to fit a single compressed chunk + CRC
+# + one block when chunk_length exceeds this value.
+# direct_write_buffer_size: 1MiB
+
 # Compression to apply to SSTables as they flush for compressed tables.
 # Note that tables without compression enabled do not respect this flag.
 #

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -362,6 +362,18 @@ public class Config
 
     public DataStorageSpec.IntKibibytesBound compressed_read_ahead_buffer_size = new DataStorageSpec.IntKibibytesBound("256KiB");
 
+    // Direct IO for background SSTable writes (compaction, streaming, cleanup, etc.)
+    // When 'direct' is set, background writes bypass the OS page cache using O_DIRECT.
+    // Memtable flushes always use buffered I/O regardless of this setting.
+    // Default is 'standard' (buffered I/O) - users must opt-in to Direct IO
+    public DiskAccessMode background_write_disk_access_mode = DiskAccessMode.standard;
+
+    // Size of the in-memory staging buffer for Direct IO background writes. Trades off syscall
+    // frequency against per-flush blocking latency on the compaction thread.
+    // Aligned up to filesystem block size; auto-expands to fit a single compressed chunk + CRC
+    // + one block when chunk_length exceeds this value.
+    public DataStorageSpec.IntKibibytesBound direct_write_buffer_size = new DataStorageSpec.IntKibibytesBound("1MiB");
+
     // fraction of free disk space available for compaction after min free space is subtracted
     public volatile Double max_space_usable_for_compactions_in_percentage = .95;
 
@@ -1275,8 +1287,7 @@ public class Config
         legacy,
 
         /**
-         * Direct-I/O is enabled for commitlog disk only.
-         * When adding support for direct IO, update {@link org.apache.cassandra.service.StartupChecks#checkKernelBug1057843}
+         * When adding support for Direct I/O, update {@link org.apache.cassandra.service.StartupChecks#checkKernelBug1057843}
          */
         direct
     }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -224,6 +224,8 @@ public class DatabaseDescriptor
 
     private static DiskAccessMode compactionReadDiskAccessMode;
 
+    private static DiskAccessMode backgroundWriteDiskAccessMode;
+
     private static AbstractCryptoProvider cryptoProvider;
     private static IAuthenticator authenticator;
     private static IAuthorizer authorizer;
@@ -896,6 +898,8 @@ public class DatabaseDescriptor
 
         if (conf.hints_directory.equals(conf.saved_caches_directory))
             throw new ConfigurationException("saved_caches_directory must not be the same as the hints_directory", false);
+
+        initializeBackgroundWriteDiskAccessMode();
 
         if (conf.memtable_flush_writers == 0)
         {
@@ -3404,6 +3408,71 @@ public class DatabaseDescriptor
         Pair<DiskAccessMode, Boolean> accessModeDirectIoPair = resolveCommitLogWriteDiskAccessMode(conf.commitlog_disk_access_mode);
         validateCommitLogWriteDiskAccessMode(accessModeDirectIoPair);
         commitLogWriteDiskAccessMode = accessModeDirectIoPair.left;
+    }
+
+    public static DiskAccessMode getBackgroundWriteDiskAccessMode()
+    {
+        return backgroundWriteDiskAccessMode;
+    }
+
+    @VisibleForTesting
+    public static void setBackgroundWriteDiskAccessMode(DiskAccessMode diskAccessMode)
+    {
+        backgroundWriteDiskAccessMode = diskAccessMode;
+        conf.background_write_disk_access_mode = diskAccessMode;
+    }
+
+    public static DataStorageSpec.IntKibibytesBound getDirectWriteBufferSize()
+    {
+        return conf.direct_write_buffer_size;
+    }
+
+    /**
+     * The directories opened with O_DIRECT for writing. Startup checks that must reason about O_DIRECT
+     * write targets (e.g. the kernel-bug 1057843 check) derive their path set from here.
+     */
+    public static Set<Path> getDirectIOWritePaths()
+    {
+        Set<Path> paths = new HashSet<>();
+
+        if (getCommitLogWriteDiskAccessMode() == DiskAccessMode.direct)
+            paths.add(new File(getCommitLogLocation()).toPath());
+
+        if (getBackgroundWriteDiskAccessMode() == DiskAccessMode.direct)
+            for (String dataDir : getAllDataFileLocations())
+                paths.add(new File(dataDir).toPath());
+
+        return paths;
+    }
+
+    @VisibleForTesting
+    public static void initializeBackgroundWriteDiskAccessMode()
+    {
+        DiskAccessMode providedMode = conf.background_write_disk_access_mode;
+
+        if (providedMode == DiskAccessMode.direct)
+        {
+            // DataStorageSpec already rejects negatives at parse time; zero is the remaining
+            // nonsense value. The writer's Math.max would silently coerce it to minRequiredSize,
+            // which masks a likely operator mistake — fail fast instead.
+            if (conf.direct_write_buffer_size.toBytes() <= 0)
+                throw new ConfigurationException("direct_write_buffer_size must be > 0 when background_write_disk_access_mode is 'direct'. " +
+                                                 "Got: " + conf.direct_write_buffer_size, false);
+
+            // Create the data directories up front (as we do for the commit log) so the kernel-bug 1057843
+            // startup check can stat each O_DIRECT write target. Direct I/O support is validated separately
+            // by the directio_support startup check.
+            if (!toolInitialized)
+                for (String dataDir : getAllDataFileLocations())
+                    PathUtils.createDirectoriesIfNotExists(new File(dataDir).toPath());
+        }
+        else if (providedMode != DiskAccessMode.standard)
+        {
+            throw new ConfigurationException("Unsupported disk access mode for background_write_disk_access_mode " +
+                                             "(options: standard/direct): " + providedMode, false);
+        }
+
+        backgroundWriteDiskAccessMode = providedMode;
     }
 
     public static String getSavedCachesLocation()

--- a/src/java/org/apache/cassandra/io/DirectIoSupport.java
+++ b/src/java/org/apache/cassandra/io/DirectIoSupport.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io;
+
+/**
+ * Classifies an operation's eligibility for a direct-IO (O_DIRECT) data path, encoding both
+ * the answer and the rationale class. Consumers maintain their own per-operation classification
+ * and apply this alongside their own gates (e.g. compression, configuration mode);
+ * {@link #SUPPORTED} is necessary but not sufficient.
+ */
+public enum DirectIoSupport
+{
+    /**
+     * Eligible for the direct-IO data path.
+     * */
+    SUPPORTED,
+
+    /**
+     * The direct-IO path is mechanically incompatible with this operation. Removing this
+     * exclusion requires code changes, not policy.
+     */
+    UNSUPPORTED_CORRECTNESS,
+
+    /**
+     * Direct IO would work but is deliberately disabled for performance or cache-residency
+     * reasons. Removing this exclusion requires re-evaluating the policy, not code changes.
+     */
+    UNSUPPORTED_POLICY,
+
+    /**
+     * The operation never constructs a data-file writer, so the direct-IO question does not apply.
+     * Exists so a consumer's classification can be total over its operation enum rather than partial.
+     */
+    NOT_A_WRITER;
+
+    public boolean isSupported()
+    {
+        return this == SUPPORTED;
+    }
+}

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -22,6 +22,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.file.OpenOption;
 import java.util.Optional;
 import java.util.zip.CRC32;
 
@@ -46,36 +47,51 @@ import static org.apache.cassandra.utils.Throwables.merge;
 
 public class CompressedSequentialWriter extends SequentialWriter
 {
-    private final ChecksumWriter crcMetadata;
+    protected final ChecksumWriter crcMetadata;
 
     // holds offset in the file where current chunk should be written
     // changed only by flush() method where data buffer gets compressed and stored to the file
-    private long chunkOffset = 0;
+    protected long chunkOffset = 0;
 
     // index file writer (random I/O)
-    private final CompressionMetadata.Writer metadataWriter;
+    protected final CompressionMetadata.Writer metadataWriter;
     private final ICompressor compressor;
 
     // used to store compressed data
     private ByteBuffer compressed;
 
     // holds a number of already written chunks
-    private int chunkCount = 0;
+    protected int chunkCount = 0;
 
-    private long uncompressedSize = 0, compressedSize = 0;
+    protected long uncompressedSize = 0;
+    protected long compressedSize = 0;
 
-    private final MetadataCollector sstableMetadataCollector;
+    protected final MetadataCollector sstableMetadataCollector;
     private final CompressionDictionaryManager compressionDictionaryManager;
 
     private final ByteBuffer crcCheckBuffer = ByteBuffer.allocate(4);
-    private final Optional<File> digestFile;
+    protected final Optional<File> digestFile;
 
     private final int maxCompressedLength;
     private final boolean isDictionaryEnabled;
 
+    private static ByteBuffer allocateBuffer(CompressionParams parameters)
+    {
+        return parameters.getSstableCompressor().preferredBufferType().allocate(parameters.chunkLength());
+    }
+
+    private static SequentialWriterOption buildOption(SequentialWriterOption option, CompressionParams parameters)
+    {
+        return SequentialWriterOption.newBuilder()
+                                     .bufferSize(parameters.chunkLength())
+                                     .bufferType(parameters.getSstableCompressor().preferredBufferType())
+                                     .finishOnClose(option.finishOnClose())
+                                     .build();
+    }
+
     public CompressedSequentialWriter(File file,
                                       File offsetsFile,
-                                      File digestFile,
+                                      @Nullable File digestFile,
                                       SequentialWriterOption option,
                                       CompressionParams parameters,
                                       MetadataCollector sstableMetadataCollector)
@@ -83,33 +99,28 @@ public class CompressedSequentialWriter extends SequentialWriter
         this(file, offsetsFile, digestFile, option, parameters, sstableMetadataCollector, null);
     }
 
-
     /**
-     * Create CompressedSequentialWriter without digest file.
+     * Create CompressedSequentialWriter with optional compression dictionary and channel options.
      *
      * @param file File to write
      * @param offsetsFile File to write compression metadata
-     * @param digestFile File to write digest
+     * @param digestFile File to write digest, or null if not needed
      * @param option Write option (buffer size and type will be set the same as compression params)
      * @param parameters Compression parameters
      * @param sstableMetadataCollector Metadata collector
      * @param compressionDictionaryManager manages compression dictionary; null if absent
+     * @param extraOpenOptions additional options to pass to FileChannel.open (e.g., ExtendedOpenOption.DIRECT)
      */
     public CompressedSequentialWriter(File file,
                                       File offsetsFile,
-                                      File digestFile,
+                                      @Nullable File digestFile,
                                       SequentialWriterOption option,
                                       CompressionParams parameters,
                                       MetadataCollector sstableMetadataCollector,
-                                      @Nullable CompressionDictionaryManager compressionDictionaryManager)
+                                      @Nullable CompressionDictionaryManager compressionDictionaryManager,
+                                      OpenOption... extraOpenOptions)
     {
-        super(file, SequentialWriterOption.newBuilder()
-                            .bufferSize(option.bufferSize())
-                            .bufferType(option.bufferType())
-                            .bufferSize(parameters.chunkLength())
-                            .bufferType(parameters.getSstableCompressor().preferredBufferType())
-                            .finishOnClose(option.finishOnClose())
-                            .build());
+        super(file, allocateBuffer(parameters), buildOption(option, parameters), true, extraOpenOptions);
         ICompressor compressor = parameters.getSstableCompressor();
         this.digestFile = Optional.ofNullable(digestFile);
 
@@ -142,7 +153,16 @@ public class CompressedSequentialWriter extends SequentialWriter
         metadataWriter = CompressionMetadata.Writer.open(parameters, offsetsFile, compressionDictionary);
 
         this.sstableMetadataCollector = sstableMetadataCollector;
-        crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)));
+        crcMetadata = createChecksumWriter();
+    }
+
+    /**
+     * Creates the {@link ChecksumWriter} for the chunk and full-file checksums. Invoked from the constructor,
+     * so overrides must not read subclass fields.
+     */
+    protected ChecksumWriter createChecksumWriter()
+    {
+        return new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)));
     }
 
     @Override
@@ -178,7 +198,9 @@ public class CompressedSequentialWriter extends SequentialWriter
     @Override
     protected void flushData()
     {
-        seekToChunkStart(); // why is this necessary? seems like it should always be at chunk start in normal operation
+        // resetAndTruncate leaves fchannel.position() past EOF after its verification reads + truncate;
+        // re-seek so the next chunk lands at chunkOffset. No-op under linear writes.
+        seekToChunkStart();
 
         try
         {
@@ -216,25 +238,15 @@ public class CompressedSequentialWriter extends SequentialWriter
         }
         compressedSize += compressedLength;
 
-        try
-        {
-            // write an offset of the newly written chunk to the index file
-            metadataWriter.addOffset(chunkOffset);
-            chunkCount++;
+        // write an offset of the newly written chunk to the index file
+        metadataWriter.addOffset(chunkOffset);
+        chunkCount++;
 
-            // write out the compressed data
-            toWrite.flip();
-            channel.write(toWrite);
+        // write out the compressed data and checksum
+        toWrite.flip();
+        writeChunk(toWrite);
+        lastFlushOffset = uncompressedSize;
 
-            // write corresponding checksum
-            toWrite.rewind();
-            crcMetadata.appendDirect(toWrite, true);
-            lastFlushOffset = uncompressedSize;
-        }
-        catch (IOException e)
-        {
-            throw new FSWriteError(e, getPath());
-        }
         if (toWrite == buffer)
             buffer.position(uncompressedLength);
 
@@ -242,6 +254,20 @@ public class CompressedSequentialWriter extends SequentialWriter
         chunkOffset += compressedLength + 4;
         if (runPostFlush != null)
             runPostFlush.accept(getLastFlushOffset());
+    }
+
+    protected void writeChunk(ByteBuffer toWrite)
+    {
+        try
+        {
+            channel.write(toWrite);
+            toWrite.rewind();
+            crcMetadata.appendDirect(toWrite, true);
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
     }
 
     public CompressionMetadata open(long overrideLength)
@@ -358,10 +384,16 @@ public class CompressedSequentialWriter extends SequentialWriter
         }
     }
 
+    protected void writeDigestFile()
+    {
+        digestFile.ifPresent(crcMetadata::writeFullChecksum);
+    }
+
     /**
      * Seek to the offset where next compressed data chunk should be stored.
+     * Subclasses may override if they manage their own channel.
      */
-    private void seekToChunkStart()
+    protected void seekToChunkStart()
     {
         if (getOnDiskFilePointer() != chunkOffset)
         {
@@ -429,7 +461,7 @@ public class CompressedSequentialWriter extends SequentialWriter
         protected void doPrepare()
         {
             syncInternal();
-            digestFile.ifPresent(crcMetadata::writeFullChecksum);
+            writeDigestFile();
             sstableMetadataCollector.addCompressionRatio(compressedSize, uncompressedSize);
             metadataWriter.finalizeLength(current(), chunkCount).prepareToCommit();
         }

--- a/src/java/org/apache/cassandra/io/compress/DirectCompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/DirectCompressedSequentialWriter.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.sun.nio.file.ExtendedOpenOption;
+
+import org.agrona.BitUtil;
+import org.agrona.BufferUtil;
+import org.agrona.collections.LongArrayQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.compression.CompressionDictionaryManager;
+import org.apache.cassandra.io.FSReadError;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.util.ChecksumWriter;
+import org.apache.cassandra.io.util.DataPosition;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.metrics.StorageMetrics;
+import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Throwables;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+
+import sun.nio.ch.DirectBuffer;
+
+import static org.apache.cassandra.utils.Throwables.merge;
+
+/**
+ * Uses O_DIRECT to bypass the OS page cache, reducing memory pressure during compaction.
+ * <p>
+ * O_DIRECT requires all writes to be block-aligned, so compressed chunks are accumulated in an aligned buffer.
+ * Only complete blocks are flushed; at finalization, remaining data is padded, written, and the file is
+ * truncated to actual size.
+ */
+public class DirectCompressedSequentialWriter extends CompressedSequentialWriter
+{
+    private static final Logger logger = LoggerFactory.getLogger(DirectCompressedSequentialWriter.class);
+
+    // Warn once per JVM that an undersized buffer was coerced up — operator-visible without per-SSTable spam.
+    private static final AtomicBoolean undersizedBufferWarned = new AtomicBoolean(false);
+
+    private static final int CRC_LENGTH = Integer.BYTES;
+
+    // capacity >= maxChunkWrite + CRC_LENGTH + blockSize: a chunk is staged in a single put, so it must fit
+    // contiguously even after a flush carries over up to blockSize - 1 unaligned bytes.
+    private ByteBuffer writeBuffer;
+    private long actualDataSize = 0;
+
+    private boolean dataFinalized = false;
+
+    // Chunks staged in writeBuffer but not yet on disk, as flat {compressedEnd, uncompressedEnd} pairs in
+    // write order: offer 2 in writeChunk, poll 2 in durableUncompressedOffset, nothing else, or pairing
+    // breaks. Lets the post-flush listener report a durable offset. Offsets are never negative, so -1 is
+    // a safe empty sentinel.
+    private final LongArrayQueue stagedChunkBoundaries = new LongArrayQueue(-1L);
+    private long durableUncompressedOffset = 0;
+
+    private final int blockSize;
+
+    // Bytes registered with StorageMetrics.directWriteBufferBytes at allocation; subtracted at cleanup so the
+    // gauge balances even on the abort path. 0 until writeBuffer is successfully allocated.
+    private int directBufferBytes = 0;
+
+    public DirectCompressedSequentialWriter(File file,
+                                            File offsetsFile,
+                                            @Nullable File digestFile,
+                                            SequentialWriterOption option,
+                                            CompressionParams parameters,
+                                            MetadataCollector sstableMetadataCollector,
+                                            @Nullable CompressionDictionaryManager compressionDictionaryManager)
+    {
+        super(file, offsetsFile, digestFile, option, parameters, sstableMetadataCollector, compressionDictionaryManager, ExtendedOpenOption.DIRECT);
+
+        // super() opened the O_DIRECT FileChannel and allocated parent buffers; if anything below throws
+        // the caller never gets a reference to clean them up, so abort the txn proxy ourselves.
+        try
+        {
+            this.blockSize = FileUtils.getBlockSize(file.parent());
+            if (blockSize <= 0)
+                throw new IllegalStateException("Unable to determine filesystem block size for Direct IO. " +
+                                                "Block size: " + blockSize);
+
+            if (!BitUtil.isPowerOfTwo(blockSize))
+                throw new IllegalStateException("Filesystem block size must be a power of two for Direct IO. " +
+                                                "Block size: " + blockSize);
+
+            int configuredSize = DatabaseDescriptor.getDirectWriteBufferSize().toBytes();
+            int maxChunkWrite = parameters.getSstableCompressor().initialCompressedBufferLength(parameters.chunkLength());
+            int minRequiredSize = maxChunkWrite + CRC_LENGTH + blockSize;
+            if (configuredSize < minRequiredSize && undersizedBufferWarned.compareAndSet(false, true))
+                logger.warn("direct_write_buffer_size ({} bytes) is below the minimum required for SSTable {} " +
+                            "(worst-case chunk {} + CRC 4 + blockSize {} = {} bytes); using the minimum. " +
+                            "Increase direct_write_buffer_size in cassandra.yaml to silence this warning.",
+                            configuredSize, file, maxChunkWrite, blockSize, minRequiredSize);
+            int bufferSize = BitUtil.align(Math.max(configuredSize, minRequiredSize), blockSize);
+
+            this.writeBuffer = BufferUtil.allocateDirectAligned(bufferSize, blockSize);
+            this.directBufferBytes = bufferSize;
+            StorageMetrics.directWriteBufferBytes.inc(bufferSize);
+            StorageMetrics.directWriteBuffersAllocated.mark();
+        }
+        catch (Throwable t)
+        {
+            Throwable merged = t;
+            try { merged = abort(t); }
+            catch (Throwable t2) { t.addSuppressed(t2); }
+            Throwables.maybeFail(merged);
+            // Unreachable: maybeFail(non-null) always throws. Present for definite-assignment of `blockSize`.
+            throw new AssertionError("Throwables.maybeFail should have thrown", merged);
+        }
+    }
+
+    // Invoked from super()'s constructor before writeBuffer exists; safe because we only capture the
+    // writeCrcToAlignedBuffer reference, which isn't called until the first chunk is written.
+    @Override
+    protected ChecksumWriter createChecksumWriter()
+    {
+        return new DirectChecksumWriter(this::writeCrcToAlignedBuffer);
+    }
+
+    // Parent reads fchannel.position(), which lags by the bytes staged in writeBuffer.
+    // getEstimatedOnDiskBytesWritten is intentionally NOT overridden: parent returns chunkOffset,
+    // which already reflects the eventual on-disk size.
+    @Override
+    public long getOnDiskFilePointer()
+    {
+        return actualDataSize;
+    }
+
+    @Override
+    protected void seekToChunkStart()
+    {
+        // No-op: bytes staged in writeBuffer would be skipped by a seek, leaving a hole.
+        // resetAndTruncate (the parent's reason for this seek) is unsupported here.
+    }
+
+    // openFinalEarly() publishes a reader right after sync(), but the inherited sync flushes only whole
+    // blocks — the last chunk's sub-block tail would stay buffered and the reader would short-read.
+    // Finalize first so the reader sees the complete file.
+    @Override
+    protected void syncInternal()
+    {
+        finalizeDataFile();
+        syncDataOnlyInternal();
+    }
+
+    // Brings the file to its final on-disk form exactly once. openFinalEarly's sync and commit's doPrepare
+    // both land here; whichever runs first does the work, the other is a no-op. Safe because the writer is
+    // switched out right after openFinalEarly, so nothing writes once the file is final.
+    private void finalizeDataFile()
+    {
+        if (dataFinalized)
+            return;
+
+        doFlush(0);
+        flushFinalWithPadding();
+        dataFinalized = true;
+    }
+
+    // The parent feeds the post-flush listener getLastFlushOffset() (== uncompressedSize), which counts bytes
+    // staged in writeBuffer that O_DIRECT has not yet written. Report instead the uncompressed offset of the
+    // last chunk whose compressed bytes are fully on disk, so a preemptive reader never short-reads past EOF.
+    @Override
+    public void setPostFlushListener(LongConsumer postFlush)
+    {
+        super.setPostFlushListener(stagedOffset -> postFlush.accept(durableUncompressedOffset()));
+    }
+
+    // fchannel.position() counts only whole blocks written, so chunks ending at or below it are durable.
+    // Chunks flush in order, so draining from the head suffices and the offset is monotonic.
+    private long durableUncompressedOffset()
+    {
+        long onDisk;
+        try
+        {
+            onDisk = fchannel.position();
+        }
+        catch (IOException e)
+        {
+            throw new FSReadError(e, getPath());
+        }
+
+        long compressedEnd;
+        while ((compressedEnd = stagedChunkBoundaries.peekLong()) != stagedChunkBoundaries.nullValue()
+               && compressedEnd <= onDisk)
+        {
+            stagedChunkBoundaries.pollLong();
+            durableUncompressedOffset = stagedChunkBoundaries.pollLong();
+        }
+        return durableUncompressedOffset;
+    }
+
+    @Override
+    protected void writeChunk(ByteBuffer toWrite)
+    {
+        Preconditions.checkState(!dataFinalized, "writeChunk after finalizeDataFile() under O_DIRECT");
+
+        Preconditions.checkArgument(toWrite.position() == 0,
+                                    "writeChunk requires a flipped buffer (position == 0), got position=%s",
+                                    toWrite.position());
+
+        int chunkLength = toWrite.remaining();
+
+        writeToAlignedBuffer(toWrite);
+
+        // writeToAlignedBuffer drained toWrite; rewind so appendDirect can re-read it for the CRC.
+        toWrite.rewind();
+        crcMetadata.appendDirect(toWrite, true);
+
+        actualDataSize = chunkOffset + chunkLength + CRC_LENGTH;
+
+        stagedChunkBoundaries.offerLong(actualDataSize);
+        stagedChunkBoundaries.offerLong(uncompressedSize);
+    }
+
+    private void writeToAlignedBuffer(ByteBuffer data)
+    {
+        int dataLength = data.remaining();
+
+        // Buffer is sized for worst-case chunk + CRC + blockSize, so a flush always frees enough room.
+        if (writeBuffer.position() + dataLength > writeBuffer.capacity())
+            flushCompleteBlocks();
+
+        writeBuffer.put(data);
+    }
+
+    private void writeCrcToAlignedBuffer(int crcValue)
+    {
+        // After flush, leftover < blockSize, so there's always room for the CRC trailer.
+        if (writeBuffer.position() + CRC_LENGTH > writeBuffer.capacity())
+            flushCompleteBlocks();
+
+        writeBuffer.putInt(crcValue);
+    }
+
+    // FileChannel.write may write fewer bytes than requested, and a partial write would short the file
+    // and desync the callers' leftover/truncate bookkeeping.
+    private void writeAlignedBlocks(int flushLimit) throws IOException
+    {
+        writeBuffer.position(0);
+        writeBuffer.limit(flushLimit);
+        while (writeBuffer.hasRemaining())
+            fchannel.write(writeBuffer);
+    }
+
+    private void flushCompleteBlocks()
+    {
+        // writeAlignedBlocks rewinds position() to 0 to drain, so snapshot the cursor first.
+        int logicalPos = writeBuffer.position();
+
+        // Align down: O_DIRECT cannot write partial blocks
+        int flushLimit = logicalPos & -blockSize;
+
+        // Callers flush only on overflow, which the sizing floor (maxChunkWrite + CRC + blockSize)
+        // guarantees cannot happen before a whole block is buffered.
+        Preconditions.checkState(flushLimit > 0,
+                                 "flush requested with no complete block buffered; writeBuffer undersized");
+
+        try
+        {
+            writeAlignedBlocks(flushLimit);
+
+            int leftover = logicalPos - flushLimit;
+            if (leftover > 0)
+            {
+                writeBuffer.limit(logicalPos);
+                writeBuffer.position(flushLimit);
+                writeBuffer.compact();
+            }
+            else
+            {
+                writeBuffer.clear();
+            }
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    private void flushFinalWithPadding()
+    {
+        int logicalPos = writeBuffer.position();
+
+        if (logicalPos == 0)
+            return;
+
+        try
+        {
+            int flushLimit = BitUtil.align(logicalPos, blockSize);
+
+            ByteBufferUtil.writeZeroes(writeBuffer, flushLimit - logicalPos);
+
+            writeAlignedBlocks(flushLimit);
+
+            // O_DIRECT required padding; truncate back to actual data size.
+            fchannel.truncate(actualDataSize);
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    // Gated out for SCRUB in DataComponent.buildWriter; these throws are a canary if the gate is bypassed.
+    @Override
+    public DataPosition mark()
+    {
+        throw new UnsupportedOperationException("mark() not supported under O_DIRECT");
+    }
+
+    @Override
+    public synchronized void resetAndTruncate(DataPosition mark)
+    {
+        throw new UnsupportedOperationException("resetAndTruncate() not supported under O_DIRECT");
+    }
+
+    @VisibleForTesting
+    ByteBuffer writeBuffer()
+    {
+        return writeBuffer;
+    }
+
+    @VisibleForTesting
+    static void resetUndersizedBufferWarned()
+    {
+        undersizedBufferWarned.set(false);
+    }
+
+    protected class DirectTransactionalProxy extends CompressedSequentialWriter.TransactionalProxy
+    {
+        @Override
+        protected void doPrepare()
+        {
+            finalizeDataFile();
+            syncDataOnlyInternal();
+            writeDigestFile();
+            sstableMetadataCollector.addCompressionRatio(compressedSize, uncompressedSize);
+            metadataWriter.finalizeLength(current(), chunkCount).prepareToCommit();
+        }
+
+        @Override
+        protected Throwable doPreCleanup(Throwable accumulate)
+        {
+            if (writeBuffer != null)
+            {
+                try
+                {
+                    // allocateDirectAligned returns a slice; clean the backing buffer via the attachment.
+                    MemoryUtil.clean((ByteBuffer) ((DirectBuffer) writeBuffer).attachment());
+                }
+                catch (Throwable t)
+                {
+                    accumulate = merge(accumulate, t);
+                }
+                StorageMetrics.directWriteBufferBytes.dec(directBufferBytes);
+                writeBuffer = null;
+            }
+
+            return super.doPreCleanup(accumulate);
+        }
+    }
+
+    @Override
+    protected SequentialWriter.TransactionalProxy txnProxy()
+    {
+        return new DirectTransactionalProxy();
+    }
+
+    /**
+     * Routes the per-chunk CRC into the block-aligned writeBuffer instead of the channel, reusing
+     * ChecksumWriter's bookkeeping rather than duplicating it. Only the CRC trailer flows through here;
+     * {@link #writeChunk} stages the chunk data.
+     */
+    private static final class DirectChecksumWriter extends ChecksumWriter
+    {
+        private final IntConsumer alignedSink;
+
+        DirectChecksumWriter(IntConsumer alignedSink)
+        {
+            this.alignedSink = alignedSink;
+        }
+
+        @Override
+        protected void writeIncrementalInt(int value)
+        {
+            alignedSink.accept(value);
+        }
+
+        @Override
+        public void writeChunkSize(int length)
+        {
+            throw new UnsupportedOperationException("writeChunkSize is unused on the compressed O_DIRECT path");
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
@@ -18,10 +18,18 @@
 
 package org.apache.cassandra.io.sstable.format;
 
+import java.util.EnumMap;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.Config.FlushCompression;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.compression.CompressionDictionaryManager;
+import org.apache.cassandra.io.DirectIoSupport;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
+import org.apache.cassandra.io.compress.DirectCompressedSequentialWriter;
 import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
@@ -32,8 +40,61 @@ import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.TableMetadata;
 
+import static org.apache.cassandra.io.DirectIoSupport.NOT_A_WRITER;
+import static org.apache.cassandra.io.DirectIoSupport.SUPPORTED;
+import static org.apache.cassandra.io.DirectIoSupport.UNSUPPORTED_CORRECTNESS;
+import static org.apache.cassandra.io.DirectIoSupport.UNSUPPORTED_POLICY;
+
 public class DataComponent
 {
+    private static final EnumMap<OperationType, DirectIoSupport> DIRECT_WRITE_SUPPORT = buildDirectWriteSupport();
+
+    private static EnumMap<OperationType, DirectIoSupport> buildDirectWriteSupport()
+    {
+        EnumMap<OperationType, DirectIoSupport> m = new EnumMap<>(OperationType.class);
+
+        // append()-only writers; safe under O_DIRECT.
+        m.put(OperationType.CLEANUP, SUPPORTED);
+        m.put(OperationType.UPGRADE_SSTABLES, SUPPORTED);
+        m.put(OperationType.MAJOR_COMPACTION, SUPPORTED);
+        m.put(OperationType.GARBAGE_COLLECT, SUPPORTED);
+        m.put(OperationType.WRITE, SUPPORTED);
+        m.put(OperationType.ANTICOMPACTION, SUPPORTED);
+        m.put(OperationType.COMPACTION, SUPPORTED);
+        m.put(OperationType.TOMBSTONE_COMPACTION, SUPPORTED);
+        m.put(OperationType.STREAM, SUPPORTED);
+        // writesData==false yet these still reach buildWriter() (RELOCATE via relocateSSTables, UNKNOWN via
+        // the offline sstablesplit tool), which is why classification can't key off writesData. CASSANDRA-21134.
+        m.put(OperationType.RELOCATE, SUPPORTED);
+        m.put(OperationType.UNKNOWN, SUPPORTED);
+
+        // tryAppend() needs mark()/resetAndTruncate(), unsupported under O_DIRECT.
+        m.put(OperationType.SCRUB, UNSUPPORTED_CORRECTNESS);
+
+        // Flushed data is hot; keep it in the page cache.
+        m.put(OperationType.FLUSH, UNSUPPORTED_POLICY);
+
+        // These never construct a data-file writer (read-only, rewrite a non-data component, or write their
+        // own files), so they never reach buildWriter(). Classified only to keep the map total.
+        m.put(OperationType.P0, NOT_A_WRITER);
+        m.put(OperationType.VERIFY, NOT_A_WRITER);
+        m.put(OperationType.VALIDATION, NOT_A_WRITER);
+        m.put(OperationType.INDEX_BUILD, NOT_A_WRITER);
+        m.put(OperationType.VIEW_BUILD, NOT_A_WRITER);
+        m.put(OperationType.INDEX_SUMMARY, NOT_A_WRITER);
+        m.put(OperationType.KEY_CACHE_SAVE, NOT_A_WRITER);
+        m.put(OperationType.ROW_CACHE_SAVE, NOT_A_WRITER);
+        m.put(OperationType.COUNTER_CACHE_SAVE, NOT_A_WRITER);
+
+        // Total over the enum so a newly-added OperationType fails here at class-load instead of throwing
+        // from buildWriter() in production (CASSANDRA-21134: RELOCATE slipped through the old writesData gate).
+        for (OperationType op : OperationType.values())
+            if (!m.containsKey(op))
+                throw new AssertionError("Missing direct-write classification for " + op
+                                         + " — every OperationType must be SUPPORTED, UNSUPPORTED_*, or NOT_A_WRITER");
+        return m;
+    }
+
     public static SequentialWriter buildWriter(Descriptor descriptor,
                                                TableMetadata metadata,
                                                SequentialWriterOption options,
@@ -44,15 +105,29 @@ public class DataComponent
     {
         if (metadata.params.compression.isEnabled())
         {
-            final CompressionParams compressionParams = buildCompressionParams(metadata, operationType, flushCompression);
+            CompressionParams compressionParams = buildCompressionParams(metadata, operationType, flushCompression);
 
-            return new CompressedSequentialWriter(descriptor.fileFor(Components.DATA),
-                                                  descriptor.fileFor(Components.COMPRESSION_INFO),
-                                                  descriptor.fileFor(Components.DIGEST),
-                                                  options,
-                                                  compressionParams,
-                                                  metadataCollector,
-                                                  compressionDictionaryManager);
+            if (DatabaseDescriptor.getBackgroundWriteDiskAccessMode() == DiskAccessMode.direct
+                && isDirectWriteSupported(operationType))
+            {
+                return new DirectCompressedSequentialWriter(descriptor.fileFor(Components.DATA),
+                                                            descriptor.fileFor(Components.COMPRESSION_INFO),
+                                                            descriptor.fileFor(Components.DIGEST),
+                                                            options,
+                                                            compressionParams,
+                                                            metadataCollector,
+                                                            compressionDictionaryManager);
+            }
+            else
+            {
+                return new CompressedSequentialWriter(descriptor.fileFor(Components.DATA),
+                                                      descriptor.fileFor(Components.COMPRESSION_INFO),
+                                                      descriptor.fileFor(Components.DIGEST),
+                                                      options,
+                                                      compressionParams,
+                                                      metadataCollector,
+                                                      compressionDictionaryManager);
+            }
         }
         else
         {
@@ -103,4 +178,14 @@ public class DataComponent
         }
         return compressionParams;
     }
+
+    @VisibleForTesting
+    static boolean isDirectWriteSupported(OperationType operationType)
+    {
+        DirectIoSupport support = DIRECT_WRITE_SUPPORT.get(operationType);
+        if (support == null)
+            throw new IllegalStateException("OperationType " + operationType + " has no direct-write classification");
+        return support.isSupported();
+    }
+
 }

--- a/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
@@ -40,6 +40,20 @@ public class ChecksumWriter
         this.incrementalOut = incrementalOut;
     }
 
+    // Subclasses with their own CRC sink (see writeIncrementalInt) use this ctor; they must not call
+    // writeChunkSize, which needs incrementalOut.
+    protected ChecksumWriter()
+    {
+        this.incrementalOut = null;
+    }
+
+    // Seam so subclasses can redirect the per-chunk CRC int without re-implementing appendDirect's
+    // checksum bookkeeping.
+    protected void writeIncrementalInt(int value) throws IOException
+    {
+        incrementalOut.writeInt(value);
+    }
+
     public void writeChunkSize(int length)
     {
         try
@@ -69,7 +83,7 @@ public class ChecksumWriter
             toAppend.reset();
 
             int incrementalChecksumValue = (int) incrementalChecksum.getValue();
-            incrementalOut.writeInt(incrementalChecksumValue);
+            writeIncrementalInt(incrementalChecksumValue);
 
             fullChecksum.update(toAppend);
             if (checksumIncrementalResult)

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -783,7 +784,14 @@ public final class FileUtils
         }
     }
 
+    private static final ConcurrentHashMap<String, Integer> blockSizeByDirectory = new ConcurrentHashMap<>();
+
     public static int getBlockSize(File directory)
+    {
+        return blockSizeByDirectory.computeIfAbsent(directory.absolutePath(), ignored -> probeBlockSize(directory));
+    }
+
+    private static int probeBlockSize(File directory)
     {
         File f = FileUtils.createTempFile("block-size-test", ".tmp", directory);
         try

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -20,7 +20,11 @@ package org.apache.cassandra.io.util;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.LongConsumer;
 
 import org.apache.cassandra.io.FSReadError;
@@ -109,25 +113,36 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
     }
 
     // TODO: we should specify as a parameter if we permit an existing file or not
-    private static FileChannel openChannel(File file)
+    private static FileChannel openChannel(File file, OpenOption... extraOptions)
     {
         try
         {
+            Set<OpenOption> options = new LinkedHashSet<>(Arrays.asList(StandardOpenOption.READ, StandardOpenOption.WRITE));
+            options.addAll(Arrays.asList(extraOptions));
+
             if (file.exists())
             {
-                return FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
+                return FileChannel.open(file.toPath(), options.toArray(OpenOption[]::new));
             }
             else
             {
-                FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+                options.add(StandardOpenOption.CREATE_NEW);
+                FileChannel channel = FileChannel.open(file.toPath(), options.toArray(OpenOption[]::new));
                 try
                 {
                     SyncUtil.trySyncDir(file.parent());
                 }
                 catch (Throwable t)
                 {
-                    try { channel.close(); }
-                    catch (Throwable t2) { t.addSuppressed(t2); }
+                    try
+                    {
+                        channel.close();
+                    }
+                    catch (Throwable t2)
+                    {
+                        t.addSuppressed(t2);
+                    }
+                    throw t;
                 }
                 return channel;
             }
@@ -170,15 +185,14 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
         this(file, option.allocateBuffer(), option, strictFlushing);
     }
 
-    protected SequentialWriter(File file, ByteBuffer buffer, SequentialWriterOption option, boolean strictFlushing)
+    protected SequentialWriter(File file, ByteBuffer buffer, SequentialWriterOption option, boolean strictFlushing,
+                               OpenOption... extraOpenOptions)
     {
-        super(openChannel(file), buffer);
+        super(openChannel(file, extraOpenOptions), buffer);
         this.strictFlushing = strictFlushing;
-        this.fchannel = (FileChannel)channel;
-
+        this.fchannel = (FileChannel) this.channel;
         this.file = file;
         this.filePath = file.absolutePath();
-
         this.option = option;
     }
 

--- a/src/java/org/apache/cassandra/metrics/StorageMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/StorageMetrics.java
@@ -53,6 +53,9 @@ public class StorageMetrics
     public static final Counter startupOpsForInvalidToken = Metrics.counter(factory.createMetricName("StartupOpsForInvalidToken"));
     public static final Meter bootstrapFilesThroughputMetric = Metrics.meter(factory.createMetricName("BootstrapFilesThroughput"));
 
+    public static final Counter directWriteBufferBytes = Metrics.counter(factory.createMetricName("DirectWriteBufferBytes"));
+    public static final Meter directWriteBuffersAllocated = Metrics.meter(factory.createMetricName("DirectWriteBuffersAllocated"));
+
     private static Gauge<Long> createSummingGauge(String name, ToLongFunction<KeyspaceMetrics> extractor)
     {
         return Metrics.register(factory.createMetricName(name),

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -198,8 +198,14 @@ public final class CompressionParams
     @VisibleForTesting
     public static CompressionParams noop()
     {
+        return noop(DEFAULT_CHUNK_LENGTH);
+    }
+
+    @VisibleForTesting
+    public static CompressionParams noop(int chunkLength)
+    {
         NoopCompressor compressor = NoopCompressor.create(Collections.emptyMap());
-        return new CompressionParams(compressor, DEFAULT_CHUNK_LENGTH, Integer.MAX_VALUE, DEFAULT_MIN_COMPRESS_RATIO, Collections.emptyMap());
+        return new CompressionParams(compressor, chunkLength, Integer.MAX_VALUE, DEFAULT_MIN_COMPRESS_RATIO, Collections.emptyMap());
     }
 
     public CompressionParams(String sstableCompressorClass, Map<String, String> otherOptions, int chunkLength, double minCompressRatio) throws ConfigurationException

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -251,11 +251,7 @@ public class StartupChecks
             if (!FBUtilities.isLinux)
                 return;
 
-            Set<Path> directIOWritePaths = new HashSet<>();
-            if (DatabaseDescriptor.getCommitLogWriteDiskAccessMode() == Config.DiskAccessMode.direct)
-                directIOWritePaths.add(new File(DatabaseDescriptor.getCommitLogLocation()).toPath());
-            // Note: Data directories for direct IO compaction reads are checked in checkDirectIOSupport.
-            // This check is specifically for direct IO writes which are currently only supported for commit log.
+            Set<Path> directIOWritePaths = DatabaseDescriptor.getDirectIOWritePaths();
 
             if (!directIOWritePaths.isEmpty() && IGNORE_KERNEL_BUG_1057843_CHECK.getBoolean())
             {
@@ -729,21 +725,27 @@ public class StartupChecks
             if (configuration.isDisabled(name()))
                 return;
 
-            // Only check if compaction_read_disk_access_mode is direct
-            if (DatabaseDescriptor.getCompactionReadDiskAccessMode() != Config.DiskAccessMode.direct)
+            boolean directReads = DatabaseDescriptor.getCompactionReadDiskAccessMode() == Config.DiskAccessMode.direct;
+            boolean directWrites = DatabaseDescriptor.getBackgroundWriteDiskAccessMode() == Config.DiskAccessMode.direct;
+
+            if (!directReads && !directWrites)
                 return;
 
             List<String> unsupportedLocations = findDirectIOUnsupportedLocations(DatabaseDescriptor.getAllDataFileLocations());
 
             if (!unsupportedLocations.isEmpty())
             {
+                String configuredModes = directReads && directWrites
+                    ? "compaction reads and background writes"
+                    : directReads ? "compaction reads" : "background writes";
+
                 throw new StartupException(StartupException.ERR_WRONG_DISK_STATE,
-                                           String.format("Direct I/O is configured for compaction reads (compaction_read_disk_access_mode=direct), " +
+                                           String.format("Direct I/O is configured for %s, " +
                                                          "but the following data directories do not support Direct I/O: %s. " +
-                                                         "Either change compaction_read_disk_access_mode to 'standard' in cassandra.yaml, " +
+                                                         "Either change the disk access mode to 'standard' in cassandra.yaml, " +
                                                          "or ensure all data directories are on filesystems that support Direct I/O. " +
                                                          "Network filesystems (NFS, CIFS) and some virtual filesystems do not support Direct I/O.",
-                                                         unsupportedLocations));
+                                                         configuredModes, unsupportedLocations));
             }
         }
     };

--- a/test/conf/latest_diff.yaml
+++ b/test/conf/latest_diff.yaml
@@ -46,6 +46,8 @@ memtable_allocation_type: offheap_objects
 
 commitlog_disk_access_mode: auto
 
+background_write_disk_access_mode: direct
+
 trickle_fsync: true
 
 sstable:

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -151,6 +151,8 @@ public class InstanceConfig implements IInstanceConfig
 
                 .set("commitlog_disk_access_mode", "auto")
 
+                .set("background_write_disk_access_mode", "direct")
+
                 .set("trickle_fsync", "true")
 
                 .set("sstable", Map.of(

--- a/test/distributed/org/apache/cassandra/distributed/test/StreamingDirectWriteTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/StreamingDirectWriteTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.metrics.StorageMetrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StreamingDirectWriteTest extends TestBaseImpl
+{
+    @Test
+    public void testChunkedStreamReceiverWithDirectWrites() throws IOException
+    {
+        // ZCS streaming bypasses DataComponent.buildWriter; disable to exercise the chunked receiver path.
+        try (Cluster cluster = init(Cluster.build(2)
+                                           .withConfig(c -> c.with(Feature.NETWORK, Feature.GOSSIP)
+                                                             .set("stream_entire_sstables", false)
+                                                             .set("background_write_disk_access_mode", "direct"))
+                                           .start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k text PRIMARY KEY, v blob) WITH compression = {'enabled':'true', 'class':'LZ4Compressor'};"));
+            cluster.stream().forEach(i -> i.nodetoolResult("disableautocompaction", KEYSPACE).asserts().success());
+
+            IInvokableInstance node1 = cluster.get(1);
+            IInvokableInstance node2 = cluster.get(2);
+
+            // ~800 KiB of incompressible data spread across many flushes — multiple sstables to stream chunked.
+            int rowCount = 100;
+            int valBytes = 8 * 1024;
+            byte[] val = new byte[valBytes];
+            new Random(42).nextBytes(val);
+            ByteBuffer blob = ByteBuffer.wrap(val);
+            for (int i = 0; i < rowCount; i++)
+            {
+                node1.executeInternal(withKeyspace("INSERT INTO %s.t (k, v) VALUES (?, ?)"), "k" + i, blob);
+                if ((i % 20) == 19)
+                    node1.flush(KEYSPACE);
+            }
+            node1.flush(KEYSPACE);
+
+            // Monotonic meter: a snapshot before/after rebuild proves the DIO writer engaged on the
+            // receiver, regardless of timing or GC — unlike the inc/dec byte gauge, which races to 0.
+            // NB: explicit lambda, not a method ref — a ref binds the non-serializable Meter and fails
+            // to ship across the instance boundary; the lambda reads the static field on the receiver.
+            long writersBefore = node2.callOnInstance(() -> StorageMetrics.directWriteBuffersAllocated.getCount());
+
+            node2.nodetoolResult("rebuild", "--keyspace", KEYSPACE).asserts().success();
+
+            Object[][] rows = node2.executeInternal(withKeyspace("SELECT k FROM %s.t"));
+            assertThat(rows.length).isEqualTo(rowCount);
+
+            long writersAfter = node2.callOnInstance(() -> StorageMetrics.directWriteBuffersAllocated.getCount());
+            assertThat(writersAfter)
+                .describedAs("DIO writer must engage for STREAM op on the chunked receiver")
+                .isGreaterThan(writersBefore);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -24,10 +24,13 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import com.google.common.base.Throwables;
@@ -41,6 +44,7 @@ import org.mockito.MockedStatic;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.security.EncryptionContext;
@@ -1073,5 +1077,117 @@ public class DatabaseDescriptorTest
     {
         Config config = DatabaseDescriptor.loadConfig();
         Assert.assertEquals(config.max_value_size.toMebibytes() * 1024 * 1024, DatabaseDescriptor.getMaxValueSize());
+    }
+
+    @Test
+    public void testInitializeBackgroundWriteDiskAccessModeRejectsZeroBufferSize()
+    {
+        Config conf = DatabaseDescriptor.getRawConfig();
+        Config.DiskAccessMode savedMode = conf.background_write_disk_access_mode;
+        DataStorageSpec.IntKibibytesBound savedBufferSize = conf.direct_write_buffer_size;
+        try
+        {
+            conf.background_write_disk_access_mode = Config.DiskAccessMode.direct;
+            conf.direct_write_buffer_size = new DataStorageSpec.IntKibibytesBound("0KiB");
+
+            try
+            {
+                DatabaseDescriptor.initializeBackgroundWriteDiskAccessMode();
+                fail("expected ConfigurationException for direct_write_buffer_size == 0");
+            }
+            catch (ConfigurationException expected)
+            {
+                Assert.assertTrue("expected message to mention direct_write_buffer_size, got: " + expected.getMessage(),
+                                  expected.getMessage().contains("direct_write_buffer_size"));
+            }
+        }
+        finally
+        {
+            conf.background_write_disk_access_mode = savedMode;
+            conf.direct_write_buffer_size = savedBufferSize;
+        }
+    }
+
+    @Test
+    public void testInitializeBackgroundWriteDiskAccessModeRejectsUnsupportedModes()
+    {
+        // Everything outside standard/direct must be rejected, including 'auto': it has no
+        // Direct I/O auto-detection for background writes yet, so it must fail rather than
+        // silently resolving to standard (unlike commitlog_disk_access_mode).
+        Config conf = DatabaseDescriptor.getRawConfig();
+        Config.DiskAccessMode savedMode = conf.background_write_disk_access_mode;
+        try
+        {
+            EnumSet<Config.DiskAccessMode> supported = EnumSet.of(Config.DiskAccessMode.standard,
+                                                                  Config.DiskAccessMode.direct);
+            for (Config.DiskAccessMode mode : EnumSet.complementOf(supported))
+            {
+                conf.background_write_disk_access_mode = mode;
+                assertThatExceptionOfType(ConfigurationException.class)
+                    .isThrownBy(DatabaseDescriptor::initializeBackgroundWriteDiskAccessMode)
+                    .withMessageContaining("background_write_disk_access_mode");
+            }
+        }
+        finally
+        {
+            conf.background_write_disk_access_mode = savedMode;
+        }
+    }
+
+    @Test
+    public void testGetDirectIOWritePaths() throws IOException
+    {
+        Config conf = DatabaseDescriptor.getRawConfig();
+        Config.DiskAccessMode savedCommitLogMode = DatabaseDescriptor.getCommitLogWriteDiskAccessMode();
+        Config.DiskAccessMode savedBgWriteMode = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
+        String savedCommitLogLocation = DatabaseDescriptor.getCommitLogLocation();
+        String[] savedDataDirs = conf.data_file_directories;
+        String savedLocalSystemDir = conf.local_system_data_file_directory;
+        try
+        {
+            Path baseDir = Files.createTempDirectory("testGetDirectIOWritePaths");
+            String dataDir1 = baseDir.resolve("dio-data-1").toString();
+            String dataDir2 = baseDir.resolve("dio-data-2").toString();
+            String commitLogDir = baseDir.resolve("dio-commitlog").toString();
+
+            conf.local_system_data_file_directory = null;
+            conf.data_file_directories = new String[]{ dataDir1, dataDir2 };
+            DatabaseDescriptor.setCommitLogLocation(commitLogDir);
+
+            Path commitLogPath = new File(commitLogDir).toPath();
+            Set<Path> dataPaths = new HashSet<>();
+            for (String dir : DatabaseDescriptor.getAllDataFileLocations())
+                dataPaths.add(new File(dir).toPath());
+
+            // Neither write path uses Direct I/O.
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.standard);
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(Config.DiskAccessMode.standard);
+            assertThat(DatabaseDescriptor.getDirectIOWritePaths()).isEmpty();
+
+            // Only the commit log uses Direct I/O.
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.direct);
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(Config.DiskAccessMode.standard);
+            assertThat(DatabaseDescriptor.getDirectIOWritePaths()).containsExactly(commitLogPath);
+
+            // Only background SSTable writes use Direct I/O, which must enumerate every data directory.
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.standard);
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(Config.DiskAccessMode.direct);
+            assertThat(DatabaseDescriptor.getDirectIOWritePaths()).containsExactlyInAnyOrderElementsOf(dataPaths);
+
+            // Both write paths use Direct I/O: the union of the commit log and data directories.
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.direct);
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(Config.DiskAccessMode.direct);
+            Set<Path> expectedUnion = new HashSet<>(dataPaths);
+            expectedUnion.add(commitLogPath);
+            assertThat(DatabaseDescriptor.getDirectIOWritePaths()).containsExactlyInAnyOrderElementsOf(expectedUnion);
+        }
+        finally
+        {
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(savedCommitLogMode);
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(savedBgWriteMode);
+            DatabaseDescriptor.setCommitLogLocation(savedCommitLogLocation);
+            conf.data_file_directories = savedDataDirs;
+            conf.local_system_data_file_directory = savedLocalSystemDir;
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -3758,6 +3758,11 @@ public abstract class CQLTester
             setupFileSystem();
 
             CQLTester.prePrepareServer();
+
+            // The in-memory (jimfs) filesystem installed above cannot do Direct I/O: its FileStore has no
+            // getBlockSize() and it rejects ExtendedOpenOption.DIRECT. cassandra_latest.yaml enables
+            // background_write_disk_access_mode: direct, which would otherwise crash every flush+compact here.
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(Config.DiskAccessMode.standard);
         }
 
         protected static void setupFileSystem()

--- a/test/unit/org/apache/cassandra/db/compaction/AntiCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/AntiCompactionTest.java
@@ -18,12 +18,15 @@
 package org.apache.cassandra.db.compaction;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -55,12 +58,15 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.SSTableTxnWriter;
+import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.DirectIoTestUtils;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.repair.NoSuchRepairSessionException;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.MockSchema;
 import org.apache.cassandra.schema.Schema;
@@ -78,6 +84,7 @@ import static org.apache.cassandra.service.ActiveRepairService.NO_PENDING_REPAIR
 import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABLE;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -89,6 +96,7 @@ public class AntiCompactionTest
 {
     private static final String KEYSPACE1 = "AntiCompactionTest";
     private static final String CF = "AntiCompactionTest";
+    private static final String CF_COMPRESSED = "AntiCompactionCompressed";
     private static final Collection<Range<Token>> NO_RANGES = Collections.emptyList();
 
     private static TableMetadata metadata;
@@ -101,7 +109,10 @@ public class AntiCompactionTest
     {
         SchemaLoader.prepareServer();
         metadata = SchemaLoader.standardCFMD(KEYSPACE1, CF).build();
-        SchemaLoader.createKeyspace(KEYSPACE1, KeyspaceParams.simple(1), metadata);
+        TableMetadata compressedMetadata = SchemaLoader.standardCFMD(KEYSPACE1, CF_COMPRESSED)
+                                                       .compression(CompressionParams.lz4())
+                                                       .build();
+        SchemaLoader.createKeyspace(KEYSPACE1, KeyspaceParams.simple(1), metadata, compressedMetadata);
         cfs = Schema.instance.getColumnFamilyStoreInstance(metadata.id);
         local = InetAddressAndPort.getByName("127.0.0.1");
     }
@@ -114,11 +125,11 @@ public class AntiCompactionTest
         store.truncateBlocking();
     }
 
-    private void registerParentRepairSession(TimeUUID sessionID, Iterable<Range<Token>> ranges, long repairedAt, TimeUUID pendingRepair) throws IOException
+    private void registerParentRepairSession(TimeUUID sessionID, ColumnFamilyStore store, Iterable<Range<Token>> ranges, long repairedAt, TimeUUID pendingRepair) throws IOException
     {
         ActiveRepairService.instance().registerParentRepairSession(sessionID,
                                                                    InetAddressAndPort.getByName("10.0.0.1"),
-                                                                   Lists.newArrayList(cfs), ImmutableSet.copyOf(ranges),
+                                                                   Lists.newArrayList(store), ImmutableSet.copyOf(ranges),
                                                                    pendingRepair != null || repairedAt != UNREPAIRED_SSTABLE,
                                                                    repairedAt, true, PreviewKind.NONE);
     }
@@ -157,7 +168,7 @@ public class AntiCompactionTest
         {
             if (txn == null)
                 throw new IllegalStateException();
-            registerParentRepairSession(sessionID, ranges.ranges(), FBUtilities.nowInSeconds(), sessionID);
+            registerParentRepairSession(sessionID, store, ranges.ranges(), FBUtilities.nowInSeconds(), sessionID);
             CompactionManager.instance.performAnticompaction(store, ranges, refs, txn, sessionID, () -> false);
         }
 
@@ -234,6 +245,72 @@ public class AntiCompactionTest
     }
 
     @Test
+    public void testAntiCompactionWithCompressedTableAndDirectWrites() throws Throwable
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_COMPRESSED);
+        try
+        {
+            store.disableAutoCompaction();
+            assertTrue("CF must be compressed for DIO to engage",
+                       store.metadata().params.compression.isEnabled());
+
+            long ts = 1L;
+            populateDeterministic(store, ts);
+            SSTableStats baselineStats = antiCompactRanges(store, atEndpoint(range(0, 4), NO_RANGES));
+            assertEquals(2, baselineStats.numLiveSSTables);
+            assertEquals(4, baselineStats.pendingKeys);
+            assertEquals(6, baselineStats.unrepairedKeys);
+            Map<Boolean, byte[]> baselineBytes = captureDataBytesByPendingRepair(store);
+            store.truncateBlocking();
+
+            populateDeterministic(store, ts);
+            SSTableStats directStats = DirectIoTestUtils.withDirectWrites(() ->
+                antiCompactRanges(store, atEndpoint(range(0, 4), NO_RANGES)));
+            assertEquals(2, directStats.numLiveSSTables);
+            assertEquals(4, directStats.pendingKeys);
+            assertEquals(6, directStats.unrepairedKeys);
+            Map<Boolean, byte[]> directBytes = captureDataBytesByPendingRepair(store);
+
+            assertArrayEquals("pending-repair data file must match standard-writer output",
+                              baselineBytes.get(true), directBytes.get(true));
+            assertArrayEquals("unrepaired data file must match standard-writer output",
+                              baselineBytes.get(false), directBytes.get(false));
+        }
+        finally
+        {
+            store.truncateBlocking();
+        }
+    }
+
+    private void populateDeterministic(ColumnFamilyStore store, long ts)
+    {
+        TableMetadata md = store.metadata();
+        for (int i = 0; i < 10; i++)
+        {
+            new RowUpdateBuilder(md, ts, Integer.toString(i))
+                .clustering("c")
+                .add("val", "val")
+                .build()
+                .applyUnsafe();
+        }
+        Util.flush(store);
+    }
+
+    private Map<Boolean, byte[]> captureDataBytesByPendingRepair(ColumnFamilyStore store) throws IOException
+    {
+        Map<Boolean, byte[]> bytes = new HashMap<>();
+        for (SSTableReader sstable : store.getLiveSSTables())
+        {
+            byte[] prev = bytes.put(sstable.isPendingRepair(),
+                                    Files.readAllBytes(sstable.descriptor.fileFor(Components.DATA).toPath()));
+            assertTrue("expected one sstable per pending-repair status; duplicate at " + sstable.isPendingRepair(),
+                       prev == null);
+        }
+        return bytes;
+    }
+
+    @Test
     public void antiCompactOneTransOnly() throws Exception
     {
         ColumnFamilyStore store = prepareColumnFamilyStore();
@@ -257,7 +334,7 @@ public class AntiCompactionTest
         List<Range<Token>> ranges = Arrays.asList(range);
         Collection<SSTableReader> sstables = cfs.getLiveSSTables();
         TimeUUID parentRepairSession = nextTimeUUID();
-        registerParentRepairSession(parentRepairSession, ranges, UNREPAIRED_SSTABLE, nextTimeUUID());
+        registerParentRepairSession(parentRepairSession, cfs, ranges, UNREPAIRED_SSTABLE, nextTimeUUID());
         try (LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.ANTICOMPACTION);
              Refs<SSTableReader> refs = Refs.ref(sstables))
         {
@@ -386,7 +463,7 @@ public class AntiCompactionTest
         Range<Token> range = new Range<Token>(new BytesToken("/".getBytes()), new BytesToken("9999".getBytes()));
         List<Range<Token>> ranges = Arrays.asList(range);
         TimeUUID pendingRepair = nextTimeUUID();
-        registerParentRepairSession(pendingRepair, ranges, UNREPAIRED_SSTABLE, pendingRepair);
+        registerParentRepairSession(pendingRepair, store, ranges, UNREPAIRED_SSTABLE, pendingRepair);
 
         try (LifecycleTransaction txn = store.getTracker().tryModify(sstables, OperationType.ANTICOMPACTION);
              Refs<SSTableReader> refs = Refs.ref(sstables))
@@ -420,7 +497,7 @@ public class AntiCompactionTest
         Range<Token> range = new Range<Token>(new BytesToken("-1".getBytes()), new BytesToken("-10".getBytes()));
         List<Range<Token>> ranges = Arrays.asList(range);
         TimeUUID parentRepairSession = nextTimeUUID();
-        registerParentRepairSession(parentRepairSession, ranges, UNREPAIRED_SSTABLE, null);
+        registerParentRepairSession(parentRepairSession, store, ranges, UNREPAIRED_SSTABLE, null);
         boolean gotException = false;
         try (LifecycleTransaction txn = store.getTracker().tryModify(sstables, OperationType.ANTICOMPACTION);
              Refs<SSTableReader> refs = Refs.ref(sstables))

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -18,13 +18,17 @@
 */
 package org.apache.cassandra.db.compaction;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -53,10 +57,16 @@ import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.Slice;
 import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
 import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.db.marshal.ValueAccessors;
 import org.apache.cassandra.db.partitions.FilteredPartition;
 import org.apache.cassandra.db.partitions.ImmutableBTreePartition;
@@ -77,6 +87,7 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.schema.CompactionParams;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaTestUtil;
 import org.apache.cassandra.schema.TableMetadata;
@@ -97,6 +108,7 @@ public class CompactionsTest
     private static final String CF_STANDARD2 = "Standard2";
     private static final String CF_STANDARD3 = "Standard3";
     private static final String CF_STANDARD4 = "Standard4";
+    private static final String CF_COMPRESSED_STANDARD1 = "CF_COMPRESSED_STANDARD1";
 
     @Parameterized.Parameter(0)
     public DiskAccessMode compactionReadDiskAccessMode;
@@ -104,25 +116,33 @@ public class CompactionsTest
     @Parameterized.Parameter(1)
     public boolean cursorCompactionEnabled;
 
-    @Parameterized.Parameters(name = "diskAccessMode={0},cursor={1}")
+    @Parameterized.Parameter(2)
+    public DiskAccessMode backgroundWriteDiskAccessMode;
+
+    @Parameterized.Parameters(name = "diskAccessMode={0},cursor={1},backgroundWriteMode={2}")
     public static Collection<Object[]> params()
     {
-        return Arrays.asList(new Object[]{ DiskAccessMode.standard, true },
-                             new Object[]{ DiskAccessMode.standard, false },
-                             new Object[]{ DiskAccessMode.direct, true },
-                             new Object[]{ DiskAccessMode.direct, false });
+        // One direct-write cell instead of cross-multiplying: uncompressed CFs ignore the write mode.
+        return Arrays.asList(new Object[]{ DiskAccessMode.standard, true, DiskAccessMode.standard },
+                             new Object[]{ DiskAccessMode.standard, false, DiskAccessMode.standard },
+                             new Object[]{ DiskAccessMode.direct, true, DiskAccessMode.standard },
+                             new Object[]{ DiskAccessMode.direct, false, DiskAccessMode.standard },
+                             new Object[]{ DiskAccessMode.standard, false, DiskAccessMode.direct });
     }
 
     private DiskAccessMode originalDiskAccessMode;
     private boolean originalCursorCompactionEnabled;
+    private DiskAccessMode originalBackgroundWriteDiskAccessMode;
 
     @Before
     public void setCompactionParams()
     {
         originalDiskAccessMode = DatabaseDescriptor.getCompactionReadDiskAccessMode();
         originalCursorCompactionEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        originalBackgroundWriteDiskAccessMode = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
         DatabaseDescriptor.setCompactionReadDiskAccessMode(compactionReadDiskAccessMode);
         DatabaseDescriptor.setCursorCompactionEnabled(cursorCompactionEnabled);
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(backgroundWriteDiskAccessMode);
     }
 
     @After
@@ -130,6 +150,7 @@ public class CompactionsTest
     {
         DatabaseDescriptor.setCompactionReadDiskAccessMode(originalDiskAccessMode);
         DatabaseDescriptor.setCursorCompactionEnabled(originalCursorCompactionEnabled);
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(originalBackgroundWriteDiskAccessMode);
     }
 
     @BeforeClass
@@ -149,7 +170,10 @@ public class CompactionsTest
                                                 .compaction(CompactionParams.stcs(compactionOptions)),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD2),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD3),
-                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD4));
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD4),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_COMPRESSED_STANDARD1,
+                                                              0, AsciiType.instance, BytesType.instance, AsciiType.instance)
+                                                .compression(CompressionParams.lz4()));
     }
 
     public static long populate(String ks, String cf, int startRowKey, int endRowKey, int ttl)
@@ -420,6 +444,75 @@ public class CompactionsTest
         }
 
         assertEquals(keys, k);
+    }
+
+    @Test
+    public void testCompactionWithSizeLimitedRewriter() throws Exception
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_COMPRESSED_STANDARD1);
+        cfs.clearUnsafe();
+        cfs.disableAutoCompaction();
+
+        assertTrue("CF_COMPRESSED_STANDARD1 must be compressed for DIO to engage",
+                   cfs.metadata().params.compression.isEnabled());
+        assertEquals(backgroundWriteDiskAccessMode, DatabaseDescriptor.getBackgroundWriteDiskAccessMode());
+
+        // ~800 KiB of incompressible random data across 200 partitions -> >=2 output sstables at 64 KiB cap.
+        int valSize = 4096;
+        byte[] val = new byte[valSize];
+        new Random(42).nextBytes(val);
+        TableMetadata table = cfs.metadata();
+        long timestamp = System.currentTimeMillis();
+        for (int i = 0; i < 200; i++)
+        {
+            DecoratedKey key = Util.dk(String.format("%05d", i));
+            new RowUpdateBuilder(table, timestamp, key.getKey())
+                .clustering("0")
+                .add("val", ByteBuffer.wrap(val))
+                .build()
+                .applyUnsafe();
+        }
+        Util.flush(cfs);
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        Set<SSTableReader> originals = new HashSet<>(cfs.getLiveSSTables());
+        long maxSSTableSize = 64L * 1024;
+
+        LifecycleTransaction txn = cfs.getTracker().tryModify(originals, OperationType.COMPACTION);
+        CompactionTask task = new CompactionTask(cfs, txn, FBUtilities.nowInSeconds())
+        {
+            @Override
+            public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs,
+                                                                  Directories directories,
+                                                                  ILifecycleTransaction transaction,
+                                                                  Set<SSTableReader> nonExpiredSSTables)
+            {
+                return new MaxSSTableSizeWriter(cfs, directories, transaction, nonExpiredSSTables, maxSSTableSize, 0);
+            }
+        };
+        task.execute(CompactionManager.instance.active);
+
+        Set<SSTableReader> result = cfs.getLiveSSTables();
+        assertTrue("expected segment rotation to produce >= 2 SSTables, got " + result.size(), result.size() >= 2);
+
+        int partitionsRead = 0;
+        for (SSTableReader sstable : result)
+        {
+            try (ISSTableScanner scanner = sstable.getScanner())
+            {
+                while (scanner.hasNext())
+                {
+                    try (UnfilteredRowIterator it = scanner.next())
+                    {
+                        while (it.hasNext())
+                            it.next();
+                        partitionsRead++;
+                    }
+                }
+            }
+        }
+        assertEquals(200, partitionsRead);
     }
 
     private void testDontPurgeAccidentally(String k, String cfname) throws InterruptedException

--- a/test/unit/org/apache/cassandra/io/compress/DirectCompressedSequentialWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/DirectCompressedSequentialWriterTest.java
@@ -1,0 +1,1888 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.compress;
+
+import java.io.IOException;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.LoggerFactory;
+
+import accord.utils.Gen;
+import accord.utils.Gens;
+import accord.utils.RandomSource;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DataStorageSpec;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.io.FSReadError;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.util.DataIntegrityMetadata;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.metrics.StorageMetrics;
+import org.apache.cassandra.schema.CompressionParams;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import static accord.utils.Property.qt;
+import static org.apache.cassandra.schema.CompressionParams.DEFAULT_CHUNK_LENGTH;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+
+public class DirectCompressedSequentialWriterTest
+{
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DirectCompressedSequentialWriterTest.class);
+
+    // Logged in @BeforeClass so a property-test failure in CI can be reproduced locally.
+    private static long seed;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        seed = new Random().nextLong();
+        logger.info("DirectCompressedSequentialWriterTest property-based seed: {}", seed);
+    }
+
+    private static MetadataCollector newCollector()
+    {
+        return new MetadataCollector(new ClusteringComparator(Collections.singletonList(BytesType.instance)));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable
+    {
+        void run() throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface DataFileTest
+    {
+        void accept(File dataFile, File metadataFile) throws Exception;
+    }
+
+    private static void withTempDataFile(String prefix, DataFileTest body) throws Exception
+    {
+        File dataFile = FileUtils.createTempFile(prefix, ".db");
+        File metadataFile = new File(dataFile.absolutePath() + ".metadata");
+        try
+        {
+            body.accept(dataFile, metadataFile);
+        }
+        finally
+        {
+            dataFile.tryDelete();
+            metadataFile.tryDelete();
+        }
+    }
+
+    private static void withDirectWriteBufferSize(int kib, ThrowingRunnable body) throws Exception
+    {
+        Config conf = DatabaseDescriptor.getRawConfig();
+        DataStorageSpec.IntKibibytesBound saved = conf.direct_write_buffer_size;
+        conf.direct_write_buffer_size = new DataStorageSpec.IntKibibytesBound(kib + "KiB");
+        try
+        {
+            body.run();
+        }
+        finally
+        {
+            conf.direct_write_buffer_size = saved;
+        }
+    }
+
+    private static void readBackVerify(File dataFile, File metadataFile, byte[] expected) throws IOException
+    {
+        try (CompressionMetadata metadata = CompressionMetadata.open(metadataFile, dataFile.length(), true);
+             FileHandle fh = new FileHandle.Builder(dataFile).withCompressionMetadata(metadata).complete();
+             RandomAccessReader reader = fh.createReader())
+        {
+            assertEquals(expected.length, reader.length());
+            byte[] readBack = new byte[expected.length];
+            reader.readFully(readBack);
+            assertArrayEquals(expected, readBack);
+        }
+    }
+
+    @Test
+    public void testBufferSizedForWorstCaseCompressedOutput() throws Exception
+    {
+        // Large chunk so minRequiredSize dominates the default configured buffer — exercises the
+        // sizing formula directly rather than letting the config mask it.
+        assertBufferSizedForWorstCaseChunk(CompressionParams.lz4(1024 * 1024, Integer.MAX_VALUE));
+
+        // Same invariant at default chunk length for every supported compressor: worst-case
+        // initialCompressedBufferLength differs per compressor.
+        assertBufferSizedForWorstCaseChunk(CompressionParams.lz4());
+        assertBufferSizedForWorstCaseChunk(CompressionParams.zstd());
+        assertBufferSizedForWorstCaseChunk(CompressionParams.snappy());
+        assertBufferSizedForWorstCaseChunk(CompressionParams.deflate());
+    }
+
+    // writeBuffer must hold a worst-case compressed chunk + its CRC trailer plus up to (blockSize - 1)
+    // leftover bytes that survive a flushCompleteBlocks. If this fails, the SUT's mid-stream flush
+    // guards become reachable — and nothing tests them.
+    private static void assertBufferSizedForWorstCaseChunk(CompressionParams params) throws Exception
+    {
+        withTempDataFile("bufferSize", (dataFile, metadataFile) ->
+        {
+            MetadataCollector collector = newCollector();
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, params, collector, null))
+            {
+                int blockSize = FileUtils.getBlockSize(dataFile.parent());
+                int maxChunkWrite = params.getSstableCompressor().initialCompressedBufferLength(params.chunkLength());
+
+                int bufferCapacity = writer.writeBuffer().capacity();
+
+                int requiredCapacity = maxChunkWrite + Integer.BYTES + blockSize;
+                Assert.assertTrue(
+                String.format("%s: write buffer (%d) too small for worst-case chunk write (%d) + CRC (%d) + blockSize (%d) = %d",
+                              params.getSstableCompressor().getClass().getSimpleName(),
+                              bufferCapacity, maxChunkWrite, Integer.BYTES, blockSize, requiredCapacity),
+                bufferCapacity >= requiredCapacity);
+            }
+        });
+    }
+
+    @Test
+    public void testDirectWriteBufferMetricBalances() throws Exception
+    {
+        long bytes0 = StorageMetrics.directWriteBufferBytes.getCount();
+        long alloc0 = StorageMetrics.directWriteBuffersAllocated.getCount();
+
+        withTempDataFile("metric", (dataFile, metadataFile) ->
+        {
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null, SequentialWriterOption.DEFAULT, CompressionParams.lz4(), newCollector(), null))
+            {
+                assertEquals("byte gauge must rise by the allocated buffer capacity",
+                             bytes0 + writer.writeBuffer().capacity(), StorageMetrics.directWriteBufferBytes.getCount());
+                assertEquals("allocation meter must be marked exactly once per writer",
+                             alloc0 + 1, StorageMetrics.directWriteBuffersAllocated.getCount());
+            }
+
+            assertEquals("byte gauge must return to baseline once the writer is cleaned up",
+                         bytes0, StorageMetrics.directWriteBufferBytes.getCount());
+        });
+    }
+
+    /**
+     * The only guaranteed NOOP round-trip: testDigestMatchesStandardWriter omits NOOP and the
+     * randomized sweep only samples it, so a given seed can skip NOOP entirely. Worth a named test
+     * because NOOP is the identity path (every chunk stored verbatim + CRC) and never reaches this
+     * writer in prod — it comes only from FLUSH, which is gated out of O_DIRECT (the gate itself is
+     * asserted separately, not here).
+     */
+    @Test
+    public void testNoopCompressor() throws Exception
+    {
+        testWriteAndRead("noop", DEFAULT_CHUNK_LENGTH * 3 + 137, CompressionParams.NOOP);
+    }
+
+    @Test
+    public void testDigestMatchesStandardWriter() throws IOException
+    {
+        CompressionParams[] paramSet = { CompressionParams.lz4(),
+                                         CompressionParams.zstd(),
+                                         CompressionParams.snappy(),
+                                         CompressionParams.deflate() };
+        int chunk = DEFAULT_CHUNK_LENGTH;
+        int[] sizes = { 1, chunk - 1, chunk, chunk + 1, chunk * 3 + 137 };
+
+        for (CompressionParams params : paramSet)
+        {
+            for (int dataSize : sizes)
+            {
+                byte[] testData = new byte[dataSize];
+                new Random(0xC0FFEEL ^ dataSize).nextBytes(testData);
+
+                byte[] standardDigest = writeAndReadDigest(testData, params, false);
+                byte[] directDigest = writeAndReadDigest(testData, params, true);
+
+                String label = params.getSstableCompressor().getClass().getSimpleName() + "/" + dataSize;
+                assertArrayEquals("Digest mismatch for " + label, standardDigest, directDigest);
+            }
+        }
+    }
+
+    private byte[] writeAndReadDigest(byte[] data, CompressionParams params, boolean direct) throws IOException
+    {
+        String prefix = (direct ? "direct" : "standard") + "_digest_";
+        File dataFile = FileUtils.createTempFile(prefix, ".db");
+        File metadataFile = new File(dataFile.absolutePath() + ".metadata");
+        File digestFile = FileUtils.createTempFile(prefix, ".digest");
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (SequentialWriter writer = direct
+                                           ? new DirectCompressedSequentialWriter(dataFile, metadataFile, digestFile,
+                                                                                  SequentialWriterOption.DEFAULT, params, collector, null)
+                                           : new CompressedSequentialWriter(dataFile, metadataFile, digestFile,
+                                                                            SequentialWriterOption.DEFAULT, params, collector))
+            {
+                writer.write(data);
+                writer.finish();
+            }
+            return Files.readAllBytes(digestFile.toPath());
+        }
+        finally
+        {
+            dataFile.tryDelete();
+            metadataFile.tryDelete();
+            digestFile.tryDelete();
+        }
+    }
+
+    @Test
+    public void testMarkThrowsUnsupportedOperationException() throws Exception
+    {
+        withTempDataFile("mark_test", (dataFile, metadataFile) ->
+        {
+            MetadataCollector collector = newCollector();
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, CompressionParams.lz4(), collector, null))
+            {
+                writer.write(new byte[100]);
+                try
+                {
+                    writer.mark();
+                    fail("Expected UnsupportedOperationException");
+                }
+                catch (UnsupportedOperationException expected)
+                {
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testResetAndTruncateThrowsUnsupportedOperationException() throws Exception
+    {
+        withTempDataFile("reset_test", (dataFile, metadataFile) ->
+        {
+            MetadataCollector collector = newCollector();
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, CompressionParams.lz4(), collector, null))
+            {
+                writer.write(new byte[100]);
+                try
+                {
+                    writer.resetAndTruncate(null);
+                    fail("Expected UnsupportedOperationException");
+                }
+                catch (UnsupportedOperationException expected)
+                {
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testAbortBeforeFlushCleansUpResources() throws Exception
+    {
+        withTempDataFile("abort_test", (dataFile, metadataFile) ->
+        {
+            byte[] testData = new byte[1024];
+            new Random(99).nextBytes(testData);
+
+            MetadataCollector collector = newCollector();
+
+            // finishOnClose(false) routes close() through the abort path instead of finish().
+            SequentialWriterOption abortOnCloseOption = SequentialWriterOption.newBuilder()
+                                                                              .finishOnClose(false)
+                                                                              .build();
+
+            DirectCompressedSequentialWriter writerRef;
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            abortOnCloseOption, CompressionParams.lz4(), collector, null))
+            {
+                writerRef = writer;
+                writer.write(testData);
+            }
+
+            // Sub-block write (1024 B < blockSize ≥4096): flushCompleteBlocks never had a full
+            // block to flush, so nothing reached the channel BEFORE the abort. doPrepare (where
+            // flushFinalWithPadding lives) does not run on the abort path either, so the file is
+            // empty. Sibling testAbortAfterFlushCleansUpResources covers abort AFTER a flush.
+            assertEquals("aborted data file should be empty (abort before any flush, no doPrepare)",
+                         0L, dataFile.length());
+
+            // doPreCleanup frees and nulls writeBuffer even when nothing was ever flushed.
+            assertNull("writeBuffer must be released by doPreCleanup on abort", writerRef.writeBuffer());
+        });
+    }
+
+    @Test
+    public void testAbortAfterFlushCleansUpResources() throws Exception
+    {
+        CompressionParams params = CompressionParams.lz4();
+        int chunk = params.chunkLength();
+
+        // Smallest warning-free buffer (worst-case chunk + CRC + one block), so a few incompressible
+        // chunks overflow it and force flushCompleteBlocks to write whole blocks to the channel.
+        int max = params.getSstableCompressor().initialCompressedBufferLength(chunk);
+        int minRequired = max + Integer.BYTES + 4096;
+        int bufferKiB = roundUpToKiB(minRequired) / 1024;
+
+        withDirectWriteBufferSize(bufferKiB, () ->
+        withTempDataFile("abort_after_flush", (dataFile, metadataFile) ->
+        {
+            int blockSize = FileUtils.getBlockSize(dataFile.parent());
+
+            // Random bytes don't compress under LZ4, so each chunk stays ~chunk-sized and
+            // several of them overflow the small buffer, forcing flushCompleteBlocks.
+            byte[] testData = new byte[chunk * 4];
+            new Random(99).nextBytes(testData);
+
+            MetadataCollector collector = newCollector();
+
+            // finishOnClose(false) routes close() through the abort path instead of finish().
+            SequentialWriterOption abortOnCloseOption = SequentialWriterOption.newBuilder()
+                                                                              .finishOnClose(false)
+                                                                              .build();
+
+            DirectCompressedSequentialWriter writerRef;
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            abortOnCloseOption, params, collector, null))
+            {
+                writerRef = writer;
+                writer.write(testData);
+
+                // While still OPEN: flushCompleteBlocks must already have written whole blocks.
+                // flushFinalWithPadding runs only on commit (doPrepare), never on abort, so any
+                // on-disk bytes at this point can only have come from flushCompleteBlocks.
+                long flushedBeforeAbort = dataFile.length();
+                assertTrue("expected flushCompleteBlocks to have written at least one block before abort, got "
+                           + flushedBeforeAbort, flushedBeforeAbort > 0);
+                assertEquals("flushed bytes must be a whole multiple of blockSize under O_DIRECT",
+                             0L, flushedBeforeAbort % blockSize);
+            }
+
+            // Abort neither truncates nor deletes: doPrepare (flushFinalWithPadding + truncate) runs
+            // only on commit, so blocks flushed by flushCompleteBlocks stay on disk. That is the
+            // contract — abort, like the base SequentialWriter's, releases only OS/off-heap resources;
+            // file cleanup belongs to the SSTable lifecycle (LogTransaction.SSTableTidier). Do not
+            // "fix" this to assert the file is gone: length > 0 is proof the after-flush path ran.
+            assertTrue("aborted data file should retain the blocks flushed before abort",
+                       dataFile.length() > 0);
+
+            // doPreCleanup frees and nulls writeBuffer even on the abort path.
+            assertNull("writeBuffer must be released by doPreCleanup on abort", writerRef.writeBuffer());
+        }));
+    }
+
+    @Test
+    public void testDirectMemoryIsCleanedOnClose() throws Exception
+    {
+        // Sized to dominate baseline allocator noise; matches DirectThreadLocalReadAheadBufferTest.
+        int bufferSize = 64 * 1024 * 1024;
+        withDirectWriteBufferSize(bufferSize / 1024, () ->
+        withTempDataFile("direct_mem_clean", (dataFile, metadataFile) ->
+        {
+            BufferPoolMXBean directPool = getDirectBufferPool();
+            MetadataCollector collector = newCollector();
+            SequentialWriterOption abortOnClose = SequentialWriterOption.newBuilder().finishOnClose(false).build();
+
+            long memoryUsedBefore;
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                 dataFile, metadataFile, null, abortOnClose, CompressionParams.lz4(), collector, null))
+            {
+                writer.write(new byte[1024]);
+                memoryUsedBefore = directPool.getMemoryUsed();
+            }
+            long memoryUsedAfter = directPool.getMemoryUsed();
+            long actualDecrease = memoryUsedBefore - memoryUsedAfter;
+
+            Assert.assertTrue("Direct memory should drop by ~bufferSize on close. before=" + memoryUsedBefore
+                              + ", after=" + memoryUsedAfter + ", decrease=" + actualDecrease + ", expected~=" + bufferSize,
+                              actualDecrease >= bufferSize * 0.9); // 10% tolerance for alignment overhead
+        }));
+    }
+
+    private static BufferPoolMXBean getDirectBufferPool()
+    {
+        for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class))
+            if (pool.getName().equals("direct"))
+                return pool;
+        throw new IllegalStateException("Direct buffer pool not found");
+    }
+
+    // The ctor call below intentionally throws before producing a writer; no AutoCloseable to manage.
+    @SuppressWarnings({ "resource", "IOResourceOpenedButNotSafelyClosed" })
+    @Test
+    public void testConstructorFailureClosesParentChannel() throws Exception
+    {
+        withTempDataFile("ctor_leak", (dataFile, metadataFile) ->
+        {
+            MetadataCollector collector = newCollector();
+
+            // Force getBlockSize() to 0 so the constructor throws after super() has opened
+            // the channel and allocated parent buffers, but before writeBuffer is assigned.
+            ChannelCapturingWriter.lastCapturedChannel = null;
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(0);
+
+                try
+                {
+                    new ChannelCapturingWriter(dataFile, metadataFile, SequentialWriterOption.DEFAULT,
+                                               CompressionParams.lz4(), collector);
+                    fail("Expected IllegalStateException from constructor");
+                }
+                catch (IllegalStateException expected)
+                {
+                    Assert.assertTrue("expected block-size message, got: " + expected.getMessage(),
+                                      expected.getMessage().contains("block size"));
+                }
+            }
+
+            FileChannel parentChannel = ChannelCapturingWriter.lastCapturedChannel;
+            assertNotNull("test subclass should have captured the parent FileChannel", parentChannel);
+            assertFalse("parent FileChannel must be closed after constructor failure",
+                        parentChannel.isOpen());
+        });
+    }
+
+    // The ctor call below intentionally throws before producing a writer; no AutoCloseable to manage.
+    @SuppressWarnings({ "resource", "IOResourceOpenedButNotSafelyClosed" })
+    @Test
+    public void testConstructorRejectsNonPowerOfTwoBlockSize() throws Exception
+    {
+        withTempDataFile("nonpow2_blocksize", (dataFile, metadataFile) ->
+        {
+            MetadataCollector collector = newCollector();
+
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(4097);
+
+                try
+                {
+                    new DirectCompressedSequentialWriter(dataFile, metadataFile, null,
+                                                         SequentialWriterOption.DEFAULT,
+                                                         CompressionParams.lz4(), collector, null);
+                    fail("Expected IllegalStateException for non-power-of-two block size");
+                }
+                catch (IllegalStateException expected)
+                {
+                    Assert.assertTrue("expected power-of-two message, got: " + expected.getMessage(),
+                                      expected.getMessage().contains("power of two"));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testUndersizedBufferLogsWarningOnce() throws Exception
+    {
+        // Reset the once-per-JVM guard so the test outcome is independent of execution order.
+        DirectCompressedSequentialWriter.resetUndersizedBufferWarned();
+
+        Logger writerLogger = (Logger) LoggerFactory.getLogger(DirectCompressedSequentialWriter.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        writerLogger.addAppender(appender);
+        try
+        {
+            // 1 KiB is well below lz4's minRequiredSize (worst-case 64 KiB chunk + 4 + 4 KiB block).
+            withDirectWriteBufferSize(1, () ->
+            {
+                for (String prefix : new String[]{ "undersized_1", "undersized_2" })
+                    withTempDataFile(prefix, (dataFile, metadataFile) ->
+                    {
+                        try (DirectCompressedSequentialWriter w = new DirectCompressedSequentialWriter(
+                             dataFile, metadataFile, null, SequentialWriterOption.DEFAULT, CompressionParams.lz4(), newCollector(), null))
+                        {
+                        }
+                    });
+            });
+
+            List<ILoggingEvent> warnings = appender.list.stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .filter(e -> e.getFormattedMessage().contains("direct_write_buffer_size"))
+                .collect(Collectors.toList());
+            assertEquals("Expected exactly one undersized-buffer warning across two writers, got: " + warnings,
+                         1, warnings.size());
+        }
+        finally
+        {
+            writerLogger.detachAppender(appender);
+            DirectCompressedSequentialWriter.resetUndersizedBufferWarned();
+        }
+    }
+
+    /**
+     * Captures the parent {@code FileChannel} via the overridden {@code txnProxy()}, which
+     * {@code SequentialWriter}'s field initializer invokes before this subclass's instance
+     * fields are assigned — hence the static slot.
+     */
+    private static class ChannelCapturingWriter extends DirectCompressedSequentialWriter
+    {
+        static volatile FileChannel lastCapturedChannel;
+
+        ChannelCapturingWriter(File file,
+                               File offsetsFile,
+                               SequentialWriterOption option,
+                               CompressionParams parameters,
+                               MetadataCollector collector)
+        {
+            super(file, offsetsFile, null, option, parameters, collector, null);
+        }
+
+        @Override
+        protected SequentialWriter.TransactionalProxy txnProxy()
+        {
+            lastCapturedChannel = (FileChannel) channel;
+            return super.txnProxy();
+        }
+    }
+
+    @Test
+    public void testDigestFileValidation() throws Exception
+    {
+        CompressionParams params = CompressionParams.lz4();
+        int chunkLength = params.chunkLength();
+
+        for (int dataSize : new int[]{ 100, chunkLength, chunkLength * 3 + 500 })
+            withTempDataFile("digest_validate_" + dataSize, (dataFile, metadataFile) ->
+            {
+                File digestFile = FileUtils.createTempFile("digest_validate_" + dataSize, ".digest");
+                try
+                {
+                    byte[] testData = new byte[dataSize];
+                    new Random(42).nextBytes(testData);
+
+                    try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                    dataFile, metadataFile, digestFile,
+                    SequentialWriterOption.DEFAULT, params, newCollector(), null))
+                    {
+                        writer.write(testData);
+                        writer.finish();
+                    }
+
+                    new DataIntegrityMetadata.FileDigestValidator(dataFile, digestFile).validate();
+                }
+                finally
+                {
+                    digestFile.tryDelete();
+                }
+            });
+    }
+
+    @Test
+    public void testCompressionFailureFallback() throws Exception
+    {
+        int chunkLength = DEFAULT_CHUNK_LENGTH;
+        // maxCompressedLength == chunkLength forces fallback to the uncompressed path when
+        // a chunk doesn't compress smaller than the input.
+        CompressionParams params = CompressionParams.lz4(chunkLength, chunkLength);
+        int dataSize = chunkLength * 3;
+
+        // Random bytes don't compress under LZ4, so at least one chunk MUST take the fallback.
+        byte[] testData = new byte[dataSize];
+        new Random(42).nextBytes(testData);
+
+        withTempDataFile("compressionFailure_direct", (dataFile, metadataFile) ->
+        {
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, params, newCollector(), null))
+            {
+                writer.write(testData);
+                writer.finish();
+            }
+
+            readBackVerify(dataFile, metadataFile, testData);
+
+            try (CompressionMetadata metadata = CompressionMetadata.open(metadataFile, dataFile.length(), true))
+            {
+                // Fallback chunks have stored length == chunkLength (data stored verbatim);
+                // compressed chunks have length < chunkLength.
+                int chunks = (dataSize + chunkLength - 1) / chunkLength;
+                boolean anyUncompressed = false;
+                for (int i = 0; i < chunks; i++)
+                    if (metadata.chunkFor((long) i * chunkLength).length == chunkLength)
+                    {
+                        anyUncompressed = true;
+                        break;
+                    }
+                assertTrue("expected at least one chunk to take the uncompressed fallback path",
+                           anyUncompressed);
+
+                // chunkOffsetsSize counts bytes, not chunks: one long offset per chunk.
+                assertEquals("metadata chunk count should match expected chunk count",
+                             chunks, (int) (metadata.chunkOffsetsSize / Long.BYTES));
+
+                // On-disk chunk offsets must strictly increase: each chunk is written after the prior.
+                long prevOffset = -1;
+                for (int i = 0; i < chunks; i++)
+                {
+                    long offset = metadata.chunkFor((long) i * chunkLength).offset;
+                    assertTrue("chunk offsets must be strictly increasing: chunk " + i +
+                               " offset " + offset + " not greater than previous " + prevOffset,
+                               offset > prevOffset);
+                    prevOffset = offset;
+                }
+            }
+        });
+    }
+
+    /**
+     * Byte equivalence with the standard writer in uncompressed-fallback mode (maxCompressedLength ==
+     * chunkLength on incompressible data) — the fallback companion to testDigestMatchesStandardWriter.
+     * Digest equivalence is implied: the digest is a deterministic function of data + per-chunk CRCs.
+     */
+    @Test
+    public void testCompressionFailureMatchesStandardWriter() throws Exception
+    {
+        int chunkLength = DEFAULT_CHUNK_LENGTH;
+        CompressionParams params = CompressionParams.lz4(chunkLength, chunkLength);
+        byte[] payload = new byte[chunkLength * 2 + 100]; // partial last chunk exercises padding
+        new Random(42).nextBytes(payload);
+        assertWriteAndReadMatchesStandardWriter(payload, params);
+    }
+
+    @Test
+    public void testPartialChannelWritesAreFullyDrained() throws Exception
+    {
+        int blockSize = 4096;
+        CompressionParams params = CompressionParams.lz4();
+        // Incompressible and several chunks, so flushes span multiple blocks — far larger than the cap.
+        byte[] payload = new byte[DEFAULT_CHUNK_LENGTH * 3];
+        new Random(42).nextBytes(payload);
+
+        withTempDataFile("partialWrite_direct", (dataFile, metadataFile) ->
+        {
+            PartialWritingFileChannel partial;
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(blockSize);
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                dataFile, metadataFile, null, SequentialWriterOption.DEFAULT, params, newCollector(), null))
+                {
+                    // Invariant: cap < blockSize. The channel is handed block-aligned flush buffers
+                    // (always >= blockSize), so a sub-block cap forces every flush to split across calls.
+                    // The multi-block payload guarantees at least one such flush exists.
+                    int writeCap = blockSize / 2;
+                    partial = installPartialChannel(writer, dataFile, writeCap);
+                    writer.write(payload);
+                    writer.finish();
+                }
+            }
+
+            // Proves the invariant actually engaged the drain loop, rather than trusting the arithmetic.
+            assertTrue("cap must force a short write, else the drain loop is untested", partial.shortWrites > 0);
+            readBackVerify(dataFile, metadataFile, payload);
+        });
+    }
+
+    /**
+     * Pins the getOnDiskFilePointer() contract: 0 before any write, advancing as chunks flush
+     * mid-stream, equal to the file length after finish() — padding is truncated away, so it never counts.
+     */
+    @Test
+    public void testOnDiskFilePointerTracksActualDataSize() throws Exception
+    {
+        int chunkLength = DEFAULT_CHUNK_LENGTH;
+        CompressionParams params = CompressionParams.lz4(chunkLength);
+
+        // Incompressible payload of exactly 4 full chunks so every chunk produces real on-disk growth.
+        byte[] payload = new byte[chunkLength * 4];
+        new Random(42).nextBytes(payload);
+
+        withTempDataFile("onDiskPointer_direct", (dataFile, metadataFile) ->
+        {
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, params, newCollector(), null))
+            {
+                assertEquals("pointer must be 0 before any write", 0L, writer.getOnDiskFilePointer());
+
+                // chunkLength-sized slices make the parent fill (and flush) a chunk per slice, so the
+                // pointer advances mid-stream rather than only at finish().
+                ByteBuffer slice = ByteBuffer.wrap(payload);
+                long previous = 0L;
+                for (int offset = 0; offset < payload.length; offset += chunkLength)
+                {
+                    slice.position(offset).limit(offset + chunkLength);
+                    writer.write(slice);
+
+                    long current = writer.getOnDiskFilePointer();
+                    assertTrue("pointer must be monotonic non-decreasing, was " + previous + " now " + current,
+                               current >= previous);
+                    previous = current;
+                }
+
+                assertTrue("pointer must advance above 0 before finish() (mid-stream chunk flushes), was " + previous,
+                           previous > 0L);
+
+                writer.finish();
+
+                assertEquals("after finish() the pointer must equal the truncated file length",
+                             dataFile.length(), writer.getOnDiskFilePointer());
+            }
+        });
+    }
+
+    /**
+     * Regression guard for the openFinalEarly (SYNC) short-read: under O_DIRECT the last chunk's sub-block tail is
+     * still buffered after sync(), so a reader bound before commit short-reads past EOF without the
+     * tail-flush. Tiny sub-block outputs (e.g. system/IndexInfo) are the prod shape.
+     */
+    @Test
+    public void testEarlyOpenAfterSyncReadsBackData() throws IOException
+    {
+        for (int size : new int[]{ 1, 64, 298, 1024, 4096, DEFAULT_CHUNK_LENGTH * 3 + 137 })
+            assertReadBack(OpenMoment.SYNC, ReaderPath.POINT, compressible(size), CompressionParams.lz4(), BufferRegime.DEFAULT);
+    }
+
+    // Compresses well below one block, so no whole block fills and nothing reaches disk before
+    // finalization — the worst case for every early-open moment.
+    private static byte[] compressible(int size)
+    {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++)
+            data[i] = (byte) (i % 7);
+        return data;
+    }
+
+    /**
+     * Regression guard for the preemptive early-open (SSTableRewriter.maybeReopenEarly) short-read: it never calls
+     * sync(), so the writer must report the durable (whole-block) offset — a staged offset would let the
+     * reader short-read chunks still parked in writeBuffer.
+     */
+    @Test
+    public void testPreemptiveOpenReadsBackSyncedData() throws IOException
+    {
+        // Many small chunks that compress far below one block: nothing reaches disk before finish, so the
+        // writer reports 0 synced (the prod system/IndexInfo shape) and the read is skipped.
+        assertReadBack(OpenMoment.PREEMPTIVE, ReaderPath.POINT,
+                       compressible(DEFAULT_CHUNK_LENGTH * 4 + 137), CompressionParams.lz4(), BufferRegime.DEFAULT);
+
+        // Several MiB of incompressible data forces real block flushes mid-write, so the synced boundary
+        // must advance past zero (preemptive open still works) yet never cross the still-buffered tail.
+        long synced = assertReadBack(OpenMoment.PREEMPTIVE, ReaderPath.POINT,
+                                     incompressible(4 * 1024 * 1024), CompressionParams.lz4(), BufferRegime.DEFAULT);
+        assertTrue("expected the synced boundary to advance for multi-MiB data", synced > 0);
+    }
+
+    private static byte[] incompressible(int size)
+    {
+        byte[] data = new byte[size];
+        new Random(42).nextBytes(data);
+        return data;
+    }
+
+    /**
+     * A scanner snapshots the data file's size at open. If commit later truncates the padded early-open file,
+     * the live scanner short-reads its last block — the CorruptSSTableException seen on
+     * system/local_metadata_log under dtest-latest.
+     */
+    @Test
+    public void testEarlyOpenScanReadsBackAfterCommitTruncate() throws IOException
+    {
+        for (int size : new int[]{ 1, 298, 1024, DEFAULT_CHUNK_LENGTH * 3 + 137 })
+            assertReadBack(OpenMoment.SYNC, ReaderPath.SCAN, compressible(size), CompressionParams.lz4(), BufferRegime.DEFAULT);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Read-back matrix for the bug class "a reader binds to a mid-flight O_DIRECT file the writer then mutates".
+    // The open-moment and reader-path axes that hid the scan-truncate short-read are enumerated, not
+    // sampled — a size-only fuzzer would miss them.
+    // ---------------------------------------------------------------------------------------------------
+
+    // The three moments a reader can bind to a live writer's data file (STREAM excluded — streaming receive
+    // never early-opens before commit; readers open only after the SSTable is finished).
+    private enum OpenMoment { SYNC, PREEMPTIVE, COMMIT }
+
+    // POINT = chunk-metadata-bounded random access; SCAN = read-ahead path that snapshots channel.size() once.
+    private enum ReaderPath { POINT, SCAN }
+
+    // DEFAULT = configured 1 MiB write buffer; SMALL = 1 KiB, coerced up to the per-writer minimum so
+    // flushCompleteBlocks fires almost every chunk (maximises block-boundary crossings under O_DIRECT).
+    private enum BufferRegime { DEFAULT, SMALL }
+
+    /**
+     * One driver for every matrix cell. Writes {@code payload} via the O_DIRECT writer, binds a reader at
+     * {@code moment} over {@code path}, and asserts the readable prefix round-trips. Returns the number of
+     * bytes verified (payload.length for SYNC/COMMIT, the durable offset for PREEMPTIVE).
+     *
+     * The read/finish order is path-dependent:
+     *  - POINT early-open binds to the chunk-metadata length, so it must read BEFORE finish() flushes the
+     *    buffered tail — that window is where the SYNC and PREEMPTIVE early-open short-reads occur.
+     *  - SCAN early-open snapshots channel.size() at reader construction, so it must read AFTER finish()
+     *    truncates the padded file — reading that post-truncate snapshot is where the scan short-read occurs.
+     * COMMIT opens only after finish() and is the safe-by-construction control.
+     */
+    private static long assertReadBack(OpenMoment moment, ReaderPath path, byte[] payload,
+                                       CompressionParams params, BufferRegime regime) throws IOException
+    {
+        // CompressedChunkReader builds the scan reader only when read-ahead exceeds chunkLength; otherwise
+        // SCAN silently degrades to a point read and the cell tests nothing.
+        if (path == ReaderPath.SCAN)
+        {
+            int readAhead = DatabaseDescriptor.getCompressedReadAheadBufferSize();
+            assertTrue("SCAN cell would silently fall back to a point read: compressed_read_ahead_buffer_size ("
+                       + readAhead + ") must exceed chunkLength (" + params.chunkLength()
+                       + "). Raise read-ahead or lower chunkLength.",
+                       readAhead > params.chunkLength());
+        }
+
+        Config conf = DatabaseDescriptor.getRawConfig();
+        DataStorageSpec.IntKibibytesBound savedBuffer = conf.direct_write_buffer_size;
+        if (regime == BufferRegime.SMALL)
+            conf.direct_write_buffer_size = new DataStorageSpec.IntKibibytesBound("1KiB");
+
+        File dataFile = FileUtils.createTempFile("readback_matrix_direct", ".db");
+        File metadataFile = new File(dataFile.absolutePath() + ".metadata");
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                dataFile, metadataFile, null, SequentialWriterOption.DEFAULT, params, collector, null))
+            {
+                // PREEMPTIVE binds to whatever offset the writer reports durable via the post-flush listener
+                // (the same hook that drives PartitionIndexBuilder.markDataSynced). Register before writing.
+                long[] capturedOffset = { 0 };
+                if (moment == OpenMoment.PREEMPTIVE)
+                    writer.setPostFlushListener(off -> capturedOffset[0] = off);
+
+                writer.write(payload);
+
+                switch (moment)
+                {
+                    case SYNC:
+                        // openFinalEarly: sync() finalizes the file, then open(0) == NO_LENGTH_OVERRIDE.
+                        writer.sync();
+                        try (CompressionMetadata md = writer.open(0))
+                        {
+                            readEarlyOpenAndFinish(writer, dataFile, md, path, payload, payload.length, moment, params, regime);
+                        }
+                        return payload.length;
+
+                    case PREEMPTIVE:
+                    {
+                        // openEarly: never calls sync(); the reader is bounded by the durable offset only.
+                        int readable = (int) capturedOffset[0];
+                        assertTrue("preemptive durable offset out of range: " + readable,
+                                   readable >= 0 && readable <= payload.length);
+                        if (readable == 0)
+                        {
+                            // Nothing durable yet (whole tail still buffered) — a legitimate prod shape; skip the read.
+                            writer.finish();
+                            return 0;
+                        }
+                        try (CompressionMetadata md = writer.open(readable))
+                        {
+                            readEarlyOpenAndFinish(writer, dataFile, md, path, payload, readable, moment, params, regime);
+                        }
+                        return readable;
+                    }
+
+                    case COMMIT:
+                        // Safe-by-construction control: open only after finish().
+                        writer.finish();
+                        try (CompressionMetadata md = CompressionMetadata.open(metadataFile, dataFile.length(), true);
+                             FileHandle fh = new FileHandle.Builder(dataFile).withCompressionMetadata(md).complete();
+                             RandomAccessReader reader = fh.createReader(null, path == ReaderPath.SCAN))
+                        {
+                            assertReadablePrefix(reader, payload, payload.length, moment, path, params, regime);
+                        }
+                        return payload.length;
+
+                    default:
+                        throw new AssertionError(moment);
+                }
+            }
+        }
+        finally
+        {
+            conf.direct_write_buffer_size = savedBuffer;
+            dataFile.tryDelete();
+            metadataFile.tryDelete();
+        }
+    }
+
+    // Read/finish order is path-dependent; see assertReadBack's contract.
+    private static void readEarlyOpenAndFinish(DirectCompressedSequentialWriter writer, File dataFile,
+                                               CompressionMetadata md, ReaderPath path, byte[] payload,
+                                               int readableLen, OpenMoment moment, CompressionParams params,
+                                               BufferRegime regime) throws IOException
+    {
+        try (FileHandle fh = new FileHandle.Builder(dataFile).withCompressionMetadata(md).complete();
+             RandomAccessReader reader = fh.createReader(null, path == ReaderPath.SCAN))
+        {
+            if (path == ReaderPath.SCAN)
+            {
+                writer.finish();
+                assertReadablePrefix(reader, payload, readableLen, moment, path, params, regime);
+            }
+            else
+            {
+                assertReadablePrefix(reader, payload, readableLen, moment, path, params, regime);
+                writer.finish();
+            }
+        }
+    }
+
+    private static void assertReadablePrefix(RandomAccessReader reader, byte[] payload, int readableLen,
+                                             OpenMoment moment, ReaderPath path, CompressionParams params,
+                                             BufferRegime regime) throws IOException
+    {
+        String ctx = moment + "/" + path + "/" + regime + " size=" + payload.length + " "
+                     + params.getSstableCompressor().getClass().getSimpleName() + " chunk=" + params.chunkLength();
+        if (path == ReaderPath.POINT)
+            assertEquals("readable length mismatch [" + ctx + ']', readableLen, reader.length());
+        byte[] readBack = new byte[readableLen];
+        reader.readFully(readBack);
+        assertArrayEquals("read-back mismatch [" + ctx + ']', Arrays.copyOf(payload, readableLen), readBack);
+    }
+
+    // Boundary shapes that have historically broken flush/early-open (see inline tags). Size 0 is excluded:
+    // an empty SSTable is never early-opened (open(0) asserts tCount>0); a COMMIT-only cell covers it.
+    private static int[] boundarySizes()
+    {
+        return new int[]{ 1, 298 /* sub-block */, 4096 /* one block */, 4097 /* one byte over */,
+                          DEFAULT_CHUNK_LENGTH - 1, DEFAULT_CHUNK_LENGTH, DEFAULT_CHUNK_LENGTH + 1,
+                          DEFAULT_CHUNK_LENGTH * 3 + 137 /* 3 chunks + non-aligned tail */ };
+    }
+
+    /**
+     * Full open × path × content × boundary-size cross on Lz4. Both content kinds matter: compressible keeps
+     * the whole tail buffered; incompressible forces a real mid-stream block flush. Plus one multi-MiB payload.
+     */
+    @Test
+    public void testReadBackAcrossOpenMomentsPathsAndBoundarySizes() throws IOException
+    {
+        for (OpenMoment moment : OpenMoment.values())
+            for (ReaderPath path : ReaderPath.values())
+            {
+                // Empty payload: only a committed reader can observe a 0-byte SSTable (early-open never fires
+                // on empty output).
+                if (moment == OpenMoment.COMMIT)
+                    assertReadBack(moment, path, new byte[0], CompressionParams.lz4(), BufferRegime.DEFAULT);
+
+                for (int size : boundarySizes())
+                {
+                    assertReadBack(moment, path, compressible(size), CompressionParams.lz4(), BufferRegime.DEFAULT);
+                    assertReadBack(moment, path, incompressible(size), CompressionParams.lz4(), BufferRegime.DEFAULT);
+                }
+                // Multi-MiB incompressible: forces many real mid-stream flushes so early-open boundaries advance.
+                assertReadBack(moment, path, incompressible(4 * 1024 * 1024), CompressionParams.lz4(), BufferRegime.DEFAULT);
+            }
+    }
+
+    // The early-open moments that bind to a mid-flight file. COMMIT (finished-file read-back) is omitted from
+    // the compressor cross below — it is already covered per-compressor by the standard-writer equality test.
+    private static final OpenMoment[] EARLY_OPEN_MOMENTS = { OpenMoment.SYNC, OpenMoment.PREEMPTIVE };
+
+    /**
+     * Early-open moment × path across all 5 compressors, three chunk lengths (all < 256 KiB read-ahead, so
+     * SCAN stays engaged), and both buffer regimes — to surface compressor- or chunk-specific flush bugs.
+     * 1 MiB incompressible forces many mid-stream flushes on every compressor.
+     */
+    @Test
+    public void testReadBackAcrossCompressorsChunkLengthsAndBufferRegimes() throws IOException
+    {
+        for (CompressorKind kind : CompressorKind.values())
+            for (int chunkLength : new int[]{ 1024, DEFAULT_CHUNK_LENGTH, 64 * 1024 })
+            {
+                CompressionParams params = paramsForKind(kind, chunkLength);
+                for (BufferRegime regime : BufferRegime.values())
+                    for (OpenMoment moment : EARLY_OPEN_MOMENTS)
+                        for (ReaderPath path : ReaderPath.values())
+                        {
+                            // per cell: compressible sub-block, incompressible multi-chunk tail, 1 MiB incompressible
+                            assertReadBack(moment, path, compressible(298), params, regime);
+                            assertReadBack(moment, path, incompressible(chunkLength * 3 + 137), params, regime);
+                            assertReadBack(moment, path, incompressible(1024 * 1024), params, regime);
+                        }
+            }
+    }
+
+    /**
+     * Random sizes 1..1 MiB with moment/path/content picked per example, to hit sizes between the enumerated
+     * boundaries. Lz4 @ default chunk keeps SCAN engaged.
+     */
+    @Test
+    public void testReadBackRandomSizesAcrossOpenMomentsAndPaths()
+    {
+        // A PREEMPTIVE example whose tail is still buffered verifies 0 bytes; assert the sweep verified
+        // some, so it can't silently degrade to all-vacuous.
+        AtomicLong totalVerified = new AtomicLong();
+        qt().withSeed(seed).withExamples(120).forAll(Gens.random()).check(rs -> {
+            OpenMoment moment = rs.pick(OpenMoment.values());
+            ReaderPath path = rs.pick(ReaderPath.values());
+            int size = rs.nextInt(1, (1024 * 1024) + 1);
+            byte[] payload = rs.nextBoolean() ? compressible(size) : incompressible(size);
+            totalVerified.addAndGet(assertReadBack(moment, path, payload, CompressionParams.lz4(), BufferRegime.DEFAULT));
+        });
+        assertTrue("random read-back sweep verified no bytes; every example degraded to a vacuous pass",
+                   totalVerified.get() > 0);
+    }
+
+    private void testWriteAndRead(String testName, int dataSize, CompressionParams params) throws Exception
+    {
+        byte[] testData = new byte[dataSize];
+        new Random(42).nextBytes(testData);
+
+        withTempDataFile(testName + "_direct", (dataFile, metadataFile) ->
+        {
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+            dataFile, metadataFile, null,
+            SequentialWriterOption.DEFAULT, params, newCollector(), null))
+            {
+                writer.write(testData);
+                writer.finish();
+            }
+            readBackVerify(dataFile, metadataFile, testData);
+        });
+    }
+
+    private enum CompressorKind { Lz4, Zstd, Snappy, Deflate, Noop }
+
+    // Powers of two 1 KiB → 64 KiB span the below-block, at-block, above-block, and many-blocks-per-chunk regimes.
+    private static Gen<Integer> mixedChunkLengths()
+    {
+        return Gens.pick(Stream.iterate(1024, n -> n <= 64 * 1024, n -> n * 2)
+                               .collect(Collectors.toList()));
+    }
+
+    private static Gen<CompressionParams> compressionParamsGen(Gen<Integer> chunkLengths)
+    {
+        return rs -> {
+            int chunkLength = chunkLengths.next(rs);
+            return paramsForKind(rs.pick(CompressorKind.values()), chunkLength);
+        };
+    }
+
+    @Test
+    public void testRandomizedWriteAndReadMatchesStandardWriter()
+    {
+        Gen<CompressionParams> paramsGen = compressionParamsGen(mixedChunkLengths());
+        // 1 B – 1 MiB covers below-chunk, single-chunk, multi-chunk, many-chunk, and
+        // large-file regimes in one sweep.
+        Gen.LongGen fileLengthGen = Gens.longs().between(1, 1024 * 1024);
+
+        // 100 examples keeps wall time bounded while sampling the (compressor, chunkLength, fileSize) space.
+        qt().withSeed(seed).withExamples(100).forAll(Gens.random(), paramsGen).check((rs, params) -> {
+            int dataSize = (int) fileLengthGen.nextLong(rs);
+            byte[] payload = new byte[dataSize];
+            rs.nextBytes(payload);
+            assertWriteAndReadMatchesStandardWriter(payload, params);
+        });
+    }
+
+    private static void assertWriteAndReadMatchesStandardWriter(byte[] payload, CompressionParams params) throws Exception
+    {
+        withTempDataFile("rt_direct", (directFile, directMeta) ->
+        withTempDataFile("rt_standard", (standardFile, standardMeta) ->
+        {
+            MetadataCollector dCollector = newCollector();
+            try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                 directFile, directMeta, null, SequentialWriterOption.DEFAULT, params, dCollector, null))
+            {
+                writer.write(payload);
+                writer.finish();
+            }
+
+            readBackVerify(directFile, directMeta, payload);
+
+            MetadataCollector sCollector = newCollector();
+            try (CompressedSequentialWriter writer = new CompressedSequentialWriter(
+                 standardFile, standardMeta, null, SequentialWriterOption.DEFAULT, params, sCollector))
+            {
+                writer.write(payload);
+                writer.finish();
+            }
+
+            byte[] standardBytes = Files.readAllBytes(standardFile.toPath());
+            byte[] directBytes = Files.readAllBytes(directFile.toPath());
+            assertArrayEquals("Direct vs standard writer on-disk bytes differ for " +
+                              params.getSstableCompressor().getClass().getSimpleName() +
+                              ", chunkLength=" + params.chunkLength() + ", size=" + payload.length,
+                              standardBytes, directBytes);
+        }));
+    }
+
+    @Test
+    public void testWriteAndReadAcrossBufferSizes() throws Exception
+    {
+        int chunk = DEFAULT_CHUNK_LENGTH;
+        CompressionParams params = CompressionParams.lz4(chunk);
+
+        int max = params.getSstableCompressor().initialCompressedBufferLength(chunk);
+        // 4 KiB is the common-case filesystem block; the writer rounds up to the actual
+        // blockSize at runtime, so these sizes remain valid lower bounds on 8 KiB FSes too.
+        int blockProxy = 4096;
+        int minRequired = max + Integer.BYTES + blockProxy;
+
+        // Three buffer regimes pin different flushCompleteBlocks branches:
+        //   exactly minRequired           → clear path dominates
+        //   minRequired + block           → frequent compact() of sub-block tail
+        //   1 MiB                          → many chunks accumulate before flush
+        // Crossed with four data sizes hitting different final-tail regimes:
+        //   chunk - 1                     → flushFinalWithPadding only
+        //   chunk * 3                     → 3 full chunks, partial-block tail at end
+        //   chunk * 3 + 137               → 3 full chunks + explicit non-aligned tail
+        //   1 MiB + chunk + 137           → overflows even the 1 MiB buffer, so
+        //                                   flushCompleteBlocks fires mid-stream in every regime
+        // Each case is proven byte-identical to the standard CompressedSequentialWriter (not just a
+        // self round-trip), so flush-boundary corruption under small buffers cannot slip through.
+        int[] bufferSizesBytes = { roundUpToKiB(minRequired),
+                                   roundUpToKiB(minRequired + blockProxy),
+                                   1024 * 1024 };
+        int[] dataSizes = { chunk - 1, chunk * 3, chunk * 3 + 137, 1024 * 1024 + chunk + 137 };
+
+        for (int sz : bufferSizesBytes)
+            withDirectWriteBufferSize(sz / 1024, () ->
+            {
+                for (int dataSize : dataSizes)
+                {
+                    byte[] payload = new byte[dataSize];
+                    new Random(0x5AFEL ^ dataSize).nextBytes(payload);
+                    assertWriteAndReadMatchesStandardWriter(payload, params);
+                }
+            });
+    }
+
+    // Round up so we never land below minRequired due to integer division when converting to KiB.
+    private static int roundUpToKiB(int bytes)
+    {
+        return ((bytes + 1023) / 1024) * 1024;
+    }
+
+    /**
+     * O_DIRECT alignment is the one gap the round-trip and byte-equality tests miss: macOS treats O_DIRECT as
+     * advisory, so a misaligned write succeeds silently and no normal test can assert alignment. So observe it:
+     * a tiny mocked block size forces mid-stream flushes (real blocks are >= 4096), and a recording channel spy
+     * asserts every {@code fchannel.write()} is a blockSize multiple at a blockSize offset.
+     */
+    @Test
+    public void testBlockAlignmentUnderSmallBlocksAndIncrementalWrites() throws Exception
+    {
+        // 1 KiB is coerced up to the per-writer minimum, so the buffer is as small as allowed and flushes
+        // fire almost every chunk.
+        withDirectWriteBufferSize(1, () ->
+            // 80 examples keeps wall time bounded while sweeping blockSize × compressor × chunkLength ×
+            // payload × write-chunking.
+            qt().withSeed(seed).withExamples(80).forAll(Gens.random()).check(rs -> {
+                int blockSize = rs.pickInt(8, 16, 64, 512);
+                int chunkLength = rs.pickInt(1024, 2048, 4096, 8192);
+                CompressionParams params = paramsForKind(rs.pick(CompressorKind.values()), chunkLength);
+                byte[] payload = new byte[rs.nextInt(1, 64 * 1024 + 1)];
+                rs.nextBytes(payload);
+                runAlignmentExample(blockSize, params, payload, sliceRandomly(payload, rs));
+            }));
+    }
+
+    /**
+     * Even with no write(), finish() emits one chunk: writeChunk always appends the 4-byte CRC trailer, so the
+     * buffer is non-empty when flushFinalWithPadding runs and its {@code logicalPos == 0} early return is
+     * unreachable. Pins that premise so nobody "fixes" the guard expecting an empty file to skip the flush.
+     */
+    @Test
+    public void testEmptyFileWritesSingleChunkMatchingStandardWriter() throws Exception
+    {
+        CompressionParams params = CompressionParams.lz4();
+        int blockSize = 8; // mocked small block: the lone padded final write is a clean multiple to assert on.
+
+        // Oracle: the standard writer's empty SSTable (one empty chunk + CRC). Computed before the mock;
+        // blockSize only affects O_DIRECT padding, which is truncated away, never the logical bytes.
+        byte[] standardBytes = standardWriterBytes(new byte[0], params);
+
+        File dataFile = FileUtils.createTempFile("empty_direct", ".db");
+        File metaFile = new File(dataFile.absolutePath() + ".metadata");
+        RecordingFileChannel recording = null;
+        long pointerAfterFinish = -1;
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(blockSize);
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metaFile, null, SequentialWriterOption.DEFAULT, params, collector, null))
+                {
+                    recording = installRecordingChannel(writer, dataFile);
+                    writer.finish();
+                    pointerAfterFinish = writer.getOnDiskFilePointer();
+                }
+            }
+
+            // At least one block-aligned O_DIRECT write — the empty-buffer early return is not taken.
+            assertFalse("empty file still writes a padded final block (empty-buffer early return is unreachable)",
+                        recording.writes.isEmpty());
+            for (long[] w : recording.writes)
+            {
+                assertEquals("channel write offset not block-aligned", 0, w[0] % blockSize);
+                assertEquals("channel write length not a block multiple", 0, w[1] % blockSize);
+            }
+
+            byte[] directBytes = Files.readAllBytes(dataFile.toPath());
+            assertArrayEquals("empty-file on-disk bytes differ from standard writer", standardBytes, directBytes);
+            assertEquals("getOnDiskFilePointer should equal final on-disk data size", standardBytes.length, pointerAfterFinish);
+            assertEquals("dataFile length should equal actualDataSize after truncate", standardBytes.length, dataFile.length());
+
+            try (CompressionMetadata metadata = CompressionMetadata.open(metaFile, dataFile.length(), true);
+                 FileHandle fh = new FileHandle.Builder(dataFile).withCompressionMetadata(metadata).complete();
+                 RandomAccessReader reader = fh.createReader())
+            {
+                assertEquals("empty SSTable should read back zero uncompressed bytes", 0L, reader.length());
+            }
+        }
+        finally
+        {
+            if (recording != null)
+                recording.closeQuietly();
+            dataFile.tryDelete();
+            metaFile.tryDelete();
+        }
+    }
+
+    /**
+     * At every post-flush callback the reported durable offset must equal the uncompressed end of the
+     * last chunk fully on disk, CRC included — more and an early-open reader short-reads; less and
+     * early-open is pointlessly conservative. The oracle is rebuilt independently from
+     * CompressionMetadata after finish().
+     */
+    @Test
+    public void testDurableOffsetExactlyTracksOnDiskChunks() throws Exception
+    {
+        // Large-buffer examples legitimately report 0 throughout (nothing reaches disk mid-stream),
+        // so require the sweep to hit partial durability somewhere.
+        AtomicBoolean sawPartialDurability = new AtomicBoolean();
+        qt().withSeed(seed).withExamples(80).forAll(Gens.random()).check(rs -> {
+            int blockSize = rs.pickInt(8, 16, 64, 512);
+            int chunkLength = rs.pickInt(1024, 2048, 4096, 8192);
+            CompressionParams params = paramsForKind(rs.pick(CompressorKind.values()), chunkLength);
+            byte[] payload = new byte[rs.nextInt(1, 64 * 1024 + 1)];
+            rs.nextBytes(payload);
+            // 1 KiB coerces to the per-writer floor: flushes nearly every chunk, draining the queue
+            // incrementally. 64 KiB flushes occasionally. 1 MiB never flushes mid-stream: the queue
+            // grows past its initial capacity of 8 and nothing is durable until finish.
+            int bufferKiB = rs.pickInt(1, 64, 1024);
+            withDirectWriteBufferSize(bufferKiB, () ->
+                runDurableOffsetExample(blockSize, params, payload, sliceRandomly(payload, rs), sawPartialDurability));
+        });
+        assertTrue("sweep never observed 0 < durable < total; the partial-durability boundary was not exercised",
+                   sawPartialDurability.get());
+    }
+
+    private void runDurableOffsetExample(int blockSize, CompressionParams params, byte[] payload,
+                                         List<byte[]> slices, AtomicBoolean sawPartialDurability) throws Exception
+    {
+        File dataFile = FileUtils.createTempFile("durable_direct", ".db");
+        File metaFile = new File(dataFile.absolutePath() + ".metadata");
+        RecordingFileChannel recording = null;
+        try
+        {
+            MetadataCollector collector = newCollector();
+            // Each entry: { reportedDurableUncompressedOffset, onDiskBytesAtCallback }.
+            List<long[]> samples = new ArrayList<>();
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(blockSize);
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metaFile, null, SequentialWriterOption.DEFAULT, params, collector, null))
+                {
+                    RecordingFileChannel channel = installRecordingChannel(writer, dataFile);
+                    recording = channel;
+                    // The listener runs synchronously after the writer computes the durable offset
+                    // from this same position — no intervening writes, so the pair is exact.
+                    writer.setPostFlushListener(durable -> {
+                        try
+                        {
+                            samples.add(new long[]{ durable, channel.position() });
+                        }
+                        catch (IOException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    for (byte[] slice : slices)
+                        writer.write(slice);
+                    writer.finish();
+                }
+            }
+
+            // Oracle: per-chunk {compressedEndWithCrc, uncompressedEnd} reconstructed from the final
+            // metadata. Chunk.length excludes the 4-byte CRC, so on-disk end = offset + length + 4.
+            int chunkLen = params.chunkLength();
+            int chunkCount = (payload.length + chunkLen - 1) / chunkLen;
+            long[] compressedEnds = new long[chunkCount];
+            long[] uncompressedEnds = new long[chunkCount];
+            try (CompressionMetadata metadata = CompressionMetadata.open(metaFile, dataFile.length(), true))
+            {
+                for (int i = 0; i < chunkCount; i++)
+                {
+                    CompressionMetadata.Chunk chunk = metadata.chunkFor((long) i * chunkLen);
+                    compressedEnds[i] = chunk.offset + chunk.length + 4;
+                    uncompressedEnds[i] = Math.min((long) (i + 1) * chunkLen, payload.length);
+                }
+            }
+
+            long previous = 0;
+            for (long[] sample : samples)
+            {
+                long reported = sample[0];
+                long onDisk = sample[1];
+                long expected = 0;
+                for (int i = 0; i < chunkCount && compressedEnds[i] <= onDisk; i++)
+                    expected = uncompressedEnds[i];
+                assertEquals("durable offset must be exactly the last chunk fully on disk (onDisk=" + onDisk +
+                             ", block=" + blockSize + ", chunkLength=" + chunkLen +
+                             ", compressor=" + params.getSstableCompressor().getClass().getSimpleName() +
+                             ", payload=" + payload.length + ')',
+                             expected, reported);
+                assertTrue("durable offset went backwards: " + reported + " < " + previous, reported >= previous);
+                previous = reported;
+                if (reported > 0 && reported < payload.length)
+                    sawPartialDurability.set(true);
+            }
+        }
+        finally
+        {
+            if (recording != null)
+                recording.closeQuietly();
+            dataFile.tryDelete();
+            metaFile.tryDelete();
+        }
+    }
+
+    /**
+     * Injects an IOException on a random channel write: the writer must surface FSWriteError carrying
+     * the injected cause, and the abort that close() runs afterwards must not throw. Fault points
+     * beyond the example's write count finish normally and must match the standard writer
+     * byte-for-byte; a sweep-level guard ensures some faults fired.
+     */
+    @Test
+    public void testWriteFailureMidStreamThrowsFSWriteErrorAndAbortsCleanly() throws Exception
+    {
+        AtomicBoolean anyFaultFired = new AtomicBoolean();
+        // Floor-sized buffer maximizes mid-stream channel writes, so most fault points land.
+        withDirectWriteBufferSize(1, () ->
+            qt().withSeed(seed).withExamples(60).forAll(Gens.random()).check(rs -> {
+                int blockSize = rs.pickInt(8, 16, 64, 512);
+                CompressionParams params = paramsForKind(rs.pick(CompressorKind.values()), rs.pickInt(1024, 2048, 4096));
+                byte[] payload = new byte[rs.nextInt(1, 64 * 1024 + 1)];
+                rs.nextBytes(payload);
+                int failOnWrite = rs.nextInt(1, 9);
+                runWriteFaultExample(blockSize, params, payload, failOnWrite, anyFaultFired);
+            }));
+        assertTrue("no example fired its injected write fault; the sweep degraded to all-success",
+                   anyFaultFired.get());
+    }
+
+    private void runWriteFaultExample(int blockSize, CompressionParams params, byte[] payload,
+                                      int failOnWrite, AtomicBoolean anyFaultFired) throws Exception
+    {
+        byte[] standardBytes = standardWriterBytes(payload, params);
+
+        File dataFile = FileUtils.createTempFile("fault_direct", ".db");
+        File metaFile = new File(dataFile.absolutePath() + ".metadata");
+        FaultInjectingFileChannel channel = null;
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(blockSize);
+                FSWriteError observed = null;
+                // finishOnClose(false): close() runs the abort path when finish() failed — the abort
+                // itself must not throw, or try-with-resources surfaces it and fails the example.
+                SequentialWriterOption abortOnCloseOption = SequentialWriterOption.newBuilder()
+                                                                                  .finishOnClose(false)
+                                                                                  .build();
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metaFile, null, abortOnCloseOption, params, collector, null))
+                {
+                    channel = installFaultChannel(writer, dataFile).failOnWriteIndex(failOnWrite);
+                    try
+                    {
+                        writer.write(payload);
+                        writer.finish();
+                    }
+                    catch (FSWriteError e)
+                    {
+                        observed = e;
+                    }
+                }
+
+                if (channel.faultFired)
+                {
+                    anyFaultFired.set(true);
+                    assertNotNull("write fault fired but no FSWriteError surfaced", observed);
+                    assertTrue("FSWriteError should carry the injected IOException, got: " + observed.getCause(),
+                               observed.getCause() instanceof IOException
+                               && FaultInjectingFileChannel.INJECTED_MESSAGE.equals(observed.getCause().getMessage()));
+                }
+                else
+                {
+                    assertNull("no fault fired yet an FSWriteError surfaced", observed);
+                    assertArrayEquals("fault-free example must match the standard writer",
+                                      standardBytes, Files.readAllBytes(dataFile.toPath()));
+                }
+            }
+        }
+        finally
+        {
+            if (channel != null)
+                channel.closeQuietly();
+            dataFile.tryDelete();
+            metaFile.tryDelete();
+        }
+    }
+
+    /** Truncate happens once, in flushFinalWithPadding: its IOException must surface as FSWriteError. */
+    @Test
+    public void testTruncateFailureDuringFinishThrowsFSWriteError() throws Exception
+    {
+        withTempDataFile("truncate_fault", (dataFile, metadataFile) ->
+        {
+            SequentialWriterOption abortOnCloseOption = SequentialWriterOption.newBuilder()
+                                                                              .finishOnClose(false)
+                                                                              .build();
+            FaultInjectingFileChannel channel = null;
+            try
+            {
+                FSWriteError observed = null;
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metadataFile, null, abortOnCloseOption, CompressionParams.lz4(), newCollector(), null))
+                {
+                    channel = installFaultChannel(writer, dataFile).failTruncate();
+                    writer.write(compressible(1024)); // sub-block tail → finish() must pad, write, truncate
+                    try
+                    {
+                        writer.finish();
+                        fail("expected FSWriteError from injected truncate failure");
+                    }
+                    catch (FSWriteError e)
+                    {
+                        observed = e;
+                    }
+                }
+                assertTrue("FSWriteError should carry the injected IOException, got: " + observed.getCause(),
+                           observed.getCause() instanceof IOException
+                           && FaultInjectingFileChannel.INJECTED_MESSAGE.equals(observed.getCause().getMessage()));
+            }
+            finally
+            {
+                if (channel != null)
+                    channel.closeQuietly();
+            }
+        });
+    }
+
+    /**
+     * durableUncompressedOffset is the only position() caller on this path and runs only via the
+     * post-flush listener: its IOException must surface as FSReadError out of write(), and the
+     * abort must stay clean.
+     */
+    @Test
+    public void testPositionFailureDuringPostFlushThrowsFSReadError() throws Exception
+    {
+        withTempDataFile("position_fault", (dataFile, metadataFile) ->
+        {
+            CompressionParams params = CompressionParams.lz4();
+            SequentialWriterOption abortOnCloseOption = SequentialWriterOption.newBuilder()
+                                                                              .finishOnClose(false)
+                                                                              .build();
+            FaultInjectingFileChannel channel = null;
+            try
+            {
+                FSReadError observed = null;
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metadataFile, null, abortOnCloseOption, params, newCollector(), null))
+                {
+                    channel = installFaultChannel(writer, dataFile).failOnPositionCall(1);
+                    writer.setPostFlushListener(offset -> {});
+                    try
+                    {
+                        // Two full chunks guarantee a mid-write chunk flush → post-flush callback →
+                        // durableUncompressedOffset → position() → injected IOException.
+                        writer.write(incompressible(params.chunkLength() * 2));
+                        writer.finish();
+                        fail("expected FSReadError from injected position() failure");
+                    }
+                    catch (FSReadError e)
+                    {
+                        observed = e;
+                    }
+                }
+                assertTrue("FSReadError should carry the injected IOException, got: " + observed.getCause(),
+                           observed.getCause() instanceof IOException
+                           && FaultInjectingFileChannel.INJECTED_MESSAGE.equals(observed.getCause().getMessage()));
+            }
+            finally
+            {
+                if (channel != null)
+                    channel.closeQuietly();
+            }
+        });
+    }
+
+    private static CompressionParams paramsForKind(CompressorKind kind, int chunkLength)
+    {
+        switch (kind)
+        {
+            case Lz4:     return CompressionParams.lz4(chunkLength);
+            case Zstd:    return CompressionParams.zstd(chunkLength);
+            case Snappy:  return CompressionParams.snappy(chunkLength, 1.1); // 1.1 = min compress ratio Snappy requires
+            case Deflate: return CompressionParams.deflate(chunkLength);
+            case Noop:    return CompressionParams.noop(chunkLength);
+            default:      throw new AssertionError();
+        }
+    }
+
+    // Many small write() calls straddling chunk/block boundaries exercise the accumulation path the
+    // single-write fuzz test never reaches. Slices are contiguous and each at least one byte.
+    private static List<byte[]> sliceRandomly(byte[] payload, RandomSource rs)
+    {
+        List<byte[]> slices = new ArrayList<>();
+        int pos = 0;
+        while (pos < payload.length)
+        {
+            int len = rs.nextInt(1, payload.length - pos + 1);
+            slices.add(Arrays.copyOfRange(payload, pos, pos + len));
+            pos += len;
+        }
+        return slices;
+    }
+
+    private void runAlignmentExample(int blockSize, CompressionParams params, byte[] payload, List<byte[]> slices) throws Exception
+    {
+        // Oracle: the standard writer's on-disk bytes (computed with the real FS block size, before the
+        // mock is active — blockSize only affects O_DIRECT padding, never the logical compressed format).
+        byte[] standardBytes = standardWriterBytes(payload, params);
+
+        File dataFile = FileUtils.createTempFile("align_direct", ".db");
+        File metaFile = new File(dataFile.absolutePath() + ".metadata");
+        RecordingFileChannel recording = null;
+        long pointerAfterFinish = -1;
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (MockedStatic<FileUtils> mocked = mockStatic(FileUtils.class, CALLS_REAL_METHODS))
+            {
+                mocked.when(() -> FileUtils.getBlockSize(any())).thenReturn(blockSize);
+                try (DirectCompressedSequentialWriter writer = new DirectCompressedSequentialWriter(
+                     dataFile, metaFile, null, SequentialWriterOption.DEFAULT, params, collector, null))
+                {
+                    recording = installRecordingChannel(writer, dataFile);
+                    for (byte[] slice : slices)
+                        writer.write(slice);
+                    writer.finish();
+                    // Sample after finish(): the final partial chunk is compressed and written only during
+                    // finish(), so actualDataSize isn't final until then.
+                    pointerAfterFinish = writer.getOnDiskFilePointer();
+                }
+            }
+
+            // The alignment assertion macOS cannot enforce: every write is a whole number of blocks at a
+            // block-aligned offset.
+            assertFalse("expected at least one channel write for a non-empty payload", recording.writes.isEmpty());
+            for (long[] w : recording.writes)
+            {
+                assertEquals("channel write offset not block-aligned (block=" + blockSize + ", offset=" + w[0] + ')',
+                             0, w[0] % blockSize);
+                assertEquals("channel write length not a block multiple (block=" + blockSize + ", length=" + w[1] + ')',
+                             0, w[1] % blockSize);
+            }
+
+            assertEquals("getOnDiskFilePointer should equal final on-disk data size", standardBytes.length, pointerAfterFinish);
+            assertEquals("dataFile length should equal actualDataSize after truncate", standardBytes.length, dataFile.length());
+
+            byte[] directBytes = Files.readAllBytes(dataFile.toPath());
+            assertArrayEquals("Direct vs standard on-disk bytes differ (block=" + blockSize +
+                              ", compressor=" + params.getSstableCompressor().getClass().getSimpleName() +
+                              ", chunkLength=" + params.chunkLength() + ", size=" + payload.length +
+                              ", writes=" + slices.size() + ')',
+                              standardBytes, directBytes);
+
+            readBackVerify(dataFile, metaFile, payload);
+        }
+        finally
+        {
+            if (recording != null)
+                recording.closeQuietly();
+            dataFile.tryDelete();
+            metaFile.tryDelete();
+        }
+    }
+
+    private static byte[] standardWriterBytes(byte[] payload, CompressionParams params) throws IOException
+    {
+        File file = FileUtils.createTempFile("align_standard", ".db");
+        File meta = new File(file.absolutePath() + ".metadata");
+        try
+        {
+            MetadataCollector collector = newCollector();
+            try (CompressedSequentialWriter writer = new CompressedSequentialWriter(
+                 file, meta, null, SequentialWriterOption.DEFAULT, params, collector))
+            {
+                writer.write(payload);
+                writer.finish();
+            }
+            return Files.readAllBytes(file.toPath());
+        }
+        finally
+        {
+            file.tryDelete();
+            meta.tryDelete();
+        }
+    }
+
+    // Swap the writer's fchannel for a wrapper over a plain channel on the same file. A plain backing
+    // channel is correct: the SUT's alignment math is OS-independent, and a plain channel won't reject the
+    // small mocked-block writes a real Linux O_DIRECT channel would.
+    private static void installChannel(DirectCompressedSequentialWriter writer, FileChannel wrapper) throws Exception
+    {
+        Field fchannel = SequentialWriter.class.getDeclaredField("fchannel");
+        fchannel.setAccessible(true);
+        fchannel.set(writer, wrapper);
+    }
+
+    private static RecordingFileChannel installRecordingChannel(DirectCompressedSequentialWriter writer, File dataFile) throws Exception
+    {
+        RecordingFileChannel recording = new RecordingFileChannel(FileChannel.open(dataFile.toPath(), StandardOpenOption.WRITE));
+        installChannel(writer, recording);
+        return recording;
+    }
+
+    private static FaultInjectingFileChannel installFaultChannel(DirectCompressedSequentialWriter writer, File dataFile) throws Exception
+    {
+        FaultInjectingFileChannel faulty = new FaultInjectingFileChannel(FileChannel.open(dataFile.toPath(), StandardOpenOption.WRITE));
+        installChannel(writer, faulty);
+        return faulty;
+    }
+
+    private static PartialWritingFileChannel installPartialChannel(DirectCompressedSequentialWriter writer, File dataFile, int maxBytesPerWrite) throws Exception
+    {
+        PartialWritingFileChannel partial = new PartialWritingFileChannel(FileChannel.open(dataFile.toPath(), StandardOpenOption.WRITE), maxBytesPerWrite);
+        installChannel(writer, partial);
+        return partial;
+    }
+
+    /** Delegates everything to a plain FileChannel; subclasses observe or perturb specific calls. */
+    private static class DelegatingFileChannel extends FileChannel
+    {
+        protected final FileChannel delegate;
+
+        DelegatingFileChannel(FileChannel delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        void closeQuietly()
+        {
+            try { delegate.close(); }
+            catch (IOException ignored) {}
+        }
+
+        @Override public int write(ByteBuffer src) throws IOException { return delegate.write(src); }
+        @Override public int read(ByteBuffer dst) throws IOException { return delegate.read(dst); }
+        @Override public long read(ByteBuffer[] dsts, int offset, int length) throws IOException { return delegate.read(dsts, offset, length); }
+        // The SUT writes blocks only via the single-buffer write(ByteBuffer); a gather or positional write
+        // would bypass subclass observation and pass their asserts vacuously, so trip loudly instead.
+        @Override public long write(ByteBuffer[] srcs, int offset, int length) { throw new AssertionError("unexpected gather write; DelegatingFileChannel subclasses do not observe it"); }
+        @Override public int write(ByteBuffer src, long position) { throw new AssertionError("unexpected positional write; DelegatingFileChannel subclasses do not observe it"); }
+        @Override public long position() throws IOException { return delegate.position(); }
+        @Override public FileChannel position(long newPosition) throws IOException { delegate.position(newPosition); return this; }
+        @Override public long size() throws IOException { return delegate.size(); }
+        @Override public FileChannel truncate(long size) throws IOException { delegate.truncate(size); return this; }
+        @Override public void force(boolean metaData) throws IOException { delegate.force(metaData); }
+        @Override public long transferTo(long position, long count, WritableByteChannel target) throws IOException { return delegate.transferTo(position, count, target); }
+        @Override public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException { return delegate.transferFrom(src, position, count); }
+        @Override public int read(ByteBuffer dst, long position) throws IOException { return delegate.read(dst, position); }
+        @Override public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException { return delegate.map(mode, position, size); }
+        @Override public FileLock lock(long position, long size, boolean shared) throws IOException { return delegate.lock(position, size, shared); }
+        @Override public FileLock tryLock(long position, long size, boolean shared) throws IOException { return delegate.tryLock(position, size, shared); }
+        @Override protected void implCloseChannel() throws IOException { delegate.close(); }
+    }
+
+    /** Records each {@link #write(ByteBuffer)}'s start offset and byte count, then delegates. */
+    private static final class RecordingFileChannel extends DelegatingFileChannel
+    {
+        // Each entry: { offsetAtWriteStart, bytesWritten }.
+        final List<long[]> writes = new ArrayList<>();
+
+        RecordingFileChannel(FileChannel delegate)
+        {
+            super(delegate);
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException
+        {
+            long offset = delegate.position();
+            int n = delegate.write(src);
+            writes.add(new long[]{ offset, n });
+            return n;
+        }
+    }
+
+    /** Caps each {@link #write(ByteBuffer)} to force the SUT drain loop to re-issue; delegates so bytes still land. */
+    private static final class PartialWritingFileChannel extends DelegatingFileChannel
+    {
+        private final int maxBytesPerWrite;
+        int shortWrites; // write() calls that returned fewer bytes than requested
+
+        PartialWritingFileChannel(FileChannel delegate, int maxBytesPerWrite)
+        {
+            super(delegate);
+            this.maxBytesPerWrite = maxBytesPerWrite;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException
+        {
+            int requested = src.remaining();
+            if (requested <= maxBytesPerWrite)
+                return delegate.write(src);
+
+            int savedLimit = src.limit();
+            src.limit(src.position() + maxBytesPerWrite);
+            int n = delegate.write(src);
+            src.limit(savedLimit);
+            if (n < requested)
+                shortWrites++;
+            return n;
+        }
+    }
+
+    /**
+     * Perturbs specific channel calls to exercise the SUT's IOException handling:
+     * fail the nth write, fail truncate, or fail the nth position() query.
+     */
+    private static final class FaultInjectingFileChannel extends DelegatingFileChannel
+    {
+        static final String INJECTED_MESSAGE = "injected fault";
+
+        private int failOnWriteIndex = -1;    // 1-based; -1 = off
+        private boolean failTruncate;
+        private int failOnPositionCall = -1;  // 1-based; -1 = off
+
+        private int writeCalls;
+        private int positionCalls;
+        boolean faultFired;
+
+        FaultInjectingFileChannel(FileChannel delegate)
+        {
+            super(delegate);
+        }
+
+        FaultInjectingFileChannel failOnWriteIndex(int n)
+        {
+            failOnWriteIndex = n;
+            return this;
+        }
+
+        FaultInjectingFileChannel failTruncate()
+        {
+            failTruncate = true;
+            return this;
+        }
+
+        FaultInjectingFileChannel failOnPositionCall(int n)
+        {
+            failOnPositionCall = n;
+            return this;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException
+        {
+            if (++writeCalls == failOnWriteIndex)
+            {
+                faultFired = true;
+                throw new IOException(INJECTED_MESSAGE);
+            }
+            return delegate.write(src);
+        }
+
+        @Override
+        public FileChannel truncate(long size) throws IOException
+        {
+            if (failTruncate)
+            {
+                faultFired = true;
+                throw new IOException(INJECTED_MESSAGE);
+            }
+            return super.truncate(size);
+        }
+
+        @Override
+        public long position() throws IOException
+        {
+            if (++positionCalls == failOnPositionCall)
+            {
+                faultFired = true;
+                throw new IOException(INJECTED_MESSAGE);
+            }
+            return super.position();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterDaemonTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterDaemonTest.java
@@ -18,18 +18,39 @@
 
 package org.apache.cassandra.io.sstable;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 
+@RunWith(Parameterized.class)
 public class CQLSSTableWriterDaemonTest extends CQLSSTableWriterTest
 {
+    @Parameterized.Parameter
+    public DiskAccessMode backgroundWriteMode;
+
+    @Parameterized.Parameters(name = "backgroundWriteMode={0}")
+    public static Collection<Object[]> modes()
+    {
+        return Arrays.asList(new Object[]{ DiskAccessMode.standard },
+                             new Object[]{ DiskAccessMode.direct });
+    }
+
+    private DiskAccessMode originalBackgroundWriteMode;
+
     @BeforeClass
     public static void setup() throws Exception
     {
@@ -40,5 +61,18 @@ public class CQLSSTableWriterDaemonTest extends CQLSSTableWriterTest
         ServerTestUtils.prepareServerNoRegister();
         MessagingService.instance().waitUntilListeningUnchecked();
         StorageService.instance.initServer();
+    }
+
+    @Before
+    public void setBackgroundWriteMode()
+    {
+        originalBackgroundWriteMode = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(backgroundWriteMode);
+    }
+
+    @After
+    public void restoreBackgroundWriteMode()
+    {
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(originalBackgroundWriteMode);
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -198,6 +199,42 @@ public abstract class CQLSSTableWriterTest
                 assertEquals(3, row.getInt("k"));
                 assertFalse(row.has("v1"));
                 assertEquals(12, row.getInt("v2"));
+            }
+        }
+    }
+
+    @Test
+    public void testCompressedWriteAndReadBack() throws Exception
+    {
+        String schema = "CREATE TABLE " + qualifiedTable + " ("
+                        + "  k int PRIMARY KEY,"
+                        + "  v text"
+                        + ") WITH compression = {'enabled':'true', 'class':'LZ4Compressor'}";
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+
+        try (CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                       .inDirectory(dataDir)
+                                                       .forTable(schema)
+                                                       .using(insert)
+                                                       .build())
+        {
+            for (int i = 0; i < 50; i++)
+                writer.addRow(i, "row-" + i);
+        }
+
+        loadSSTables(dataDir, keyspace, table);
+
+        if (verifyDataAfterLoading)
+        {
+            UntypedResultSet rs = QueryProcessor.executeInternal("SELECT k, v FROM " + qualifiedTable);
+            assertEquals(50, rs.size());
+
+            Set<Integer> seen = new HashSet<>();
+            for (UntypedResultSet.Row row : rs)
+            {
+                int k = row.getInt("k");
+                assertTrue("duplicate key " + k, seen.add(k));
+                assertEquals("row-" + k, row.getString("v"));
             }
         }
     }

--- a/test/unit/org/apache/cassandra/io/sstable/format/DataComponentDirectWriteSelectionTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/DataComponentDirectWriteSelectionTest.java
@@ -1,0 +1,182 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.cassandra.io.sstable.format;
+
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.Config.FlushCompression;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.io.compress.CompressedSequentialWriter;
+import org.apache.cassandra.io.compress.DirectCompressedSequentialWriter;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
+import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.util.ChecksummedSequentialWriter;
+import org.apache.cassandra.io.util.DirectIoTestUtils;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DataComponentDirectWriteSelectionTest
+{
+    private static final String KS = "ks_dio_selection";
+    private static final String CF = "cf_dio_selection";
+
+    private File tmpDir;
+    private int nextId;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        tmpDir = new File(Files.createTempDirectory("dio_selection"));
+        nextId = 0;
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (tmpDir != null)
+            FileUtils.deleteRecursive(tmpDir);
+    }
+
+    @Test
+    public void testWriterSelectionMatchesAllowListForEveryOp() throws Exception
+    {
+        DirectIoTestUtils.withDirectWrites(() -> {
+            for (OperationType op : OperationType.values())
+            {
+                boolean expectDirect = DataComponent.isDirectWriteSupported(op);
+                try (SequentialWriter w = build(compressedMetadata(), op))
+                {
+                    assertEquals("buildWriter selection must match the direct-write allow-list for " + op
+                                 + ", got " + w.getClass().getSimpleName(),
+                                 expectDirect, w instanceof DirectCompressedSequentialWriter);
+                }
+            }
+        });
+    }
+
+    // The allow-list loop test takes its oracle from isDirectWriteSupported, so it can't catch a bad
+    // reclassification of these ops. Pin their intent independently.
+    @Test
+    public void testScrubAndFlushAreNeverDirectWriteSupported()
+    {
+        assertFalse("SCRUB must never use direct writes (needs mark()/resetAndTruncate())",
+                    DataComponent.isDirectWriteSupported(OperationType.SCRUB));
+        assertFalse("FLUSH must never use direct writes (hot output stays in the page cache)",
+                    DataComponent.isDirectWriteSupported(OperationType.FLUSH));
+    }
+
+    // RELOCATE and UNKNOWN are writesData==false but DO reach buildWriter (relocateSSTables / offline
+    // sstablesplit). Pin them SUPPORTED so they can't silently regress to NOT_A_WRITER (CASSANDRA-21134).
+    @Test
+    public void testRelocateAndUnknownAreDirectWriteSupported()
+    {
+        assertTrue("RELOCATE rewrites SSTables via a compaction task and must use direct writes",
+                   DataComponent.isDirectWriteSupported(OperationType.RELOCATE));
+        assertTrue("UNKNOWN reaches buildWriter via the offline sstablesplit tool and must use direct writes",
+                   DataComponent.isDirectWriteSupported(OperationType.UNKNOWN));
+    }
+
+    @Test
+    public void testUncompressedAlwaysUsesStandardWriter() throws Exception
+    {
+        DirectIoTestUtils.withDirectWrites(() -> {
+            for (OperationType op : OperationType.values())
+            {
+                try (SequentialWriter w = build(uncompressedMetadata(), op))
+                {
+                    assertTrue("Uncompressed tables must use ChecksummedSequentialWriter for " + op + ", got " + w.getClass().getSimpleName(),
+                               w instanceof ChecksummedSequentialWriter);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testBufferedModeNeverPicksDirectWriter()
+    {
+        DiskAccessMode original = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(DiskAccessMode.standard);
+        try
+        {
+            for (OperationType op : OperationType.values())
+            {
+                try (SequentialWriter w = build(compressedMetadata(), op))
+                {
+                    assertTrue("Buffered mode must not produce DirectCompressedSequentialWriter for " + op + ", got " + w.getClass().getSimpleName(),
+                               w instanceof CompressedSequentialWriter && !(w instanceof DirectCompressedSequentialWriter));
+                }
+            }
+        }
+        finally
+        {
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(original);
+        }
+    }
+
+    private SequentialWriter build(TableMetadata metadata, OperationType op)
+    {
+        Descriptor descriptor = new Descriptor(tmpDir, KS, CF, new SequenceBasedSSTableId(nextId++),
+                                               DatabaseDescriptor.getSelectedSSTableFormat());
+        MetadataCollector collector = new MetadataCollector(new ClusteringComparator(Collections.singletonList(BytesType.instance)));
+        // finishOnClose(false) routes try-with-resources close through abort, avoiding finish() side effects on an empty writer.
+        SequentialWriterOption options = SequentialWriterOption.newBuilder().finishOnClose(false).build();
+        return DataComponent.buildWriter(descriptor, metadata, options, collector, op, FlushCompression.fast, null);
+    }
+
+    private static TableMetadata compressedMetadata()
+    {
+        return TableMetadata.builder(KS, CF)
+                            .addPartitionKeyColumn("k", BytesType.instance)
+                            .compression(CompressionParams.lz4())
+                            .build();
+    }
+
+    private static TableMetadata uncompressedMetadata()
+    {
+        return TableMetadata.builder(KS, CF)
+                            .addPartitionKeyColumn("k", BytesType.instance)
+                            .compression(CompressionParams.noCompression())
+                            .build();
+    }
+}

--- a/test/unit/org/apache/cassandra/io/util/DirectIoTestUtils.java
+++ b/test/unit/org/apache/cassandra/io/util/DirectIoTestUtils.java
@@ -1,0 +1,49 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.cassandra.io.util;
+
+import java.util.concurrent.Callable;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.utils.Throwables.ThrowingRunnable;
+
+public final class DirectIoTestUtils
+{
+    private DirectIoTestUtils() {}
+
+    public static void withDirectWrites(ThrowingRunnable body) throws Exception
+    {
+        withDirectWrites(() -> { body.run(); return null; });
+    }
+
+    public static <T> T withDirectWrites(Callable<T> body) throws Exception
+    {
+        DiskAccessMode original = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
+        DatabaseDescriptor.setBackgroundWriteDiskAccessMode(DiskAccessMode.direct);
+        try
+        {
+            return body.call();
+        }
+        finally
+        {
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(original);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/StartupChecksTest.java
+++ b/test/unit/org/apache/cassandra/service/StartupChecksTest.java
@@ -303,12 +303,23 @@ public class StartupChecksTest
     {
         Assume.assumeTrue(DatabaseDescriptor.getCommitLogCompression() == null); // we would not be able to enable direct io otherwise
         Assume.assumeTrue("Skipping this test on non-Linux OS", FBUtilities.isLinux);
-        testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.63.1-generic"), false);
-        testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.64.1-generic"), true);
-        testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.65.1-generic"), true);
-        testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.66.1-generic"), false);
-        testKernelBug1057843Check("tmpfs", DiskAccessMode.direct, new Semver("6.1.64.1-generic"), false);
-        testKernelBug1057843Check("ext4", DiskAccessMode.mmap, new Semver("6.1.64.1-generic"), false);
+
+        // Commit log direct writes
+        testKernelBug1057843Check("ext4", DiskAccessMode.direct, DiskAccessMode.standard, new Semver("6.1.63.1-generic"), false);
+        testKernelBug1057843Check("ext4", DiskAccessMode.direct, DiskAccessMode.standard, new Semver("6.1.64.1-generic"), true);
+        testKernelBug1057843Check("ext4", DiskAccessMode.direct, DiskAccessMode.standard, new Semver("6.1.65.1-generic"), true);
+        testKernelBug1057843Check("ext4", DiskAccessMode.direct, DiskAccessMode.standard, new Semver("6.1.66.1-generic"), false);
+        testKernelBug1057843Check("tmpfs", DiskAccessMode.direct, DiskAccessMode.standard, new Semver("6.1.64.1-generic"), false);
+        testKernelBug1057843Check("ext4", DiskAccessMode.mmap, DiskAccessMode.standard, new Semver("6.1.64.1-generic"), false);
+
+        // Background (data dir) direct writes hit the same check; kernel/fs-type logic is swept above, so
+        // here we only prove the data-dir branch reaches it (ext4 trips, tmpfs filtered out). Commit log is
+        // mmap, not standard: standard is rejected for the commit log unless compression/encryption is on.
+        testKernelBug1057843Check("ext4", DiskAccessMode.mmap, DiskAccessMode.direct, new Semver("6.1.64.1-generic"), true);
+        testKernelBug1057843Check("tmpfs", DiskAccessMode.mmap, DiskAccessMode.direct, new Semver("6.1.64.1-generic"), false);
+
+        // Both commit log and background data dir direct writes at once
+        testKernelBug1057843Check("ext4", DiskAccessMode.direct, DiskAccessMode.direct, new Semver("6.1.64.1-generic"), true);
     }
 
     @SuppressWarnings("unchecked")
@@ -549,19 +560,25 @@ public class StartupChecksTest
         }
     }
 
-    private void testKernelBug1057843Check(String fsType, DiskAccessMode diskAccessMode, Semver kernelVersion, boolean expectToFail) throws Exception
+    private void testKernelBug1057843Check(String fsType,
+                                           DiskAccessMode commitLogMode,
+                                           DiskAccessMode backgroundMode,
+                                           Semver kernelVersion,
+                                           boolean expectToFail) throws Exception
     {
         String commitLogLocation = Files.createTempDirectory("testKernelBugCheck").toString();
 
         String savedCommitLogLocation = DatabaseDescriptor.getCommitLogLocation();
         DiskAccessMode savedCommitLogWriteDiskAccessMode = DatabaseDescriptor.getCommitLogWriteDiskAccessMode();
+        DiskAccessMode savedBackgroundWriteDiskAccessMode = DatabaseDescriptor.getBackgroundWriteDiskAccessMode();
         SystemInfo savedSystemInfo = FBUtilities.getSystemInfo();
         try
         {
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(backgroundMode);
             DatabaseDescriptor.setCommitLogLocation(commitLogLocation);
-            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(diskAccessMode);
+            DatabaseDescriptor.setCommitLogWriteDiskAccessMode(commitLogMode);
             DatabaseDescriptor.initializeCommitLogDiskAccessMode();
-            assertThat(DatabaseDescriptor.getCommitLogWriteDiskAccessMode()).isEqualTo(diskAccessMode);
+            assertThat(DatabaseDescriptor.getCommitLogWriteDiskAccessMode()).isEqualTo(commitLogMode);
             FBUtilities.setSystemInfoSupplier(() -> new SystemInfo()
             {
                 @Override
@@ -570,7 +587,15 @@ public class StartupChecksTest
                     return kernelVersion;
                 }
             });
-            withPathOverriddingFileSystem(Map.of(commitLogLocation, fsType), () -> {
+
+            // Override the filesystem type for every path getDirectIOWritePaths() may return (commit log and
+            // all data dirs) so the check sees only our synthetic type, never the real test filesystem.
+            Map<String, String> pathOverrides = new HashMap<>();
+            pathOverrides.put(commitLogLocation, fsType);
+            for (String dataDir : DatabaseDescriptor.getAllDataFileLocations())
+                pathOverrides.put(dataDir, fsType);
+
+            withPathOverriddingFileSystem(pathOverrides, () -> {
                 if (expectToFail)
                     assertThatExceptionOfType(StartupException.class).isThrownBy(() -> StartupChecks.checkKernelBug1057843.execute(options));
                 else
@@ -583,6 +608,7 @@ public class StartupChecksTest
             DatabaseDescriptor.setCommitLogLocation(savedCommitLogLocation);
             DatabaseDescriptor.setCommitLogWriteDiskAccessMode(savedCommitLogWriteDiskAccessMode);
             DatabaseDescriptor.initializeCommitLogDiskAccessMode();
+            DatabaseDescriptor.setBackgroundWriteDiskAccessMode(savedBackgroundWriteDiskAccessMode);
             FBUtilities.setSystemInfoSupplier(() -> savedSystemInfo);
         }
     }


### PR DESCRIPTION
# CASSANDRA-21134: Direct I/O for background SSTable writes

## Summary

Opt-in `O_DIRECT` write path for background SSTable producers, bypassing the OS page cache for write-once read-never data. Memtable flushes remain buffered (hot data benefits from the cache).

```yaml
background_write_disk_access_mode: direct    # default: standard
direct_write_buffer_size: 1MiB                # aligned up to FS block size; auto-grows to chunk_length
```

Gated by (1) config, (2) table compression enabled, (3) an `OperationType` allowlist (`DataComponent#DIRECT_WRITE_SUPPORT`). Selection is central in `DataComponent.buildWriter`; producers are unchanged.

## Performance

Benchmark results are attached to the JIRA. Significant p99 read latency improvements under throttled compaction.

## Operations covered (DIO eligible)

| OperationType | End-to-end test |
| --- | --- |
| `WRITE` | `CQLSSTableWriterDaemonTest` (parameterised on disk mode) |
| `COMPACTION` | `CompactionsTest` (parameterised on disk mode) |
| `MAJOR_COMPACTION` | `CompactionsTest.testCompactionWithSizeLimitedRewriter` |
| `CLEANUP`, `GARBAGE_COLLECT`, `TOMBSTONE_COMPACTION`, `UPGRADE_SSTABLES` | `CompactionsTest` (transitive) |
| `ANTICOMPACTION` | `AntiCompactionTest.testAntiCompactionWithCompressedTableAndDirectWrites` |
| `STREAM` | `DataComponentDirectWriteSelectionTest` (selection only — incoming stream buffers reach the writer like any other producer) |


The allowlist is exhaustive: any new `OperationType` with `writesData == true` that is not classified fails static initialization (`AssertionError`).

## Operations NOT covered

| Path | Classification | Reason | Coverage |
| --- | --- | --- | --- |
| `FLUSH` (memtable) | `UNSUPPORTED_POLICY` | Just-flushed data is hot — keep it in the page cache. | `DataComponentDirectWriteSelectionTest` |
| `SCRUB` | `UNSUPPORTED_CORRECTNESS` | `tryAppend` needs `mark()` / `resetAndTruncate()`, which DIO cannot satisfy. | `DataComponentDirectWriteSelectionTest` |
| Zero-Copy Streaming | n/a (path bypass) | Entire-SSTable streaming bypasses `DataComponent.buildWriter`. | n/a (never reaches the selection gate) |
| Uncompressed writers | n/a (path bypass) | Only `CompressedSequentialWriter` has a DIO subclass. | `DataComponentDirectWriteSelectionTest` (compression gate) |

Removing an `UNSUPPORTED_CORRECTNESS` entry requires code changes; `UNSUPPORTED_POLICY` is a policy decision.

## Key code

- `io/DirectIoSupport.java` — eligibility enum (`SUPPORTED` / `UNSUPPORTED_CORRECTNESS` /
  `UNSUPPORTED_POLICY` / `NOT_APPLICABLE`).
- `io/sstable/format/DataComponent.java` — selection, allowlist, exhaustiveness check.
- `io/compress/DirectCompressedSequentialWriter.java` — new writer; aligned buffers,
  `mark()`/`resetAndTruncate()` unsupported; durable-offset tracking (chunk-boundary ring
  buffer + post-flush listener) so preemptive early open binds only to whole-block durable
  offsets.
- `io/compress/CompressedSequentialWriter.java` — refactored so the DIO subclass can
  override the write-chunk path; `writeChunk` contract documented and asserted.
- `config/Config.java`, `config/DatabaseDescriptor.java` — new knobs, validation, startup
  wiring; buffer size aligned to FS block size, auto-grown to chunk length.
- `service/StartupChecks.java` — fails fast if `direct` is requested on a platform/FS
  that does not support `O_DIRECT`.

## Tests introduced

- **Property-based DIO-writer sweep** — write/read integrity and on-disk byte-identity
  vs. the buffered writer over compressors × chunk lengths × random payload sizes;
  seed-logged for repro (`DirectCompressedSequentialWriterTest`).
- **Durable-offset + fault-injection tests** — property-test that the post-flush listener
  reports exactly the on-disk whole-block offsets (including under preemptive early open);
  fault-injecting `FileChannel` verifies write/truncate/position failures surface as
  `FSWriteError`/`FSReadError` with clean abort (`DirectCompressedSequentialWriterTest`).
- **Parameterised buffer-size tests** — three regimes pinning the distinct branches of
  `flushCompleteBlocks` (`DirectCompressedSequentialWriterTest`).
- **Selection-matrix tests** — per-`OperationType` eligibility, allowlist exhaustiveness,
  compression gate, config-mode gate (`DataComponentDirectWriteSelectionTest`).
- **End-to-end coverage per allowlist arm** — `WRITE` (`CQLSSTableWriterDaemonTest`) and
  the compaction family + `ANTICOMPACTION` (extended `CompactionsTest`,
  `AntiCompactionTest`).
- **Regression guards** — constructor channel-leak protection, non-power-of-two
  block-size rejection, once-per-JVM undersized-buffer warn, SCRUB-gating canaries
  (`DirectCompressedSequentialWriterTest`).
- **Resource-leak detection** — `BufferPoolMXBean` check that the off-heap aligned
  buffer is returned on close (`DirectCompressedSequentialWriterTest`).
- **Config validation** — new YAML knobs (mode parsing, buffer-size bounds, defaults)
  in `DatabaseDescriptorTest`.

## Not in scope

- Uncompressed SSTable writers.
- ZCS streaming.

## Reviewer notes

Findings from the Cassandra bug-hunting skills (Opus 4.7 xhigh & kimi-k2.6:cloud) were addressed prior to
review.