### PR TITLE
Remove inFlightEcho entry on ECHO_REQ failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -143,7 +143,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -298,10 +298,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -408,10 +408,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -565,10 +565,10 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -654,7 +654,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -847,7 +847,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -936,10 +936,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1050,7 +1050,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1169,7 +1169,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1260,7 +1260,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1377,10 +1377,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1487,10 +1487,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1601,7 +1601,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1693,7 +1693,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1886,10 +1886,10 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1973,10 +1973,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2108,10 +2108,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2218,10 +2218,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2329,10 +2329,10 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2419,7 +2419,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2508,10 +2508,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2618,10 +2618,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2797,7 +2797,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2991,7 +2991,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3107,10 +3107,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3241,10 +3241,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3376,10 +3376,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3513,7 +3513,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3748,7 +3748,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3941,7 +3941,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4029,10 +4029,10 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4189,10 +4189,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4299,10 +4299,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4436,7 +4436,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4525,10 +4525,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4685,7 +4685,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4776,7 +4776,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4867,7 +4867,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4984,10 +4984,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5094,10 +5094,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5208,7 +5208,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5296,10 +5296,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5410,7 +5410,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5498,10 +5498,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5633,10 +5633,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5746,7 +5746,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5834,10 +5834,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5968,10 +5968,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6079,10 +6079,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6165,10 +6165,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6277,7 +6277,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6365,10 +6365,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6479,7 +6479,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6568,10 +6568,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6682,7 +6682,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6770,10 +6770,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6859,7 +6859,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6978,7 +6978,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7098,7 +7098,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7296,10 +7296,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7382,10 +7382,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7536,7 +7536,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7624,10 +7624,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7736,7 +7736,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8004,7 +8004,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8120,10 +8120,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8230,10 +8230,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8367,7 +8367,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8591,10 +8591,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8704,7 +8704,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8930,10 +8930,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9042,7 +9042,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9130,10 +9130,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9267,7 +9267,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9467,302 +9467,575 @@ workflows:
     - j8_build:
         requires:
         - start_j8_build
+        upstream:
+          start_j8_build:
+          - success
     - start_j8_unit_tests:
         type: approval
     - j8_unit_tests:
         requires:
         - start_j8_unit_tests
         - j8_build
+        upstream:
+          start_j8_unit_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
         requires:
         - start_j8_jvm_dtests
         - j8_build
+        upstream:
+          start_j8_jvm_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_jvm_dtests_vnode:
         type: approval
     - j8_jvm_dtests_vnode:
         requires:
         - start_j8_jvm_dtests_vnode
         - j8_build
+        upstream:
+          start_j8_jvm_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j8_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j8_build:
+          - success
     - start_j11_jvm_dtests_vnode:
         type: approval
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
         - j8_build
+        upstream:
+          start_j11_jvm_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j8_simulator_dtests:
         type: approval
     - j8_simulator_dtests:
         requires:
         - start_j8_simulator_dtests
         - j8_build
+        upstream:
+          start_j8_simulator_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlshlib_tests:
         type: approval
     - j8_cqlshlib_tests:
         requires:
         - start_j8_cqlshlib_tests
         - j8_build
+        upstream:
+          start_j8_cqlshlib_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlshlib_cython_tests:
         type: approval
     - j8_cqlshlib_cython_tests:
         requires:
         - start_j8_cqlshlib_cython_tests
         - j8_build
+        upstream:
+          start_j8_cqlshlib_cython_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j8_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j8_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j8_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_j8_utests_long
         - j8_build
+        upstream:
+          start_j8_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j8_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_j8_utests_cdc
         - j8_build
+        upstream:
+          start_j8_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j8_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_j8_utests_compression
         - j8_build
+        upstream:
+          start_j8_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j8_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_j8_utests_stress
         - j8_build
+        upstream:
+          start_j8_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j8_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_j8_utests_fqltool
         - j8_build
+        upstream:
+          start_j8_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j8_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_j8_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - start_j8_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j8_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_j8_dtest_jars_build
+        upstream:
+          j8_build:
+          - success
+          start_j8_dtest_jars_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
         - j8_dtest_jars_build
+        upstream:
+          start_jvm_upgrade_dtests:
+          - success
+          j8_dtest_jars_build:
+          - success
     - start_j8_dtests:
         type: approval
     - j8_dtests:
         requires:
         - start_j8_dtests
         - j8_build
+        upstream:
+          start_j8_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_vnode:
         type: approval
     - j8_dtests_vnode:
         requires:
         - start_j8_dtests_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j8_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large_vnode:
         type: approval
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j8_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j8_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j8_build:
+          - success
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - start_upgrade_dtests
         - j8_build
+        upstream:
+          start_upgrade_dtests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests:
         type: approval
     - j8_cqlsh_dtests_py3:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - start_j8_cqlsh_tests
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j8_cqlsh_tests_offheap:
         type: approval
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j8_build:
+          - success
     - start_j11_cqlsh_tests_offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh_tests_offheap:
+          - success
+          j8_build:
+          - success
   java8_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -9770,221 +10043,436 @@ workflows:
     - j8_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j8_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_simulator_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_jvm_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_jvm_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_jvm_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlshlib_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlshlib_cython_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_unit_tests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_utests_long:
         type: approval
     - j8_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - j11_utests_long:
         requires:
         - start_utests_long
         - j8_build
