### PR TITLE
 Fix bugs in CEP-59 graceful disconnect implementation

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1097,13 +1097,13 @@ native_transport_allow_older_protocols: true
 # graceful_disconnect_enabled: false
 
 # Time given to clients to stop sending new requests after the
-# GRACEFUL_DISCONNECT event is emitted. Must not exceed graceful_disconnect_max_drain_ms.
-# graceful_disconnect_grace_period_ms: 5000
+# GRACEFUL_DISCONNECT event is emitted. Must not exceed graceful_disconnect_max_drain.
+# graceful_disconnect_grace_period: 5000
 
 # Hard timeout for draining connections. Once this limit is reached,
 # remaining connections are force-closed regardless of in-flight requests.
 # Must be greater than 0 when graceful_disconnect_enabled is true.
-# graceful_disconnect_max_drain_ms: 30000
+# graceful_disconnect_max_drain: 30000
 
 
 # The address or interface to bind the native transport server to.

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1114,7 +1114,7 @@ graceful_disconnect_enabled: false
 # (i.e. it will be based on the configured hostname of the node).
 #
 # Note that unlike listen_address, you can specify 0.0.0.0, but you must also
- set broadcast_rpc_address to a value other than 0.0.0.0.
+# set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 rpc_address: localhost

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1094,7 +1094,7 @@ native_transport_allow_older_protocols: true
 
 # Enable or disable graceful disconnect. When false, shutdown behavior is
 # unchanged from previous versions.
-# graceful_disconnect_enabled: false
+graceful_disconnect_enabled: false
 
 # Time given to clients to stop sending new requests after the
 # GRACEFUL_DISCONNECT event is emitted. Must not exceed graceful_disconnect_max_drain.
@@ -1114,7 +1114,7 @@ native_transport_allow_older_protocols: true
 # (i.e. it will be based on the configured hostname of the node).
 #
 # Note that unlike listen_address, you can specify 0.0.0.0, but you must also
-# set broadcast_rpc_address to a value other than 0.0.0.0.
+ set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 rpc_address: localhost

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1083,6 +1083,29 @@ native_transport_allow_older_protocols: true
 # native_transport_rate_limiting_enabled: false
 # native_transport_max_requests_per_second: 1000000
 
+# When enabled, nodes will signal connected clients before shutting down,
+# allowing in-flight requests to complete without client-visible timeouts.
+# This applies to intentional shutdowns (nodetool drain, rolling restarts,
+# controlled JVM shutdown). Clients must subscribe to the GRACEFUL_DISCONNECT
+# event via REGISTER to benefit from this behavior.
+#
+# Requires driver support for the GRACEFUL_DISCONNECT event type.
+# See: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=406619103
+
+# Enable or disable graceful disconnect. When false, shutdown behavior is
+# unchanged from previous versions.
+# graceful_disconnect_enabled: false
+
+# Time given to clients to stop sending new requests after the
+# GRACEFUL_DISCONNECT event is emitted. Must not exceed graceful_disconnect_max_drain_ms.
+# graceful_disconnect_grace_period_ms: 5000
+
+# Hard timeout for draining connections. Once this limit is reached,
+# remaining connections are force-closed regardless of in-flight requests.
+# Must be greater than 0 when graceful_disconnect_enabled is true.
+# graceful_disconnect_max_drain_ms: 30000
+
+
 # The address or interface to bind the native transport server to.
 #
 # Set rpc_address OR rpc_interface, not both.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -169,9 +169,9 @@ public class Config
 
     public boolean graceful_disconnect_enabled = false;
 
-    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_grace_period_ms = new  DurationSpec.LongMillisecondsBound("5s");
+    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_grace_period = new  DurationSpec.LongMillisecondsBound("5s");
 
-    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_max_drain_ms = new  DurationSpec.LongMillisecondsBound("30s");
+    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_max_drain = new  DurationSpec.LongMillisecondsBound("30s");
 
     @Replaces(oldName = "truncate_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound truncate_request_timeout = new DurationSpec.LongMillisecondsBound("60000ms");

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -167,6 +167,12 @@ public class Config
 
     public volatile DurationSpec.LongMillisecondsBound accord_preaccept_timeout = new DurationSpec.LongMillisecondsBound("1s");
 
+    public boolean graceful_disconnect_enabled = false;
+
+    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_grace_period_ms = new  DurationSpec.LongMillisecondsBound("5s");
+
+    public volatile DurationSpec.LongMillisecondsBound graceful_disconnect_max_drain_ms = new  DurationSpec.LongMillisecondsBound("30s");
+
     @Replaces(oldName = "truncate_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound truncate_request_timeout = new DurationSpec.LongMillisecondsBound("60000ms");
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2634,6 +2634,15 @@ public class DatabaseDescriptor
         return conf.graceful_disconnect_enabled;
     }
 
+    /**
+     * Updating graceful_disconnect_enabled via JMX isn't supported. This function exists solely for test cases
+     * @param gracefulDisconnectEnabled
+     */
+    public static void setGracefulDisconnectEnabled(boolean  gracefulDisconnectEnabled)
+    {
+        conf.graceful_disconnect_enabled = gracefulDisconnectEnabled;
+    }
+
     public static long getReadRpcTimeout(TimeUnit unit)
     {
         return conf.read_request_timeout.to(unit);

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -685,6 +685,17 @@ public class DatabaseDescriptor
             throw new ConfigurationException("phi_convict_threshold must be between 5 and 16, but was " + conf.phi_convict_threshold, false);
         }
 
+        if (conf.graceful_disconnect_enabled && conf.graceful_disconnect_max_drain_ms.toMilliseconds() <= 0)
+        {
+            throw new ConfigurationException("graceful_disconnect_max_drain_ms must be greater than 0 when graceful_disconnect_enabled is set to true.", false);
+        }
+
+        if (conf.graceful_disconnect_enabled &&
+            conf.graceful_disconnect_grace_period_ms.toMilliseconds() > conf.graceful_disconnect_max_drain_ms.toMilliseconds())
+        {
+            throw new ConfigurationException("graceful_disconnect_grace_period_ms cannot exceed graceful_disconnect_max_drain_ms.", false);
+        }
+
         /* Thread per pool */
         if (conf.concurrent_reads < 2)
         {
@@ -2596,6 +2607,31 @@ public class DatabaseDescriptor
     public static void setRpcTimeout(long timeOutInMillis)
     {
         conf.request_timeout = new DurationSpec.LongMillisecondsBound(timeOutInMillis);
+    }
+
+    public static long getGracefulDisconnectGracePeriodMs()
+    {
+        return conf.graceful_disconnect_grace_period_ms.toMilliseconds();
+    }
+
+    public static void setGracefulDisconnectGracePeriodMs(long gracefulDisconnectGracePeriodMs)
+    {
+        conf.graceful_disconnect_grace_period_ms = new DurationSpec.LongMillisecondsBound(gracefulDisconnectGracePeriodMs);
+    }
+
+    public static long getGracefulDisconnectMaxDrainMs()
+    {
+        return conf.graceful_disconnect_max_drain_ms.toMilliseconds();
+    }
+
+    public static void setGracefulDisconnectMaxDrainMs(long gracefulDisconnectMaxDrainMs)
+    {
+        conf.graceful_disconnect_max_drain_ms = new DurationSpec.LongMillisecondsBound(gracefulDisconnectMaxDrainMs);
+    }
+
+    public static boolean getGracefulDisconnectEnabled()
+    {
+        return conf.graceful_disconnect_enabled;
     }
 
     public static long getReadRpcTimeout(TimeUnit unit)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -685,15 +685,15 @@ public class DatabaseDescriptor
             throw new ConfigurationException("phi_convict_threshold must be between 5 and 16, but was " + conf.phi_convict_threshold, false);
         }
 
-        if (conf.graceful_disconnect_enabled && conf.graceful_disconnect_max_drain_ms.toMilliseconds() <= 0)
+        if (conf.graceful_disconnect_enabled && conf.graceful_disconnect_max_drain.toMilliseconds() <= 0)
         {
-            throw new ConfigurationException("graceful_disconnect_max_drain_ms must be greater than 0 when graceful_disconnect_enabled is set to true.", false);
+            throw new ConfigurationException("graceful_disconnect_max_drain must be greater than 0 when graceful_disconnect_enabled is set to true.", false);
         }
 
         if (conf.graceful_disconnect_enabled &&
-            conf.graceful_disconnect_grace_period_ms.toMilliseconds() > conf.graceful_disconnect_max_drain_ms.toMilliseconds())
+            conf.graceful_disconnect_grace_period.toMilliseconds() > conf.graceful_disconnect_max_drain.toMilliseconds())
         {
-            throw new ConfigurationException("graceful_disconnect_grace_period_ms cannot exceed graceful_disconnect_max_drain_ms.", false);
+            throw new ConfigurationException("graceful_disconnect_grace_period cannot exceed graceful_disconnect_max_drain.", false);
         }
 
         /* Thread per pool */
@@ -2609,24 +2609,24 @@ public class DatabaseDescriptor
         conf.request_timeout = new DurationSpec.LongMillisecondsBound(timeOutInMillis);
     }
 
-    public static long getGracefulDisconnectGracePeriodMs()
+    public static long getGracefulDisconnectGracePeriod()
     {
-        return conf.graceful_disconnect_grace_period_ms.toMilliseconds();
+        return conf.graceful_disconnect_grace_period.toMilliseconds();
     }
 
-    public static void setGracefulDisconnectGracePeriodMs(long gracefulDisconnectGracePeriodMs)
+    public static void setGracefulDisconnectGracePeriod(long gracefulDisconnectGracePeriod)
     {
-        conf.graceful_disconnect_grace_period_ms = new DurationSpec.LongMillisecondsBound(gracefulDisconnectGracePeriodMs);
+        conf.graceful_disconnect_grace_period = new DurationSpec.LongMillisecondsBound(gracefulDisconnectGracePeriod);
     }
 
-    public static long getGracefulDisconnectMaxDrainMs()
+    public static long getGracefulDisconnectMaxDrain()
     {
-        return conf.graceful_disconnect_max_drain_ms.toMilliseconds();
+        return conf.graceful_disconnect_max_drain.toMilliseconds();
     }
 
-    public static void setGracefulDisconnectMaxDrainMs(long gracefulDisconnectMaxDrainMs)
+    public static void setGracefulDisconnectMaxDrain(long gracefulDisconnectMaxDrain)
     {
-        conf.graceful_disconnect_max_drain_ms = new DurationSpec.LongMillisecondsBound(gracefulDisconnectMaxDrainMs);
+        conf.graceful_disconnect_max_drain = new DurationSpec.LongMillisecondsBound(gracefulDisconnectMaxDrain);
     }
 
     public static boolean getGracefulDisconnectEnabled()

--- a/src/java/org/apache/cassandra/metrics/ClientMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientMetrics.java
@@ -131,6 +131,13 @@ public final class ClientMetrics
             meterByMode.mark();
     }
 
+    @VisibleForTesting
+    public void initForTesting()
+    {
+        connectionsDraining = new AtomicInteger();
+        forcedDisconnects = Metrics.meter(factory.createMetricName("ForcedDisconnects"));
+    }
+
     /**
      * @deprecated by {@link #markAuthFailure(AuthenticationMode)}
      */

--- a/src/java/org/apache/cassandra/metrics/ClientMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientMetrics.java
@@ -71,6 +71,13 @@ public final class ClientMetrics
     @VisibleForTesting
     Gauge<Integer> connectedNativeClients;
 
+    private AtomicInteger connectionsDraining;
+
+    @SuppressWarnings({ "unused", "FieldCanBeLocal" })
+    private Gauge<Integer> connectionsDrainingGauge;
+
+    private Meter forcedDisconnects;
+
     @VisibleForTesting
     Gauge<Integer> encryptedConnectedNativeClients;
 
@@ -173,6 +180,26 @@ public final class ClientMetrics
         protocolException.mark();
     }
 
+    public void incrementConnectionsDraining()
+    {
+        connectionsDraining.incrementAndGet();
+    }
+
+    public void decrementConnectionsDraining()
+    {
+        connectionsDraining.decrementAndGet();
+    }
+
+    public void decrementConnectionsDraining(int drainingConnections)
+    {
+        connectionsDraining.addAndGet(-drainingConnections);
+    }
+
+    public void markForcedDisconnect(int forceDisconnectedClients)
+    {
+        forcedDisconnects.mark(forceDisconnectedClients);
+    }
+
     public void markSSLHandshakeException()
     {
         sslHandshakeException.mark();
@@ -196,6 +223,10 @@ public final class ClientMetrics
         registerGauge("Connections", "connections", this::connectedClients);
         registerGauge("ClientsByProtocolVersion", "clientsByProtocolVersion", this::recentClientStats);
         registerGauge("RequestsSize", ClientResourceLimits::getCurrentGlobalUsage);
+
+        connectionsDraining = new AtomicInteger();
+        connectionsDrainingGauge = registerGauge("ConnectionsDraining", connectionsDraining::get);
+        forcedDisconnects = registerMeter("ForcedDisconnects");
 
         CassandraReservoir ipUsageReservoir = ClientResourceLimits.ipUsageReservoir();
         Metrics.register(factory.createMetricName("RequestsSizeByIpDistribution"),

--- a/src/java/org/apache/cassandra/metrics/ClientMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientMetrics.java
@@ -71,7 +71,7 @@ public final class ClientMetrics
     @VisibleForTesting
     Gauge<Integer> connectedNativeClients;
 
-    private AtomicInteger connectionsDraining;
+    public AtomicInteger connectionsDraining;
 
     @SuppressWarnings({ "unused", "FieldCanBeLocal" })
     private Gauge<Integer> connectionsDrainingGauge;

--- a/src/java/org/apache/cassandra/service/NativeTransportService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportService.java
@@ -158,7 +158,7 @@ public class NativeTransportService
     }
 
     @VisibleForTesting
-    Server getServer()
+    public Server getServer()
     {
         return server;
     }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1197,6 +1197,48 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return DatabaseDescriptor.getRpcTimeout(MILLISECONDS);
     }
 
