### PR TITLE
[CASSANDRA-21388][trunk] Reduce microbenchmark smoke tests execution

### DIFF
--- a/.build/build-bench.xml
+++ b/.build/build-bench.xml
@@ -49,9 +49,11 @@
         <!-- Only used to test jmh classes run without error.  Not to be used for actual performance tests -->
         <jmh>
             <extra-args>
-                <arg value="-f"/><arg value="1"/>
-                <arg value="-wi"/><arg value="0"/>
-                <arg value="-i"/><arg value="1"/>
+                <arg value="-f"/><arg value="1"/>    <!-- forks -->
+                <arg value="-wi"/><arg value="0"/>   <!-- warmup iterations -->
+                <arg value="-i"/><arg value="1"/>    <!-- fork -->
+                <arg value="-r"/><arg value="1"/>    <!-- measurement iteration time -->
+                <arg value="-t"/><arg value="1"/>    <!-- threads -->
             </extra-args>
         </jmh>
     </target>

--- a/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -33,6 +34,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.profile.GCProfiler;
@@ -63,6 +65,7 @@ import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.TestHelper;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -118,6 +121,12 @@ public class BatchStatementBench
         }
         bs = new BatchStatement(BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), modifications, Attributes.none());
         bqo = BatchQueryOptions.withPerStatementVariables(QueryOptions.DEFAULT, parameters, queryOrIdList);
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception
+    {
+        TestHelper.teardown();
     }
 
     @Benchmark

--- a/test/microbench/org/apache/cassandra/test/microbench/CIDRAuthorizerBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CIDRAuthorizerBench.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -50,6 +49,7 @@ import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.cql3.CIDR;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.utils.TestHelper;
 
 /**
  * Benchmark CIDR authorizer (enforce mode)
@@ -99,9 +99,9 @@ public class CIDRAuthorizerBench extends CQLTester
     }
 
     @TearDown(Level.Trial)
-    public void teardown() throws IOException, ExecutionException, InterruptedException
+    public void teardown() throws Exception
     {
-        CQLTester.cleanup();
+        TestHelper.teardown();
     }
 
     @State(Scope.Thread)

--- a/test/microbench/org/apache/cassandra/test/microbench/CacheLoaderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CacheLoaderBench.java
@@ -46,18 +46,17 @@ import org.apache.cassandra.cache.KeyCacheKey;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DataStorageSpec;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.RowUpdateBuilder;
-import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.TestHelper;
 
 @SuppressWarnings("unused")
 @BenchmarkMode(Mode.SampleTime)
@@ -151,11 +150,9 @@ public class CacheLoaderBench
     }
 
     @TearDown(Level.Trial)
-    public void teardown()
+    public void teardown() throws Exception
     {
-        CQLTester.tearDownClass();
-        CommitLog.instance.stopUnsafe(true);
-        CQLTester.cleanup();
+        TestHelper.teardown();
     }
 
     @Benchmark

--- a/test/microbench/org/apache/cassandra/test/microbench/FunctionWithTerminalArgsBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/FunctionWithTerminalArgsBench.java
@@ -41,7 +41,7 @@ import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.utils.TestHelper;
 
 /**
  * Benchmarks the performance of CQL functions calls with terminal arguments.
@@ -101,11 +101,9 @@ public class FunctionWithTerminalArgsBench extends CQLTester
     }
 
     @TearDown(Level.Trial)
-    public void teardown() throws InterruptedException
+    public void teardown() throws Exception
     {
-        CommitLog.instance.shutdownBlocking();
-        CQLTester.tearDownClass();
-        CQLTester.cleanup();
+        TestHelper.teardown();
     }
 
     @Benchmark

--- a/test/microbench/org/apache/cassandra/test/microbench/MetadataCollectorBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/MetadataCollectorBench.java
@@ -27,6 +27,7 @@ import org.jctools.util.Pow2;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -34,6 +35,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 import org.apache.cassandra.cql3.CQLTester;
@@ -47,6 +49,7 @@ import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.TestHelper;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -120,6 +123,12 @@ public class MetadataCollectorBench
             clusterings[i] = clusterings[to];
             clusterings[to] = temp;
         }
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception
+    {
+        TestHelper.teardown();
     }
 
     @Benchmark

--- a/test/microbench/org/apache/cassandra/test/microbench/ZstdDictionaryCompressorBenchBase.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ZstdDictionaryCompressorBenchBase.java
@@ -39,7 +39,7 @@ import org.apache.cassandra.db.compression.CompressionDictionary.Kind;
 import org.apache.cassandra.db.compression.ZstdCompressionDictionary;
 import org.apache.cassandra.io.compress.ZstdDictionaryCompressor;
 
-// The bench takes over 20 minutes to finish
+// The full bench takes over 20 minutes to finish
 @State(Scope.Benchmark)
 public abstract class ZstdDictionaryCompressorBenchBase
 {
@@ -52,7 +52,8 @@ public abstract class ZstdDictionaryCompressorBenchBase
     @Param({"0", "65536"})
     protected int dictionarySize;
 
-    @Param({"3", "5", "7"})
+    // @Param({"3", "5", "7"})
+    @Param({"3"})
     protected int compressionLevel;
 
     protected byte[] inputData;

--- a/test/microbench/org/apache/cassandra/test/microbench/tries/ComparisonReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/tries/ComparisonReadBench.java
@@ -77,10 +77,12 @@ public class ComparisonReadBench
     @Param({"ON_HEAP"})
     BufferType bufferType = BufferType.OFF_HEAP;
 
-    @Param({"1000", "100000", "10000000"})
+    // @Param({"1000", "100000", "10000000"})
+    @Param({"1000", "100000"})
     int count = 1000;
 
-    @Param({"TREE_MAP", "CSLM", "TRIE"})
+    // @Param({"TREE_MAP", "CSLM", "TRIE"})
+    @Param({"CSLM", "TRIE"})
     MapOption map = MapOption.TRIE;
 
     @Param({"LONG"})

--- a/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieUnionBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieUnionBench.java
@@ -56,10 +56,12 @@ public class InMemoryTrieUnionBench
     @Param({"ON_HEAP", "OFF_HEAP"})
     BufferType bufferType = BufferType.OFF_HEAP;
 
-    @Param({"1000", "100000", "10000000"})
+    // @Param({"1000", "100000", "10000000"})
+    @Param({"1000", "100000"})
     int count = 1000;
 
-    @Param({"2", "3", "8"})
+    // @Param({"2", "3", "8"})
+    @Param({"2", "3"})
     int sources = 2;
 
     @Param({"false", "true"})


### PR DESCRIPTION
- set explicitly duration for an iteration to 1 sec
- reduce number of option combinations in tests (all the details are not so needed for a regression testing to see if the benchmarks are still alive)
- fix the tests which do not release resources properly and JMH waits for a timeout to kill a forked JVM
- support splits for microbench-test
- 
CASSANDRA-21388