+        upstream:
+          start_utests_long:
+          - success
+          j8_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j8_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j8_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j8_build:
+          - success
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j8_build
+        upstream:
+          start_utests_compression:
+          - success
+          j8_build:
+          - success
     - start_utests_stress:
         type: approval
     - j8_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j8_build
+        upstream:
+          start_utests_stress:
+          - success
+          j8_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j8_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j8_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j8_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j8_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_dtest_jars_build:
         requires:
         - j8_build
         - start_jvm_upgrade_dtests
+        upstream:
+          j8_build:
+          - success
+          start_jvm_upgrade_dtests:
+          - success
     - j8_jvm_upgrade_dtests:
         requires:
         - j8_dtest_jars_build
+        upstream:
+          j8_dtest_jars_build:
+          - success
     - j8_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_dtests_offheap:
         type: approval
     - j8_dtests_offheap:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_dtests:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j8_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - start_j8_dtests_large:
         type: approval
     - j8_dtests_large:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - j8_dtests_large_vnode:
         requires:
         - start_j8_dtests_large
         - j8_build
+        upstream:
+          start_j8_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j8_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j8_build:
+          - success
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - j8_build
         - start_upgrade_dtests
+        upstream:
+          j8_build:
+          - success
+          start_upgrade_dtests:
+          - success
     - j8_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j8_cqlsh_dtests_offheap:
         type: approval
     - j8_cqlsh_dtests_py3_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py38_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j8_cqlsh_dtests_py311_offheap:
         requires:
         - start_j8_cqlsh_dtests_offheap
         - j8_build
+        upstream:
+          start_j8_cqlsh_dtests_offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j8_build
+        upstream:
+          j8_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j8_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j8_build:
+          - success
   java11_separate_tests:
     jobs:
     - start_j11_build:
@@ -9992,142 +10480,270 @@ workflows:
     - j11_build:
         requires:
         - start_j11_build
+        upstream:
+          start_j11_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j11_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j11_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests_vnode:
         type: approval
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_jvm_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j11_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py3:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j11_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j11_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j11_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10135,108 +10751,210 @@ workflows:
     - j11_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j11_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
         - j11_build
+        upstream:
+          start_j11_dtests_offheap:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py3_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_cqlsh-dtests-offheap:
         type: approval
     - j11_cqlsh_dtests_py3_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_offheap:
         requires:
         - start_j11_cqlsh-dtests-offheap
         - j11_build
+        upstream:
+          start_j11_cqlsh-dtests-offheap:
+          - success
+          j11_build:
+          - success
     - start_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -656,6 +657,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     private void evictFromMembership(InetAddressAndPort endpoint)
     {
         checkProperThreadForStateMutation();
+        inflightEcho.remove(endpoint);
         unreachableEndpoints.remove(endpoint);
         endpointStateMap.remove(endpoint);
         expireTimeEndpointMap.remove(endpoint);
@@ -1396,13 +1398,30 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         {
             Message<NoPayload> echoMessage = Message.out(ECHO_REQ, noPayload);
             logger.trace("Sending ECHO_REQ to {}", addr);
-            RequestCallback echoHandler = msg ->
+            RequestCallback echoHandler = new RequestCallback()
             {
-                runInGossipStageBlocking(() -> {
-                    EndpointState epState = inflightEcho.remove(addr);
-                    if (epState != null)
-                        realMarkAlive(addr, epState);
-                });
+                @Override
+                public void onResponse(Message msg)
+                {
+                    runInGossipStageBlocking(() -> {
+                        EndpointState epState = inflightEcho.remove(addr);
+                        if (epState != null)
+                            realMarkAlive(addr, epState);
+                    });
+                }
+
+                @Override
+                public boolean invokeOnFailure()
+                {
+                    return true;
+                }
+
+                @Override
+                public void onFailure(InetAddressAndPort from, RequestFailureReason failureReason)
+                {
+                    logger.trace("ECHO_REQ to {} failed ({})", addr, failureReason);
+                    inflightEcho.remove(addr);
+                }
             };
             MessagingService.instance().sendWithCallback(echoMessage, addr, echoHandler);
         }


### PR DESCRIPTION
In Gossiper, echoHandler only implements onResponse. RequestCallback.onFailure has a default no-op, so when the ECHO_REQ times out or the remote node returns an error, inflightEcho.remove(addr) is never called. The stale entry persists. Any subsequent markAlive(addr, localState) call — where localState is the same in-place-mutated object already in inflightEcho — sees localState.equals(prevState) = true (identity equality, same reference) and skips indefinitely. In a temporary-partition scenario (node briefly unreachable, echo times out, node recovers with the same generation), the node can get stuck permanently dead: the failure detector sees it as alive and keeps triggering markAlive, but every invocation is suppressed by the stale entry. The stale entry is only cleared by removeEndpoint() (explicit removal) or silentlyMarkDead() via markDead() (failure detector conviction) — neither of which fires if the failure detector is reporting the node as healthy.

Fix: override onFailure in echoHandler to call inflightEcho.remove(addr).