+    @Override
+    public void setGracefulDisconnectGracePeriodMs(long value)
+    {
+        if (value > DatabaseDescriptor.getGracefulDisconnectMaxDrainMs())
+            throw new IllegalArgumentException("graceful_disconnect_grace_period_ms cannot exceed graceful_disconnect_max_drain_ms.");
+
+        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(value);
+        logger.info("set graceful disconnect grace period to {} ms", value);
+    }
+
+    @Override
+    public long getGracefulDisconnectGracePeriodMs()
+    {
+        return DatabaseDescriptor.getGracefulDisconnectGracePeriodMs();
+    }
+
+    @Override
+    public void setGracefulDisconnectMaxDrainMs(long value)
+    {
+        if (value <= 0)
+            throw new IllegalArgumentException("graceful_disconnect_max_drain_ms must be greater than 0 when graceful_disconnect_enabled is set to true.");
+
+        if (value < DatabaseDescriptor.getGracefulDisconnectGracePeriodMs())
+            throw new IllegalArgumentException("graceful_disconnect_max_drain_ms cannot be less than graceful_disconnect_grace_period_ms.");
+
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(value);
+        logger.info("set graceful disconnect max drain to {} ms", value);
+    }
+
+
+    @Override
+    public long getGracefulDisconnectMaxDrainMs()
+    {
+        return DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
+    }
+
+    @Override
+    public boolean getGracefulDisconnectEnabled()
+    {
+        return DatabaseDescriptor.getGracefulDisconnectEnabled();
+    }
+
     public void setReadRpcTimeout(long value)
     {
         DatabaseDescriptor.setReadRpcTimeout(value);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1198,39 +1198,39 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     @Override
-    public void setGracefulDisconnectGracePeriodMs(long value)
+    public void setGracefulDisconnectGracePeriod(long value)
     {
-        if (value > DatabaseDescriptor.getGracefulDisconnectMaxDrainMs())
-            throw new IllegalArgumentException("graceful_disconnect_grace_period_ms cannot exceed graceful_disconnect_max_drain_ms.");
+        if (value > DatabaseDescriptor.getGracefulDisconnectMaxDrain())
+            throw new IllegalArgumentException("graceful_disconnect_grace_period cannot exceed graceful_disconnect_max_drain.");
 
-        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(value);
+        DatabaseDescriptor.setGracefulDisconnectGracePeriod(value);
         logger.info("set graceful disconnect grace period to {} ms", value);
     }
 
     @Override
-    public long getGracefulDisconnectGracePeriodMs()
+    public long getGracefulDisconnectGracePeriod()
     {
-        return DatabaseDescriptor.getGracefulDisconnectGracePeriodMs();
+        return DatabaseDescriptor.getGracefulDisconnectGracePeriod();
     }
 
     @Override
-    public void setGracefulDisconnectMaxDrainMs(long value)
+    public void setGracefulDisconnectMaxDrain(long value)
     {
         if (value <= 0)
-            throw new IllegalArgumentException("graceful_disconnect_max_drain_ms must be greater than 0 when graceful_disconnect_enabled is set to true.");
+            throw new IllegalArgumentException("graceful_disconnect_max_drain must be greater than 0 when graceful_disconnect_enabled is set to true.");
 
-        if (value < DatabaseDescriptor.getGracefulDisconnectGracePeriodMs())
-            throw new IllegalArgumentException("graceful_disconnect_max_drain_ms cannot be less than graceful_disconnect_grace_period_ms.");
+        if (value < DatabaseDescriptor.getGracefulDisconnectGracePeriod())
+            throw new IllegalArgumentException("graceful_disconnect_max_drain cannot be less than graceful_disconnect_grace_period.");
 
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(value);
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(value);
         logger.info("set graceful disconnect max drain to {} ms", value);
     }
 
 
     @Override
-    public long getGracefulDisconnectMaxDrainMs()
+    public long getGracefulDisconnectMaxDrain()
     {
-        return DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
+        return DatabaseDescriptor.getGracefulDisconnectMaxDrain();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3885,7 +3885,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             ChannelGroup channelGroup = CassandraDaemon.instance.nativeTransportService()
                                                                 .getServer()
-                                                                .getChannelsSubsribedToGracefulDisconnect();
+                                                                .getChannelsSubscribedToGracefulDisconnect();
 
             if (channelGroup != null && !channelGroup.isEmpty())
             {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3885,7 +3885,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 drainComplete.countDown();
             }
         });
-        drainComplete.await(DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
+        drainComplete.await(DatabaseDescriptor.getGracefulDisconnectMaxDrain(), MILLISECONDS);
     }
 
     private void gracefulDisconnect(Runnable defaultAction)
@@ -3925,7 +3925,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             }
         };
         ScheduledFuture<?> timeoutTask = ScheduledExecutors.nonPeriodicTasks
