### PR TITLE
CASSANDRA-21448: Fix structural Antora errors in in-tree docs

### DIFF
--- a/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
@@ -1809,7 +1809,7 @@ doing'', you can force the execution of this query by using
 SELECT firstname, lastname FROM users WHERE birth_year = 1981 AND
 country = 'FR' ALLOW FILTERING;
 
-include::security.adoc[]
+include::security.adoc[leveloffset=+1]
 
 [[types]]
 === Data Types
@@ -2979,4 +2979,4 @@ names as their name.
 |`macaddr`
 |===
 
-include::changes.adoc[]
+include::changes.adoc[leveloffset=+1]

--- a/doc/modules/cassandra/pages/developing/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/ddl.adoc
@@ -112,7 +112,7 @@ replication factor independently for each data-center. The rest of the
 sub-options are key-value pairs, with a key set to a data-center name and
 its value set to the associated replication factor. Options:
 
-[cols=",,,",options="header",]
+[cols=",,",options="header",]
 |===
 |sub-option |type |description
 |`'<datacenter>'` | int | The number of replicas to store per range in the provided datacenter.

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_conceptual.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_conceptual.adoc
@@ -30,7 +30,7 @@ underlined. Relationships between entities are represented as diamonds,
 and the connectors between the relationship and each entity show the
 multiplicity of the connection.
 
-image::images/data_modeling_hotel_erd.png[image]
+image::data_modeling_hotel_erd.png[image]
 
 Obviously, in the real world, there would be many more considerations
 and much more complexity. For example, hotel rates are notoriously

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_logical.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_logical.adoc
@@ -34,7 +34,7 @@ informative way to visualize the relationships between queries and
 tables in your designs. This figure shows the Chebotko notation for a
 logical data model.
 
-image::images/data_modeling_chebotko_logical.png[image]
+image::data_modeling_chebotko_logical.png[image]
 
 Each table is shown with its title and a list of columns. Primary key
 columns are identified via symbols such as *K* for partition key columns
@@ -51,7 +51,7 @@ dedicated tables for rooms or amenities, as you had in the relational
 design. This is because the workflow didn't identify any queries
 requiring this direct access.
 
-image::images/data_modeling_hotel_logical.png[image]
+image::data_modeling_hotel_logical.png[image]
 
 Let's explore the details of each of these tables.
 
@@ -127,7 +127,7 @@ shows a logical data model for reservations. You'll notice that these
 tables represent a denormalized design; the same data appears in
 multiple tables, with differing keys.
 
-image::images/data_modeling_reservation_logical.png[image]
+image::data_modeling_reservation_logical.png[image]
 
 In order to satisfy Q6, the `reservations_by_guest` table can be used to
 look up the reservation by guest name. You could envision query Q7 being

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_physical.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_physical.adoc
@@ -19,7 +19,7 @@ notation for physical data models. To draw physical models, you need to
 be able to add the typing information for each column. This figure shows
 the addition of a type for each column in a sample table.
 
-image::images/data_modeling_chebotko_physical.png[image]
+image::data_modeling_chebotko_physical.png[image]
 
 The figure includes a designation of the keyspace containing each table
 and visual cues for columns represented using collections and
@@ -61,7 +61,7 @@ As you work to create physical representations of various tables in the
 logical hotel data model, you use the same approach. The resulting
 design is shown in this figure:
 
-image::images/data_modeling_hotel_physical.png[image]
+image::data_modeling_hotel_physical.png[image]
 
 Note that the `address` type is also included in the design. It is
 designated with an asterisk to denote that it is a user-defined type,
@@ -86,7 +86,7 @@ first iteration of your physical data model design, assume you're going
 to manage this denormalization manually. Note that this design could be
 revised to use Cassandra's (experimental) materialized view feature.
 
-image::images/data_modeling_reservation_physical.png[image]
+image::data_modeling_reservation_physical.png[image]
 
 Note that the `address` type is reproduced in this keyspace and
 `guest_id` is modeled as a `uuid` type in all of the tables.

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_queries.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_queries.adoc
@@ -53,7 +53,7 @@ to obtain detailed description of the hotel. The act of booking a room
 creates a reservation record that may be accessed by the guest and hotel
 staff at a later time through various additional queries.
 
-image::images/data_modeling_hotel_queries.png[image]
+image::data_modeling_hotel_queries.png[image]
 
 _Material adapted from Cassandra, The Definitive Guide. Published by
 O'Reilly Media, Inc. Copyright © 2020 Jeff Carpenter, Eben Hewitt. All

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_rdbms.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_rdbms.adoc
@@ -12,7 +12,7 @@ relationships from the conceptual model of hotels-to-points of interest,
 rooms-to-amenities, rooms-to-availability, and guests-to-rooms (via a
 reservation).
 
