### PR TITLE
CASSANDRA-21426: AssertionError in hasReplicaWithOngoingRepair when parallel_repair_count > 1

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -735,7 +735,7 @@ public class AutoRepairUtils
         for (Map.Entry<AbstractReplicationStrategy, List<String>> entry : replicationStrategies.entrySet())
         {
             AbstractReplicationStrategy replicationStrategy = entry.getKey();
-            EndpointsByRange endpointsByRange = replicationStrategy.getRangeAddresses(StorageService.instance.getTokenMetadata());
+            EndpointsByRange endpointsByRange = replicationStrategy.getRangeAddresses(StorageService.instance.getTokenMetadata().cachedOnlyTokenMap());
 
             // get ranges of the eligible address for the given replication strategy.
             RangesAtEndpoint rangesAtEndpoint = StorageService.instance.getReplicas(replicationStrategy, eligibleBroadcastAddress);


### PR DESCRIPTION
An assetion error is thrown from AutoRepairUtils.java when calling StorageService.instance.getTokenMetadata().  works fine when only 1 node is allowed parallel_repair_count: 1.  When you increase this > 1 you start getting the assertion error

the change is to instead use StorageService.instance.getTokenMetadata().cachedOnlyTokenMap()

patch by Patrick Lee; reviewed by TBD for [CASSANDRA-21426](https://issues.apache.org/jira/browse/CASSANDRA-21426)

using CCM and 9 nodes, with the auto-repair config 
```
auto_repair:
  enabled: true
  repair_check_interval: 30s
  repair_task_min_duration: 5s
  repair_type_overrides:
    incremental:
      enabled: true
      min_repair_interval: 1m
  global_settings:
    parallel_repair_count: 3
    allow_parallel_replica_repair: false
```

you can reproduce and get the assertion error.  running the same in CCM with the patched version validates that there are no assertion errors and there were 2 nodes running incremental repairs concurrently.