-                                         .schedule(runOnceAction, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
+                                         .schedule(runOnceAction, DatabaseDescriptor.getGracefulDisconnectMaxDrain(), MILLISECONDS);
 
         // Use a counter rather than channelGroup.isEmpty() because DefaultChannelGroup removes
         // channels on close; under concurrent closes, a listener could see isEmpty()==true

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -244,7 +244,6 @@ import org.apache.cassandra.utils.progress.ProgressListener;
 import org.apache.cassandra.utils.progress.jmx.JMXBroadcastExecutor;
 import org.apache.cassandra.utils.progress.jmx.JMXProgressSupport;
 
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.util.AttributeKey;
 
@@ -304,7 +303,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public static final int INDEFINITE = -1;
     public static final int RING_DELAY_MILLIS = getRingDelay(); // delay after which we assume ring has stablized
 
-    private final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
+    static final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
 
     {
         PathUtils.setDeletionListener(path -> {
@@ -631,7 +630,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         gracefulDisconnect(() -> {
             daemon.stopNativeTransport(force);
         });
-        daemon.stopNativeTransport(force);
     }
 
     public boolean isNativeTransportRunning()
@@ -3890,44 +3888,51 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             defaultAction.run();
             return;
         }
-
+        nts.getServer().stopAcceptingNewConnections();
         ChannelGroup channelGroup = nts.getServer().getChannelsSubscribedToGracefulDisconnect();
         if (channelGroup == null || channelGroup.isEmpty())
         {
             defaultAction.run();
             return;
         }
+        gracefulDisconnect(defaultAction, channelGroup);
+    }
 
+    void gracefulDisconnect(Runnable defaultAction, ChannelGroup channelGroup)
+    {
+        if (channelGroup == null || channelGroup.isEmpty())
+        {
+            defaultAction.run();
+            return;
+        }
         AtomicBoolean actionStarted = new AtomicBoolean(false);
         Runnable runOnceAction = () -> {
             if (actionStarted.compareAndSet(false, true))
                 defaultAction.run();
         };
-
         ScheduledFuture<?> timeoutTask = ScheduledExecutors.nonPeriodicTasks
                                          .schedule(runOnceAction, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
 
-        AtomicInteger pendingRegistrations = new AtomicInteger(1);
+        // Use a counter rather than channelGroup.isEmpty() because DefaultChannelGroup removes
+        // channels on close; under concurrent closes, a listener could see isEmpty()==true
+        // before all listeners have fired, triggering the action prematurely.
+        AtomicInteger connectedChannels = new AtomicInteger(channelGroup.size());
         EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
-
         channelGroup.forEach(channel -> {
-            pendingRegistrations.incrementAndGet();
-
             Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
             if (dispatcher != null)
                 dispatcher.accept(gracefulDisconnectEventMessage);
-
-            // in-flight requests complete when the driver closes socket connection
-            channel.closeFuture().addListener((ChannelFutureListener) future -> {
-                if (pendingRegistrations.decrementAndGet() == 0 && channelGroup.isEmpty())
+            channel.closeFuture().addListener((future -> {
+                if (connectedChannels.decrementAndGet() == 0)
                 {
                     runOnceAction.run();
                     timeoutTask.cancel(false);
                 }
-            });
+            }));
         });
-
-        if (pendingRegistrations.decrementAndGet() == 0 && channelGroup.isEmpty())
+        // All channels were already closed before we could register listeners
+        // close futures fired inline and decremented the counter to 0 during forEach.
+        if (connectedChannels.get() == 0)
         {
             runOnceAction.run();
             timeoutTask.cancel(false);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -220,7 +221,9 @@ import org.apache.cassandra.tcm.transformations.Register;
 import org.apache.cassandra.tcm.transformations.Startup;
 import org.apache.cassandra.tcm.transformations.Unregister;
 import org.apache.cassandra.transport.ClientResourceLimits;
+import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.messages.EventMessage;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -239,6 +242,9 @@ import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.cassandra.utils.progress.ProgressListener;
 import org.apache.cassandra.utils.progress.jmx.JMXBroadcastExecutor;
 import org.apache.cassandra.utils.progress.jmx.JMXProgressSupport;
+
+import io.netty.channel.group.ChannelGroup;
+import io.netty.util.AttributeKey;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -618,6 +624,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             throw new IllegalStateException("No configured daemon");
         }
+        gracefulDisconnect(() -> {
+            daemon.stopNativeTransport(force);
+        });
         daemon.stopNativeTransport(force);
     }
 
@@ -716,7 +725,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     {
         if (daemon == null)
             throw new IllegalStateException("No configured daemon");
-        daemon.deactivate();
+        gracefulDisconnect(() -> {
+            daemon.deactivate();
+        });
     }
 
     // for testing only
@@ -3855,7 +3866,40 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public synchronized void drain() throws IOException, InterruptedException, ExecutionException
     {
-        drain(false);
+        gracefulDisconnect(() -> {
+            try
+            {
+                drain(false);
+            }
+            catch (IOException | InterruptedException | ExecutionException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void gracefulDisconnect(Runnable defaultAction)
+    {
+        if (CassandraDaemon.instance.nativeTransportService() != null &&
+            CassandraDaemon.instance.nativeTransportService().getServer() != null)
+        {
+            ChannelGroup channelGroup = CassandraDaemon.instance.nativeTransportService()
+                                                                .getServer()
+                                                                .getChannelsSubsribedToGracefulDisconnect();
+
+            if (channelGroup != null && !channelGroup.isEmpty())
+            {
+                EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
+                final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
+                channelGroup.forEach(channel -> {
+                    Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
+                    if (dispatcher != null)
+                        dispatcher.accept(gracefulDisconnectEventMessage);
+                });
+
+            } else
+                defaultAction.run();
+        }
     }
 
     protected synchronized void drain(boolean isFinalShutdown) throws IOException, InterruptedException, ExecutionException

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -243,6 +244,7 @@ import org.apache.cassandra.utils.progress.ProgressListener;
 import org.apache.cassandra.utils.progress.jmx.JMXBroadcastExecutor;
 import org.apache.cassandra.utils.progress.jmx.JMXProgressSupport;
 
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.util.AttributeKey;
 
@@ -301,6 +303,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public static final int INDEFINITE = -1;
     public static final int RING_DELAY_MILLIS = getRingDelay(); // delay after which we assume ring has stablized
+
+    private final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
 
     {
         PathUtils.setDeletionListener(path -> {
@@ -3880,25 +3884,53 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     private void gracefulDisconnect(Runnable defaultAction)
     {
-        if (CassandraDaemon.instance.nativeTransportService() != null &&
-            CassandraDaemon.instance.nativeTransportService().getServer() != null)
+        NativeTransportService nts = CassandraDaemon.instance.nativeTransportService();
+        if (nts == null || nts.getServer() == null)
         {
-            ChannelGroup channelGroup = CassandraDaemon.instance.nativeTransportService()
-                                                                .getServer()
-                                                                .getChannelsSubscribedToGracefulDisconnect();
+            defaultAction.run();
+            return;
+        }
 
-            if (channelGroup != null && !channelGroup.isEmpty())
-            {
-                EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
-                final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
-                channelGroup.forEach(channel -> {
-                    Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
-                    if (dispatcher != null)
-                        dispatcher.accept(gracefulDisconnectEventMessage);
-                });
+        ChannelGroup channelGroup = nts.getServer().getChannelsSubscribedToGracefulDisconnect();
+        if (channelGroup == null || channelGroup.isEmpty())
+        {
+            defaultAction.run();
+            return;
+        }
 
-            } else
+        AtomicBoolean actionStarted = new AtomicBoolean(false);
+        Runnable runOnceAction = () -> {
+            if (actionStarted.compareAndSet(false, true))
                 defaultAction.run();
+        };
+
+        ScheduledFuture<?> timeoutTask = ScheduledExecutors.nonPeriodicTasks
+                                         .schedule(runOnceAction, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
+
+        AtomicInteger pendingRegistrations = new AtomicInteger(1);
+        EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
+
+        channelGroup.forEach(channel -> {
+            pendingRegistrations.incrementAndGet();
+
+            Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
+            if (dispatcher != null)
+                dispatcher.accept(gracefulDisconnectEventMessage);
+
+            // in-flight requests complete when the driver closes socket connection
+            channel.closeFuture().addListener((ChannelFutureListener) future -> {
+                if (pendingRegistrations.decrementAndGet() == 0 && channelGroup.isEmpty())
+                {
+                    runOnceAction.run();
+                    timeoutTask.cancel(false);
+                }
+            });
+        });
+
+        if (pendingRegistrations.decrementAndGet() == 0 && channelGroup.isEmpty())
+        {
+            runOnceAction.run();
+            timeoutTask.cancel(false);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -40,6 +40,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -3869,6 +3870,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public synchronized void drain() throws IOException, InterruptedException, ExecutionException
     {
+        CountDownLatch drainComplete = new CountDownLatch(1);
         gracefulDisconnect(() -> {
             try
             {
@@ -3878,7 +3880,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 throw new RuntimeException(e);
             }
+            finally
+            {
+                drainComplete.countDown();
+            }
         });
+        drainComplete.await(DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
     }
 
     private void gracefulDisconnect(Runnable defaultAction)
@@ -3899,7 +3906,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         gracefulDisconnect(defaultAction, channelGroup);
     }
 
-    void gracefulDisconnect(Runnable defaultAction, ChannelGroup channelGroup)
+    public void gracefulDisconnect(Runnable defaultAction, ChannelGroup channelGroup)
     {
         if (channelGroup == null || channelGroup.isEmpty())
         {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -158,6 +158,7 @@ import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.Replicas;
 import org.apache.cassandra.locator.SnitchAdapter;
 import org.apache.cassandra.locator.SystemReplicas;
+import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.SamplingManager;
 import org.apache.cassandra.metrics.StorageMetrics;
@@ -3906,9 +3907,15 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             return;
         }
         AtomicBoolean actionStarted = new AtomicBoolean(false);
+        AtomicInteger connectedChannels = new AtomicInteger(channelGroup.size());
         Runnable runOnceAction = () -> {
             if (actionStarted.compareAndSet(false, true))
+            {
+                int remaining = connectedChannels.get();
+                ClientMetrics.instance.markForcedDisconnect(remaining);
+                ClientMetrics.instance.decrementConnectionsDraining(remaining);
                 defaultAction.run();
+            }
         };
         ScheduledFuture<?> timeoutTask = ScheduledExecutors.nonPeriodicTasks
                                          .schedule(runOnceAction, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs(), MILLISECONDS);
@@ -3916,19 +3923,20 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         // Use a counter rather than channelGroup.isEmpty() because DefaultChannelGroup removes
         // channels on close; under concurrent closes, a listener could see isEmpty()==true
         // before all listeners have fired, triggering the action prematurely.
-        AtomicInteger connectedChannels = new AtomicInteger(channelGroup.size());
         EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
         channelGroup.forEach(channel -> {
             Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
             if (dispatcher != null)
                 dispatcher.accept(gracefulDisconnectEventMessage);
             channel.closeFuture().addListener((future -> {
+                ClientMetrics.instance.decrementConnectionsDraining();
                 if (connectedChannels.decrementAndGet() == 0)
                 {
                     runOnceAction.run();
                     timeoutTask.cancel(false);
                 }
             }));
+            ClientMetrics.instance.incrementConnectionsDraining();
         });
         // All channels were already closed before we could register listeners
         // close futures fired inline and decremented the counter to 0 during forEach.

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -224,6 +224,7 @@ import org.apache.cassandra.tcm.transformations.Register;
 import org.apache.cassandra.tcm.transformations.Startup;
 import org.apache.cassandra.tcm.transformations.Unregister;
 import org.apache.cassandra.transport.ClientResourceLimits;
+import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.EventMessage;
@@ -305,7 +306,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public static final int INDEFINITE = -1;
     public static final int RING_DELAY_MILLIS = getRingDelay(); // delay after which we assume ring has stablized
 
-    static final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
 
     {
         PathUtils.setDeletionListener(path -> {
@@ -1215,6 +1215,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @Override
     public void setGracefulDisconnectGracePeriod(long value)
     {
+        if (value < 0)
+            throw new IllegalArgumentException("graceful_disconnect_grace_period must not be negative.");
+
         if (value > DatabaseDescriptor.getGracefulDisconnectMaxDrain())
             throw new IllegalArgumentException("graceful_disconnect_grace_period cannot exceed graceful_disconnect_max_drain.");
 
@@ -1232,7 +1235,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void setGracefulDisconnectMaxDrain(long value)
     {
         if (value <= 0)
-            throw new IllegalArgumentException("graceful_disconnect_max_drain must be greater than 0 when graceful_disconnect_enabled is set to true.");
+            throw new IllegalArgumentException("graceful_disconnect_max_drain must be greater than 0.");
 
         if (value < DatabaseDescriptor.getGracefulDisconnectGracePeriod())
             throw new IllegalArgumentException("graceful_disconnect_max_drain cannot be less than graceful_disconnect_grace_period.");
@@ -3919,8 +3922,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             if (actionStarted.compareAndSet(false, true))
             {
                 int remaining = connectedChannels.get();
-                ClientMetrics.instance.markForcedDisconnect(remaining);
-                ClientMetrics.instance.decrementConnectionsDraining(remaining);
+                if (remaining > 0)
+                    ClientMetrics.instance.markForcedDisconnect(remaining);
                 defaultAction.run();
             }
         };
@@ -3932,7 +3935,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         // before all listeners have fired, triggering the action prematurely.
         EventMessage gracefulDisconnectEventMessage = new EventMessage(new Event.GracefulDisconnect());
         channelGroup.forEach(channel -> {
-            Consumer<EventMessage> dispatcher = channel.attr(EVENT_DISPATCHER).get();
+            // Increment before registering listener to avoid race where the listener fires
+            // and decrements before we increment.
+            ClientMetrics.instance.incrementConnectionsDraining();
+            Consumer<EventMessage> dispatcher = channel.attr(Dispatcher.EVENT_DISPATCHER).get();
             if (dispatcher != null)
                 dispatcher.accept(gracefulDisconnectEventMessage);
             channel.closeFuture().addListener((future -> {
@@ -3943,9 +3949,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     timeoutTask.cancel(false);
                 }
             }));
-            ClientMetrics.instance.incrementConnectionsDraining();
         });
-        // All channels were already closed before we could register listeners
+        // All channels were already closed before we could register listeners;
         // close futures fired inline and decremented the counter to 0 during forEach.
         if (connectedChannels.get() == 0)
         {

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -773,6 +773,14 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void setRpcTimeout(long value);
     public long getRpcTimeout();
 
+    void setGracefulDisconnectGracePeriodMs(long value);
+    long getGracefulDisconnectGracePeriodMs();
+
+    void setGracefulDisconnectMaxDrainMs(long value);
+    long getGracefulDisconnectMaxDrainMs();
+
+    boolean getGracefulDisconnectEnabled();
+
     public void setReadRpcTimeout(long value);
     public long getReadRpcTimeout();
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -773,11 +773,11 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void setRpcTimeout(long value);
     public long getRpcTimeout();
 
-    public void setGracefulDisconnectGracePeriodMs(long value);
-    public long getGracefulDisconnectGracePeriodMs();
+    public void setGracefulDisconnectGracePeriod(long value);
+    public long getGracefulDisconnectGracePeriod();
 
-    public void setGracefulDisconnectMaxDrainMs(long value);
-    public long getGracefulDisconnectMaxDrainMs();
+    public void setGracefulDisconnectMaxDrain(long value);
+    public long getGracefulDisconnectMaxDrain();
 
     public boolean getGracefulDisconnectEnabled();
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -773,13 +773,13 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void setRpcTimeout(long value);
     public long getRpcTimeout();
 
-    void setGracefulDisconnectGracePeriodMs(long value);
-    long getGracefulDisconnectGracePeriodMs();
+    public void setGracefulDisconnectGracePeriodMs(long value);
+    public long getGracefulDisconnectGracePeriodMs();
 
-    void setGracefulDisconnectMaxDrainMs(long value);
-    long getGracefulDisconnectMaxDrainMs();
+    public void setGracefulDisconnectMaxDrainMs(long value);
+    public long getGracefulDisconnectMaxDrainMs();
 
-    boolean getGracefulDisconnectEnabled();
+    public boolean getGracefulDisconnectEnabled();
 
     public void setReadRpcTimeout(long value);
     public long getReadRpcTimeout();

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -525,7 +525,7 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
      *
      * Pre-v5 connections simply write the EventMessage directly to the pipeline.
      */
-    static final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
+    public static final AttributeKey<Consumer<EventMessage>> EVENT_DISPATCHER = AttributeKey.valueOf("EVTDISP");
     Consumer<EventMessage> eventDispatcher(final Channel channel,
                                            final ProtocolVersion version,
                                            final FrameEncoder.PayloadAllocator allocator)

--- a/src/java/org/apache/cassandra/transport/Event.java
+++ b/src/java/org/apache/cassandra/transport/Event.java
@@ -36,7 +36,8 @@ public abstract class Event
         TOPOLOGY_CHANGE(ProtocolVersion.V3),
         STATUS_CHANGE(ProtocolVersion.V3),
         SCHEMA_CHANGE(ProtocolVersion.V3),
-        TRACE_COMPLETE(ProtocolVersion.V4);
+        TRACE_COMPLETE(ProtocolVersion.V4),
+        GRACEFUL_DISCONNECT(ProtocolVersion.V5);
 
         public final ProtocolVersion minimumVersion;
 

--- a/src/java/org/apache/cassandra/transport/Event.java
+++ b/src/java/org/apache/cassandra/transport/Event.java
@@ -67,6 +67,8 @@ public abstract class Event
                 return StatusChange.deserializeEvent(cb, version);
             case SCHEMA_CHANGE:
                 return SchemaChange.deserializeEvent(cb, version);
+            case GRACEFUL_DISCONNECT:
+                return GracefulDisconnect.deserializeEvent(cb, version);
         }
         throw new AssertionError();
     }
@@ -441,6 +443,28 @@ public abstract class Event
                 && Objects.equal(keyspace, scc.keyspace)
                 && Objects.equal(name, scc.name)
                 && Objects.equal(argTypes, scc.argTypes);
+        }
+    }
+
+    public static class GracefulDisconnect extends Event
+    {
+        public GracefulDisconnect()
+        {
+            super(Type.GRACEFUL_DISCONNECT);
+        }
+
+        @Override
+        protected int eventSerializedSize(ProtocolVersion version)
+        {
+            return 0;
+        }
+
+        @Override
+        protected void serializeEvent(ByteBuf dest, ProtocolVersion version) {}
+
+        public static GracefulDisconnect deserializeEvent(ByteBuf cb, ProtocolVersion version)
+        {
+            return new GracefulDisconnect();
         }
     }
 }

--- a/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
+++ b/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.net.AsyncChannelPromise;
 import org.apache.cassandra.transport.ClientResourceLimits.Overload;
@@ -90,6 +91,8 @@ public class InitialConnectionHandler extends ByteToMessageDecoder
                     supportedOptions.put(StartupMessage.CQL_VERSION, cqlVersions);
                     supportedOptions.put(StartupMessage.COMPRESSION, compressions);
                     supportedOptions.put(StartupMessage.PROTOCOL_VERSIONS, ProtocolVersion.supportedVersions());
+                    if (DatabaseDescriptor.getGracefulDisconnectEnabled())
+                        supportedOptions.put(StartupMessage.GRACEFUL_DISCONNECT, List.of("true"));
                     SupportedMessage supported = new SupportedMessage(supportedOptions);
                     supported.setStreamId(inbound.header.streamId);
                     outbound = supported.encode(inbound.header.version);

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -126,6 +126,11 @@ public class Server implements CassandraDaemon.Server
         Schema.instance.registerListener(notifier);
     }
 
+    public ChannelGroup getChannelsSubsribedToGracefulDisconnect()
+    {
+        return connectionTracker.groups.get(Event.Type.GRACEFUL_DISCONNECT);
+    }
+
     public void stop()
     {
         stop(false);

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -126,7 +126,7 @@ public class Server implements CassandraDaemon.Server
         Schema.instance.registerListener(notifier);
     }
 
-    public ChannelGroup getChannelsSubsribedToGracefulDisconnect()
+    public ChannelGroup getChannelsSubscribedToGracefulDisconnect()
     {
         return connectionTracker.groups.get(Event.Type.GRACEFUL_DISCONNECT);
     }

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -347,6 +347,8 @@ public class Server implements CassandraDaemon.Server
 
         public void register(Event.Type type, Channel ch)
         {
+            if (type == Event.Type.GRACEFUL_DISCONNECT && !DatabaseDescriptor.getGracefulDisconnectEnabled())
+                return;
             groups.get(type).add(ch);
         }
 

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -80,6 +80,7 @@ public class Server implements CassandraDaemon.Server
     private static final boolean useEpoll = NativeTransportService.useEpoll();
 
     private final ConnectionTracker connectionTracker;
+    private Channel bindChannel;
 
     private final Connection.Factory connectionFactory = new Connection.Factory()
     {
@@ -154,12 +155,23 @@ public class Server implements CassandraDaemon.Server
 
         // Configure the server.
         ChannelFuture bindFuture = pipelineConfigurator.initializeChannel(workerGroup, socket, connectionFactory);
+        bindChannel = bindFuture.channel();
         if (!bindFuture.awaitUninterruptibly().isSuccess())
             throw new IllegalStateException(String.format("Failed to bind port %d on %s.", socket.getPort(), socket.getAddress().getHostAddress()),
                                             bindFuture.cause());
 
         connectionTracker.allChannels.add(bindFuture.channel());
         isRunning.set(true);
+    }
+
+    public void stopAcceptingNewConnections()
+    {
+        if (bindChannel != null && bindChannel.isOpen())
+        {
+            logger.info("Stopping native transport acceptor on {}", bindChannel.localAddress());
+            // syncUninterruptibly ensures we wait for the port to actually close
+            bindChannel.close().syncUninterruptibly();
+        }
     }
 
     public int countConnectedClients()

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -636,9 +636,14 @@ public class SimpleClient implements Closeable
     private void handleGracefulDisconnect()
     {
         draining.set(true);
+        // Wait for the last write to complete, then close the channel.
+        // New requests are rejected by the draining check in execute().
+        // In-flight responses will still be delivered via the ResponseHandler
+        // before the channel fully closes.
         if (lastWriteFuture != null)
-            lastWriteFuture.awaitUninterruptibly();
-        close();
+            lastWriteFuture.addListener(f -> close());
+        else
+            close();
     }
 
 
@@ -733,9 +738,8 @@ public class SimpleClient implements Closeable
 
                     if (event.type == Event.Type.GRACEFUL_DISCONNECT)
                     {
-                        client.draining.set(true);
-                        client.handleGracefulDisconnect();
                         logger.info("Received GRACEFUL_DISCONNECT. Entering draining mode.");
+                        client.handleGracefulDisconnect();
                     }
 
                     if (eventHandler != null)

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.SynchronousQueue; // checkstyle: permit this import
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -62,7 +62,6 @@ import org.apache.cassandra.transport.messages.EventMessage;
 import org.apache.cassandra.transport.messages.ExecuteMessage;
 import org.apache.cassandra.transport.messages.PrepareMessage;
 import org.apache.cassandra.transport.messages.QueryMessage;
-import org.apache.cassandra.transport.messages.RegisterMessage;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.utils.concurrent.NonBlockingRateLimiter;
@@ -83,7 +82,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.concurrent.Promise; // checkstyle: permit this import
+import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
@@ -241,10 +240,9 @@ public class SimpleClient implements Closeable
             options.put(StartupMessage.COMPRESSION, "LZ4");
             connection.setCompressor(Compressor.LZ4Compressor.instance);
         }
-        // real driver will check the protocol version before sending GRACEFUL_DISCONNECT, here for checking
-        // sever behavior on receiving GRACEFUL_DISCONNECT with lesser supported protocol version, we will send it anyway
+        if (version.isGreaterOrEqualTo(ProtocolVersion.V5))
+            options.put(StartupMessage.GRACEFUL_DISCONNECT, "GRACEFUL_DISCONNECT");
         execute(new StartupMessage(options));
-        execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
         return this;
     }
 

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -62,6 +62,7 @@ import org.apache.cassandra.transport.messages.EventMessage;
 import org.apache.cassandra.transport.messages.ExecuteMessage;
 import org.apache.cassandra.transport.messages.PrepareMessage;
 import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.transport.messages.RegisterMessage;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.utils.concurrent.NonBlockingRateLimiter;
@@ -100,6 +101,8 @@ public class SimpleClient implements Closeable
 
     public static final int TIMEOUT_SECONDS = 10;
 
+    private final AtomicBoolean draining = new AtomicBoolean(false);
+
     static
     {
         InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
@@ -112,7 +115,7 @@ public class SimpleClient implements Closeable
     private final EncryptionOptions.ClientEncryptionOptions encryptionOptions;
     private final int largeMessageThreshold;
 
-    protected final ResponseHandler responseHandler = new ResponseHandler();
+    protected final ResponseHandler responseHandler = new ResponseHandler(this);
     protected final Connection.Tracker tracker = new ConnectionTracker();
     protected final ProtocolVersion version;
     // We don't track connection really, so we don't need one Connection per channel
@@ -238,8 +241,10 @@ public class SimpleClient implements Closeable
             options.put(StartupMessage.COMPRESSION, "LZ4");
             connection.setCompressor(Compressor.LZ4Compressor.instance);
         }
+        // real driver will check the protocol version before sending GRACEFUL_DISCONNECT, here for checking
+        // sever behavior on receiving GRACEFUL_DISCONNECT with lesser supported protocol version, we will send it anyway
         execute(new StartupMessage(options));
-
+        execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
         return this;
     }
 
@@ -324,6 +329,10 @@ public class SimpleClient implements Closeable
 
     public Message.Response execute(Message.Request request, boolean throwOnErrorResponse)
     {
+        if (draining.get())
+        {
+            throw new RuntimeException("Connection is draining (GRACEFUL_DISCONNECT received)");
+        }
         try
         {
             request.attach(connection);
@@ -626,6 +635,15 @@ public class SimpleClient implements Closeable
         }
     }
 
+    private void handleGracefulDisconnect()
+    {
+        draining.set(true);
+        if (lastWriteFuture != null)
+            lastWriteFuture.awaitUninterruptibly();
+        close();
+    }
+
+
     @ChannelHandler.Sharable
      static class MessageBatchEncoder extends MessageToMessageEncoder<List<Message>>
     {
@@ -686,6 +704,14 @@ public class SimpleClient implements Closeable
     @ChannelHandler.Sharable
     static class ResponseHandler extends SimpleChannelInboundHandler<Message.Response>
     {
+
+        private final SimpleClient client;
+
+        public ResponseHandler(SimpleClient client)
+        {
+            this.client = client;
+        }
+
         public final BlockingQueue<Message.Response> responses = new SynchronousQueue<>(true);
         public EventHandler eventHandler;
 
@@ -705,8 +731,17 @@ public class SimpleClient implements Closeable
 
                 if (r instanceof EventMessage)
                 {
+                    Event event = ((EventMessage) r).event;
+
+                    if (event.type == Event.Type.GRACEFUL_DISCONNECT)
+                    {
+                        client.draining.set(true);
+                        client.handleGracefulDisconnect();
+                        logger.info("Received GRACEFUL_DISCONNECT. Entering draining mode.");
+                    }
+
                     if (eventHandler != null)
-                        eventHandler.onEvent(((EventMessage) r).event);
+                        eventHandler.onEvent(event);
                 }
                 else
                     responses.put(r);

--- a/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Compressor;
@@ -73,6 +74,8 @@ public class OptionsMessage extends Message.Request
         Map<String, List<String>> supported = new HashMap<String, List<String>>();
         supported.put(StartupMessage.CQL_VERSION, cqlVersions);
         supported.put(StartupMessage.COMPRESSION, compressions);
+        if (DatabaseDescriptor.getGracefulDisconnectEnabled())
+            supported.put(StartupMessage.GRACEFUL_DISCONNECT, List.of("true"));
         supported.put(StartupMessage.PROTOCOL_VERSIONS, ProtocolVersion.supportedVersions());
 
         return new SupportedMessage(supported);

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -42,7 +42,7 @@ import static org.apache.cassandra.utils.LocalizeString.toUpperCaseLocalized;
  * The initial message of the protocol.
  * Sets up a number of connection options.
  */
-public class StartupMessage extends Message.Request
+public class StartupMessage extends Message.Reuest
 {
     public static final String CQL_VERSION = "CQL_VERSION";
     public static final String COMPRESSION = "COMPRESSION";
@@ -50,6 +50,7 @@ public class StartupMessage extends Message.Request
     public static final String DRIVER_NAME = "DRIVER_NAME";
     public static final String DRIVER_VERSION = "DRIVER_VERSION";
     public static final String THROW_ON_OVERLOAD = "THROW_ON_OVERLOAD";
+    public static final String GRACEFUL_DISCONNECT = "GRACEFUL_DISCONNECT";
 
     public static final Message.Codec<StartupMessage> codec = new Message.Codec<StartupMessage>()
     {

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -42,7 +42,7 @@ import static org.apache.cassandra.utils.LocalizeString.toUpperCaseLocalized;
  * The initial message of the protocol.
  * Sets up a number of connection options.
  */
-public class StartupMessage extends Message.Reuest
+public class StartupMessage extends Message.Request
 {
     public static final String CQL_VERSION = "CQL_VERSION";
     public static final String COMPRESSION = "COMPRESSION";

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -161,6 +161,15 @@ public class GracefulDisconnectIT
                 Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> client.connect(false));
                 Assertions.assertTrue(exception.getCause() instanceof ProtocolException, "Expected cause to be ProtocolException but was " + exception.getCause().getClass().getName());
                 Assertions.assertTrue(exception.getMessage().contains("GRACEFUL_DISCONNECT not valid"), "Error message did not contain expected text. Found: " + exception.getMessage());
+                int subscribedCount = cluster.get(1).callOnInstance(() ->
+                                                                    CassandraDaemon.getInstanceForTesting()
+                                                                                   .nativeTransportService()
+                                                                                   .getServer()
+                                                                                   .getChannelsSubscribedToGracefulDisconnect()
+                                                                                   .size());
+
+                Assertions.assertEquals(0, subscribedCount,
+                                        "One channel should be subscribed to GRACEFUL_DISCONNECT");
             }
         }
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -21,7 +21,10 @@ package org.apache.cassandra.distributed.test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,7 +32,9 @@ import org.junit.jupiter.api.Test;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.service.CassandraDaemon;
+import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -40,32 +45,10 @@ import org.apache.cassandra.transport.messages.RegisterMessage;
 import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.transport.messages.SupportedMessage;
 
-// TODO: Expand integration tests once Java driver GRACEFUL_DISCONNECT support is complete.
-// Test cases to cover:
-// 5. In-flight requests complete successfully after GRACEFUL_DISCONNECT is received
-// 6. No new requests are sent by driver after receiving event
-// 7. Driver closes connection after all in-flight requests complete
-// 8. Server proceeds with drain() after all subscribed connections close
-// 9. Server force-closes connections that don't close within max_drain_ms
-// 10. drain() proceeds after max_drain_ms even if connections are still open
-// 11. Mixed fleet — some connections subscribed, some not — drain proceeds correctly
-// 12. Non-subscribed connections continue serving requests during drain window
-// 13. Server stops accepting new connections after emitting GRACEFUL_DISCONNECT
-// 14. connections_draining increments correctly when event is emitted
-// 15. connections_draining decrements when connection closes cleanly
-// 16. connections_draining decrements when connection is force-closed
-// 17. forced_disconnects increments when max_drain_ms is exceeded
-// 18. forced_disconnects does NOT increment on clean drain
-// 19. max_drain_ms updated via JMX — new value respected during drain
-// 20. grace_period_ms updated via JMX — reflected correctly
-// 21. No subscribed connections — drain proceeds immediately
-// 22. All connections already closed before drain — drain proceeds immediately
-// 23. Single connection drains cleanly
-// 24. Multiple connections all drain cleanly
-// 25. Multiple connections — some clean, some force-closed
-// 25. Connection closes mid-drain (before event is sent)
-// 26. Node restart after drain — new connections can subscribe again
-// 27. Rapid consecutive drains — no state leakage between drains
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
+
 public class GracefulDisconnectIT
 {
 
@@ -166,6 +149,392 @@ public class GracefulDisconnectIT
 
                 Assertions.assertEquals(0, subscribedCount,
                                         "One channel should be subscribed to GRACEFUL_DISCONNECT");
+            }
+        }
+    }
+
+    @Test
+    public void testNonSubscribedClientDoesNotReceiveEvent() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V4)
+                                                   .build())
+            {
+                client.connect(false);
+                int subscribedCount = cluster.get(1).callOnInstance(() ->
+                                                                    CassandraDaemon.getInstanceForTesting()
+                                                                                   .nativeTransportService()
+                                                                                   .getServer()
+                                                                                   .getChannelsSubscribedToGracefulDisconnect()
+                                                                                   .size());
+                Assertions.assertEquals(0, subscribedCount,
+                                        "V4 client should not be subscribed to GRACEFUL_DISCONNECT");
+            }
+        }
+    }
+
+    @Test
+    public void testServerStopsAcceptingNewConnectionsOnDrain() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).build())
+            {
+                client.connect(false);
+                cluster.get(1).runOnInstance(() -> {
+                    CassandraDaemon.getInstanceForTesting()
+                                   .nativeTransportService()
+                                   .getServer()
+                                   .stopAcceptingNewConnections();
+                });
+                Assertions.assertThrows(Exception.class, () -> {
+                    SimpleClient newClient = SimpleClient.builder(nativeAddr.getHostString(), 9042).build();
+                    newClient.connect(false);
+                }, "Server should reject new connections after stopAcceptingNewConnections");
+            }
+        }
+    }
+
+    @Test
+    public void testNoEventEmittedWhenDisabled() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, false))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).build())
+            {
+                client.connect(false);
+                client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+                int subscribedCount = cluster.get(1).callOnInstance(() ->
+                                                                    CassandraDaemon.getInstanceForTesting()
+                                                                                   .nativeTransportService()
+                                                                                   .getServer()
+                                                                                   .getChannelsSubscribedToGracefulDisconnect()
+                                                                                   .size());
+
+                Assertions.assertEquals(0, subscribedCount);
+                boolean gracefulDisconnectCalled = cluster.get(1).callOnInstance(() -> !DatabaseDescriptor.getGracefulDisconnectEnabled());
+                Assertions.assertTrue(gracefulDisconnectCalled,
+                                      "graceful_disconnect_enabled=false should skip event emission");
+            }
+        }
+    }
+
+    @Test
+    public void testMaxDrainMsUpdatedViaJMX() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            cluster.get(1).runOnInstance(() ->
+                                         StorageService.instance.setGracefulDisconnectMaxDrainMs(15000));
+
+            long maxDrainMs = cluster.get(1).callOnInstance(StorageService.instance::getGracefulDisconnectMaxDrainMs);
+
+            Assertions.assertEquals(15000, maxDrainMs,
+                                    "max_drain_ms should be updated to 15000 via JMX");
+        }
+    }
+
+    @Test
+    public void testGracePeriodMsUpdatedViaJMX() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            cluster.get(1).runOnInstance(() -> {
+                StorageService.instance.setGracefulDisconnectGracePeriodMs(3000);
+            });
+
+            long gracePeriodMs = cluster.get(1).callOnInstance(StorageService.instance::getGracefulDisconnectGracePeriodMs);
+
+            Assertions.assertEquals(3000, gracePeriodMs,
+                                    "grace_period_ms should be updated to 3000 via JMX");
+        }
+    }
+
+    @Test
+    public void testDrainProceedsImmediatelyWithNoSubscribedConnections() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V4)
+                                                   .build())
+            {
+                client.connect(false);
+                long start = System.currentTimeMillis();
+                cluster.get(1).runOnInstance(() -> {
+                    try
+                    {
+                        StorageService.instance.gracefulDisconnect(() -> {
+                        }, new DefaultChannelGroup(GlobalEventExecutor.INSTANCE));
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+                // the one hardcoded 1s limit may make this a flaky test case
+                long elapsed = System.currentTimeMillis() - start;
+                Assertions.assertTrue(elapsed < 1000,
+                                      "Should proceed immediately with no subscribed connections, took: " + elapsed + "ms");
+            }
+        }
+    }
+
+    @Test
+    public void testMultipleConnectionsCanSubscribe() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client1 = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                    .protocolVersion(ProtocolVersion.V5)
+                                                    .build();
+                 SimpleClient client2 = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                    .protocolVersion(ProtocolVersion.V5)
+                                                    .build())
+            {
+                client1.connect(false);
+                client2.connect(false);
+
+                client1.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+                client2.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                int subscribedCount = cluster.get(1).callOnInstance(() ->
+                                                                    CassandraDaemon.getInstanceForTesting()
+                                                                                   .nativeTransportService()
+                                                                                   .getServer()
+                                                                                   .getChannelsSubscribedToGracefulDisconnect()
+                                                                                   .size());
+
+                Assertions.assertEquals(2, subscribedCount,
+                                        "Both connections should be subscribed to GRACEFUL_DISCONNECT");
+            }
+        }
+    }
+
+    @Test
+    public void testConnectionsDrainingMetric() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V5)
+                                                   .build())
+            {
+                client.connect(false);
+                client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+
+                int drainingCount = cluster.get(1).callOnInstance(() ->
+                                                                  ClientMetrics.instance.connectionsDraining.get());
+
+                Assertions.assertEquals(0, drainingCount,
+                                        "connections_draining should be 0 before drain");
+            }
+        }
+    }
+
+    @Test
+    public void testGracefulDisconnectEventReceivedOnDrain() throws IOException, InterruptedException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V5)
+                                                   .build())
+            {
+                SimpleClient.SimpleEventHandler handler = new SimpleClient.SimpleEventHandler();
+                client.setEventHandler(handler);
+                client.connect(false);
+                client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                cluster.get(1).runOnInstance(() -> {
+                    ChannelGroup channelGroup = CassandraDaemon.getInstanceForTesting()
+                                                               .nativeTransportService()
+                                                               .getServer()
+                                                               .getChannelsSubscribedToGracefulDisconnect();
+                    StorageService.instance.gracefulDisconnect(() -> {
+                    }, channelGroup);
+                });
+
+                Event event = handler.queue.poll(10, TimeUnit.SECONDS);
+                Assertions.assertNotNull(event, "Expected GRACEFUL_DISCONNECT event but got null");
+                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event.type,
+                                        "Expected GRACEFUL_DISCONNECT event type");
+            }
+        }
+    }
+
+    @Test
+    public void testDefaultActionCalledAfterAllConnectionsClose() throws IOException, InterruptedException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V5)
+                                                   .build())
+            {
+                client.connect(false);
+                client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                client.close();
+                Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                    int drainingCount = cluster.get(1).callOnInstance(() ->
+                                                                      ClientMetrics.instance.connectionsDraining.get());
+                    Assertions.assertEquals(0, drainingCount,
+                                            "connections_draining should be 0 after all connections close");
+                });
+
+                boolean actionCalled = cluster.get(1).callOnInstance(() -> {
+                    AtomicBoolean called = new AtomicBoolean(false);
+                    ChannelGroup channelGroup = CassandraDaemon.getInstanceForTesting()
+                                                               .nativeTransportService()
+                                                               .getServer()
+                                                               .getChannelsSubscribedToGracefulDisconnect();
+                    StorageService.instance.gracefulDisconnect(() -> called.set(true), channelGroup);
+                    return called.get();
+                });
+
+                Assertions.assertTrue(actionCalled,
+                                      "Default action should be called immediately when no subscribed connections");
+            }
+        }
+    }
+
+    @Test
+    public void testDefaultActionCalledAfterMaxDrainMs() throws IOException, InterruptedException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V5)
+                                                   .build())
+            {
+                client.connect(false);
+                client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                cluster.get(1).runOnInstance(() -> {
+                    StorageService.instance.setGracefulDisconnectGracePeriodMs(500);
+                    StorageService.instance.setGracefulDisconnectMaxDrainMs(1000);
+                });
+
+                cluster.get(1).runOnInstance(() -> {
+                    ChannelGroup channelGroup = CassandraDaemon.getInstanceForTesting()
+                                                               .nativeTransportService()
+                                                               .getServer()
+                                                               .getChannelsSubscribedToGracefulDisconnect();
+                    StorageService.instance.gracefulDisconnect(() -> {
+                    }, channelGroup);
+                });
+
+                Thread.sleep(3000);
+
+                boolean actionCalled = cluster.get(1).callOnInstance(() -> ClientMetrics.instance.connectionsDraining.get() == 0);
+
+                Assertions.assertTrue(actionCalled,
+                                      "Default action should be called after max_drain_ms timeout");
+            }
+            finally
+            {
+                cluster.get(1).runOnInstance(() -> {
+                    StorageService.instance.setGracefulDisconnectMaxDrainMs(30000);
+                    StorageService.instance.setGracefulDisconnectGracePeriodMs(5000);
+                });
+            }
+        }
+    }
+
+    @Test
+    public void testMultipleConnectionsAllReceiveEvent() throws IOException, InterruptedException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client1 = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                    .protocolVersion(ProtocolVersion.V5)
+                                                    .build();
+                 SimpleClient client2 = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                    .protocolVersion(ProtocolVersion.V5)
+                                                    .build())
+            {
+                SimpleClient.SimpleEventHandler handler1 = new SimpleClient.SimpleEventHandler();
+                SimpleClient.SimpleEventHandler handler2 = new SimpleClient.SimpleEventHandler();
+                client1.setEventHandler(handler1);
+                client2.setEventHandler(handler2);
+
+                client1.connect(false);
+                client2.connect(false);
+
+                client1.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+                client2.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                cluster.get(1).runOnInstance(() -> {
+                    ChannelGroup channelGroup = CassandraDaemon.getInstanceForTesting()
+                                                               .nativeTransportService()
+                                                               .getServer()
+                                                               .getChannelsSubscribedToGracefulDisconnect();
+                    StorageService.instance.gracefulDisconnect(() -> {
+                    }, channelGroup);
+                });
+
+                Event event1 = handler1.queue.poll(10, TimeUnit.SECONDS);
+                Event event2 = handler2.queue.poll(10, TimeUnit.SECONDS);
+
+                Assertions.assertNotNull(event1, "client1 should receive GRACEFUL_DISCONNECT");
+                Assertions.assertNotNull(event2, "client2 should receive GRACEFUL_DISCONNECT");
+                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event1.type);
+                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event2.type);
+            }
+        }
+    }
+
+    @Test
+    public void testMixedFleetOnlySubscribedReceivesEvent() throws IOException, InterruptedException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient subscribedClient = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                             .protocolVersion(ProtocolVersion.V5)
+                                                             .build();
+                 SimpleClient nonSubscribedClient = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                                .protocolVersion(ProtocolVersion.V4)
+                                                                .build())
+            {
+                SimpleClient.SimpleEventHandler subscribedHandler = new SimpleClient.SimpleEventHandler();
+                SimpleClient.SimpleEventHandler nonSubscribedHandler = new SimpleClient.SimpleEventHandler();
+                subscribedClient.setEventHandler(subscribedHandler);
+                nonSubscribedClient.setEventHandler(nonSubscribedHandler);
+
+                subscribedClient.connect(false);
+                nonSubscribedClient.connect(false);
+                subscribedClient.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                cluster.get(1).runOnInstance(() -> {
+                    ChannelGroup channelGroup = CassandraDaemon.getInstanceForTesting()
+                                                               .nativeTransportService()
+                                                               .getServer()
+                                                               .getChannelsSubscribedToGracefulDisconnect();
+                    StorageService.instance.gracefulDisconnect(() -> {
+                    }, channelGroup);
+                });
+
+                Event subscribedEvent = subscribedHandler.queue.poll(10, TimeUnit.SECONDS);
+                Event nonSubscribedEvent = nonSubscribedHandler.queue.poll(3, TimeUnit.SECONDS);
+
+                Assertions.assertNotNull(subscribedEvent, "Subscribed client should receive GRACEFUL_DISCONNECT");
+                Assertions.assertNull(nonSubscribedEvent, "Non-subscribed client should not receive GRACEFUL_DISCONNECT");
             }
         }
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -20,32 +20,148 @@ package org.apache.cassandra.distributed.test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.service.CassandraDaemon;
+import org.apache.cassandra.transport.Event;
+import org.apache.cassandra.transport.Message;
+import org.apache.cassandra.transport.ProtocolException;
+import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.SimpleClient;
+import org.apache.cassandra.transport.messages.OptionsMessage;
+import org.apache.cassandra.transport.messages.ReadyMessage;
+import org.apache.cassandra.transport.messages.RegisterMessage;
+import org.apache.cassandra.transport.messages.StartupMessage;
+import org.apache.cassandra.transport.messages.SupportedMessage;
 
