### PR TITLE
CASSANDRA-21133 Make bin/sstableupgrade functionally on par with nodetool upgradesstables

### DIFF
--- a/doc/modules/cassandra/pages/managing/tools/sstable/sstableupgrade.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/sstable/sstableupgrade.adoc
@@ -25,6 +25,7 @@ sstableupgrade <options> <keyspace> <table> [snapshot_name]
 |===
 |--debug |display stack traces
 |-h,--help |display this help message
+|-a,--include-all-sstables |include all sstables, even those already on the current version
 |-k,--keep-source |do not delete the source sstables
 |===
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1025,12 +1025,21 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     public Descriptor newSSTableDescriptor(File directory, Version version)
     {
-        Descriptor newDescriptor = new Descriptor(version,
-                                                  directory,
-                                                  getKeyspaceName(),
-                                                  name,
-                                                  sstableIdGenerator.get());
-        assert !newDescriptor.fileFor(Components.DATA).exists();
+        Descriptor newDescriptor;
+        while (true)
+        {
+            newDescriptor = new Descriptor(version,
+                                           directory,
+                                           getKeyspaceName(),
+                                           name,
+                                           sstableIdGenerator.get());
+
+            if (!newDescriptor.fileFor(Components.DATA).exists())
+                break;
+
+            logger.warn("Generated SSTable id {} collides with existing file; advancing.", newDescriptor.id);
+        }
+
         return newDescriptor;
     }
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1026,6 +1026,16 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     public Descriptor newSSTableDescriptor(File directory, Version version)
     {
         Descriptor newDescriptor;
+
+        /*
+         * Note that thread safety is managed by the underlying sstableIdGenerator (e.g., via AtomicInteger),
+         * guaranteeing unique IDs for concurrent callers within the process.
+         * * This loop acts as a collision-resolution mechanism for offline vs. online operations.
+         * Offline tools (such as bin/sstableupgrade) may generate new SSTables on disk, bypassing
+         * the in-memory ID generator. If the live process encounters a collision due to such
+         * out-of-band generation, this loop ensures the process advances the generator until a
+         * free ID is found.
+         */
         while (true)
         {
             newDescriptor = new Descriptor(version,
@@ -1037,7 +1047,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             if (!newDescriptor.fileFor(Components.DATA).exists())
                 break;
 
-            logger.warn("Generated SSTable id {} collides with existing file; advancing.", newDescriptor.id);
+            logger.debug("Generated SSTable id {} collides with existing file; advancing.", newDescriptor.id);
         }
 
         return newDescriptor;

--- a/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
+++ b/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
@@ -217,7 +217,7 @@ public class StandaloneUpgrader
             options.addOption(null, DEBUG_OPTION,          "display stack traces");
             options.addOption("h",  HELP_OPTION,           "display this help message");
             options.addOption("k",  KEEP_SOURCE,           "do not delete the source sstables");
-            options.addOption("a",  "include-all-sstables", "include all sstables, even those already on the current version");
+            options.addOption("a",  INCLUDE_ALL, "include all sstables, even those already on the current version");
             return options;
         }
 

--- a/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
+++ b/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
@@ -53,6 +53,7 @@ public class StandaloneUpgrader
     private static final String DEBUG_OPTION  = "debug";
     private static final String HELP_OPTION  = "help";
     private static final String KEEP_SOURCE = "keep-source";
+    private static final String INCLUDE_ALL = "include-all-sstables";
 
     public static void main(String args[])
     {
@@ -91,7 +92,7 @@ public class StandaloneUpgrader
                 try
                 {
                     SSTableReader sstable = SSTableReader.openNoValidation(entry.getKey(), components, cfs);
-                    if (sstable.descriptor.version.equals(DatabaseDescriptor.getSelectedSSTableFormat().getLatestVersion()))
+                    if (!options.includeAll && sstable.descriptor.version.equals(DatabaseDescriptor.getSelectedSSTableFormat().getLatestVersion()))
                     {
                         sstable.selfRef().release();
                         continue;
@@ -151,6 +152,7 @@ public class StandaloneUpgrader
 
         public boolean debug;
         public boolean keepSource;
+        public boolean includeAll;
 
         private Options(String keyspace, String cf, String snapshot)
         {
@@ -191,6 +193,7 @@ public class StandaloneUpgrader
 
                 opts.debug = cmd.hasOption(DEBUG_OPTION);
                 opts.keepSource = cmd.hasOption(KEEP_SOURCE);
+                opts.includeAll = cmd.hasOption(INCLUDE_ALL);
 
                 return opts;
             }
@@ -214,6 +217,7 @@ public class StandaloneUpgrader
             options.addOption(null, DEBUG_OPTION,          "display stack traces");
             options.addOption("h",  HELP_OPTION,           "display this help message");
             options.addOption("k",  KEEP_SOURCE,           "do not delete the source sstables");
+            options.addOption("a",  "include-all-sstables", "include all sstables, even those already on the current version");
             return options;
         }
 

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.UpdateBuilder;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -71,8 +72,11 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTableIdFactory;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.ScrubTest;
+import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
@@ -837,6 +841,52 @@ public class ColumnFamilyStoreTest
             schemaAndManifestFileSizes += manifestFile.length();
 
         return schemaAndManifestFileSizes;
+    }
+
+   @Test
+    public void testNewSSTableDescriptorCollision() throws Exception
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
+        File dir = cfs.getDirectories().getDirectoryForNewSSTables();
+        Version version = DatabaseDescriptor.getSelectedSSTableFormat().getLatestVersion();
+
+        Descriptor probe = cfs.newSSTableDescriptor(dir, version);
+
+        int currentId;
+        try {
+            currentId = Integer.parseInt(probe.id.toString());
+        } catch (NumberFormatException e) {
+            return;
+        }
+
+        SSTableId blockedId1 = SSTableIdFactory.instance.fromString(String.valueOf(currentId + 1));
+        SSTableId blockedId2 = SSTableIdFactory.instance.fromString(String.valueOf(currentId + 2));
+
+        Descriptor blockedDesc1 = new Descriptor(version, dir, cfs.getKeyspaceName(), cfs.name, blockedId1);
+        Descriptor blockedDesc2 = new Descriptor(version, dir, cfs.getKeyspaceName(), cfs.name, blockedId2);
+
+        File blockedDataFile1 = blockedDesc1.fileFor(Components.DATA);
+        File blockedDataFile2 = blockedDesc2.fileFor(Components.DATA);
+
+        try
+        {
+            blockedDataFile1.createFileIfNotExists();
+            blockedDataFile2.createFileIfNotExists();
+
+            Descriptor nextDesc = cfs.newSSTableDescriptor(dir, version);
+
+            Assert.assertNotEquals("The loop should have skipped the first blocked ID",
+                                   blockedDesc1.id, nextDesc.id);
+            Assert.assertNotEquals("The loop should have skipped the second blocked ID",
+                                   blockedDesc2.id, nextDesc.id);
+            Assert.assertFalse("The returned descriptor must not already exist on disk",
+                               nextDesc.fileFor(Components.DATA).exists());
+        }
+        finally
+        {
+            blockedDataFile1.deleteIfExists();
+            blockedDataFile2.deleteIfExists();
+        }
     }
 
     private Memtable fakeMemTableWithMinTS(ColumnFamilyStore cfs, long minTS)

--- a/test/unit/org/apache/cassandra/tools/StandaloneUpgraderTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneUpgraderTest.java
@@ -48,9 +48,11 @@ public class StandaloneUpgraderTest extends OfflineToolUtils
                        "hard links to live sstables.\n" + 
                        "--\n" + 
                        "Options are:\n" + 
-                       "    --debug         display stack traces\n" + 
-                       " -h,--help          display this help message\n" + 
-                       " -k,--keep-source   do not delete the source sstables\n";
+                       " -a,--include-all-sstables   include all sstables, even those already on the\n" +
+                       "                             current version\n" +
+                       "    --debug                  display stack traces\n" +
+                       " -h,--help                   display this help message\n" +
+                       " -k,--keep-source            do not delete the source sstables\n";
         Assertions.assertThat(tool.getStdout()).isEqualTo(help);
     }
 