-image::images/data_modeling_hotel_relational.png[image]
+image::data_modeling_hotel_relational.png[image]
 
 == Design Differences Between RDBMS and Cassandra
 

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
@@ -188,7 +188,7 @@ the original design is shown in the figure below. While the `month`
 column is partially duplicative of the `date`, it provides a nice way of
 grouping related data in a partition that will not get too large.
 
-image::images/data_modeling_hotel_bucketing.png[image]
+image::data_modeling_hotel_bucketing.png[image]
 
 If you really felt strongly about preserving a wide partition design,
 you could instead add the `room_id` to the partition key, so that each

--- a/doc/modules/cassandra/pages/developing/data-modeling/intro.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/intro.adoc
@@ -150,7 +150,7 @@ consist of `id` ( for partition key), magazine name and publication
 frequency as shown in Figure 1.
 
 .Data Model for Q1
-image::images/Figure_1_data_model.jpg[image]
+image::Figure_1_data_model.jpg[image]
 
 Another query (Q2) is to list all the magazine names by publisher. For
 Q2 the data model would consist of an additional attribute `publisher`
@@ -159,7 +159,7 @@ sorting within a partition. Data model for Q2 is illustrated in Figure
 2.
 
 .Data Model for Q2
-image::images/Figure_2_data_model.jpg[image]
+image::Figure_2_data_model.jpg[image]
 
 == Designing Schema
 

--- a/doc/modules/cassandra/pages/managing/tools/sstable/sstablemetadata.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/sstable/sstablemetadata.adoc
@@ -337,7 +337,7 @@ seconds
 |Count Row Size Cell Count |two histograms in two columns; one
 represents distribution of Row Size and the other represents
 distribution of Cell Count
-|Estimated cardinality an estimate of unique
+|Estimated cardinality |an estimate of unique
 values, used for compaction
 |EncodingStats* minTTL |in epoch milliseconds
 |EncodingStats* minLocalDeletionTime |in epoch seconds


### PR DESCRIPTION
Fixes the three structural (non-xref) error classes surfaced by the Antora 3 trial build of the in-tree docs. Child of epic CASSANDRA-21314; together with CASSANDRA-21449 this blocks the Antora 3 reland (CASSANDRA-21315), which is gated on a zero-error build.

### What changed

**1. Missing data-modeling images (12 image macros, 7 pages)**

All 12 referenced files (`data_modeling_*.png` ×10, `Figure_*_data_model.jpg` ×2) already exist in `doc/modules/cassandra/assets/images/` — nothing was ever lost, so nothing needed restoring from history. The page sources carry a stale `images/` path prefix from the original rST→AsciiDoc migration (`image::images/foo.png[]`), which Antora resolves against the module's image family as `assets/images/images/foo.png` and fails. The fix strips the prefix. Every image renders again; no figure was removed and no pedagogical content is affected.

**2. Level-0 section errors (`security.adoc`, `changes.adoc`)**

The standalone pages are fine — the errors come from `cql_singlefile.adoc`, which includes both pages whole, turning their `=` doctitles into illegal level-0 sections inside the including document. Fixed by adding `leveloffset=+1` to the two includes, so the included titles land as `==` sections — consistent siblings of the singlefile's existing `== CQL Syntax` / `== Terms` / `== Data Definition`. No prose changed; the rendered singlefile now nests "Database Roles" and "CQL Changes" as proper h2 sections.

**3. Malformed tables (2 sites)**

- `developing/cql/ddl.adoc` — the `NetworkTopologyStrategy` options table declared four columns (`cols=",,,"`) while every row has three cells. Corrected the spec to `cols=",,"`.
- `managing/tools/sstable/sstablemetadata.adoc` — the value-explanation table row `|Estimated cardinality an estimate of unique values…` was missing its cell separator, leaving the 2-column table with an odd cell count. Restored the `|` between value and explanation.

Table content is unchanged in both.

### Verification

Antora 3 trial build (cassandra-website at the Antora 3.1.14 / Node 24 stack commit `897d1a67`, JSON logging, `./run.sh website build -e .xref-env -g -u cassandra:../cassandra -b cassandra:trunk`), measured with `xref-report.sh`:

| | before (trunk `0d87b2d76a`) | after (this branch) |
|---|---|---|
| total error-level entries | **33** | **17** |
| image | 12 | 0 |
| section | 2 | 0 |
| table | 2 | 0 |
| xref | 17 | 17 |

All 16 structural error entries are gone; the surviving 17 xref entries are byte-identical before and after (zero new errors). These 16 sites are the same population the trial-build log reported as 32 entries — that log carried each message twice. The remaining 17 xref errors are tracked separately (CASSANDRA-21449 and the Phase 4 long-tail under CASSANDRA-21342).

### AI-assistance disclosure

This change was prepared with AI assistance (Claude). All edits were validated against a full Antora 3 site build as described above, and the before/after error inventories were diffed mechanically. Per project convention the AI attribution lives in this PR body rather than in commit trailers.