-public class GracefulDisconnectIT extends TestBaseImpl
+// TODO: Expand integration tests once Java driver GRACEFUL_DISCONNECT support is complete.
+// Test cases to cover:
+// 5. Non-subscribed clients do NOT receive the event
+// 6. In-flight requests complete successfully after GRACEFUL_DISCONNECT is received
+// 7. No new requests are sent by driver after receiving event
+// 8. Driver closes connection after all in-flight requests complete
+// 9. Server proceeds with drain() after all subscribed connections close
+// 10. Server force-closes connections that don't close within max_drain_ms
+// 11. drain() proceeds after max_drain_ms even if connections are still open
+// 12. Mixed fleet — some connections subscribed, some not — drain proceeds correctly
+// 13. Non-subscribed connections continue serving requests during drain window
+// 14. Server stops accepting new connections after emitting GRACEFUL_DISCONNECT
+// 15. connections_draining increments correctly when event is emitted
+// 16. connections_draining decrements when connection closes cleanly
+// 17. connections_draining decrements when connection is force-closed
+// 18. forced_disconnects increments when max_drain_ms is exceeded
+// 19. forced_disconnects does NOT increment on clean drain
+// 20. max_drain_ms updated via JMX — new value respected during drain
+// 21. grace_period_ms updated via JMX — reflected correctly
+// 22. No subscribed connections — drain proceeds immediately
+// 23. All connections already closed before drain — drain proceeds immediately
+// 24. Single connection drains cleanly
+// 25. Multiple connections all drain cleanly
+// 26. Multiple connections — some clean, some force-closed
+// 26. Connection closes mid-drain (before event is sent)
+// 27. Node restart after drain — new connections can subscribe again
+// 28. Rapid consecutive drains — no state leakage between drains
+public class GracefulDisconnectIT
 {
-    @Test
-    public void testGracefulDisconnectIntegrated() throws IOException
+
+    @BeforeAll
+    public static void setUp() throws IOException
     {
-        try (Cluster cluster = Cluster.build(1).withConfig(config -> config.with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)).start())
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    public Cluster buildCluster(int nodeCount, boolean gracefulDisconnectEnabled) throws IOException
+    {
+        return Cluster
+               .build(nodeCount)
+               .withConfig(config ->
+                           config
+                           .with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)
+                           .set("graceful_disconnect_enabled", gracefulDisconnectEnabled))
+               .start();
+    }
+
+    @Test
+    public void testGracefulDisconnectAdvertisedWhenEnabled() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
         {
-            cluster.get(1).runOnInstance(() -> {
-                org.apache.cassandra.config.DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(10000);
-            });
             InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
-            SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
-                                              .build();
-            client.connect(false);
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).build())
+            {
+                client.connect(false);
+                Message.Response response = client.execute(new OptionsMessage());
+                SupportedMessage supported = (SupportedMessage) response;
+                Assertions.assertTrue(supported.supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT),
+                                      "GRACEFUL_DISCONNECT should be advertised in SUPPORTED when enabled");
+            }
         }
