### PR TITLE
CASSANDRA-21369: Backport to 5.0

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -389,7 +389,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
 
     // Lazily creates SSTableBoundedScanner for sstable that are assumed to be from the
     // same level (e.g. non overlapping) - see #4142
-    private static class LeveledScanner extends AbstractIterator<UnfilteredRowIterator> implements ISSTableScanner
+    protected static class LeveledScanner extends AbstractIterator<UnfilteredRowIterator> implements ISSTableScanner
     {
         private final TableMetadata metadata;
         private final Collection<Range<Token>> ranges;
@@ -444,8 +444,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
             {
                 for (SSTableReader sstable : sstables)
                 {
-                    Range<Token> sstableRange = new Range<>(sstable.getFirst().getToken(), sstable.getLast().getToken());
-                    if (range == null || sstableRange.intersects(range))
+                    if (range == null || range.intersects(sstable.getBounds()))
                         filtered.add(sstable);
                 }
             }

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -75,6 +75,7 @@ import org.apache.cassandra.utils.TimeUUID;
 import org.awaitility.Awaitility;
 
 import static java.util.Collections.singleton;
+import static org.apache.cassandra.schema.MockSchema.readerBounds;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -1046,6 +1047,32 @@ public class LeveledCompactionStrategyTest
             assertFalse(task.reduceScopeForLimitedSpace(Sets.newHashSet(sstables), 0));
             assertEquals(Sets.newHashSet(sstables), txn.originals());
         }
+    }
+
+    @Test
+    public void testLevelScannerIntersection()
+    {
+        Collection<SSTableReader> sstable = Collections.singleton(MockSchema.sstableWithLevel(1, 10, 20, 1, cfs));
+
+        // SSTable range - [10, 20]
+        // range - (1, 9]
+        Range<Token> range = new Range<>(readerBounds(1).getToken(), readerBounds(9).getToken());
+        assertEquals(0, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (1, 10]
+        range = new Range<>(readerBounds(1).getToken(), readerBounds(10).getToken());
+        assertEquals(1, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (1, 15]
+        range = new Range<>(readerBounds(1).getToken(), readerBounds(15).getToken());
+        assertEquals(1, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
+
+        // SSTable range - [10, 20]
+        // range - (20, 25]
+        range = new Range<>(readerBounds(20).getToken(), readerBounds(25).getToken());
+        assertEquals(0, LeveledCompactionStrategy.LeveledScanner.intersecting(sstable, Collections.singleton(range)).size());
     }
 
     private Pair<Set<SSTableReader>, Set<SSTableReader>> groupByLevel(Iterable<SSTableReader> sstables)


### PR DESCRIPTION
[CASSANDRA-21369](https://issues.apache.org/jira/browse/CASSANDRA-21369): Backport fix to 5.0

Reference PR: https://github.com/apache/cassandra/pull/4808

patch by Alan Wang;

reviewed by for [CASSANDRA-21369](https://issues.apache.org/jira/browse/CASSANDRA-21369)

Co-authored-by: Name1
Co-authored-by: Name2