### PR TITLE
[CASSANDRA-21362][trunk] Avoid ByteBuffer wrapping in cql3.selection.Selector.InputRow to reduce memory allocation rate

### DIFF
--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -46,17 +46,25 @@ public class ResultSet
     public static final Codec codec = new Codec();
 
     public final ResultMetadata metadata;
-    public final List<List<ByteBuffer>> rows;
+    public final List<List<byte[]>> rows;
 
     public ResultSet(ResultMetadata resultMetadata)
     {
-        this(resultMetadata, new ArrayList<List<ByteBuffer>>());
+        this(resultMetadata, new ArrayList<List<byte[]>>());
     }
 
-    public ResultSet(ResultMetadata resultMetadata, List<List<ByteBuffer>> rows)
+    public ResultSet(ResultMetadata resultMetadata, List<List<byte[]>> rows)
     {
         this.metadata = resultMetadata;
         this.rows = rows;
+    }
+
+    public static ResultSet fromByteBufferRows(ResultMetadata resultMetadata, List<List<ByteBuffer>> bbRows)
+    {
+        List<List<byte[]>> converted = new ArrayList<>(bbRows.size());
+        for (List<ByteBuffer> bbRow : bbRows)
+            converted.add(convertByteBufferList(bbRow));
+        return new ResultSet(resultMetadata, converted);
     }
 
     public int size()
@@ -69,21 +77,40 @@ public class ResultSet
         return size() == 0;
     }
 
-    public void addRow(List<ByteBuffer> row)
+    public void addRow(List<byte[]> row)
     {
         assert row.size() == metadata.valueCount();
         rows.add(row);
     }
 
-    public void addColumnValue(ByteBuffer value)
+    public void addByteBufferRow(List<ByteBuffer> row)
+    {
+        assert row.size() == metadata.valueCount();
+        rows.add(convertByteBufferList(row));
+    }
+
+    private static List<byte[]> convertByteBufferList(List<ByteBuffer> row)
+    {
+        List<byte[]> converted = new ArrayList<>(row.size());
+        for (ByteBuffer bb : row)
+            converted.add(ByteBufferUtil.getArrayUnsafeNullable(bb));
+        return converted;
+    }
+
+    public void addColumnValue(byte[] value)
     {
         if (rows.isEmpty() || lastRow().size() == metadata.valueCount())
-            rows.add(new ArrayList<ByteBuffer>(metadata.valueCount()));
+            rows.add(new ArrayList<byte[]>(metadata.valueCount()));
 
         lastRow().add(value);
     }
 
-    private List<ByteBuffer> lastRow()
+    public void addColumnValue(ByteBuffer value)
+    {
+        addColumnValue(ByteBufferUtil.getArrayUnsafeNullable(value));
+    }
+
+    private List<byte[]> lastRow()
     {
         return rows.get(rows.size() - 1);
     }