-        catch (Exception e)
+    }
+
+    @Test
+    public void testGracefulDisconnectDoesNotAdvertisedWhenNotEnabled() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, false))
         {
-            Assert.fail(e.getMessage());
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).build())
+            {
+                client.connect(false);
+                Assertions.assertFalse(((SupportedMessage) client.execute(new OptionsMessage())).supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT),
+                                       "GRACEFUL_DISCONNECT should be advertised in SUPPORTED when enabled");
+            }
+        }
+    }
+
+    @Test
+    public void testSubscriptionViaREGISTER() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                                   .protocolVersion(ProtocolVersion.V5)
+                                                   .build())
+            {
+                client.connect(false);
+                Message.Response response = client.execute(
+                new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
+                Assertions.assertTrue(response instanceof ReadyMessage,
+                                      "REGISTER for GRACEFUL_DISCONNECT should be accepted with READY");
+
+                int subscribedCount = cluster.get(1).callOnInstance(() ->
+                                                                    CassandraDaemon.getInstanceForTesting()
+                                                                                   .nativeTransportService()
+                                                                                   .getServer()
+                                                                                   .getChannelsSubscribedToGracefulDisconnect()
+                                                                                   .size());
+
+                Assertions.assertEquals(1, subscribedCount,
+                                        "One channel should be subscribed to GRACEFUL_DISCONNECT");
+            }
+        }
+    }
+
+    @Test
+    public void testRegisterGracefulDisconnectRejectedOnV4() throws IOException
+    {
+        try (Cluster cluster = buildCluster(1, true))
+        {
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).protocolVersion(ProtocolVersion.V4).build())
+            {
+                Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> client.connect(false));
+                Assertions.assertTrue(exception.getCause() instanceof ProtocolException, "Expected cause to be ProtocolException but was " + exception.getCause().getClass().getName());
+                Assertions.assertTrue(exception.getMessage().contains("GRACEFUL_DISCONNECT not valid"), "Error message did not contain expected text. Found: " + exception.getMessage());
+            }
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.transport.SimpleClient;
+
+public class GracefulDisconnectIT extends TestBaseImpl
+{
+    @Test
+    public void testGracefulDisconnectIntegrated() throws IOException
+    {
+        try (Cluster cluster = Cluster.build(1).withConfig(config -> config.with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)).start())
+        {
+            cluster.get(1).runOnInstance(() -> {
+                org.apache.cassandra.config.DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(10000);
+            });
+            InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
+            SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
+                                              .build();
+            client.connect(false);
+        }
+        catch (Exception e)
+        {
+            Assert.fail(e.getMessage());
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -32,7 +32,6 @@ import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.Message;
-import org.apache.cassandra.transport.ProtocolException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.SimpleClient;
 import org.apache.cassandra.transport.messages.OptionsMessage;
@@ -43,31 +42,30 @@ import org.apache.cassandra.transport.messages.SupportedMessage;
 
 // TODO: Expand integration tests once Java driver GRACEFUL_DISCONNECT support is complete.
 // Test cases to cover:
-// 5. Non-subscribed clients do NOT receive the event
-// 6. In-flight requests complete successfully after GRACEFUL_DISCONNECT is received
-// 7. No new requests are sent by driver after receiving event
-// 8. Driver closes connection after all in-flight requests complete
-// 9. Server proceeds with drain() after all subscribed connections close
-// 10. Server force-closes connections that don't close within max_drain_ms
-// 11. drain() proceeds after max_drain_ms even if connections are still open
-// 12. Mixed fleet — some connections subscribed, some not — drain proceeds correctly
-// 13. Non-subscribed connections continue serving requests during drain window
-// 14. Server stops accepting new connections after emitting GRACEFUL_DISCONNECT
-// 15. connections_draining increments correctly when event is emitted
-// 16. connections_draining decrements when connection closes cleanly
-// 17. connections_draining decrements when connection is force-closed
-// 18. forced_disconnects increments when max_drain_ms is exceeded
-// 19. forced_disconnects does NOT increment on clean drain
-// 20. max_drain_ms updated via JMX — new value respected during drain
-// 21. grace_period_ms updated via JMX — reflected correctly
-// 22. No subscribed connections — drain proceeds immediately
-// 23. All connections already closed before drain — drain proceeds immediately
-// 24. Single connection drains cleanly
-// 25. Multiple connections all drain cleanly
-// 26. Multiple connections — some clean, some force-closed
-// 26. Connection closes mid-drain (before event is sent)
-// 27. Node restart after drain — new connections can subscribe again
-// 28. Rapid consecutive drains — no state leakage between drains
+// 5. In-flight requests complete successfully after GRACEFUL_DISCONNECT is received
+// 6. No new requests are sent by driver after receiving event
+// 7. Driver closes connection after all in-flight requests complete
+// 8. Server proceeds with drain() after all subscribed connections close
+// 9. Server force-closes connections that don't close within max_drain_ms
+// 10. drain() proceeds after max_drain_ms even if connections are still open
+// 11. Mixed fleet — some connections subscribed, some not — drain proceeds correctly
+// 12. Non-subscribed connections continue serving requests during drain window
+// 13. Server stops accepting new connections after emitting GRACEFUL_DISCONNECT
+// 14. connections_draining increments correctly when event is emitted
+// 15. connections_draining decrements when connection closes cleanly
+// 16. connections_draining decrements when connection is force-closed
+// 17. forced_disconnects increments when max_drain_ms is exceeded
+// 18. forced_disconnects does NOT increment on clean drain
+// 19. max_drain_ms updated via JMX — new value respected during drain
+// 20. grace_period_ms updated via JMX — reflected correctly
+// 21. No subscribed connections — drain proceeds immediately
+// 22. All connections already closed before drain — drain proceeds immediately
+// 23. Single connection drains cleanly
+// 24. Multiple connections all drain cleanly
+// 25. Multiple connections — some clean, some force-closed
+// 25. Connection closes mid-drain (before event is sent)
+// 26. Node restart after drain — new connections can subscribe again
+// 27. Rapid consecutive drains — no state leakage between drains
 public class GracefulDisconnectIT
 {
 
@@ -158,9 +156,7 @@ public class GracefulDisconnectIT
             InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
             try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).protocolVersion(ProtocolVersion.V4).build())
             {
-                Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> client.connect(false));
-                Assertions.assertTrue(exception.getCause() instanceof ProtocolException, "Expected cause to be ProtocolException but was " + exception.getCause().getClass().getName());
-                Assertions.assertTrue(exception.getMessage().contains("GRACEFUL_DISCONNECT not valid"), "Error message did not contain expected text. Found: " + exception.getMessage());
+                client.connect(false);
                 int subscribedCount = cluster.get(1).callOnInstance(() ->
                                                                     CassandraDaemon.getInstanceForTesting()
                                                                                    .nativeTransportService()

--- a/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/GracefulDisconnectIT.java
@@ -25,9 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
@@ -49,10 +48,13 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class GracefulDisconnectIT
 {
 
-    @BeforeAll
+    @BeforeClass
     public static void setUp() throws IOException
     {
         DatabaseDescriptor.daemonInitialization();
@@ -80,8 +82,10 @@ public class GracefulDisconnectIT
                 client.connect(false);
                 Message.Response response = client.execute(new OptionsMessage());
                 SupportedMessage supported = (SupportedMessage) response;
-                Assertions.assertTrue(supported.supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT),
-                                      "GRACEFUL_DISCONNECT should be advertised in SUPPORTED when enabled");
+
+                assertThat(supported.supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT))
+                .as("GRACEFUL_DISCONNECT should be advertised in SUPPORTED when enabled")
+                .isTrue();
             }
         }
     }