@@ -82,6 +84,16 @@ public class StandaloneUpgraderTest extends OfflineToolUtils
                                                        "system_schema",
                                                        "tables");
             Assertions.assertThat(tool.getStdout()).as("Arg: [%s]", arg).isEqualTo("Found 0 sstables that need upgrading.\n");
+            Assertions.assertThat(tool.getCleanedStderr()).as("Arg: [%s]", arg).isEmpty();
+            assertEquals(0, tool.getExitCode());
+            assertCorrectEnvPostTest();
+        });
+
+        Arrays.asList("-a", "--include-all-sstables").forEach(arg -> {
+            ToolResult tool = ToolRunner.invokeClass(StandaloneUpgrader.class,
+                                                       arg,
+                                                       "system_schema",
+                                                       "tables");
             Assertions.assertThat(tool.getCleanedStderr()).as("Arg: [%s]", arg).isEmpty();
             assertEquals(0, tool.getExitCode());
             assertCorrectEnvPostTest();


### PR DESCRIPTION
Make bin/sstableupgrade functionally on par with nodetool upgradesstables

### What this PR does / why we need it:
This PR brings functional parity between `bin/sstableupgrade` and `nodetool upgradesstables` by introducing the `-a` / `--include-all-sstables` flag to the offline tool. 

Previously, `bin/sstableupgrade` would automatically skip SSTables that were already on the latest version. This patch allows users to force a rewrite of all SSTables even if they are on the current format.

### Technical Details & Safety:
Adding this flag to an offline tool introduced a known edge case: If the offline tool is run while the Cassandra node is online, it consumes a new SSTable ID on disk. However, the live node's internal `sstableIdGenerator` remains unaware of this. Upon the next flush, the live node attempts to use the same ID, which previously triggered a `java.lang.AssertionError` in `ColumnFamilyStore.newSSTableDescriptor()`.

To safely resolve this without introducing regressions:
1. Replaced the strict `assert !newDescriptor.fileFor(Components.DATA).exists();` check in `newSSTableDescriptor` with a safe `while(true)` loop. It checks if the generated ID already exists on disk. If a collision is detected, it logs a warning and advances the generator, self-healing the state.
2. Updated `StandaloneUpgrader` to parse and apply the `-a` option consistently.
3. Added a robust test (`testNewSSTableDescriptorCollision`) in `ColumnFamilyStoreTest` that probes the current ID, uses `SSTableIdFactory` to pre-create files for future IDs (`N+1`, `N+2`), and verifies that the loop correctly skips them and yields `N+3`.
4. Updated flag assertions in `StandaloneUpgraderTest`.
5. Updated documentation in `sstableupgrade.adoc`.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-21133