### PR TITLE
Remove inFlightEcho entry on ECHO_REQ failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -140,7 +140,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -330,10 +330,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -437,10 +437,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -544,10 +544,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -698,10 +698,10 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -784,7 +784,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -971,7 +971,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1161,10 +1161,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1272,7 +1272,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1464,7 +1464,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1578,10 +1578,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1685,10 +1685,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1796,7 +1796,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1989,7 +1989,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2172,10 +2172,10 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2256,10 +2256,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2388,10 +2388,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2495,10 +2495,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2690,7 +2690,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2880,10 +2880,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2987,10 +2987,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3098,7 +3098,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3286,7 +3286,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3399,10 +3399,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3530,10 +3530,10 @@ jobs:
   j8_cqlsh-dtests-py2-offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3637,10 +3637,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3769,10 +3769,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3903,7 +3903,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4090,7 +4090,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4279,10 +4279,10 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4362,10 +4362,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4540,10 +4540,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4647,10 +4647,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4778,10 +4778,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4889,7 +4889,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5079,10 +5079,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5236,7 +5236,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5428,7 +5428,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5542,10 +5542,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5649,10 +5649,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5757,10 +5757,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5868,7 +5868,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6057,10 +6057,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6189,10 +6189,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6299,7 +6299,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6488,10 +6488,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6619,10 +6619,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6727,10 +6727,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6810,10 +6810,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6919,7 +6919,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7108,10 +7108,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7219,7 +7219,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7409,10 +7409,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7520,7 +7520,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7709,10 +7709,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7795,7 +7795,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7911,7 +7911,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8131,10 +8131,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8214,10 +8214,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8322,10 +8322,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8470,7 +8470,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8659,10 +8659,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8768,7 +8768,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9023,7 +9023,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9136,10 +9136,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9243,10 +9243,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9377,7 +9377,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9595,10 +9595,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9702,10 +9702,10 @@ jobs:
   j11_cqlsh-dtests-py2-offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9813,7 +9813,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10134,10 +10134,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10243,7 +10243,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10432,10 +10432,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10566,7 +10566,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10864,284 +10864,552 @@ workflows:
     - j8_build:
         requires:
         - start_j8_build
+        upstream:
+          start_j8_build:
+          - success
     - start_j8_unit_tests:
         type: approval
     - j8_unit_tests:
         requires:
         - start_j8_unit_tests
         - j8_build
+        upstream:
+          start_j8_unit_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
         requires:
         - start_j8_jvm_dtests
         - j8_build
+        upstream:
+          start_j8_jvm_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlshlib_tests:
         type: approval
     - j8_cqlshlib_tests:
         requires:
         - start_j8_cqlshlib_tests
         - j8_build
+        upstream:
+          start_j8_cqlshlib_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j8_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_j8_utests_long
         - j8_build
+        upstream:
+          start_j8_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j8_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_j8_utests_cdc
         - j8_build
+        upstream:
+          start_j8_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j8_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_j8_utests_compression
         - j8_build
+        upstream:
+          start_j8_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j8_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_j8_utests_stress
         - j8_build
+        upstream:
+          start_j8_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j8_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_j8_utests_fqltool
         - j8_build
+        upstream:
+          start_j8_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j8_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - start_j8_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j8_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_j8_dtest_jars_build
+        upstream:
+          j8_build:
+          - success
+          start_j8_dtest_jars_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
         - j8_dtest_jars_build
+        upstream:
+          start_jvm_upgrade_dtests:
+          - success
+          j8_dtest_jars_build:
+          - success
     - start_j8_dtests:
         type: approval
     - j8_dtests:
         requires:
         - start_j8_dtests
         - j8_build
+        upstream:
+          start_j8_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_vnode:
         type: approval
     - j8_dtests_vnode:
         requires:
         - start_j8_dtests_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large_vnode:
         type: approval
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j8_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_upgrade_tests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - start_upgrade_tests
         - j8_build