@@ -95,8 +99,11 @@ public class GracefulDisconnectIT
             try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042).build())
             {
                 client.connect(false);
-                Assertions.assertFalse(((SupportedMessage) client.execute(new OptionsMessage())).supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT),
-                                       "GRACEFUL_DISCONNECT should be advertised in SUPPORTED when enabled");
+                SupportedMessage supported = (SupportedMessage) client.execute(new OptionsMessage());
+
+                assertThat(supported.supported.containsKey(StartupMessage.GRACEFUL_DISCONNECT))
+                .as("GRACEFUL_DISCONNECT should NOT be advertised in SUPPORTED when disabled")
+                .isFalse();
             }
         }
     }
@@ -115,8 +122,7 @@ public class GracefulDisconnectIT
                 Message.Response response = client.execute(
                 new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
 
-                Assertions.assertTrue(response instanceof ReadyMessage,
-                                      "REGISTER for GRACEFUL_DISCONNECT should be accepted with READY");
+                assertThat(response).isInstanceOf(ReadyMessage.class);
 
                 int subscribedCount = cluster.get(1).callOnInstance(() ->
                                                                     CassandraDaemon.getInstanceForTesting()
@@ -125,8 +131,9 @@ public class GracefulDisconnectIT
                                                                                    .getChannelsSubscribedToGracefulDisconnect()
                                                                                    .size());
 
-                Assertions.assertEquals(1, subscribedCount,
-                                        "One channel should be subscribed to GRACEFUL_DISCONNECT");
+                assertThat(subscribedCount)
+                .as("One channel should be subscribed to GRACEFUL_DISCONNECT")
+                .isEqualTo(1);
             }
         }
     }
@@ -147,8 +154,9 @@ public class GracefulDisconnectIT
                                                                                    .getChannelsSubscribedToGracefulDisconnect()
                                                                                    .size());
 
-                Assertions.assertEquals(0, subscribedCount,
-                                        "One channel should be subscribed to GRACEFUL_DISCONNECT");
+                assertThat(subscribedCount)
+                .as("V4 client should not be able to subscribe")
+                .isEqualTo(0);
             }
         }
     }
@@ -170,8 +178,7 @@ public class GracefulDisconnectIT
                                                                                    .getServer()
                                                                                    .getChannelsSubscribedToGracefulDisconnect()
                                                                                    .size());
-                Assertions.assertEquals(0, subscribedCount,
-                                        "V4 client should not be subscribed to GRACEFUL_DISCONNECT");
+                assertThat(subscribedCount).isEqualTo(0);
             }
         }
     }
@@ -191,10 +198,12 @@ public class GracefulDisconnectIT
                                    .getServer()
                                    .stopAcceptingNewConnections();
                 });
-                Assertions.assertThrows(Exception.class, () -> {
+
+                assertThatThrownBy(() -> {
                     SimpleClient newClient = SimpleClient.builder(nativeAddr.getHostString(), 9042).build();
                     newClient.connect(false);
-                }, "Server should reject new connections after stopAcceptingNewConnections");
+                }).as("Server should reject new connections after stopAcceptingNewConnections")
+                  .isNotNull();
             }
         }
     }
@@ -209,6 +218,7 @@ public class GracefulDisconnectIT
             {
                 client.connect(false);
                 client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
+
                 int subscribedCount = cluster.get(1).callOnInstance(() ->
                                                                     CassandraDaemon.getInstanceForTesting()
                                                                                    .nativeTransportService()
@@ -216,10 +226,10 @@ public class GracefulDisconnectIT
                                                                                    .getChannelsSubscribedToGracefulDisconnect()
                                                                                    .size());
 
-                Assertions.assertEquals(0, subscribedCount);
-                boolean gracefulDisconnectCalled = cluster.get(1).callOnInstance(() -> !DatabaseDescriptor.getGracefulDisconnectEnabled());
-                Assertions.assertTrue(gracefulDisconnectCalled,
-                                      "graceful_disconnect_enabled=false should skip event emission");
+                assertThat(subscribedCount).isEqualTo(0);
+
+                boolean disabled = cluster.get(1).callOnInstance(() -> !DatabaseDescriptor.getGracefulDisconnectEnabled());
+                assertThat(disabled).isTrue();
             }
         }
     }
@@ -230,12 +240,13 @@ public class GracefulDisconnectIT
         try (Cluster cluster = buildCluster(1, true))
         {
             cluster.get(1).runOnInstance(() ->
-                                         StorageService.instance.setGracefulDisconnectMaxDrainMs(15000));
+                                         StorageService.instance.setGracefulDisconnectMaxDrain(15000));
 
-            long maxDrainMs = cluster.get(1).callOnInstance(StorageService.instance::getGracefulDisconnectMaxDrainMs);
+            long maxDrain = cluster.get(1).callOnInstance(() -> {
+                return StorageService.instance.getGracefulDisconnectMaxDrain();
+            });
 
-            Assertions.assertEquals(15000, maxDrainMs,
-                                    "max_drain_ms should be updated to 15000 via JMX");
+            assertThat(maxDrain).isEqualTo(15000L);
         }
     }
 
@@ -245,13 +256,14 @@ public class GracefulDisconnectIT
         try (Cluster cluster = buildCluster(1, true))
         {
             cluster.get(1).runOnInstance(() -> {
-                StorageService.instance.setGracefulDisconnectGracePeriodMs(3000);
+                StorageService.instance.setGracefulDisconnectGracePeriod(3000);
             });
 
-            long gracePeriodMs = cluster.get(1).callOnInstance(StorageService.instance::getGracefulDisconnectGracePeriodMs);
+            long gracePeriodMs = cluster.get(1).callOnInstance(() -> {
+                return StorageService.instance.getGracefulDisconnectGracePeriod();
+            });
 
-            Assertions.assertEquals(3000, gracePeriodMs,
-                                    "grace_period_ms should be updated to 3000 via JMX");
+            assertThat(gracePeriodMs).isEqualTo(3000L);
         }
     }
 
@@ -260,7 +272,6 @@ public class GracefulDisconnectIT
     {
         try (Cluster cluster = buildCluster(1, true))
         {
-
             InetSocketAddress nativeAddr = cluster.get(1).config().broadcastAddress();
             try (SimpleClient client = SimpleClient.builder(nativeAddr.getHostString(), 9042)
                                                    .protocolVersion(ProtocolVersion.V4)
@@ -279,10 +290,11 @@ public class GracefulDisconnectIT
                         throw new RuntimeException(e);
                     }
                 });
-                // the one hardcoded 1s limit may make this a flaky test case
+
                 long elapsed = System.currentTimeMillis() - start;
-                Assertions.assertTrue(elapsed < 1000,
-                                      "Should proceed immediately with no subscribed connections, took: " + elapsed + "ms");
+                assertThat(elapsed)
+                .as("Should proceed immediately with no subscribed connections")
+                .isLessThan(1000L);
             }
         }
     }
@@ -313,8 +325,7 @@ public class GracefulDisconnectIT
                                                                                    .getChannelsSubscribedToGracefulDisconnect()
                                                                                    .size());
 
-                Assertions.assertEquals(2, subscribedCount,
-                                        "Both connections should be subscribed to GRACEFUL_DISCONNECT");
+                assertThat(subscribedCount).isEqualTo(2);
             }
         }
     }