@@ -110,11 +137,11 @@ public class ResultSet
         {
             StringBuilder sb = new StringBuilder();
             sb.append(metadata).append('\n');
-            for (List<ByteBuffer> row : rows)
+            for (List<byte[]> row : rows)
             {
                 for (int i = 0; i < row.size(); i++)
                 {
-                    ByteBuffer v = row.get(i);
+                    byte[] v = row.get(i);
                     if (v == null)
                     {
                         sb.append(" | null");
@@ -123,9 +150,9 @@ public class ResultSet
                     {
                         sb.append(" | ");
                         if (metadata.flags.contains(Flag.NO_METADATA))
-                            sb.append("0x").append(ByteBufferUtil.bytesToHex(v));
+                            sb.append("0x").append(ByteBufferUtil.bytesToHex(ByteBuffer.wrap(v)));
                         else
-                            sb.append(metadata.names.get(i).type.getString(v));
+                            sb.append(metadata.names.get(i).type.getString(ByteBuffer.wrap(v)));
                     }
                 }
                 sb.append('\n');
@@ -151,12 +178,12 @@ public class ResultSet
         {
             ResultMetadata m = ResultMetadata.codec.decode(body, version);
             int rowCount = body.readInt();
-            ResultSet rs = new ResultSet(m, new ArrayList<List<ByteBuffer>>(rowCount));
+            ResultSet rs = new ResultSet(m, new ArrayList<List<byte[]>>(rowCount));
 
             // rows
             int totalValues = rowCount * m.columnCount;
             for (int i = 0; i < totalValues; i++)
-                rs.addColumnValue(CBUtil.readValue(body));
+                rs.addColumnValue(CBUtil.readValueAsBytes(body));
 
             return rs;
         }
@@ -165,7 +192,7 @@ public class ResultSet
         {
             ResultMetadata.codec.encode(rs.metadata, dest, version);
             dest.writeInt(rs.rows.size());
-            for (List<ByteBuffer> row : rs.rows)
+            for (List<byte[]> row : rs.rows)
             {
                 // Note that we do only want to serialize only the first columnCount values, even if the row
                 // as more: see comment on ResultMetadata.names field.
@@ -177,7 +204,7 @@ public class ResultSet
         public int encodedSize(ResultSet rs, ProtocolVersion version)
         {
             int size = ResultMetadata.codec.encodedSize(rs.metadata, version) + 4;
-            for (List<ByteBuffer> row : rs.rows)
+            for (List<byte[]> row : rs.rows)
             {
                 for (int i = 0; i < rs.metadata.columnCount; i++)
                     size += CBUtil.sizeOfValue(row.get(i));

--- a/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
@@ -130,7 +130,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
         {
             return new AbstractIterator<Row>()
             {
-                final Iterator<List<ByteBuffer>> iter = cqlRows.rows.iterator();
+                final Iterator<List<byte[]>> iter = cqlRows.rows.iterator();
 
                 protected Row computeNext()
                 {
@@ -176,7 +176,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
         {
             return new AbstractIterator<Row>()
             {
-                private Iterator<List<ByteBuffer>> currentPage;
+                private Iterator<List<byte[]>> currentPage;
 
                 protected Row computeNext()
                 {
@@ -242,7 +242,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
         {
             return new AbstractIterator<Row>()
             {
-                private Iterator<List<ByteBuffer>> currentPage;
+                private Iterator<List<byte[]>> currentPage;
 
                 protected Row computeNext()
                 {
@@ -275,11 +275,27 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
         @Nonnull
         private final List<ColumnSpecification> columns;
 
-        public Row(@Nonnull List<ColumnSpecification> names, @Nonnull List<ByteBuffer> columns)
+        public Row(@Nonnull List<ColumnSpecification> names, @Nonnull List<byte[]> columns)
         {
             this.columns = ImmutableList.copyOf(names);
             for (int i = 0; i < names.size(); i++)
-                data.put(names.get(i).name.toString(), columns.get(i));
+            {
+                byte[] v = columns.get(i);
+                data.put(names.get(i).name.toString(), v == null ? null : ByteBuffer.wrap(v));
+            }
+        }
+
+        public static Row fromByteBuffers(@Nonnull List<ColumnSpecification> names, @Nonnull List<ByteBuffer> columns)
+        {
+            Row row = new Row(names);
+            for (int i = 0; i < names.size(); i++)
+                row.data.put(names.get(i).name.toString(), columns.get(i));
+            return row;
+        }
+
+        private Row(@Nonnull List<ColumnSpecification> names)
+        {
+            this.columns = ImmutableList.copyOf(names);
         }
 
         public boolean has(String column)

--- a/src/java/org/apache/cassandra/cql3/selection/ResultSetBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ResultSetBuilder.java
@@ -75,12 +75,12 @@ public final class ResultSetBuilder
         selectors.prepare(context);
     }
 
-    private void addSize(List<ByteBuffer> row)
+    private void addSize(List<byte[]> row)
     {
         for (int i=0, isize=row.size(); i<isize; i++)
         {
-            ByteBuffer value = row.get(i);
-            size += value != null ? value.remaining() : 0;
+            byte[] value = row.get(i);
+            size += value != null ? value.length : 0;
         }
     }
 
@@ -105,6 +105,11 @@ public final class ResultSetBuilder
     }
 
     public void add(ByteBuffer v)
+    {
+        inputRow.add(v);
+    }
+
+    public void add(byte[] v)
     {
         inputRow.add(v);
     }
@@ -172,9 +177,9 @@ public final class ResultSetBuilder
         return resultSet;
     }
 
-    private List<ByteBuffer> getOutputRow()
+    private List<byte[]> getOutputRow()
     {
-        List<ByteBuffer> row = selectors.getOutputRow();
+        List<byte[]> row = selectors.getOutputRow();
         addSize(row);
         return row;
     }

--- a/src/java/org/apache/cassandra/cql3/selection/Selection.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selection.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.cql3.selection;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,11 +39,13 @@ import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.selection.Selector.InputRow;
 import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JsonUtils;
 
 import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
@@ -319,22 +320,22 @@ public abstract class Selection
                           .toString();
     }
 
-    private static List<ByteBuffer> rowToJson(List<ByteBuffer> row,
-                                              ProtocolVersion protocolVersion,
-                                              ResultSet.ResultMetadata metadata,
-                                              List<ColumnMetadata> orderingColumns)
+    private static List<byte[]> rowToJson(List<byte[]> row,
+                                          ProtocolVersion protocolVersion,
+                                          ResultSet.ResultMetadata metadata,
+                                          List<ColumnMetadata> orderingColumns)
     {
-        ByteBuffer[] jsonRow = new ByteBuffer[orderingColumns.size() + 1];
+        byte[][] jsonRow = new byte[orderingColumns.size() + 1][];
         StringBuilder sb = new StringBuilder("{");
         for (int i = 0; i < metadata.names.size(); i++)
         {
             ColumnSpecification spec = metadata.names.get(i);
-            ByteBuffer buffer = row.get(i);
+            byte[] value = row.get(i);
 
             // If it is an ordering column we need to keep it in case we need it for post ordering
             int index = orderingColumns.indexOf(spec);
             if (index >= 0)
-                jsonRow[index + 1] = buffer;
+                jsonRow[index + 1] = value;
 
             // If the column is only used for ordering we can stop here.
             if (i >= metadata.getColumnCount())
@@ -350,14 +351,14 @@ public abstract class Selection
             sb.append('"');
             sb.append(JsonUtils.quoteAsJsonString(columnName));
             sb.append("\": ");
-            if (buffer == null)
+            if (value == null)
                 sb.append("null");
             else
-                sb.append(spec.type.toJSONString(buffer, protocolVersion));
+                sb.append(spec.type.toJSONString(value, ByteArrayAccessor.instance, protocolVersion));
         }
         sb.append("}");
 
-        jsonRow[0] = UTF8Type.instance.getSerializer().serialize(sb.toString());
+        jsonRow[0] = ByteBufferUtil.getArrayUnsafeNullable(UTF8Type.instance.getSerializer().serialize(sb.toString()));
         return Arrays.asList(jsonRow);
     }
 
@@ -403,14 +404,14 @@ public abstract class Selection
          */
         void addInputRow(InputRow input);
 
-        List<ByteBuffer> getOutputRow();
+        List<byte[]> getOutputRow();
 
         void reset();
     }
 
     public static class SimpleSelectors implements Selectors
     {
-        protected List<ByteBuffer> current;
+        protected List<byte[]> current;
 
         @Override
         public void addInputRow(InputRow input)
@@ -419,7 +420,7 @@ public abstract class Selection
         }
 
         @Override
-        public List<ByteBuffer> getOutputRow()
+        public List<byte[]> getOutputRow()
         {
             return current;
         }
@@ -503,7 +504,7 @@ public abstract class Selection
             return new SimpleSelectors()
             {
                 @Override
-                public List<ByteBuffer> getOutputRow()
+                public List<byte[]> getOutputRow()
                 {
                     if (isJson)
                         return rowToJson(current, options.getProtocolVersion(), metadata, orderingColumns);
@@ -594,12 +595,12 @@ public abstract class Selection
                     return true;
                 }
 
-                public List<ByteBuffer> getOutputRow()
+                public List<byte[]> getOutputRow()
                 {
-                    List<ByteBuffer> outputRow = new ArrayList<>(selectors.size());
+                    List<byte[]> outputRow = new ArrayList<>(selectors.size());
 
                     for (Selector selector: selectors)
-                        outputRow.add(selector.getOutput(options.getProtocolVersion()));
+                        outputRow.add(selector.getOutputAsBytes(options.getProtocolVersion()));
 
                     return isJson ? rowToJson(outputRow, options.getProtocolVersion(), metadata, orderingColumns) : outputRow;
                 }

--- a/src/java/org/apache/cassandra/cql3/selection/Selector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selector.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
@@ -312,7 +313,7 @@ public abstract class Selector
         private final boolean collectWritetimes;
         private final boolean collectTTLs;
 
-        private ByteBuffer[] values;
+        private byte[][] values;
         private RowTimestamps writetimes;
         private RowTimestamps ttls;
         private int index;
@@ -334,7 +335,7 @@ public abstract class Selector
             this.collectWritetimes = collectWritetimes;
             this.collectTTLs = collectTTLs;
 
-            values = new ByteBuffer[columns.size()];
+            values = new byte[columns.size()][];
             writetimes = initTimestamps(TimestampsType.WRITETIMES, collectWritetimes, columns);
             ttls = initTimestamps(TimestampsType.TTLS, collectTTLs, columns);
         }
@@ -359,6 +360,18 @@ public abstract class Selector
 
         public void add(ByteBuffer v)
         {
+            values[index] = ByteBufferUtil.getArrayUnsafeNullable(v);
+
+            if (v != null)
+            {
+                writetimes.addNoTimestamp(index);
+                ttls.addNoTimestamp(index);
+            }
+            index++;
+        }
+
+        public void add(byte[] v)
+        {
             values[index] = v;
 
             if (v != null)
@@ -374,7 +387,7 @@ public abstract class Selector
             ColumnMetadata column = columns.get(index);
             if (columnData == null)
             {
-                add(null);
+                add((byte[]) null);
             }
             else
             {
@@ -391,7 +404,7 @@ public abstract class Selector
 
         private void add(Cell<?> c, long nowInSec)
         {
-            values[index] = value(c);
+            values[index] = valueAsArray(c);
             writetimes.addTimestamp(index, c, nowInSec);
             ttls.addTimestamp(index, c, nowInSec);
             index++;
@@ -402,7 +415,7 @@ public abstract class Selector
             AbstractType<?> type = columns.get(index).type;
             if (type.isCollection())
             {
-                values[index] = ((CollectionType<?>) type).serializeForNativeProtocol(ccd.iterator());
+                values[index] = ((CollectionType<?>) type).serializeForNativeProtocolAsByteArrays(ccd.iterator());
 
                 for (Cell<?> cell : ccd)
                 {
@@ -415,7 +428,7 @@ public abstract class Selector
                 UserType udt = (UserType) type;
                 int size = udt.size();
 
-                values[index] = udt.serializeForNativeProtocol(ccd.iterator());
+                values[index] = udt.serializeForNativeProtocolAsByteArrays(ccd.iterator());
 
                 short fieldPosition = 0;
                 for (Cell<?> cell : ccd)
@@ -445,11 +458,11 @@ public abstract class Selector
             index++;
         }
 
-        private <V> ByteBuffer value(Cell<V> c)
+        private <V> byte[] valueAsArray(Cell<V> c)
         {
             return c.isCounterCell()
-                 ? ByteBufferUtil.bytes(CounterContext.instance().total(c.value(), c.accessor()))
-                 : c.buffer();
+                 ? ByteArrayUtil.bytes(CounterContext.instance().total(c.value(), c.accessor()))
+                 : c.accessor().toArray(c.value());
         }
 
         /**
@@ -459,6 +472,12 @@ public abstract class Selector
          * @return the value of the column with the specified index
          */
         public ByteBuffer getValue(int index)
+        {
+            byte[] v = values[index];
+            return v == null ? null : ByteBuffer.wrap(v);
+        }
+
+        public byte[] getValueAsBytes(int index)
         {
             return values[index];
         }
@@ -478,7 +497,7 @@ public abstract class Selector
             this.ttls = initTimestamps(TimestampsType.TTLS, collectTTLs, columns);
 
             if (deep)
-                values = new ByteBuffer[values.length];
+                values = new byte[values.length][];
         }
 
         /**
@@ -508,7 +527,7 @@ public abstract class Selector
          *
          * @return the column values as list.
          */
-        public List<ByteBuffer> getValues()
+        public List<byte[]> getValues()
         {
             return Arrays.asList(values);
         }
@@ -530,6 +549,19 @@ public abstract class Selector
      * @throws InvalidRequestException if a problem occurs while computing the output value
      */
     public abstract ByteBuffer getOutput(ProtocolVersion protocolVersion) throws InvalidRequestException;
+
+    /**
+     * Returns the selector output as a byte array.
+     *
+     * @param protocolVersion protocol version used for serialization
+     * @return the selector output as byte[], or null
+     * @throws InvalidRequestException if a problem occurs while computing the output value
+     */
+    public byte[] getOutputAsBytes(ProtocolVersion protocolVersion) throws InvalidRequestException
+    {
+        ByteBuffer output = getOutput(protocolVersion);
+        return ByteBufferUtil.getArrayUnsafeNullable(output);
+    }
 
     protected ColumnTimestamps getWritetimes(ProtocolVersion protocolVersion)
     {

--- a/src/java/org/apache/cassandra/cql3/selection/SimpleSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SimpleSelector.java
@@ -124,7 +124,7 @@ public final class SimpleSelector extends Selector
     public final ColumnMetadata column;
     private final int idx;
     private ColumnMask.Masker masker;
-    private ByteBuffer current;
+    private byte[] currentBytes;
     private ColumnTimestamps writetimes;
     private ColumnTimestamps ttls;
     private boolean isSet;
@@ -155,16 +155,23 @@ public final class SimpleSelector extends Selector
             - The input row is for a user with UNMASK permission, indicated by input.unmask()
             - Dynamic data masking is globally disabled
              */
-            ByteBuffer value = input.getValue(idx);
-            current = masker == null || input.unmask() || !DatabaseDescriptor.getDynamicDataMaskingEnabled()
-                      ? value : masker.mask(value);
+            if (masker == null || input.unmask() || !DatabaseDescriptor.getDynamicDataMaskingEnabled())
+                currentBytes = input.getValueAsBytes(idx);
+            else
+                currentBytes = ByteBufferUtil.getArrayUnsafeNullable(masker.mask(input.getValue(idx)));
         }
     }
 
     @Override
     public ByteBuffer getOutput(ProtocolVersion protocolVersion)
     {
-        return current;
+        return currentBytes == null ? null : ByteBuffer.wrap(currentBytes);
+    }
+
+    @Override
+    public byte[] getOutputAsBytes(ProtocolVersion protocolVersion)
+    {
+        return currentBytes;
     }
 
     @Override
@@ -183,7 +190,7 @@ public final class SimpleSelector extends Selector
     public void reset()
     {
         isSet = false;
-        current = null;
+        currentBytes = null;
         writetimes = null;
         ttls = null;
     }

--- a/src/java/org/apache/cassandra/cql3/statements/DescribeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DescribeStatement.java
@@ -182,13 +182,13 @@ public abstract class DescribeStatement<T> extends CQLStatement.Raw implements C
         if (pageSize > 0)
             stream = stream.limit(pageSize);
 
-        List<List<ByteBuffer>> rows = stream.map(e -> toRow(e, includeInternalDetails))
-                                            .collect(Collectors.toList());
+        List<List<ByteBuffer>> bbRows = stream.map(e -> toRow(e, includeInternalDetails))
+                                              .collect(Collectors.toList());
 
         ResultSet.ResultMetadata resultMetadata = new ResultSet.ResultMetadata(metadata(state.getClientState()));
-        ResultSet result = new ResultSet(resultMetadata, rows);
+        ResultSet result = ResultSet.fromByteBufferRows(resultMetadata, bbRows);
 
-        if (pageSize > 0 && rows.size() == pageSize)
+        if (pageSize > 0 && bbRows.size() == pageSize)
             result.metadata.setHasMorePages(getPagingState(offset + pageSize, schemaVersion));
 
         return new ResultMessage.Rows(result);

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -777,7 +777,11 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         boolean success = partition == null;
 
         ResultSet.ResultMetadata metadata = buildCASSuccessMetadata(ksName, tableName);
-        List<List<ByteBuffer>> rows = Collections.singletonList(Collections.singletonList(BooleanType.instance.decompose(success)));
+        List<List<byte[]>> rows = Collections.singletonList(
+            Collections.singletonList(
+                ByteBufferUtil.getArrayUnsafeNullable(BooleanType.instance.decompose(success))
+            )
+        );
 
         ResultSet rs = new ResultSet(metadata, rows);
         return success ? rs : merge(rs, buildCasFailureResultSet(partition, columnsWithConditions, isBatch, options, options.getNowInSeconds(state)));
@@ -795,10 +799,10 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         List<ColumnSpecification> specs = new ArrayList<>(size);
         specs.addAll(left.metadata.names);
         specs.addAll(right.metadata.names);
-        List<List<ByteBuffer>> rows = new ArrayList<>(right.size());
+        List<List<byte[]>> rows = new ArrayList<>(right.size());
         for (int i = 0; i < right.size(); i++)
         {
-            List<ByteBuffer> row = new ArrayList<>(size);
+            List<byte[]> row = new ArrayList<>(size);
             row.addAll(left.rows.get(0));
             row.addAll(right.rows.get(i));
             rows.add(row);

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -99,6 +99,8 @@ import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.partitions.PartitionIterator;
@@ -131,6 +133,7 @@ import org.apache.cassandra.service.pager.QueryPager;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NoSpamLogger;
 
@@ -191,7 +194,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
     /**
      * The comparator used to orders results when multiple keys are selected (using IN).
      */
-    private final ColumnComparator<List<ByteBuffer>> orderingComparator;
+    private final ColumnComparator<List<byte[]>> orderingComparator;
 
     private final List<Function> functions;
 
@@ -211,7 +214,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
                            StatementRestrictions restrictions,
                            boolean isReversed,
                            AggregationSpecification.Factory aggregationSpecFactory,
-                           ColumnComparator<List<ByteBuffer>> orderingComparator,
+                           ColumnComparator<List<byte[]>> orderingComparator,
                            Term limit,
                            Term perPartitionLimit,
                            StatementSource source,
@@ -1107,19 +1110,18 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
         return cqlRows;
     }
 
-    public static ByteBuffer[] getComponents(TableMetadata metadata, DecoratedKey dk)
+    private static byte[][] getPartitionKeyComponentsAsBytes(TableMetadata metadata, DecoratedKey dk)
     {
         ByteBuffer key = dk.getKey();
-        if (metadata.partitionKeyColumns().size() == 1)
-            return new ByteBuffer[]{ key };
-        if (metadata.partitionKeyType instanceof CompositeType)
+        if (metadata.partitionKeyColumns().size() != 1 && metadata.partitionKeyType instanceof CompositeType)
         {
-            return ((CompositeType)metadata.partitionKeyType).split(key);
+            ByteBuffer[] components = ((CompositeType) metadata.partitionKeyType).split(key);
+            byte[][] result = new byte[components.length][];
+            for (int i = 0; i < components.length; i++)
+                result[i] = ByteBufferUtil.getArrayUnsafeNullable(components[i]);
+            return result;
         }
-        else
-        {
-            return new ByteBuffer[]{ key };
-        }
+        return new byte[][]{ ByteBufferUtil.getArrayUnsafeNullable(key) };
     }
 
     private void maybeWarn(ResultSetBuilder result, QueryOptions options)
@@ -1178,7 +1180,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
         maybeFail(result, options);
         ProtocolVersion protocolVersion = options.getProtocolVersion();
 
-        ByteBuffer[] keyComponents = getComponents(table, partition.partitionKey());
+        byte[][] keyComponents = getPartitionKeyComponentsAsBytes(table, partition.partitionKey());
 
         Row staticRow = partition.staticRow();
         // If there is no rows, we include the static content if we should and we're done.
@@ -1199,7 +1201,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
                             result.add(partition.staticRow().getColumnData(def), nowInSec);
                             break;
                         default:
-                            result.add((ByteBuffer)null);
+                            result.add((byte[])null);
                     }
                 }
             }
@@ -1226,7 +1228,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
                         result.add(keyComponents[def.position()]);
                         break;
                     case CLUSTERING:
-                        result.add(row.clustering().bufferAt(def.position()));
+                        result.add(row.clustering().arrayAt(def.position()));
                         break;
                     case REGULAR:
                         result.add(row.getColumnData(def), nowInSec);
@@ -1260,7 +1262,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
         if (cqlRows.size() == 0 || !needsPostQueryOrdering())
             return;
 
-        Comparator<List<ByteBuffer>> comparator = orderingComparator.prepareFor(table, getRowFilter(options, state), options);
+        Comparator<List<byte[]>> comparator = orderingComparator.prepareFor(table, getRowFilter(options, state), options);
         if (comparator != null)
             cqlRows.rows.sort(comparator);
     }
@@ -1366,7 +1368,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
                        && perPartitionLimit != null,
                        "PER PARTITION LIMIT is not allowed with aggregate queries.");
 
-            ColumnComparator<List<ByteBuffer>> orderingComparator = null;
+            ColumnComparator<List<byte[]>> orderingComparator = null;
             boolean isReversed = false;
 
             if (!orderingColumns.isEmpty())
@@ -1653,9 +1655,9 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
             checkFalse(f.isAggregate(), "Aggregate functions are not supported within the GROUP BY clause, got: %s", f.name());
         }
 
-        private ColumnComparator<List<ByteBuffer>> getOrderingComparator(Selection selection,
-                                                                         StatementRestrictions restrictions,
-                                                                         Map<ColumnMetadata, Ordering> orderingColumns) throws InvalidRequestException
+        private ColumnComparator<List<byte[]>> getOrderingComparator(Selection selection,
+                                                                     StatementRestrictions restrictions,
+                                                                     Map<ColumnMetadata, Ordering> orderingColumns) throws InvalidRequestException
         {
             for (Map.Entry<ColumnMetadata, Ordering> e : orderingColumns.entrySet())
             {
@@ -1670,7 +1672,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
                 return null;
 
             List<Integer> idToSort = new ArrayList<>(orderingColumns.size());
-            List<Comparator<ByteBuffer>> sorters = new ArrayList<>(orderingColumns.size());
+            List<AbstractType<?>> sorters = new ArrayList<>(orderingColumns.size());
 
             for (ColumnMetadata orderingColumn : orderingColumns.keySet())
             {
@@ -1796,12 +1798,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
 
     private static abstract class ColumnComparator<T> implements Comparator<T>
     {
-        protected final int compare(Comparator<ByteBuffer> comparator, ByteBuffer aValue, ByteBuffer bValue)
+        protected final int compare(AbstractType<?> type, byte[] aValue, byte[] bValue)
         {
             if (aValue == null)
                 return bValue == null ? 0 : -1;
 
-            return bValue == null ? 1 : comparator.compare(aValue, bValue);
+            return bValue == null ? 1 : type.compare(aValue, ByteArrayAccessor.instance, bValue, ByteArrayAccessor.instance);
         }
 
         public ColumnComparator<T> reverse()
@@ -1845,24 +1847,24 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
     /**
      * Used in orderResults(...) method when single 'ORDER BY' condition where given
      */
-    private static class SingleColumnComparator extends ColumnComparator<List<ByteBuffer>>
+    private static class SingleColumnComparator extends ColumnComparator<List<byte[]>>
     {
         private final int index;
-        private final Comparator<ByteBuffer> comparator;
+        private final AbstractType<?> comparator;
 
-        public SingleColumnComparator(int columnIndex, Comparator<ByteBuffer> orderer)
+        public SingleColumnComparator(int columnIndex, AbstractType<?> orderer)
         {
             index = columnIndex;
             comparator = orderer;
         }
 
-        public int compare(List<ByteBuffer> a, List<ByteBuffer> b)
+        public int compare(List<byte[]> a, List<byte[]> b)
         {
             return compare(comparator, a.get(index), b.get(index));
         }
     }
 
-    private static class IndexColumnComparator extends ColumnComparator<List<ByteBuffer>>
+    private static class IndexColumnComparator extends ColumnComparator<List<byte[]>>
     {
         private final SingleRestriction restriction;
         private final int columnIndex;
@@ -1880,7 +1882,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
         }
 
         @Override
-        public Comparator<List<ByteBuffer>> prepareFor(TableMetadata table, RowFilter rowFilter, QueryOptions options)
+        public Comparator<List<byte[]>> prepareFor(TableMetadata table, RowFilter rowFilter, QueryOptions options)
         {
             if (table.indexes.isEmpty() || rowFilter.isEmpty())
                 return this;
@@ -1891,11 +1893,19 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
             Index index = restriction.findSupportingIndex(indexQueryPlan.getIndexes(), IndexHints.NONE);
             assert index != null;
             Comparator<ByteBuffer> comparator = index.getPostQueryOrdering(restriction, options);
-            return (a, b) -> compare(comparator, a.get(columnIndex), b.get(columnIndex));
+            return (a, b) -> {
+                byte[] aVal = a.get(columnIndex);
+                byte[] bVal = b.get(columnIndex);
+                if (aVal == null)
+                    return bVal == null ? 0 : -1;
+                if (bVal == null)
+                    return 1;
+                return comparator.compare(ByteBuffer.wrap(aVal), ByteBuffer.wrap(bVal));
+            };
         }
 
         @Override
-        public int compare(List<ByteBuffer> o1, List<ByteBuffer> o2)
+        public int compare(List<byte[]> o1, List<byte[]> o2)
         {
             throw new UnsupportedOperationException();
         }
@@ -1904,22 +1914,22 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement,
     /**
      * Used in orderResults(...) method when multiple 'ORDER BY' conditions where given
      */
-    private static class CompositeComparator extends ColumnComparator<List<ByteBuffer>>
+    private static class CompositeComparator extends ColumnComparator<List<byte[]>>
     {
-        private final List<Comparator<ByteBuffer>> orderTypes;
+        private final List<AbstractType<?>> orderTypes;
         private final List<Integer> positions;
 
-        private CompositeComparator(List<Comparator<ByteBuffer>> orderTypes, List<Integer> positions)
+        private CompositeComparator(List<AbstractType<?>> orderTypes, List<Integer> positions)
         {
             this.orderTypes = orderTypes;
             this.positions = positions;
         }
 
-        public int compare(List<ByteBuffer> a, List<ByteBuffer> b)
+        public int compare(List<byte[]> a, List<byte[]> b)
         {
             for (int i = 0; i < positions.size(); i++)
             {
-                Comparator<ByteBuffer> type = orderTypes.get(i);
+                AbstractType<?> type = orderTypes.get(i);
                 int columnPos = positions.get(i);
 
                 int comparison = compare(type, a.get(columnPos), b.get(columnPos));

--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -313,6 +313,11 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
         return accessor().toBuffer(get(i));
     }
 
+    default byte[] arrayAt(int i)
+    {
+        return accessor().toArray(get(i));
+    }
+
     default String stringAt(int i, ClusteringComparator comparator)
     {
         return comparator.subtype(i).getString(get(i), accessor());

--- a/src/java/org/apache/cassandra/db/marshal/CollectionType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CollectionType.java
@@ -103,6 +103,8 @@ public abstract class CollectionType<T> extends MultiElementType<T>
 
     protected abstract List<ByteBuffer> serializedValues(Iterator<Cell<?>> cells);
 
+    protected abstract List<byte[]> serializedValuesAsByteArrays(Iterator<Cell<?>> cells);
+
     @Override
     public abstract CollectionSerializer<T> getSerializer();
 
@@ -182,6 +184,13 @@ public abstract class CollectionType<T> extends MultiElementType<T>
         assert isMultiCell();
         List<ByteBuffer> values = serializedValues(cells);
         return getSerializer().pack(values);
+    }
+
+    public byte[] serializeForNativeProtocolAsByteArrays(Iterator<Cell<?>> cells)
+    {
+        assert isMultiCell();
+        List<byte[]> values = serializedValuesAsByteArrays(cells);
+        return getSerializer().pack(values, ByteArrayAccessor.instance);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -222,6 +222,15 @@ public class ListType<T> extends CollectionType<List<T>>
         return bbs;
     }
 
+    public List<byte[]> serializedValuesAsByteArrays(Iterator<Cell<?>> cells)
+    {
+        assert isMultiCell;
+        List<byte[]> bbs = new ArrayList<>();
+        while (cells.hasNext())
+            bbs.add(cells.next().valueAsArray());
+        return bbs;
+    }
+
     @Override
     public Term fromJSONObject(Object parsed) throws MarshalException
     {

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.serializers.CollectionSerializer;
 import org.apache.cassandra.serializers.MapSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JsonUtils;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
@@ -311,6 +312,19 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
             Cell<?> c = cells.next();
             bbs.add(c.path().get(0));
             bbs.add(c.buffer());
+        }
+        return bbs;
+    }
+
+    public List<byte[]> serializedValuesAsByteArrays(Iterator<Cell<?>> cells)
+    {
+        assert isMultiCell;
+        List<byte[]> bbs = new ArrayList<>();
+        while (cells.hasNext())
+        {
+            Cell<?> c = cells.next();
+            bbs.add(ByteBufferUtil.getArrayUnsafeNullable(c.path().get(0)));
+            bbs.add(c.valueAsArray());
         }
         return bbs;
     }

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.SetSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JsonUtils;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
@@ -210,6 +211,14 @@ public class SetType<T> extends CollectionType<Set<T>>
         List<ByteBuffer> bbs = new ArrayList<>();
         while (cells.hasNext())
             bbs.add(cells.next().path().get(0));
+        return bbs;
+    }
+
+    public List<byte[]> serializedValuesAsByteArrays(Iterator<Cell<?>> cells)
+    {
+        List<byte[]> bbs = new ArrayList<>();
+        while (cells.hasNext())
+            bbs.add(ByteBufferUtil.getArrayUnsafeNullable(cells.next().path().get(0)));
         return bbs;
     }
 

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -237,9 +237,19 @@ public class UserType extends TupleType implements SchemaElement
 
     public ByteBuffer serializeForNativeProtocol(Iterator<Cell<?>> cells)
     {
+        return serializeForNativeProtocol(cells, ByteBufferAccessor.instance);
+    }
+
+    public byte[] serializeForNativeProtocolAsByteArrays(Iterator<Cell<?>> cells)
+    {
+        return serializeForNativeProtocol(cells, ByteArrayAccessor.instance);
+    }
+
+    public <V> V serializeForNativeProtocol(Iterator<Cell<?>> cells, ValueAccessor<V> accessor)
+    {
         assert isMultiCell;
 
-        List<ByteBuffer> components = new ArrayList<>(size());
+        List<V> components = new ArrayList<>(size());
         while (cells.hasNext())
         {
             Cell<?> cell = cells.next();
@@ -249,14 +259,19 @@ public class UserType extends TupleType implements SchemaElement
             while (components.size() < fieldPositionOfCell)
                 components.add(null);
 
-            components.add(cell.buffer());
+            components.add(getValue(cell, accessor));
         }
 
         // append trailing nulls for missing cells
         while (components.size() < size())
             components.add(null);
 
-        return pack(components);
+        return pack(components, accessor);
+    }
+
+    private static <V1, V2> V2 getValue(Cell<V1> cell, ValueAccessor<V2> targetAccessor)
+    {
+        return targetAccessor.convert(cell.value(), cell.accessor());
     }
 
     public <V> void validateCell(Cell<V> cell) throws MarshalException

--- a/src/java/org/apache/cassandra/transport/CBUtil.java
+++ b/src/java/org/apache/cassandra/transport/CBUtil.java
@@ -458,6 +458,15 @@ public abstract class CBUtil
         return ByteBuffer.wrap(readRawBytes(cb, length));
     }
 
+    public static byte[] readValueAsBytes(ByteBuf cb)
+    {
+        int length = cb.readInt();
+        if (length < 0)
+            return null;
+
+        return readRawBytes(cb, length);
+    }
+
     public static ByteBuffer readValueNoCopy(ByteBuf cb)
     {
         int length = cb.readInt();

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import net.nicoulaj.compilecommand.annotations.DontInline;
 import net.nicoulaj.compilecommand.annotations.Inline;
 
@@ -224,6 +226,14 @@ public class ByteBufferUtil
      */
     public static byte[] getArrayUnsafe(ByteBuffer buffer)
     {
+        return getArrayUnsafe(buffer, buffer.position(), buffer.remaining());
+    }
+
+    @Nullable
+    public static byte[] getArrayUnsafeNullable(ByteBuffer buffer)
+    {
+        if (buffer == null)
+            return null;
         return getArrayUnsafe(buffer, buffer.position(), buffer.remaining());
     }
 

--- a/test/burn/org/apache/cassandra/transport/BurnTestUtil.java
+++ b/test/burn/org/apache/cassandra/transport/BurnTestUtil.java
@@ -109,7 +109,7 @@ public class BurnTestUtil
             rows.add(row);
         }
 
-        ResultSet resultSet = new ResultSet(new ResultSet.ResultMetadata(columns), rows);
+        ResultSet resultSet = ResultSet.fromByteBufferRows(new ResultSet.ResultMetadata(columns), rows);
         return new ResultMessage.Rows(resultSet);
     }
 

--- a/test/burn/org/apache/cassandra/transport/DriverBurnTest.java
+++ b/test/burn/org/apache/cassandra/transport/DriverBurnTest.java
@@ -170,11 +170,11 @@ public class DriverBurnTest extends CQLTester
 
                             for (int i = 0; i < actualRS.size(); i++)
                             {
-                                List<ByteBuffer> expected = expectedRS.result.rows.get(i);
+                                List<byte[]> expected = expectedRS.result.rows.get(i);
                                 Row actual = actualRS.get(i);
 
                                 for (int col = 0; col < expected.size(); col++)
-                                    Assert.assertEquals(actual.getBytes(col), expected.get(col));
+                                    Assert.assertEquals(actual.getBytes(col), ByteBuffer.wrap(expected.get(col)));
                             }
                         }
                         counter++;

--- a/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.transport;
 
 import java.net.InetAddress;
 import java.net.ServerSocket;
-import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -190,11 +189,11 @@ public class SimpleClientBurnTest
                             Assert.assertEquals(expected.result.rows.size(), actual.result.rows.size());
                             for (int i = 0; i < expected.result.rows.size(); i++)
                             {
-                                List<ByteBuffer> expectedRow = expected.result.rows.get(i);
-                                List<ByteBuffer> actualRow = actual.result.rows.get(i);
+                                List<byte[]> expectedRow = expected.result.rows.get(i);
+                                List<byte[]> actualRow = actual.result.rows.get(i);
                                 Assert.assertEquals(expectedRow.size(), actualRow.size());
                                 for (int col = 0; col < expectedRow.size(); col++)
-                                    Assert.assertEquals(expectedRow.get(col), actualRow.get(col));
+                                    Assert.assertArrayEquals(expectedRow.get(col), actualRow.get(col));
                             }
                         }
                         counter++;

--- a/test/distributed/org/apache/cassandra/distributed/impl/RowUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/RowUtil.java
@@ -31,9 +31,11 @@ import com.google.common.collect.Lists;
 
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.distributed.api.QueryResults;
 import org.apache.cassandra.distributed.api.SimpleQueryResult;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
 
 public class RowUtil
 {
@@ -79,24 +81,26 @@ public class RowUtil
         return toObjects(rows.result.metadata.requestNames(), rows.result.rows, deserialize);
     }
 
-    public static Object[][] toObjects(List<ColumnSpecification> specs, List<List<ByteBuffer>> rows)
+    public static Object[][] toObjects(List<ColumnSpecification> specs, List<List<byte[]>> rows)
     {
         return toObjects(specs, rows, true);
     }
 
-    public static Object[][] toObjects(List<ColumnSpecification> specs, List<List<ByteBuffer>> rows, boolean deserialize)
+    public static Object[][] toObjects(List<ColumnSpecification> specs, List<List<byte[]>> rows, boolean deserialize)
     {
         Object[][] result = new Object[rows.size()][];
         for (int i = 0; i < rows.size(); i++)
         {
-            List<ByteBuffer> row = rows.get(i);
+            List<byte[]> row = rows.get(i);
             result[i] = new Object[specs.size()];
             for (int j = 0; j < specs.size(); j++)
             {
-                ByteBuffer bb = row.get(j);
+                byte[] bytes = row.get(j);
 
-                if (bb != null)
-                    result[i][j] = deserialize ? specs.get(j).type.getSerializer().deserialize(bb) : bb;
+                if (bytes != null)
+                {
+                    result[i][j] = deserialize ? specs.get(j).type.getSerializer().deserialize(bytes, ByteArrayAccessor.instance) : ByteBuffer.wrap(bytes);
+                }
             }
         }
         return result;
@@ -149,20 +153,21 @@ public class RowUtil
 
     public static Iterator<Object[]> toIter(List<ColumnSpecification> columnSpecs, Iterator<UntypedResultSet.Row> rs)
     {
-        Iterator<List<ByteBuffer>> iter = Iterators.transform(rs,
-                                                              (row) -> {
-                                                                  List<ByteBuffer> bbs = new ArrayList<>(columnSpecs.size());
-                                                                  for (int i = 0; i < columnSpecs.size(); i++)
-                                                                  {
-                                                                      ColumnSpecification columnSpec = columnSpecs.get(i);
-                                                                      bbs.add(row.getBytes(columnSpec.name.toString()));
-                                                                  }
-                                                                  return bbs;
-                                                              });
+        Iterator<List<byte[]>> iter = Iterators.transform(rs,
+                                                          (row) -> {
+                                                              List<byte[]> bbs = new ArrayList<>(columnSpecs.size());
+                                                              for (int i = 0; i < columnSpecs.size(); i++)
+                                                              {
+                                                                  ColumnSpecification columnSpec = columnSpecs.get(i);
+                                                                  ByteBuffer bb = row.getBytes(columnSpec.name.toString());
+                                                                  bbs.add(ByteBufferUtil.getArrayUnsafeNullable(bb));
+                                                              }
+                                                              return bbs;
+                                                          });
         return toIterInternal(columnSpecs, Lists.newArrayList(iter));
     }
 
-    private static Iterator<Object[]> toIterInternal(List<ColumnSpecification> columnSpecs, List<List<ByteBuffer>> rs)
+    private static Iterator<Object[]> toIterInternal(List<ColumnSpecification> columnSpecs, List<List<byte[]>> rs)
     {
         return Iterators.transform(rs.iterator(),
                                    (row) -> {
@@ -170,10 +175,10 @@ public class RowUtil
                                        for (int i = 0; i < columnSpecs.size(); i++)
                                        {
                                            ColumnSpecification columnSpec = columnSpecs.get(i);
-                                           ByteBuffer bb = row.get(i);
+                                           byte[] bytes = row.get(i);
 
-                                           if (bb != null)
-                                               objectRow[i] = columnSpec.type.getSerializer().deserialize(bb);
+                                           if (bytes != null)
+                                               objectRow[i] = columnSpec.type.getSerializer().deserialize(bytes, ByteArrayAccessor.instance);
 
                                        }
                                        return objectRow;

--- a/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
@@ -617,8 +617,8 @@ public class PreparedStatementsTest extends CQLTester
                      rows.result.metadata.names.stream().map(cs -> cs.name.toString()).collect(Collectors.toList()));
         assertEquals(1,
                      rows.result.size());
-        assertEquals(expectedRow,
-                     rows.result.rows.get(0));
+        assertEqualRows(expectedRow,
+                        rows.result.rows.get(0));
 
         if (resultFlags.contains(org.apache.cassandra.cql3.ResultSet.Flag.METADATA_CHANGED))
             prepSelect = prepSelect.withResultMetadata(rows.result.metadata);
@@ -644,8 +644,8 @@ public class PreparedStatementsTest extends CQLTester
                      rows.result.metadata.names.stream().map(cs -> cs.name.toString()).collect(Collectors.toList()));
         assertEquals(1,
                      rows.result.size());
-        assertEquals(expectedRow,
-                     rows.result.rows.get(0));
+        assertEqualRows(expectedRow,
+                        rows.result.rows.get(0));
     }
 
     @Test
@@ -783,6 +783,15 @@ public class PreparedStatementsTest extends CQLTester
     public void testPrepareWithAccordCurrent()
     {
         testPrepareWithAccord(ProtocolVersion.CURRENT);
+    }
+
+    private static void assertEqualRows(List<ByteBuffer> expectedRow, List<byte[]> actualRow)
+    {
+        assertEquals(expectedRow.size(), actualRow.size());
+
+        for (int i = 0; i < expectedRow.size(); i++) {
+            assertEquals(expectedRow.get(i), actualRow.get(i) != null ? ByteBuffer.wrap(actualRow.get(i)) : null);
+        }
     }
 
     private void testPrepareWithAccord(ProtocolVersion version)

--- a/test/unit/org/apache/cassandra/cql3/UntypedResultSetTest.java
+++ b/test/unit/org/apache/cassandra/cql3/UntypedResultSetTest.java
@@ -85,7 +85,7 @@ public class UntypedResultSetTest
                 AbstractTypeGenerators.TypeSupport<?> support = AbstractTypeGenerators.getTypeSupport(columns.get(i).type);
                 data.add(fromQT(support.bytesGen()).next(rs));
             }
-            return new UntypedResultSet.Row(columns, data);
+            return UntypedResultSet.Row.fromByteBuffers(columns, data);
         });
     }
 
@@ -99,7 +99,7 @@ public class UntypedResultSetTest
             for (int i = 0; i < numRows; i++)
             {
                 List<ByteBuffer> row = dataGens.stream().map(g -> g.next(rs)).collect(Collectors.toList());
-                result.addRow(row);
+                result.addByteBufferRow(row);
             }
             return result;
         };

--- a/test/unit/org/apache/cassandra/db/guardrails/AbstractGenerationalTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/AbstractGenerationalTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.cassandra.db.guardrails;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
 import org.junit.Ignore;
 
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.messages.ResultMessage;
@@ -92,10 +92,10 @@ public abstract class AbstractGenerationalTest extends GuardrailTester
         assertEquals(1, rows.result.metadata.names.size());
         assertEquals(UTF8Type.instance.asCQL3Type(), rows.result.metadata.names.get(0).type.asCQL3Type());
         assertEquals(columnName, rows.result.metadata.names.get(0).name.toString());
-        List<ByteBuffer> byteBuffer = rows.result.rows.get(0);
-        assertNotNull(byteBuffer);
-        assertEquals(1, byteBuffer.size());
-        return UTF8Type.instance.getSerializer().deserialize(byteBuffer.get(0));
+        List<byte[]> byteArrayRow = rows.result.rows.get(0);
+        assertNotNull(byteArrayRow);
+        assertEquals(1, byteArrayRow.size());
+        return UTF8Type.instance.getSerializer().deserialize(byteArrayRow.get(0), ByteArrayAccessor.instance);
     }
 
     protected Pair<String, String> extractPasswordAndRoleName(ResultMessage resultMessage)
@@ -112,11 +112,11 @@ public abstract class AbstractGenerationalTest extends GuardrailTester
         assertEquals(UTF8Type.instance.asCQL3Type(), rows.result.metadata.names.get(1).type.asCQL3Type());
         assertEquals("generated_password", rows.result.metadata.names.get(0).name.toString());
         assertEquals("generated_role_name", rows.result.metadata.names.get(1).name.toString());
-        List<ByteBuffer> row = rows.result.rows.get(0);
+        List<byte[]> row = rows.result.rows.get(0);
         assertNotNull(row);
         assertEquals(2, row.size());
-        String password = UTF8Type.instance.getSerializer().deserialize(row.get(0));
-        String roleName = UTF8Type.instance.getSerializer().deserialize(row.get(1));
+        String password = UTF8Type.instance.getSerializer().deserialize(row.get(0), ByteArrayAccessor.instance);
+        String roleName = UTF8Type.instance.getSerializer().deserialize(row.get(1), ByteArrayAccessor.instance);
         return Pair.create(password, roleName);
     }
 }

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
@@ -434,10 +434,13 @@ public abstract class CqlOperation<V> extends PredefinedOperation
                     ByteBuffer[][] r = new ByteBuffer[rows.result.size()][];
                     for (int i = 0 ; i < r.length ; i++)
                     {
-                        List<ByteBuffer> row = rows.result.rows.get(i);
+                        List<byte[]> row = rows.result.rows.get(i);
                         r[i] = new ByteBuffer[row.size()];
                         for (int j = 0 ; j < row.size() ; j++)
-                            r[i][j] = row.get(j);
+                        {
+                            byte[] v = row.get(j);
+                            r[i][j] = v == null ? null : ByteBuffer.wrap(v);
+                        }
                     }
                     return r;
                 }
@@ -484,7 +487,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
                         ResultMessage.Rows rows = ((ResultMessage.Rows) result);
                         byte[][] r = new byte[rows.result.size()][];
                         for (int i = 0 ; i < r.length ; i++)
-                            r[i] = rows.result.rows.get(i).get(0).array();
+                            r[i] = rows.result.rows.get(i).get(0);
                         return r;
                     }
                     return null;


### PR DESCRIPTION
Current ReadCommand logic returns ArrayCell values, so when we retrieve a cell value as a ByteBuffer we allocate ByteBuffer instances

patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21362