### PR TITLE
CASSANDRA-21425 / CASSANDRA-21262: Fix skipped tests, typos, and flaky test in CassandraRoleManagerTest

### DIFF
--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -81,7 +81,7 @@ public class CassandraRoleManagerTest
     public void getGrantedRolesImplMinimizesReads()
     {
         // IRoleManager::getRoleDetails was not in the initial API, so a default impl
-        // was added which uses the existing methods on IRoleManager as primitive to
+        // was added which uses the existing methods on IRoleManager as primitives to
         // construct the Role objects. While this will work for any IRoleManager impl
         // it is inefficient, so CassandraRoleManager has its own implementation which
         // collects all of the necessary info with a single query for each granted role.
@@ -104,7 +104,7 @@ public class CassandraRoleManagerTest
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
 
         // Check that when granted roles appear multiple times in parallel levels of the hierarchy, we don't
-        // do redundant reads. E.g. here role_b_1, role_b_2 and role_b3 are granted to both role_b and role_c
+        // do redundant reads. E.g. here role_b_1, role_b_2 and role_b_3 are granted to both role_b and role_c
         // but we only want to actually read them once
         grantRolesTo(roleManager, ROLE_C, ROLE_B_1, ROLE_B_2, ROLE_B_3);
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
@@ -165,6 +165,7 @@ public class CassandraRoleManagerTest
         }
     }
 
+    @Test
     public void testPasswordUpdateRateLimiting() throws Exception
     {
         try
@@ -194,7 +195,7 @@ public class CassandraRoleManagerTest
             }
             catch (OverloadedException e)
             {
-                assertEquals("Password for role test_password_role can only be changed every 100ms. ", e.getMessage());
+                assertEquals("Password for role test_password_role can only be changed every 100ms.", e.getMessage());
             }
 
             // Wait for the rate limit interval to pass
@@ -301,6 +302,7 @@ public class CassandraRoleManagerTest
         Assertions.assertThat(crm.getInvalidClientDisconnectMaxJitterMillis()).isEqualTo(1000);
     }
 
+    @Test
     public void testPasswordUpdateRateLimitingDisabled() throws Exception
     {
         try

--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -347,14 +347,11 @@ public class CassandraRoleManagerTest
             RoleOptions options2 = getLoginRoleOptions("password2");
             roleManager.createRole(AuthenticatedUser.ANONYMOUS_USER, role2, options2);
 
-            // Wait for the rate limit interval to pass
+            // Wait for the rate limit interval to pass since creation
             Thread.sleep(150);
 
             RoleOptions newOptions1 = getLoginRoleOptions("new_password1");
             roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role1, newOptions1);
-
-            RoleOptions newOptions2 = getLoginRoleOptions("new_password2");
-            roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role2, newOptions2);
 
             try
             {
@@ -365,6 +362,20 @@ public class CassandraRoleManagerTest
             catch (OverloadedException e)
             {
                 assertEquals("Password for role test_role_1 can only be changed every 100ms.", e.getMessage());
+            }
+
+            RoleOptions newOptions2 = getLoginRoleOptions("new_password2");
+            roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role2, newOptions2);
+
+            try
+            {
+                RoleOptions newOptions2Again = getLoginRoleOptions("another_password2");
+                roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role2, newOptions2Again);
+                fail("Expected OverloadedException for test_role_2");
+            }
+            catch (OverloadedException e)
+            {
+                assertEquals("Password for role test_role_2 can only be changed every 100ms.", e.getMessage());
             }
 
             roleManager.dropRole(AuthenticatedUser.ANONYMOUS_USER, role1);


### PR DESCRIPTION
Fix skipped tests (missing @Test), typos, and test flakiness in CassandraRoleManagerTest.

**Context & Changes:**
This PR addresses two separate tickets to improve test coverage, consistency, and stability in `CassandraRoleManagerTest.java`:

**1. CASSANDRA-21425 (Skipped tests & typos):**
* Enabled skipped tests: Added missing `@Test` annotations to `testPasswordUpdateRateLimiting()` and `testPasswordUpdateRateLimitingDisabled()`, which were previously being silently skipped by JUnit.
* Fixed typos and inconsistencies: Corrected a typo in an inline comment (`role_b3` -> `role_b_3`). Removed an inconsistent trailing space in the `OverloadedException` assertion message ("100ms. " -> "100ms.") so it correctly matches the system's actual exception string. Fixed grammar in a comment (`primitive` -> `primitives`).

**2. CASSANDRA-21262 (Flaky Test):**
* Fixed flaky `testPasswordUpdateRateLimitingPerRole` test. In slower CI environments, bcrypt latency on an intermediate role (`role2`) caused the 100ms rate-limit window for `role1` to naturally expire, leading to random test failures. 
* Restructured the test to group the updates and immediate rate-limit checks consecutively for each role independently. This removes the hardware/timing dependency entirely and makes the test 100% deterministic.

**Testing:**
* Ran `ant test -Dtest.name=CassandraRoleManagerTest` locally. 
* Verified that the newly enabled tests execute successfully and the flaky test passes consistently without timing issues.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-21425 and CASSANDRA-21262