@@ -332,12 +343,10 @@ public class GracefulDisconnectIT
                 client.connect(false);
                 client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
 
-
                 int drainingCount = cluster.get(1).callOnInstance(() ->
                                                                   ClientMetrics.instance.connectionsDraining.get());
 
-                Assertions.assertEquals(0, drainingCount,
-                                        "connections_draining should be 0 before drain");
+                assertThat(drainingCount).isEqualTo(0);
             }
         }
     }
@@ -367,9 +376,8 @@ public class GracefulDisconnectIT
                 });
 
                 Event event = handler.queue.poll(10, TimeUnit.SECONDS);
-                Assertions.assertNotNull(event, "Expected GRACEFUL_DISCONNECT event but got null");
-                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event.type,
-                                        "Expected GRACEFUL_DISCONNECT event type");
+                assertThat(event).isNotNull();
+                assertThat(event.type).isEqualTo(Event.Type.GRACEFUL_DISCONNECT);
             }
         }
     }
@@ -391,8 +399,7 @@ public class GracefulDisconnectIT
                 Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
                     int drainingCount = cluster.get(1).callOnInstance(() ->
                                                                       ClientMetrics.instance.connectionsDraining.get());
-                    Assertions.assertEquals(0, drainingCount,
-                                            "connections_draining should be 0 after all connections close");
+                    assertThat(drainingCount).isEqualTo(0);
                 });
 
                 boolean actionCalled = cluster.get(1).callOnInstance(() -> {
@@ -405,8 +412,7 @@ public class GracefulDisconnectIT
                     return called.get();
                 });
 
-                Assertions.assertTrue(actionCalled,
-                                      "Default action should be called immediately when no subscribed connections");
+                assertThat(actionCalled).isTrue();
             }
         }
     }
@@ -425,8 +431,8 @@ public class GracefulDisconnectIT
                 client.execute(new RegisterMessage(Collections.singletonList(Event.Type.GRACEFUL_DISCONNECT)));
 
                 cluster.get(1).runOnInstance(() -> {
-                    StorageService.instance.setGracefulDisconnectGracePeriodMs(500);
-                    StorageService.instance.setGracefulDisconnectMaxDrainMs(1000);
+                    StorageService.instance.setGracefulDisconnectGracePeriod(500);
+                    StorageService.instance.setGracefulDisconnectMaxDrain(1000);
                 });
 
                 cluster.get(1).runOnInstance(() -> {
@@ -440,16 +446,14 @@ public class GracefulDisconnectIT
 
                 Thread.sleep(3000);
 
-                boolean actionCalled = cluster.get(1).callOnInstance(() -> ClientMetrics.instance.connectionsDraining.get() == 0);
-
-                Assertions.assertTrue(actionCalled,
-                                      "Default action should be called after max_drain_ms timeout");
+                boolean finishedDraining = cluster.get(1).callOnInstance(() -> ClientMetrics.instance.connectionsDraining.get() == 0);
+                assertThat(finishedDraining).isTrue();
             }
             finally
             {
                 cluster.get(1).runOnInstance(() -> {
-                    StorageService.instance.setGracefulDisconnectMaxDrainMs(30000);
-                    StorageService.instance.setGracefulDisconnectGracePeriodMs(5000);
+                    StorageService.instance.setGracefulDisconnectMaxDrain(30000);
+                    StorageService.instance.setGracefulDisconnectGracePeriod(5000);
                 });
             }
         }
@@ -491,10 +495,10 @@ public class GracefulDisconnectIT
                 Event event1 = handler1.queue.poll(10, TimeUnit.SECONDS);
                 Event event2 = handler2.queue.poll(10, TimeUnit.SECONDS);
 
-                Assertions.assertNotNull(event1, "client1 should receive GRACEFUL_DISCONNECT");
-                Assertions.assertNotNull(event2, "client2 should receive GRACEFUL_DISCONNECT");
-                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event1.type);
-                Assertions.assertEquals(Event.Type.GRACEFUL_DISCONNECT, event2.type);
+                assertThat(event1).isNotNull();
+                assertThat(event2).isNotNull();
+                assertThat(event1.type).isEqualTo(Event.Type.GRACEFUL_DISCONNECT);
+                assertThat(event2.type).isEqualTo(Event.Type.GRACEFUL_DISCONNECT);
             }
         }
     }
@@ -533,8 +537,9 @@ public class GracefulDisconnectIT
                 Event subscribedEvent = subscribedHandler.queue.poll(10, TimeUnit.SECONDS);
                 Event nonSubscribedEvent = nonSubscribedHandler.queue.poll(3, TimeUnit.SECONDS);
 
-                Assertions.assertNotNull(subscribedEvent, "Subscribed client should receive GRACEFUL_DISCONNECT");
-                Assertions.assertNull(nonSubscribedEvent, "Non-subscribed client should not receive GRACEFUL_DISCONNECT");
+                assertThat(subscribedEvent).isNotNull();
+                assertThat(subscribedEvent.type).isEqualTo(Event.Type.GRACEFUL_DISCONNECT);
+                assertThat(nonSubscribedEvent).isNull();
             }
         }
     }

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -800,23 +800,23 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testGracefulDisconnectGracePeriodMs()
+    public void testGracefulDisconnectGracePeriod()
     {
-        long originalValue = DatabaseDescriptor.getGracefulDisconnectGracePeriodMs();
-        Assert.assertEquals("Default value of graceful_disconnect_grace_period_ms must be 5000", 5000, originalValue);
-        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(3000);
-        Assert.assertEquals("graceful_disconnect_grace_period_ms should be updated to 3000", 3000, DatabaseDescriptor.getGracefulDisconnectGracePeriodMs());
-        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(originalValue);
+        long originalValue = DatabaseDescriptor.getGracefulDisconnectGracePeriod();
+        Assert.assertEquals("Default value of graceful_disconnect_grace_period must be 5000", 5000, originalValue);
+        DatabaseDescriptor.setGracefulDisconnectGracePeriod(3000);
+        Assert.assertEquals("graceful_disconnect_grace_period should be updated to 3000", 3000, DatabaseDescriptor.getGracefulDisconnectGracePeriod());
+        DatabaseDescriptor.setGracefulDisconnectGracePeriod(originalValue);
     }
 
     @Test
-    public void testGracefulDisconnectMaxDrainMs()
+    public void testGracefulDisconnectMaxDrain()
     {
-        long originalValue = DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
-        Assert.assertEquals("Default value of graceful_disconnect_max_drain_ms must be 30000", 30000, originalValue);
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(45000);
-        Assert.assertEquals("graceful_disconnect_max_drain_ms should be updated to 45000", 45000, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs());
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(originalValue);
+        long originalValue = DatabaseDescriptor.getGracefulDisconnectMaxDrain();
+        Assert.assertEquals("Default value of graceful_disconnect_max_drain must be 30000", 30000, originalValue);
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(45000);
+        Assert.assertEquals("graceful_disconnect_max_drain should be updated to 45000", 45000, DatabaseDescriptor.getGracefulDisconnectMaxDrain());
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(originalValue);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -792,6 +792,34 @@ public class DatabaseDescriptorTest
     }
 
     @Test
+    public void testGracefulDisconnectEnabled()
+    {
+        Config config = new Config();
+        boolean originalValue = config.graceful_disconnect_enabled;
+        Assert.assertFalse("Default value of graceful_disconnect_enabled must be false", originalValue);
+    }
+
+    @Test
+    public void testGracefulDisconnectGracePeriodMs()
+    {
+        long originalValue = DatabaseDescriptor.getGracefulDisconnectGracePeriodMs();
+        Assert.assertEquals("Default value of graceful_disconnect_grace_period_ms must be 5000", 5000, originalValue);
+        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(3000);
+        Assert.assertEquals("graceful_disconnect_grace_period_ms should be updated to 3000", 3000, DatabaseDescriptor.getGracefulDisconnectGracePeriodMs());
+        DatabaseDescriptor.setGracefulDisconnectGracePeriodMs(originalValue);
+    }
+
+    @Test
+    public void testGracefulDisconnectMaxDrainMs()
+    {
+        long originalValue = DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
+        Assert.assertEquals("Default value of graceful_disconnect_max_drain_ms must be 30000", 30000, originalValue);
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(45000);
+        Assert.assertEquals("graceful_disconnect_max_drain_ms should be updated to 45000", 45000, DatabaseDescriptor.getGracefulDisconnectMaxDrainMs());
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(originalValue);
+    }
+
+    @Test
     public void testRowIndexSizeAbortEnabledWarnDisabled()
     {
         Config conf = new Config();

--- a/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
+++ b/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
@@ -22,21 +22,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.transport.Event;
-import org.apache.cassandra.transport.messages.EventMessage;
-
 import io.netty.channel.DefaultChannelId;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.GlobalEventExecutor;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.metrics.ClientMetrics;
+import org.apache.cassandra.transport.Event;
+import org.apache.cassandra.transport.messages.EventMessage;
+import org.awaitility.Awaitility;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GracefulDisconnectTest
 {
@@ -44,6 +45,7 @@ public class GracefulDisconnectTest
     public void setup()
     {
         DatabaseDescriptor.daemonInitialization();
+        ClientMetrics.instance.initForTesting();
     }
 
     @Test
@@ -62,7 +64,9 @@ public class GracefulDisconnectTest
 
         StorageService.instance.gracefulDisconnect(defaultAction, channelGroup);
 
-        Assert.assertFalse("Action should wait for channels to close", wasActionRun.get());
+        assertThat(wasActionRun.get())
+            .as("Action should wait for channels to close")
+            .isFalse();
 
         ch1.close();
     }
@@ -72,7 +76,7 @@ public class GracefulDisconnectTest
     {
         DatabaseDescriptor.setGracefulDisconnectMaxDrain(60000);
 
-        DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(2);
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(2);
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
         EmbeddedChannel ch1 = new EmbeddedChannel(DefaultChannelId.newInstance());
@@ -89,11 +93,16 @@ public class GracefulDisconnectTest
         StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
 
         ch1.close().sync();
-        Assert.assertFalse("Action should not run while ch2 is still open", wasActionRun.get());
+        assertThat(wasActionRun.get())
+            .as("Action should not run while ch2 is still open")
+            .isFalse();
 
         ch2.close().sync();
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(wasActionRun::get);
-        Assert.assertTrue("Action should run now that all channels are closed", wasActionRun.get());
+
+        assertThat(wasActionRun.get())
+            .as("Action should run now that all channels are closed")
+            .isTrue();
 
         eventLoopGroup.shutdownGracefully();
     }
@@ -114,13 +123,18 @@ public class GracefulDisconnectTest
         AtomicBoolean wasActionRun = new AtomicBoolean(false);
         StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
 
-        Assert.assertFalse("Should not run immediately", wasActionRun.get());
+        assertThat(wasActionRun.get())
+            .as("Should not run immediately")
+            .isFalse();
 
         Awaitility.await()
                   .atMost(timeoutMs + 2000, TimeUnit.MILLISECONDS)
                   .until(wasActionRun::get);
 
-        Assert.assertTrue("Action should have run due to timeout", wasActionRun.get());
+        assertThat(wasActionRun.get())
+            .as("Action should have run due to timeout")
+            .isTrue();
+
         ch1.close();
     }
 
@@ -137,8 +151,12 @@ public class GracefulDisconnectTest
         StorageService.instance.gracefulDisconnect(() -> {
         }, channelGroup);
 
-        Assert.assertNotNull("EventMessage should have been dispatched", capturedMessage.get());
-        Assert.assertTrue(capturedMessage.get().event instanceof Event.GracefulDisconnect);
+        assertThat(capturedMessage.get())
+            .as("EventMessage should have been dispatched")
+            .isNotNull();
+
+        assertThat(capturedMessage.get().event)
+            .isInstanceOf(Event.GracefulDisconnect.class);
     }
 
     @Test
@@ -152,7 +170,10 @@ public class GracefulDisconnectTest
 
         StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
 
-        Assert.assertFalse("Should not have run yet, waiting for ch1 to close", wasActionRun.get());
+        assertThat(wasActionRun.get())
+            .as("Should not have run yet, waiting for ch1 to close")
+            .isFalse();
+
         ch1.close();
     }
 }

--- a/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
+++ b/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
@@ -33,6 +33,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.metrics.ClientMetrics;
+import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.messages.EventMessage;
 import org.awaitility.Awaitility;
@@ -55,7 +56,7 @@ public class GracefulDisconnectTest
 
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
         EmbeddedChannel ch1 = new EmbeddedChannel();
-        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        ch1.attr(Dispatcher.EVENT_DISPATCHER).set(msg -> {
         });
         channelGroup.add(ch1);
 
@@ -82,9 +83,9 @@ public class GracefulDisconnectTest
         EmbeddedChannel ch1 = new EmbeddedChannel(DefaultChannelId.newInstance());
         EmbeddedChannel ch2 = new EmbeddedChannel(DefaultChannelId.newInstance());
 
-        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        ch1.attr(Dispatcher.EVENT_DISPATCHER).set(msg -> {
         });
-        ch2.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        ch2.attr(Dispatcher.EVENT_DISPATCHER).set(msg -> {
         });
         channelGroup.add(ch1);
         channelGroup.add(ch2);
@@ -113,7 +114,7 @@ public class GracefulDisconnectTest
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
         EmbeddedChannel ch1 = new EmbeddedChannel();
-        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        ch1.attr(Dispatcher.EVENT_DISPATCHER).set(msg -> {
         });
         channelGroup.add(ch1);
 
@@ -145,7 +146,7 @@ public class GracefulDisconnectTest
 
         EmbeddedChannel ch1 = new EmbeddedChannel();
         AtomicReference<EventMessage> capturedMessage = new AtomicReference<>();
