### PR TITLE
CASSANDRA-21415: Document COPY TO limitation for control characters in text columns

### DIFF
--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -463,8 +463,8 @@ See `shared-copy-options` for options that apply to both `COPY TO` and
 
 [NOTE]
 ====
-`COPY TO` only supports printable characters in text column values, in
-accordance with RFC 4180. Text columns containing control characters
+`COPY TO` exports CSV using a restricted RFC 4180-compatible format and does not
+preserve control characters in text column values. Text columns containing control characters
 such as newlines (`\n`), carriage returns (`\r`), null bytes (`\x00`),
 or other non-printable characters cannot be reliably exported — values
 will be corrupted on re-import via `COPY FROM`. Beyond data integrity,

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -461,6 +461,19 @@ value `STDOUT` (without single quotes) to print the CSV to stdout.
 See `shared-copy-options` for options that apply to both `COPY TO` and
 `COPY FROM`.
 
+[NOTE]
+====
+`COPY TO` only supports printable characters in text column values, in
+accordance with RFC 4180. Text columns containing control characters
+such as newlines (`\n`), carriage returns (`\r`), null bytes (`\x00`),
+or other non-printable characters cannot be reliably exported — values
+will be corrupted on re-import via `COPY FROM`. Beyond data integrity,
+non-printable characters in CSV output can pose security risks, including
+CSV injection and other forms of malicious data embedding. If your data
+contains such characters, consider using DSBulk, Spark, or
+`sstableloader` for data migration instead.
+====
+
 ==== Options for `COPY TO`
 
 `MAXREQUESTS`::


### PR DESCRIPTION
COPY TO does not support control characters (such as newlines, carriage
returns, or null bytes) in text column values. Any text column containing
these characters will be silently corrupted on round-trip — COPY TO
succeeds and COPY FROM succeeds, but the re-imported values differ from
the originals.

This patch documents that limitation clearly in the COPY TO section of
the cqlsh reference, in accordance with RFC 4180 which defines CSV
TEXTDATA as printable characters only. Users with such data are directed
to sstableloader for data migration instead.

patch by Arvind Kandpal; reviewed by for CASSANDRA-21415