+        upstream:
+          start_upgrade_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests:
         type: approval
     - j8_cqlsh-dtests-py2-with-vnodes:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh-dtests-py2-no-vnodes:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests_offheap:
         type: approval
     - j8_cqlsh-dtests-py2-offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh-dtests-py2-with-vnodes:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh-dtests-py2-no-vnodes:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests_offheap:
         type: approval
     - j11_cqlsh-dtests-py2-offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
   java8_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -11149,220 +11417,436 @@ workflows:
     - j8_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j8_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_jvm_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlshlib_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - j11_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_jvm_upgrade_dtests
+        upstream:
+          j8_build:
+          - success
+          start_jvm_upgrade_dtests:
+          - success
     - j8_jvm_upgrade_dtests:
         requires:
         - j8_dtest_jars_build
+        upstream:
+          j8_dtest_jars_build:
+          - success
     - j8_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_upgrade_tests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - j8_build
         - start_upgrade_tests
+        upstream:
+          j8_build:
+          - success
+          start_upgrade_tests:
+          - success
     - j8_cqlsh-dtests-py2-with-vnodes:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh-dtests-py2-no-vnodes:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_cqlsh_dtests_offheap:
         type: approval
     - j8_cqlsh-dtests-py2-offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh-dtests-py2-with-vnodes:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh-dtests-py2-no-vnodes:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh-dtests-py2-offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
   java11_separate_tests:
     jobs:
     - start_j11_build:
@@ -11370,142 +11854,275 @@ workflows:
     - j11_build:
         requires:
         - start_j11_build
+        upstream:
+          start_j11_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j11_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j11_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j11_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh-dtests-py2-with-vnodes:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh-dtests-py2-no-vnodes:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh-dtests-py2-offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j11_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j11_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j11_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -11513,118 +12130,231 @@ workflows:
     - j11_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j11_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh-dtests-py2-with-vnodes:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh-dtests-py2-no-vnodes:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh-dtests-py2-offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -633,6 +634,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     private void evictFromMembership(InetAddressAndPort endpoint)
     {
         checkProperThreadForStateMutation();
+        inflightEcho.remove(endpoint);
         unreachableEndpoints.remove(endpoint);
         endpointStateMap.remove(endpoint);
         expireTimeEndpointMap.remove(endpoint);
@@ -1339,13 +1341,30 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         {
             Message<NoPayload> echoMessage = Message.out(ECHO_REQ, noPayload);
             logger.trace("Sending ECHO_REQ to {}", addr);
-            RequestCallback echoHandler = msg ->
+            RequestCallback echoHandler = new RequestCallback()
             {
-                runInGossipStageBlocking(() -> {
-                    EndpointState epState = inflightEcho.remove(addr);
-                    if (epState != null)
-                        realMarkAlive(addr, epState);
-                });
+                @Override
+                public void onResponse(Message msg)
+                {
+                    runInGossipStageBlocking(() -> {
+                        EndpointState epState = inflightEcho.remove(addr);
+                        if (epState != null)
+                            realMarkAlive(addr, epState);
+                    });
+                }
+
+                @Override
+                public boolean invokeOnFailure()
+                {
+                    return true;
+                }
+
+                @Override
+                public void onFailure(InetAddressAndPort from, RequestFailureReason failureReason)
+                {
+                    logger.trace("ECHO_REQ to {} failed ({})", addr, failureReason);
+                    inflightEcho.remove(addr);
+                }
             };
             MessagingService.instance().sendWithCallback(echoMessage, addr, echoHandler);
         }


### PR DESCRIPTION
In Gossiper, echoHandler only implements onResponse. RequestCallback.onFailure has a default no-op, so when the ECHO_REQ times out or the remote node returns an error, inflightEcho.remove(addr) is never called. The stale entry persists. Any subsequent markAlive(addr, localState) call — where localState is the same in-place-mutated object already in inflightEcho — sees localState.equals(prevState) = true (identity equality, same reference) and skips indefinitely. In a temporary-partition scenario (node briefly unreachable, echo times out, node recovers with the same generation), the node can get stuck permanently dead: the failure detector sees it as alive and keeps triggering markAlive, but every invocation is suppressed by the stale entry. The stale entry is only cleared by removeEndpoint() (explicit removal) or silentlyMarkDead() via markDead() (failure detector conviction) — neither of which fires if the failure detector is reporting the node as healthy.

Fix: override onFailure in echoHandler to call inflightEcho.remove(addr).