-        ch1.attr(StorageService.EVENT_DISPATCHER).set(capturedMessage::set);
+        ch1.attr(Dispatcher.EVENT_DISPATCHER).set(capturedMessage::set);
         channelGroup.add(ch1);
 
         StorageService.instance.gracefulDisconnect(() -> {

--- a/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
+++ b/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.transport.Event;
+import org.apache.cassandra.transport.messages.EventMessage;
+
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
+
+public class GracefulDisconnectTest
+{
+    @Before
+    public void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test
+    public void testGracefulDisconnectWithActiveChannels()
+    {
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(10000);
+
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        EmbeddedChannel ch1 = new EmbeddedChannel();
+        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        });
+        channelGroup.add(ch1);
+
+        AtomicBoolean wasActionRun = new AtomicBoolean(false);
+        Runnable defaultAction = () -> wasActionRun.set(true);
+
+        StorageService.instance.gracefulDisconnect(defaultAction, channelGroup);
+
+        Assert.assertFalse("Action should wait for channels to close", wasActionRun.get());
+
+        ch1.close();
+    }
+
+    @Test
+    public void testTriggerOnLastChannelClose() throws InterruptedException
+    {
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(60000);
+
+        DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(2);
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+        EmbeddedChannel ch1 = new EmbeddedChannel(DefaultChannelId.newInstance());
+        EmbeddedChannel ch2 = new EmbeddedChannel(DefaultChannelId.newInstance());
+
+        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        });
+        ch2.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        });
+        channelGroup.add(ch1);
+        channelGroup.add(ch2);
+
+        AtomicBoolean wasActionRun = new AtomicBoolean(false);
+        StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
+
+        ch1.close().sync();
+        Assert.assertFalse("Action should not run while ch2 is still open", wasActionRun.get());
+
+        ch2.close().sync();
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(wasActionRun::get);
+        Assert.assertTrue("Action should run now that all channels are closed", wasActionRun.get());
+
+        eventLoopGroup.shutdownGracefully();
+    }
+
+    @Test
+    public void testTriggerOnTimeout()
+    {
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+        EmbeddedChannel ch1 = new EmbeddedChannel();
+        ch1.attr(StorageService.EVENT_DISPATCHER).set(msg -> {
+        });
+        channelGroup.add(ch1);
+
+        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(1000);
+        long timeoutMs = DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
+
+        AtomicBoolean wasActionRun = new AtomicBoolean(false);
+        StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
+
+        Assert.assertFalse("Should not run immediately", wasActionRun.get());
+
+        Awaitility.await()
+                  .atMost(timeoutMs + 2000, TimeUnit.MILLISECONDS)
+                  .until(wasActionRun::get);
+
+        Assert.assertTrue("Action should have run due to timeout", wasActionRun.get());
+        ch1.close();
+    }
+
+    @Test
+    public void testEventMessageDispatched()
+    {
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+        EmbeddedChannel ch1 = new EmbeddedChannel();
+        AtomicReference<EventMessage> capturedMessage = new AtomicReference<>();
+        ch1.attr(StorageService.EVENT_DISPATCHER).set(capturedMessage::set);
+        channelGroup.add(ch1);
+
+        StorageService.instance.gracefulDisconnect(() -> {
+        }, channelGroup);
+
+        Assert.assertNotNull("EventMessage should have been dispatched", capturedMessage.get());
+        Assert.assertTrue(capturedMessage.get().event instanceof Event.GracefulDisconnect);
+    }
+
+    @Test
+    public void testResilienceToMissingDispatcherAttribute()
+    {
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        EmbeddedChannel ch1 = new EmbeddedChannel();
+        channelGroup.add(ch1);
+
+        AtomicBoolean wasActionRun = new AtomicBoolean(false);
+
+        StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);
+
+        Assert.assertFalse("Should not have run yet, waiting for ch1 to close", wasActionRun.get());
+        ch1.close();
+    }
+}

--- a/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
+++ b/test/unit/org/apache/cassandra/service/GracefulDisconnectTest.java
@@ -49,7 +49,7 @@ public class GracefulDisconnectTest
     @Test
     public void testGracefulDisconnectWithActiveChannels()
     {
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(10000);
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(10000);
 
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
         EmbeddedChannel ch1 = new EmbeddedChannel();
@@ -70,7 +70,7 @@ public class GracefulDisconnectTest
     @Test
     public void testTriggerOnLastChannelClose() throws InterruptedException
     {
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(60000);
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(60000);
 
         DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(2);
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
@@ -108,8 +108,8 @@ public class GracefulDisconnectTest
         });
         channelGroup.add(ch1);
 
-        DatabaseDescriptor.setGracefulDisconnectMaxDrainMs(1000);
-        long timeoutMs = DatabaseDescriptor.getGracefulDisconnectMaxDrainMs();
+        DatabaseDescriptor.setGracefulDisconnectMaxDrain(1000);
+        long timeoutMs = DatabaseDescriptor.getGracefulDisconnectMaxDrain();
 
         AtomicBoolean wasActionRun = new AtomicBoolean(false);
         StorageService.instance.gracefulDisconnect(() -> wasActionRun.set(true), channelGroup);

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -202,59 +202,59 @@ public class StorageServiceTest extends TestBaseImpl
     }
 
     @Test
-    public void testGracefulDisconnectMaxDrainMs()
+    public void testGracefulDisconnectMaxDrain()
     {
         StorageService storageService = StorageService.instance;
-        long originalMaxDrainMs = storageService.getGracefulDisconnectMaxDrainMs();
-        long originalGracePeriodMs = storageService.getGracefulDisconnectGracePeriodMs();
+        long originalMaxDrain = storageService.getGracefulDisconnectMaxDrain();
+        long originalGracePeriod = storageService.getGracefulDisconnectGracePeriod();
         try
         {
-            storageService.setGracefulDisconnectGracePeriodMs(1000);
+            storageService.setGracefulDisconnectGracePeriod(1000);
 
-            storageService.setGracefulDisconnectMaxDrainMs(10000);
-            assertEquals(10000, storageService.getGracefulDisconnectMaxDrainMs());
+            storageService.setGracefulDisconnectMaxDrain(10000);
+            assertEquals(10000, storageService.getGracefulDisconnectMaxDrain());
             try
             {
-                storageService.setGracefulDisconnectMaxDrainMs(0);
-                fail("Should have received an IllegalArgumentException for max_drain_ms of 0");
+                storageService.setGracefulDisconnectMaxDrain(0);
+                fail("Should have received an IllegalArgumentException for max_drain of 0");
             }
             catch (IllegalArgumentException ignored)
             {
             }
-            assertEquals(10000, storageService.getGracefulDisconnectMaxDrainMs());
+            assertEquals(10000, storageService.getGracefulDisconnectMaxDrain());
         }
         finally
         {
-            storageService.setGracefulDisconnectMaxDrainMs(originalMaxDrainMs);
-            storageService.setGracefulDisconnectGracePeriodMs(originalGracePeriodMs);
+            storageService.setGracefulDisconnectMaxDrain(originalMaxDrain);
+            storageService.setGracefulDisconnectGracePeriod(originalGracePeriod);
         }
     }
 
     @Test
-    public void testGracefulDisconnectGracePeriodMs()
+    public void testGracefulDisconnectGracePeriod()
     {
         StorageService storageService = StorageService.instance;
-        long originalMaxDrainMs = storageService.getGracefulDisconnectMaxDrainMs();
-        long originalGracePeriodMs = storageService.getGracefulDisconnectGracePeriodMs();
+        long originalMaxDrain = storageService.getGracefulDisconnectMaxDrain();
+        long originalGracePeriod = storageService.getGracefulDisconnectGracePeriod();
         try
         {
-            storageService.setGracefulDisconnectMaxDrainMs(20000);
+            storageService.setGracefulDisconnectMaxDrain(20000);
 
-            storageService.setGracefulDisconnectGracePeriodMs(5000);
-            assertEquals(5000, storageService.getGracefulDisconnectGracePeriodMs());
+            storageService.setGracefulDisconnectGracePeriod(5000);
+            assertEquals(5000, storageService.getGracefulDisconnectGracePeriod());
 
             try
             {
-                storageService.setGracefulDisconnectGracePeriodMs(30000);
-                fail("Should have received an IllegalArgumentException when grace_period_ms exceeds max_drain_ms");
+                storageService.setGracefulDisconnectGracePeriod(30000);
+                fail("Should have received an IllegalArgumentException when grace_period exceeds max_drain");
             }
             catch (IllegalArgumentException ignored) {}
-            assertEquals(5000, storageService.getGracefulDisconnectGracePeriodMs());
+            assertEquals(5000, storageService.getGracefulDisconnectGracePeriod());
         }
         finally
         {
-            storageService.setGracefulDisconnectMaxDrainMs(originalMaxDrainMs);
-            storageService.setGracefulDisconnectGracePeriodMs(originalGracePeriodMs);
+            storageService.setGracefulDisconnectMaxDrain(originalMaxDrain);
+            storageService.setGracefulDisconnectGracePeriod(originalGracePeriod);
         }
     }
 

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -202,6 +202,63 @@ public class StorageServiceTest extends TestBaseImpl
     }
 
     @Test
+    public void testGracefulDisconnectMaxDrainMs()
+    {
+        StorageService storageService = StorageService.instance;
+        long originalMaxDrainMs = storageService.getGracefulDisconnectMaxDrainMs();
+        long originalGracePeriodMs = storageService.getGracefulDisconnectGracePeriodMs();
+        try
+        {
+            storageService.setGracefulDisconnectGracePeriodMs(1000);
+
+            storageService.setGracefulDisconnectMaxDrainMs(10000);
+            assertEquals(10000, storageService.getGracefulDisconnectMaxDrainMs());
+            try
+            {
+                storageService.setGracefulDisconnectMaxDrainMs(0);
+                fail("Should have received an IllegalArgumentException for max_drain_ms of 0");
+            }
+            catch (IllegalArgumentException ignored)
+            {
+            }
+            assertEquals(10000, storageService.getGracefulDisconnectMaxDrainMs());
+        }
+        finally
+        {
+            storageService.setGracefulDisconnectMaxDrainMs(originalMaxDrainMs);
+            storageService.setGracefulDisconnectGracePeriodMs(originalGracePeriodMs);
+        }
+    }
+
+    @Test
+    public void testGracefulDisconnectGracePeriodMs()
+    {
+        StorageService storageService = StorageService.instance;
+        long originalMaxDrainMs = storageService.getGracefulDisconnectMaxDrainMs();
+        long originalGracePeriodMs = storageService.getGracefulDisconnectGracePeriodMs();
+        try
+        {
+            storageService.setGracefulDisconnectMaxDrainMs(20000);
+
+            storageService.setGracefulDisconnectGracePeriodMs(5000);
+            assertEquals(5000, storageService.getGracefulDisconnectGracePeriodMs());
+
+            try
+            {
+                storageService.setGracefulDisconnectGracePeriodMs(30000);
+                fail("Should have received an IllegalArgumentException when grace_period_ms exceeds max_drain_ms");
+            }
+            catch (IllegalArgumentException ignored) {}
+            assertEquals(5000, storageService.getGracefulDisconnectGracePeriodMs());
+        }
+        finally
+        {
+            storageService.setGracefulDisconnectMaxDrainMs(originalMaxDrainMs);
+            storageService.setGracefulDisconnectGracePeriodMs(originalGracePeriodMs);
+        }
+    }
+
+    @Test
     public void testColumnIndexCacheSizeInKiB()
     {
         StorageService storageService = StorageService.instance;


### PR DESCRIPTION
Found and fixed several bugs while testing the Java driver (CASSJAVA-124)
  against this branch.

  ### Fixes

  1. **EVENT_DISPATCHER AttributeKey lookup returns null**: `StorageService`
  defined its own `AttributeKey.valueOf("EVTDISP")` instead of using
  `Dispatcher.EVENT_DISPATCHER`. Since these are different object instances,
  the dispatcher lookup in `gracefulDisconnect()` always returned null,
  meaning the GRACEFUL_DISCONNECT event was never actually dispatched to
  clients. Fixed by using `Dispatcher.EVENT_DISPATCHER` directly and making it
   public.

  2. **Metrics double-decrement**: When the timeout fires, `runOnceAction`
  called `decrementConnectionsDraining(remaining)` for all remaining channels.
   But the individual channel close listeners also call
  `decrementConnectionsDraining()` when those channels eventually close,
  causing the counter to go negative. Fixed by only tracking forced
  disconnects in `runOnceAction` and letting close listeners handle all
  decrements.

  3. **Metrics race condition**: `incrementConnectionsDraining()` was called
  after registering the close listener. If a channel closed synchronously
  during `forEach`, the decrement would fire before the increment. Fixed by
  moving the increment before the listener registration.

  4. **Missing negative value validation**:
  `setGracefulDisconnectGracePeriod()` didn't reject negative values via JMX.

  5. **Misleading error message**: `setGracefulDisconnectMaxDrain()` error
  message referenced `graceful_disconnect_enabled` even though the check runs
  regardless.

  6. **SimpleClient blocks on drain**: `handleGracefulDisconnect()` called
  `lastWriteFuture.awaitUninterruptibly()` which blocks the Netty event loop
  thread, then immediately called `close()` without waiting for in-flight
  responses. Fixed by using `addListener()` for non-blocking close after the
  write completes.

  ### Testing
  - End-to-end tested with the Java driver: 200 queries during nodetool drain,
   0 errors
  - Updated `GracefulDisconnectTest` to use `Dispatcher.EVENT_DISPATCHER`
  JIRA:
  [CASSANDRA-21191](https://issues.apache.org/jira/browse/CASSANDRA-21191)