### PR TITLE
CASSANDRA-21458 Update serializers to allow comparison between two LET variables

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -73,6 +73,9 @@ options {
         if (!isParsingTxn)
             throw new SyntaxException("Cannot create a row data reference unless parsing a transaction");
 
+        if (tuple == null)
+            throw new SyntaxException("Invalid syntax for row data reference");
+
         if (references == null)
             references = new ArrayList<>();
 

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -836,15 +836,6 @@ txnConditionKind returns [ConditionStatement.Kind op]
     | '!=' { $op = ConditionStatement.Kind.NEQ; }
     ;
 
-txnConditionKindRef returns [ConditionStatement.Kind op]
-    : '='  { $op = ConditionStatement.Kind.EQ_REF; }
-    | '<'  { $op = ConditionStatement.Kind.LT_REF; }
-    | '<=' { $op = ConditionStatement.Kind.LTE_REF; }
-    | '>'  { $op = ConditionStatement.Kind.GT_REF; }
-    | '>=' { $op = ConditionStatement.Kind.GTE_REF; }
-    | '!=' { $op = ConditionStatement.Kind.NEQ_REF; }
-    ;
-
 txnColumnCondition[List<ConditionStatement.Raw> conditions]
     : lhs=rowDataReference
       ( 
@@ -854,7 +845,7 @@ txnColumnCondition[List<ConditionStatement.Raw> conditions]
             | K_NULL { conditions.add(new ConditionStatement.Raw(lhs, ConditionStatement.Kind.IS_NULL, null)); }
         )
         | (txnConditionKind term)=> op=txnConditionKind t=term { conditions.add(new ConditionStatement.Raw(lhs, op, t)); }
-        | (txnConditionKindRef rowDataReference)=> op=txnConditionKindRef rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
+        | (txnConditionKind rowDataReference)=> op=txnConditionKind rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
       )
     | lhs=term op=txnConditionKind rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
     ;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -837,7 +837,8 @@ txnConditionKind returns [ConditionStatement.Kind op]
     ;
 
 txnColumnCondition[List<ConditionStatement.Raw> conditions]
-    : lhs=rowDataReference
+    :  '!' lhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, ConditionStatement.Kind.EQ, Constants.Literal.bool("false"))); }
+    | lhs=rowDataReference
       ( 
         K_IS 
         (
@@ -846,6 +847,7 @@ txnColumnCondition[List<ConditionStatement.Raw> conditions]
         )
         | (txnConditionKind term)=> op=txnConditionKind t=term { conditions.add(new ConditionStatement.Raw(lhs, op, t)); }
         | (txnConditionKind rowDataReference)=> op=txnConditionKind rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
+        | { conditions.add(new ConditionStatement.Raw(lhs, ConditionStatement.Kind.EQ, Constants.Literal.bool("true"))); }
       )
     | lhs=term op=txnConditionKind rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
     ;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -836,6 +836,15 @@ txnConditionKind returns [ConditionStatement.Kind op]
     | '!=' { $op = ConditionStatement.Kind.NEQ; }
     ;
 
+txnConditionKindRef returns [ConditionStatement.Kind op]
+    : '='  { $op = ConditionStatement.Kind.EQ_REF; }
+    | '<'  { $op = ConditionStatement.Kind.LT_REF; }
+    | '<=' { $op = ConditionStatement.Kind.LTE_REF; }
+    | '>'  { $op = ConditionStatement.Kind.GT_REF; }
+    | '>=' { $op = ConditionStatement.Kind.GTE_REF; }
+    | '!=' { $op = ConditionStatement.Kind.NEQ_REF; }
+    ;
+
 txnColumnCondition[List<ConditionStatement.Raw> conditions]
     : lhs=rowDataReference
       ( 
@@ -845,6 +854,7 @@ txnColumnCondition[List<ConditionStatement.Raw> conditions]
             | K_NULL { conditions.add(new ConditionStatement.Raw(lhs, ConditionStatement.Kind.IS_NULL, null)); }
         )
         | (txnConditionKind term)=> op=txnConditionKind t=term { conditions.add(new ConditionStatement.Raw(lhs, op, t)); }
+        | (txnConditionKindRef rowDataReference)=> op=txnConditionKindRef rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
       )
     | lhs=term op=txnConditionKind rhs=rowDataReference { conditions.add(new ConditionStatement.Raw(lhs, op, rhs)); }
     ;

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.terms.Term;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.accord.txn.TxnCondition;
 import org.apache.cassandra.service.accord.txn.TxnReference;
 
@@ -108,7 +109,7 @@ public class ConditionStatement
                 if (((RowDataReference.Raw) rhs).column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 if (!((RowDataReference.Raw) lhs).column().type.equals(((RowDataReference.Raw) rhs).column().type))
-                    throw new IllegalStateException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
+                    throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
             }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -40,8 +40,14 @@ public class ConditionStatement
         GT(TxnCondition.Kind.GREATER_THAN, TxnCondition.Kind.LESS_THAN),
         GTE(TxnCondition.Kind.GREATER_THAN_OR_EQUAL, TxnCondition.Kind.LESS_THAN_OR_EQUAL),
         LT(TxnCondition.Kind.LESS_THAN, TxnCondition.Kind.GREATER_THAN),
-        LTE(TxnCondition.Kind.LESS_THAN_OR_EQUAL, TxnCondition.Kind.GREATER_THAN_OR_EQUAL);
-        
+        LTE(TxnCondition.Kind.LESS_THAN_OR_EQUAL, TxnCondition.Kind.GREATER_THAN_OR_EQUAL),
+        EQ_REF(TxnCondition.Kind.EQUAL_REF, TxnCondition.Kind.EQUAL_REF),
+        NEQ_REF(TxnCondition.Kind.NOT_EQUAL_REF, TxnCondition.Kind.NOT_EQUAL_REF),
+        GT_REF(TxnCondition.Kind.GREATER_THAN_REF, TxnCondition.Kind.LESS_THAN_REF),
+        GTE_REF(TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF, TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF),
+        LT_REF(TxnCondition.Kind.LESS_THAN_REF, TxnCondition.Kind.GREATER_THAN_REF),
+        LTE_REF(TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF, TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF);
+
         // TODO: Support for IN, CONTAINS, CONTAINS KEY
 
         private final TxnCondition.Kind kind;
@@ -100,8 +106,13 @@ public class ConditionStatement
             RowDataReference reference;
             Term value;
             boolean reversed = false;
-            
-            if (lhs instanceof RowDataReference.Raw)
+
+            if (lhs instanceof RowDataReference.Raw && rhs instanceof RowDataReference.Raw)
+            {
+                reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
+                value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
+            }
+            else if (lhs instanceof RowDataReference.Raw)
             {
                 if (((RowDataReference.Raw) lhs).column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
@@ -143,13 +154,31 @@ public class ConditionStatement
             case GTE:
             case LT:
             case LTE:
-                // TODO: Support for references on LHS and RHS
-                TxnReference ref = reference.toTxnReference(options);
-                checkTrue(ref.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, ref.kind);
-                return new TxnCondition.Value(ref.asColumn(),
+            {
+                TxnReference refLHS = reference.toTxnReference(options);
+                checkTrue(refLHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refLHS.kind);
+
+                return new TxnCondition.Value(refLHS.asColumn(),
                                               kind.toTxnKind(reversed),
                                               value.bindAndGet(options),
                                               options.getProtocolVersion());
+            }
+            case EQ_REF:
+            case NEQ_REF:
+            case GT_REF:
+            case GTE_REF:
+            case LT_REF:
+            case LTE_REF:
+            {
+                TxnReference refLHS = reference.toTxnReference(options);
+                checkTrue(refLHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refLHS.kind);
+                TxnReference refRHS = ((RowDataReference) value).toTxnReference(options);
+                checkTrue(refRHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refRHS.kind);
+                return new TxnCondition.Reference(refLHS.asColumn(),
+                                                  kind.toTxnKind(reversed),
+                                                  refRHS.asColumn(),
+                                                  options.getProtocolVersion());
+            }
             default:
                 throw new IllegalStateException();
         }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -104,15 +104,15 @@ public class ConditionStatement
 
             if (lhs instanceof RowDataReference.Raw && rhs instanceof RowDataReference.Raw)
             {
-                RowDataReference.Raw rawDataReferenceLHS = ((RowDataReference.Raw) lhs);
-                RowDataReference.Raw rawDataReferenceRHS = ((RowDataReference.Raw) rhs);
+                RowDataReference.Raw rowDataReferenceLHS = ((RowDataReference.Raw) lhs);
+                RowDataReference.Raw rowDataReferenceRHS = ((RowDataReference.Raw) rhs);
 
-                if (rawDataReferenceLHS.column() == null)
+                if (rowDataReferenceLHS.column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
-                if (rawDataReferenceRHS.column() == null)
+                if (rowDataReferenceRHS.column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
-                reference = rawDataReferenceLHS.prepareAsReceiver();
-                value = rawDataReferenceRHS.prepareAsReceiver();
+                reference = rowDataReferenceLHS.prepareAsReceiver();
+                value = rowDataReferenceRHS.prepareAsReceiver();
                 if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.terms.Term;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.accord.txn.TxnCondition;
 import org.apache.cassandra.service.accord.txn.TxnReference;
@@ -118,7 +119,10 @@ public class ConditionStatement
                 reference.getValueReceiver();
                 ((RowDataReference) value).getValueReceiver();
 
-                if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
+                AbstractType<?> lhsType = reference.toResultMetadata().type.unwrap();
+                AbstractType<?> rhsType = ((RowDataReference) value).toResultMetadata().type.unwrap();
+
+                if (!lhsType.unwrap().equals(rhsType.unwrap()))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }
             else if (lhs instanceof RowDataReference.Raw)

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -40,13 +40,7 @@ public class ConditionStatement
         GT(TxnCondition.Kind.GREATER_THAN, TxnCondition.Kind.LESS_THAN),
         GTE(TxnCondition.Kind.GREATER_THAN_OR_EQUAL, TxnCondition.Kind.LESS_THAN_OR_EQUAL),
         LT(TxnCondition.Kind.LESS_THAN, TxnCondition.Kind.GREATER_THAN),
-        LTE(TxnCondition.Kind.LESS_THAN_OR_EQUAL, TxnCondition.Kind.GREATER_THAN_OR_EQUAL),
-        EQ_REF(TxnCondition.Kind.EQUAL_REF, TxnCondition.Kind.EQUAL_REF),
-        NEQ_REF(TxnCondition.Kind.NOT_EQUAL_REF, TxnCondition.Kind.NOT_EQUAL_REF),
-        GT_REF(TxnCondition.Kind.GREATER_THAN_REF, TxnCondition.Kind.LESS_THAN_REF),
-        GTE_REF(TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF, TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF),
-        LT_REF(TxnCondition.Kind.LESS_THAN_REF, TxnCondition.Kind.GREATER_THAN_REF),
-        LTE_REF(TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF, TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF);
+        LTE(TxnCondition.Kind.LESS_THAN_OR_EQUAL, TxnCondition.Kind.GREATER_THAN_OR_EQUAL);
 
         // TODO: Support for IN, CONTAINS, CONTAINS KEY
 
@@ -160,31 +154,22 @@ public class ConditionStatement
             case GTE:
             case LT:
             case LTE:
-            {
                 TxnReference refLHS = reference.toTxnReference(options);
                 checkTrue(refLHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refLHS.kind);
+                if (value instanceof RowDataReference)
+                {
+                    TxnReference refRHS = ((RowDataReference) value).toTxnReference(options);
+                    checkTrue(refRHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refRHS.kind);
+                    return new TxnCondition.Reference(refLHS.asColumn(),
+                                                      kind.toTxnKind(reversed),
+                                                      refRHS.asColumn(),
+                                                      options.getProtocolVersion());
+                }
 
                 return new TxnCondition.Value(refLHS.asColumn(),
                                               kind.toTxnKind(reversed),
                                               value.bindAndGet(options),
                                               options.getProtocolVersion());
-            }
-            case EQ_REF:
-            case NEQ_REF:
-            case GT_REF:
-            case GTE_REF:
-            case LT_REF:
-            case LTE_REF:
-            {
-                TxnReference refLHS = reference.toTxnReference(options);
-                checkTrue(refLHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refLHS.kind);
-                TxnReference refRHS = ((RowDataReference) value).toTxnReference(options);
-                checkTrue(refRHS.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, refRHS.kind);
-                return new TxnCondition.Reference(refLHS.asColumn(),
-                                                  kind.toTxnKind(reversed),
-                                                  refRHS.asColumn(),
-                                                  options.getProtocolVersion());
-            }
             default:
                 throw new IllegalStateException();
         }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -118,13 +118,13 @@ public class ConditionStatement
                 reference.getValueReceiver();
                 ((RowDataReference) value).getValueReceiver();
 
-                if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
+                if (!(reference.toResultMetadata().type == (((RowDataReference) value).toResultMetadata().type)))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }
             else if (lhs instanceof RowDataReference.Raw)
             {
                 if (((RowDataReference.Raw) lhs).column() == null)
-                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
+                    throw new InvalidRequestException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 ColumnSpecification receiver = reference.getValueReceiver();
                 value = rhs.prepare(keyspace, receiver);
@@ -132,7 +132,7 @@ public class ConditionStatement
             else if (rhs instanceof RowDataReference.Raw)
             {
                 if (((RowDataReference.Raw) rhs).column() == null)
-                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
+                    throw new InvalidRequestException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 reference = ((RowDataReference.Raw) rhs).prepareAsReceiver();
                 ColumnSpecification receiver = reference.getValueReceiver();
                 value = lhs.prepare(keyspace, receiver);

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -118,7 +118,7 @@ public class ConditionStatement
                 reference.getValueReceiver();
                 ((RowDataReference) value).getValueReceiver();
 
-                if (!(reference.toResultMetadata().type == (((RowDataReference) value).toResultMetadata().type)))
+                if (!(reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type)))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }
             else if (lhs instanceof RowDataReference.Raw)

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -108,9 +108,9 @@ public class ConditionStatement
                 RowDataReference.Raw rowDataReferenceRHS = ((RowDataReference.Raw) rhs);
 
                 if (rowDataReferenceLHS.column() == null)
-                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
+                    throw new InvalidRequestException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
                 if (rowDataReferenceRHS.column() == null)
-                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
+                    throw new InvalidRequestException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 reference = rowDataReferenceLHS.prepareAsReceiver();
                 value = rowDataReferenceRHS.prepareAsReceiver();
                 if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -118,7 +118,7 @@ public class ConditionStatement
                 reference.getValueReceiver();
                 ((RowDataReference) value).getValueReceiver();
 
-                if (!(reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type)))
+                if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }
             else if (lhs instanceof RowDataReference.Raw)

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -104,12 +104,15 @@ public class ConditionStatement
 
             if (lhs instanceof RowDataReference.Raw && rhs instanceof RowDataReference.Raw)
             {
-                if (((RowDataReference.Raw) lhs).column() == null)
+                RowDataReference.Raw rawDataReferenceLHS = ((RowDataReference.Raw) lhs);
+                RowDataReference.Raw rawDataReferenceRHS = ((RowDataReference.Raw) rhs);
+
+                if (rawDataReferenceLHS.column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
-                if (((RowDataReference.Raw) rhs).column() == null)
+                if (rawDataReferenceRHS.column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
-                reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
-                value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
+                reference = rawDataReferenceLHS.prepareAsReceiver();
+                value = rawDataReferenceRHS.prepareAsReceiver();
                 if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -109,6 +109,12 @@ public class ConditionStatement
 
             if (lhs instanceof RowDataReference.Raw && rhs instanceof RowDataReference.Raw)
             {
+                if (((RowDataReference.Raw) lhs).column() == null)
+                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
+                if (((RowDataReference.Raw) rhs).column() == null)
+                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
+                if (!((RowDataReference.Raw) lhs).column().type.equals(((RowDataReference.Raw) rhs).column().type))
+                    throw new IllegalStateException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
             }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.terms.Term;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.accord.txn.TxnCondition;
 import org.apache.cassandra.service.accord.txn.TxnReference;
 
@@ -109,6 +110,8 @@ public class ConditionStatement
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
+                if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
+                    throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }
             else if (lhs instanceof RowDataReference.Raw)
             {

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -24,7 +24,6 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.terms.Term;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.accord.txn.TxnCondition;
 import org.apache.cassandra.service.accord.txn.TxnReference;
 
@@ -108,8 +107,6 @@ public class ConditionStatement
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
                 if (((RowDataReference.Raw) rhs).column() == null)
                     throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
-                if (!((RowDataReference.Raw) lhs).column().type.equals(((RowDataReference.Raw) rhs).column().type))
-                    throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 value = ((RowDataReference.Raw) rhs).prepareAsReceiver();
             }

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -113,6 +113,11 @@ public class ConditionStatement
                     throw new InvalidRequestException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 reference = rowDataReferenceLHS.prepareAsReceiver();
                 value = rowDataReferenceRHS.prepareAsReceiver();
+
+                // Done for validation of element selection
+                reference.getValueReceiver();
+                ((RowDataReference) value).getValueReceiver();
+
                 if (!reference.toResultMetadata().type.equals(((RowDataReference) value).toResultMetadata().type))
                     throw new InvalidRequestException(String.format("Row reference (%s) must have the same type as row reference (%s)", lhs.getText(), rhs.getText()));
             }

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -104,39 +104,39 @@ public abstract class TxnCondition
         long serializedSize(T condition, TableMetadatas tables);
     }
 
+    // For enums with a REF suffixed, we are performing a comparison of two LET variables
+    // otherwise EQUAL, NOT_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL
+    // are used for comparisions between a LET variable and a value
     public enum Kind
     {
-        NONE("n/a", null, null),
-        AND("AND", null, null),
-        OR("OR", null, null),
-        IS_NOT_NULL("IS NOT NULL", null, null),
-        IS_NULL("IS NULL", null, null),
-        EQUAL("=", Operator.EQ, false),
-        NOT_EQUAL("!=", Operator.NEQ, false),
-        GREATER_THAN(">", Operator.GT, false),
-        GREATER_THAN_OR_EQUAL(">=", Operator.GTE, false),
-        LESS_THAN("<", Operator.LT, false),
-        LESS_THAN_OR_EQUAL("<=", Operator.LTE, false),
-        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null, false),
-        EQUAL_REF("=", Operator.EQ, true),
-        NOT_EQUAL_REF("!=", Operator.NEQ, true),
-        GREATER_THAN_REF(">", Operator.GT, true),
-        GREATER_THAN_OR_EQUAL_REF(">=", Operator.GTE, true),
-        LESS_THAN_REF("<", Operator.LT, true),
-        LESS_THAN_OR_EQUAL_REF("<=", Operator.LTE, true);
+        NONE("n/a", null),
+        AND("AND", null),
+        OR("OR", null),
+        IS_NOT_NULL("IS NOT NULL", null),
+        IS_NULL("IS NULL", null),
+        EQUAL("=", Operator.EQ),
+        NOT_EQUAL("!=", Operator.NEQ),
+        GREATER_THAN(">", Operator.GT),
+        GREATER_THAN_OR_EQUAL(">=", Operator.GTE),
+        LESS_THAN("<", Operator.LT),
+        LESS_THAN_OR_EQUAL("<=", Operator.LTE),
+        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null),
+        EQUAL_REF("=", Operator.EQ),
+        NOT_EQUAL_REF("!=", Operator.NEQ),
+        GREATER_THAN_REF(">", Operator.GT),
+        GREATER_THAN_OR_EQUAL_REF(">=", Operator.GTE),
+        LESS_THAN_REF("<", Operator.LT),
+        LESS_THAN_OR_EQUAL_REF("<=", Operator.LTE);
 
         @Nonnull
         private final String symbol;
         @Nullable
         private final Operator operator;
-        @Nullable
-        private final Boolean isReference;
 
-        Kind(String symbol, Operator operator, Boolean isReference)
+        Kind(String symbol, Operator operator)
         {
             this.symbol = symbol;
             this.operator = operator;
-            this.isReference = isReference;
         }
 
         @SuppressWarnings("rawtypes")

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -700,8 +700,10 @@ public abstract class TxnCondition
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
             AbstractType<?> typeRHS = getColumnType(referenceRHS);
 
+            Invariants.require(typeLHS.equals(typeRHS));
+
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
-            ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeRHS);
+            ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeLHS);
 
             if (lhs == null || rhs == null)
                 return false;

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -674,7 +674,7 @@ public abstract class TxnCondition
             return referenceLHS.toString() + ' ' + kind.symbol + ' ' + referenceRHS.toString();
         }
 
-        public AbstractType<?> getColumnType(TxnReference.ColumnReference reference)
+        private static AbstractType<?> getColumnType(TxnReference.ColumnReference reference)
         {
             ColumnMetadata column = reference.column();
             if (reference.isElementSelection())
@@ -700,12 +700,12 @@ public abstract class TxnCondition
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
             AbstractType<?> typeRHS = getColumnType(referenceRHS);
 
-            Invariants.require(typeLHS.equals(typeRHS));
+            Invariants.require(typeLHS == typeRHS);
 
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
             ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeLHS);
 
-            if (lhs == null || rhs == null)
+            if (lhs == null || rhs == null || typeLHS.isNull(lhs) || typeLHS.isNull(rhs))
                 return false;
 
             return kind.operator.isSatisfiedBy(typeLHS, lhs, rhs);

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -797,10 +797,14 @@ public abstract class TxnCondition
 
     public static final ParameterisedUnversionedSerializer<TxnCondition, TableMetadatas> serializer = new ParameterisedUnversionedSerializer<>()
     {
-        // TOP_BIT is used to differentiate between Value.Serializer and Reference.Serialzer.
-        // This is so done to preserve upgrade compatibility with the prior serializer.
-        // Nodes that are not yet upgraded can still deserialize all values modulo those that are
-        // of Reference type and upgraded nodes can deserialize all values from older nodes.
+        // TOP_BIT is used to differentiate between Value.Serializer and Reference.Serialzer,
+        // in order to implement comparison between LET variables.
+        // The reason we use TOP_BIT is to support users who have been deploying off trunk
+        // to upgrade nodes without breaking them. Upgrading is safe under the following assumptions:
+        // 1) `ref op ref` feature is only used after all nodes have been upgraded
+        // 2) cluster can be mixed mode as long as `ref op ref` is not used
+        // If a user tries to use `ref op ref` in a mixed mode this will lead to undefined errors,
+        // where the only recovery process is to force older nodes to upgrade
         // See CASSANDRA-21458
         private static final int TOP_BIT = 0x40000000;
 

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -106,28 +106,37 @@ public abstract class TxnCondition
 
     public enum Kind
     {
-        NONE("n/a", null),
-        AND("AND", null),
-        OR("OR", null),
-        IS_NOT_NULL("IS NOT NULL", null),
-        IS_NULL("IS NULL", null),
-        EQUAL("=", Operator.EQ),
-        NOT_EQUAL("!=", Operator.NEQ),
-        GREATER_THAN(">", Operator.GT),
-        GREATER_THAN_OR_EQUAL(">=", Operator.GTE),
-        LESS_THAN("<", Operator.LT),
-        LESS_THAN_OR_EQUAL("<=", Operator.LTE),
-        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null);
+        NONE("n/a", null, null),
+        AND("AND", null, null),
+        OR("OR", null, null),
+        IS_NOT_NULL("IS NOT NULL", null, null),
+        IS_NULL("IS NULL", null, null),
+        EQUAL("=", Operator.EQ, false),
+        NOT_EQUAL("!=", Operator.NEQ, false),
+        GREATER_THAN(">", Operator.GT, false),
+        GREATER_THAN_OR_EQUAL(">=", Operator.GTE, false),
+        LESS_THAN("<", Operator.LT, false),
+        LESS_THAN_OR_EQUAL("<=", Operator.LTE, false),
+        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null, false),
+        EQUAL_REF("=", Operator.EQ, true),
+        NOT_EQUAL_REF("!=", Operator.NEQ, true),
+        GREATER_THAN_REF(">", Operator.GT, true),
+        GREATER_THAN_OR_EQUAL_REF(">=", Operator.GTE, true),
+        LESS_THAN_REF("<", Operator.LT, true),
+        LESS_THAN_OR_EQUAL_REF("<=", Operator.LTE, true);
 
         @Nonnull
         private final String symbol;
         @Nullable
         private final Operator operator;
+        @Nullable
+        private final Boolean isReference;
 
-        Kind(String symbol, Operator operator)
+        Kind(String symbol, Operator operator, Boolean isReference)
         {
             this.symbol = symbol;
             this.operator = operator;
+            this.isReference = isReference;
         }
 
         @SuppressWarnings("rawtypes")
@@ -145,6 +154,13 @@ public abstract class TxnCondition
                 case GREATER_THAN:
                 case GREATER_THAN_OR_EQUAL:
                     return Value.serializer;
+                case EQUAL_REF:
+                case NOT_EQUAL_REF:
+                case LESS_THAN_REF:
+                case LESS_THAN_OR_EQUAL_REF:
+                case GREATER_THAN_REF:
+                case GREATER_THAN_OR_EQUAL_REF:
+                    return Reference.serializer;
                 case AND:
                 case OR:
                     return BooleanGroup.serializer;
@@ -612,6 +628,107 @@ public abstract class TxnCondition
                 long size = 0;
                 size += TxnReference.serializer.serializedSize(condition.reference, tables);
                 size += ByteBufferUtil.serializedSizeWithVIntLength(condition.value);
+                size += TypeSizes.sizeof(condition.version.name());
+                return size;
+            }
+        };
+    }
+
+    public static class Reference extends TxnCondition
+    {
+        private static final EnumSet<Kind> KINDS = EnumSet.of(Kind.EQUAL_REF, Kind.NOT_EQUAL_REF,
+                                                              Kind.GREATER_THAN_REF, Kind.GREATER_THAN_OR_EQUAL_REF,
+                                                              Kind.LESS_THAN_REF, Kind.LESS_THAN_OR_EQUAL_REF);
+
+        private final TxnReference.ColumnReference referenceLHS;
+        private final TxnReference.ColumnReference referenceRHS;
+        private final ProtocolVersion version;
+
+        public Reference(TxnReference.ColumnReference referenceLHS, Kind kind, TxnReference.ColumnReference referenceRHS, ProtocolVersion version)
+        {
+            super(kind);
+            Invariants.requireArgument(KINDS.contains(kind), "Kind " + kind + " cannot be used with a value condition");
+            this.referenceLHS = referenceLHS;
+            this.referenceRHS = referenceRHS;
+            this.version = version;
+        }
+
+        public static EnumSet<Kind> supported()
+        {
+            return EnumSet.copyOf(KINDS);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Reference reference1 = (Reference) o;
+            return referenceLHS.equals(reference1.referenceLHS) && referenceRHS.equals(reference1.referenceRHS);
+        }
+
+        @Override
+        public void collect(TableMetadatas.Collector collector)
+        {
+            referenceLHS.collect(collector);
+            referenceRHS.collect(collector);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(super.hashCode(), referenceLHS, referenceRHS);
+        }
+
+        @Override
+        public String toString()
+        {
+            return referenceLHS.toString() + ' ' + kind.symbol + ' ' + referenceRHS.toString();
+        }
+
+        @Override
+        public boolean applies(TxnData data)
+        {
+            ColumnMetadata columnLHS = referenceLHS.column();
+            ColumnMetadata columnRHS = referenceRHS.column();
+
+            Preconditions.checkArgument(columnLHS.type.equals(columnRHS.type), columnLHS.type + " != " + columnRHS.type);
+
+            ByteBuffer lhs = referenceLHS.toByteBuffer(data, columnLHS.type);
+            ByteBuffer rhs = referenceRHS.toByteBuffer(data, columnRHS.type);
+
+            if (lhs == null || rhs == null)
+                return false;
+
+            return kind.operator.isSatisfiedBy(columnLHS.type, lhs, rhs);
+        }
+
+        private static final ConditionSerializer<Reference> serializer = new ConditionSerializer<>()
+        {
+            @Override
+            public void serialize(Reference condition, TableMetadatas tables, DataOutputPlus out) throws IOException
+            {
+                TxnReference.serializer.serialize(condition.referenceLHS, tables, out);
+                TxnReference.serializer.serialize(condition.referenceRHS, tables, out);
+                out.writeUTF(condition.version.name());
+            }
+
+            @Override
+            public Reference deserialize(TableMetadatas tables, DataInputPlus in, Kind kind) throws IOException
+            {
+                TxnReference.ColumnReference referenceLHS = TxnReference.serializer.deserialize(tables, in).asColumn();
+                TxnReference.ColumnReference referenceRHS = TxnReference.serializer.deserialize(tables, in).asColumn();
+                ProtocolVersion protocolVersion = ProtocolVersion.valueOf(in.readUTF());
+                return new Reference(referenceLHS, kind, referenceRHS, protocolVersion);
+            }
+
+            @Override
+            public long serializedSize(Reference condition, TableMetadatas tables)
+            {
+                long size = 0;
+                size += TxnReference.serializer.serializedSize(condition.referenceLHS, tables);
+                size += TxnReference.serializer.serializedSize(condition.referenceRHS, tables);
                 size += TypeSizes.sizeof(condition.version.name());
                 return size;
             }

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -104,9 +104,6 @@ public abstract class TxnCondition
         long serializedSize(T condition, TableMetadatas tables);
     }
 
-    // For enums with a REF suffixed, we are performing a comparison of two LET variables
-    // otherwise EQUAL, NOT_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL
-    // are used for comparisions between a LET variable and a value
     public enum Kind
     {
         NONE("n/a", null),
@@ -120,13 +117,7 @@ public abstract class TxnCondition
         GREATER_THAN_OR_EQUAL(">=", Operator.GTE),
         LESS_THAN("<", Operator.LT),
         LESS_THAN_OR_EQUAL("<=", Operator.LTE),
-        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null),
-        EQUAL_REF("=", Operator.EQ),
-        NOT_EQUAL_REF("!=", Operator.NEQ),
-        GREATER_THAN_REF(">", Operator.GT),
-        GREATER_THAN_OR_EQUAL_REF(">=", Operator.GTE),
-        LESS_THAN_REF("<", Operator.LT),
-        LESS_THAN_OR_EQUAL_REF("<=", Operator.LTE);
+        COLUMN_CONDITIONS("COLUMN_CONDITIONS", null);
 
         @Nonnull
         private final String symbol;
@@ -154,13 +145,6 @@ public abstract class TxnCondition
                 case GREATER_THAN:
                 case GREATER_THAN_OR_EQUAL:
                     return Value.serializer;
-                case EQUAL_REF:
-                case NOT_EQUAL_REF:
-                case LESS_THAN_REF:
-                case LESS_THAN_OR_EQUAL_REF:
-                case GREATER_THAN_REF:
-                case GREATER_THAN_OR_EQUAL_REF:
-                    return Reference.serializer;
                 case AND:
                 case OR:
                     return BooleanGroup.serializer;
@@ -636,9 +620,9 @@ public abstract class TxnCondition
 
     public static class Reference extends TxnCondition
     {
-        private static final EnumSet<Kind> KINDS = EnumSet.of(Kind.EQUAL_REF, Kind.NOT_EQUAL_REF,
-                                                              Kind.GREATER_THAN_REF, Kind.GREATER_THAN_OR_EQUAL_REF,
-                                                              Kind.LESS_THAN_REF, Kind.LESS_THAN_OR_EQUAL_REF);
+        private static final EnumSet<Kind> KINDS = EnumSet.of(Kind.EQUAL, Kind.NOT_EQUAL,
+                                                              Kind.GREATER_THAN, Kind.GREATER_THAN_OR_EQUAL,
+                                                              Kind.LESS_THAN, Kind.LESS_THAN_OR_EQUAL);
 
         private final TxnReference.ColumnReference referenceLHS;
         private final TxnReference.ColumnReference referenceRHS;
@@ -813,27 +797,60 @@ public abstract class TxnCondition
 
     public static final ParameterisedUnversionedSerializer<TxnCondition, TableMetadatas> serializer = new ParameterisedUnversionedSerializer<>()
     {
+        // TOP_BIT is used to differentiate between Value.Serializer and Reference.Serialzer.
+        // This is so done to preserve upgrade compatibility with the prior serializer.
+        // Nodes that are not yet upgraded can still deserialize all values modulo those that are
+        // of Reference type and upgraded nodes can deserialize all values from older nodes.
+        // See CASSANDRA-21458
+        private static final int TOP_BIT = 0x40000000;
+
         @SuppressWarnings("unchecked")
         @Override
         public void serialize(TxnCondition condition, TableMetadatas tables, DataOutputPlus out) throws IOException
         {
-            out.writeUnsignedVInt32(condition.kind.ordinal());
-            condition.kind.serializer().serialize(condition, tables, out);
+            if (condition instanceof Reference)
+            {
+                out.writeUnsignedVInt32(condition.kind.ordinal() | TOP_BIT);
+                Reference.serializer.serialize((Reference) condition, tables, out);
+            }
+            else
+            {
+                out.writeUnsignedVInt32(condition.kind.ordinal());
+                condition.kind.serializer().serialize(condition, tables, out);
+            }
         }
 
         @Override
         public TxnCondition deserialize(TableMetadatas tables, DataInputPlus in) throws IOException
         {
-            Kind kind = Kind.values()[in.readUnsignedVInt32()];
-            return kind.serializer().deserialize(tables, in, kind);
+            int flag = in.readUnsignedVInt32();
+            if ((flag & TOP_BIT) != 0)
+            {
+                Kind kind = Kind.values()[flag ^ TOP_BIT];
+                return Reference.serializer.deserialize(tables, in, kind);
+            }
+            else
+            {
+                Kind kind = Kind.values()[flag];
+                return kind.serializer().deserialize(tables, in, kind);
+            }
         }
 
         @SuppressWarnings("unchecked")
         @Override
         public long serializedSize(TxnCondition condition, TableMetadatas tables)
         {
-            long size = TypeSizes.sizeofUnsignedVInt(condition.kind.ordinal());
-            size += condition.kind.serializer().serializedSize(condition, tables);
+            long size;
+            if (condition instanceof Reference)
+            {
+                size = TypeSizes.sizeofUnsignedVInt(condition.kind.ordinal() | TOP_BIT);
+                size += Reference.serializer.serializedSize((Reference) condition, tables);
+            }
+            else
+            {
+                size = TypeSizes.sizeofUnsignedVInt(condition.kind.ordinal());
+                size += condition.kind.serializer().serializedSize(condition, tables);
+            }
             return size;
         }
     };

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -634,7 +634,7 @@ public abstract class TxnCondition
         public Reference(TxnReference.ColumnReference referenceLHS, Kind kind, TxnReference.ColumnReference referenceRHS, ProtocolVersion version)
         {
             super(kind);
-            Invariants.requireArgument(KINDS.contains(kind), "Kind " + kind + " cannot be used with a value condition");
+            Invariants.requireArgument(KINDS.contains(kind), "Kind " + kind + " cannot be used with a reference condition");
             this.referenceLHS = referenceLHS;
             this.referenceRHS = referenceRHS;
             this.version = version;
@@ -822,7 +822,7 @@ public abstract class TxnCondition
 
     public static final ParameterisedUnversionedSerializer<TxnCondition, TableMetadatas> serializer = new ParameterisedUnversionedSerializer<>()
     {
-        // TOP_BIT is used to differentiate between Value.Serializer and Reference.Serialzer,
+        // TOP_BIT is used to differentiate between Value.Serializer and Reference.Serializer,
         // in order to implement comparison between LET variables.
         // The reason we use TOP_BIT is to support users who have been deploying off trunk
         // to upgrade nodes without breaking them. Upgrading is safe under the following assumptions:

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -698,6 +698,7 @@ public abstract class TxnCondition
         public boolean applies(TxnData data)
         {
             // We have already checked earlier that the type for the LHS is the same as the type for the RHS
+            // See ConditionStatement.java
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
 
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -51,7 +51,6 @@ import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ColumnData;
 import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.db.rows.Row;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.io.ParameterisedUnversionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -700,9 +699,6 @@ public abstract class TxnCondition
         {
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
             AbstractType<?> typeRHS = getColumnType(referenceRHS);
-
-            if (typeLHS != typeRHS)
-                throw new InvalidRequestException(String.format("Invalid type comparison: cannot compare type %s with type %s", typeLHS.asCQL3Type(), typeRHS.asCQL3Type()));
 
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
             ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeRHS);

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -42,12 +42,16 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ColumnData;
 import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.io.ParameterisedUnversionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -671,19 +675,42 @@ public abstract class TxnCondition
             return referenceLHS.toString() + ' ' + kind.symbol + ' ' + referenceRHS.toString();
         }
 
+        public AbstractType<?> getColumnType(TxnReference.ColumnReference reference)
+        {
+            ColumnMetadata column = reference.column();
+            if (reference.isElementSelection())
+            {
+                if (column.type instanceof ListType)
+                    return ((ListType<?>) column.type).valueComparator();
+                else if (column.type instanceof SetType)
+                    return ((SetType<?>) column.type).nameComparator();
+                else if (column.type instanceof MapType)
+                    return ((MapType<?, ?>) column.type).valueComparator();
+            }
+            else if (reference.isFieldSelection())
+            {
+                return reference.getFieldSelectionType();
+            }
+
+            return column.type;
+        }
+
         @Override
         public boolean applies(TxnData data)
         {
-            ColumnMetadata columnLHS = referenceLHS.column();
-            ColumnMetadata columnRHS = referenceRHS.column();
+            AbstractType<?> typeLHS = getColumnType(referenceLHS);
+            AbstractType<?> typeRHS = getColumnType(referenceRHS);
 
-            ByteBuffer lhs = referenceLHS.toByteBuffer(data, columnLHS.type);
-            ByteBuffer rhs = referenceRHS.toByteBuffer(data, columnRHS.type);
+            if (typeLHS != typeRHS)
+                throw new InvalidRequestException(String.format("Invalid type comparison: cannot compare type %s with type %s", typeLHS.asCQL3Type(), typeRHS.asCQL3Type()));
+
+            ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
+            ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeRHS);
 
             if (lhs == null || rhs == null)
                 return false;
 
-            return kind.operator.isSatisfiedBy(columnLHS.type, lhs, rhs);
+            return kind.operator.isSatisfiedBy(typeLHS, lhs, rhs);
         }
 
         private static final ConditionSerializer<Reference> serializer = new ConditionSerializer<>()

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -697,10 +697,8 @@ public abstract class TxnCondition
         @Override
         public boolean applies(TxnData data)
         {
+            // We have already checked earlier that the type for the LHS is the same as the type for the RHS
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
-            AbstractType<?> typeRHS = getColumnType(referenceRHS);
-
-            Invariants.require(typeLHS.equals(typeRHS));
 
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
             ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeLHS);

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -693,8 +693,6 @@ public abstract class TxnCondition
             ColumnMetadata columnLHS = referenceLHS.column();
             ColumnMetadata columnRHS = referenceRHS.column();
 
-            Preconditions.checkArgument(columnLHS.type.equals(columnRHS.type), columnLHS.type + " != " + columnRHS.type);
-
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, columnLHS.type);
             ByteBuffer rhs = referenceRHS.toByteBuffer(data, columnRHS.type);
 

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -700,7 +700,7 @@ public abstract class TxnCondition
             AbstractType<?> typeLHS = getColumnType(referenceLHS);
             AbstractType<?> typeRHS = getColumnType(referenceRHS);
 
-            Invariants.require(typeLHS == typeRHS);
+            Invariants.require(typeLHS.equals(typeRHS));
 
             ByteBuffer lhs = referenceLHS.toByteBuffer(data, typeLHS);
             ByteBuffer rhs = referenceRHS.toByteBuffer(data, typeLHS);

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReference.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReference.java
@@ -438,7 +438,7 @@ public abstract class TxnReference
 
             // Account for frozen collection and reversed clustering key references:
             AbstractType<?> receiveType = type.isFrozenCollection() ? receiver.freeze().unwrap() : receiver.unwrap();
-            if (!(receiveType.equals(type.unwrap())))
+            if (!receiveType.equals(type.unwrap()))
                 throw new IllegalArgumentException("Receiving type " + receiveType + " does not match " + type.unwrap());
 
             if (column().isPartitionKey())

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReference.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReference.java
@@ -438,7 +438,7 @@ public abstract class TxnReference
 
             // Account for frozen collection and reversed clustering key references:
             AbstractType<?> receiveType = type.isFrozenCollection() ? receiver.freeze().unwrap() : receiver.unwrap();
-            if (!(receiveType == type.unwrap()))
+            if (!(receiveType.equals(type.unwrap())))
                 throw new IllegalArgumentException("Receiving type " + receiveType + " does not match " + type.unwrap());
 
             if (column().isPartitionKey())

--- a/src/java/org/apache/cassandra/utils/NullableSerializer.java
+++ b/src/java/org/apache/cassandra/utils/NullableSerializer.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
-import org.apache.cassandra.io.ParameterisedUnversionedSerializer;
 import org.apache.cassandra.io.UnversionedSerializer;
 import org.apache.cassandra.io.VersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -36,14 +35,6 @@ public class NullableSerializer
         if (value != null)
             serializer.serialize(value, out);
     }
-
-    public static <T, P> void serializeNullable(T value, P param, DataOutputPlus out, ParameterisedUnversionedSerializer<T, P> serializer) throws IOException
-    {
-        out.writeBoolean(value != null);
-        if (value != null)
-            serializer.serialize(value, param, out);
-    }
-
     public static <T> void serializeNullable(T value, DataOutputPlus out, int version, IVersionedSerializer<T> serializer) throws IOException
     {
         out.writeBoolean(value != null);
@@ -63,11 +54,6 @@ public class NullableSerializer
         return in.readBoolean() ? serializer.deserialize(in) : null;
     }
 
-    public static <T, P> T deserializeNullable(DataInputPlus in, P param, ParameterisedUnversionedSerializer<T, P> serializer) throws IOException
-    {
-        return in.readBoolean() ? serializer.deserialize(param, in) : null;
-    }
-
     public static <T> T deserializeNullable(DataInputPlus in, int version, IVersionedSerializer<T> serializer) throws IOException
     {
         return in.readBoolean() ? serializer.deserialize(in, version) : null;
@@ -82,13 +68,6 @@ public class NullableSerializer
     {
         return value != null
                ? TypeSizes.sizeof(true) + serializer.serializedSize(value)
-               : TypeSizes.sizeof(false);
-    }
-
-    public static <T, P> long serializedNullableSize(T value, P param, ParameterisedUnversionedSerializer<T, P> serializer)
-    {
-        return value != null
-               ? TypeSizes.sizeof(true) + serializer.serializedSize(value, param)
                : TypeSizes.sizeof(false);
     }
 

--- a/src/java/org/apache/cassandra/utils/NullableSerializer.java
+++ b/src/java/org/apache/cassandra/utils/NullableSerializer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
+import org.apache.cassandra.io.ParameterisedUnversionedSerializer;
 import org.apache.cassandra.io.UnversionedSerializer;
 import org.apache.cassandra.io.VersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -34,6 +35,13 @@ public class NullableSerializer
         out.writeBoolean(value != null);
         if (value != null)
             serializer.serialize(value, out);
+    }
+
+    public static <T, P> void serializeNullable(T value, P param, DataOutputPlus out, ParameterisedUnversionedSerializer<T, P> serializer) throws IOException
+    {
+        out.writeBoolean(value != null);
+        if (value != null)
+            serializer.serialize(value, param, out);
     }
 
     public static <T> void serializeNullable(T value, DataOutputPlus out, int version, IVersionedSerializer<T> serializer) throws IOException
@@ -55,6 +63,11 @@ public class NullableSerializer
         return in.readBoolean() ? serializer.deserialize(in) : null;
     }
 
+    public static <T, P> T deserializeNullable(DataInputPlus in, P param, ParameterisedUnversionedSerializer<T, P> serializer) throws IOException
+    {
+        return in.readBoolean() ? serializer.deserialize(param, in) : null;
+    }
+
     public static <T> T deserializeNullable(DataInputPlus in, int version, IVersionedSerializer<T> serializer) throws IOException
     {
         return in.readBoolean() ? serializer.deserialize(in, version) : null;
@@ -69,6 +82,13 @@ public class NullableSerializer
     {
         return value != null
                ? TypeSizes.sizeof(true) + serializer.serializedSize(value)
+               : TypeSizes.sizeof(false);
+    }
+
+    public static <T, P> long serializedNullableSize(T value, P param, ParameterisedUnversionedSerializer<T, P> serializer)
+    {
+        return value != null
+               ? TypeSizes.sizeof(true) + serializer.serializedSize(value, param)
                : TypeSizes.sizeof(false);
     }
 

--- a/src/java/org/apache/cassandra/utils/NullableSerializer.java
+++ b/src/java/org/apache/cassandra/utils/NullableSerializer.java
@@ -35,6 +35,7 @@ public class NullableSerializer
         if (value != null)
             serializer.serialize(value, out);
     }
+
     public static <T> void serializeNullable(T value, DataOutputPlus out, int version, IVersionedSerializer<T> serializer) throws IOException
     {
         out.writeBoolean(value != null);

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3765,7 +3765,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     @Test
     public void testLetComparisonWithFrozenCollections() throws Throwable
     {
-        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v list<int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v frozen<list<int>>) WITH " + transactionalMode.asCqlParam(), cluster -> {
 
             String insert = "BEGIN TRANSACTION\n" +
                             "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (0, [9, 5]);\n" +

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3606,6 +3606,34 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
+    public void testLetComparisonWithDifferentTypesFails() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k text PRIMARY KEY, customer person) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                Object personValue = CQLTester.userType("height", 74, "age", 37);
+                ByteBuffer personBuffer = CQLTester.makeByteBuffer(personValue, null);
+                String query = "BEGIN TRANSACTION\n" +
+                               "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 'first');\n" +
+                               "LET k2 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 'second');\n" +
+                               "IF k1.k < k2.customer.height THEN \n" +
+                               "    UPDATE " + qualifiedAccordTableName + " SET customer = ? WHERE k = 'first';\n" +
+                               "END IF\n" +
+                               "COMMIT TRANSACTION";
+
+
+                cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL, personBuffer);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals("Invalid type comparison: cannot compare type text with type int", t.getMessage());
+            }
+        });
+    }
+
+    @Test
     public void testLetComparisonTransactionStatement() throws Throwable
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
@@ -3636,28 +3664,72 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
-    public void testLetComparisonWithDifferentTypesFails() throws Throwable
+    public void testLetComparisonWithDifferentTypes() throws Throwable
     {
-        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int, c text) WITH " + transactionalMode.asCqlParam(), cluster -> {
-            try
-            {
-                String query = "BEGIN TRANSACTION\n" +
-                               "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
-                               "LET k2 = (SELECT c FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
-                               "IF k1.v < k2.c THEN \n" +
-                               "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
-                               "END IF\n" +
-                               "COMMIT TRANSACTION";
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, customer person) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            Object personValue1 = CQLTester.userType("height", 74, "age", 37);
+            ByteBuffer personBuffer1 = CQLTester.makeByteBuffer(personValue1, null);
 
+            Object personValue2 = CQLTester.userType("height", 74, "age", 38);
+            ByteBuffer personBuffer2 = CQLTester.makeByteBuffer(personValue2, null);
 
-                cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
-                fail("Expected exception");
-            }
-            catch (Throwable t)
-            {
-                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
-                assertEquals("Row reference (k1.v) must have the same type as row reference (k2.c)", t.getMessage());
-            }
+            String insert = "BEGIN TRANSACTION\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, customer) VALUES (?, ?);\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, customer) VALUES (?, ?);\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.ANY, 0, personBuffer1, 32, personBuffer2);
+
+            String update = "BEGIN TRANSACTION\n" +
+                            "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 0);\n" +
+                            "LET k2 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 32);\n" +
+                            "IF k1.customer.height > k2.k THEN \n" +
+                            "    UPDATE " + qualifiedAccordTableName + " SET customer = ? WHERE k = 32;\n" +
+                            "END IF\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.SERIAL, personBuffer1);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 32;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(32, personBuffer1);
+        });
+    }
+
+    @Test
+    public void testLetComparisonWithUDT() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, customer person) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            Object personValue1 = CQLTester.userType("height", 74, "age", 37);
+            ByteBuffer personBuffer1 = CQLTester.makeByteBuffer(personValue1, null);
+
+            Object personValue2 = CQLTester.userType("height", 74, "age", 38);
+            ByteBuffer personBuffer2 = CQLTester.makeByteBuffer(personValue2, null);
+
+            String insert = "BEGIN TRANSACTION\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, customer) VALUES (?, ?);\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, customer) VALUES (?, ?);\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.ANY, 0, personBuffer1, 1, personBuffer2);
+
+            String update = "BEGIN TRANSACTION\n" +
+                            "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 0);\n" +
+                            "LET k2 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                            "IF k1.customer.height = k2.customer.height THEN \n" +
+                            "    UPDATE " + qualifiedAccordTableName + " SET customer = ? WHERE k = 1;\n" +
+                            "END IF\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.SERIAL, personBuffer1);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, personBuffer1);
         });
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3619,7 +3619,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             String query = "BEGIN TRANSACTION\n" +
                            "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
                            "LET k2 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
-                           "IF k1.v < k2.v THEN \n" +
+                           "IF k1.v IS NOT NULL AND k1.v < k2.v THEN \n" +
                            "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
                            "END IF\n" +
                            "COMMIT TRANSACTION";

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3738,7 +3738,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v map<int, int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
             String insert = "BEGIN TRANSACTION\n" +
-                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (0, {1:3});\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (0, {1:3, 2:6});\n" +
                             "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, {0:5});\n" +
                             "COMMIT TRANSACTION";
             cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.ANY);

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3846,4 +3846,35 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, true);
         });
     }
+
+    @Test
+    public void testLetComparisonWithTwoRowsOfSameType() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v tuple<int, int>, z tuple<int, int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v, z) VALUES (1, (3, 3), (3, 3));\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v, z) VALUES (2, (3, 3), (3, 3));\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                           "LET k2 = (SELECT z FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
+                           "IF k1.v = k2.z THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET v = (8, 8) WHERE k = 1;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+
+            assertThat(result).hasSize(1).contains(1, tuple(8, 8), tuple(3, 3));
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3604,4 +3604,33 @@ public abstract class AccordCQLTestBase extends AccordTestBase
                       .hasMessage("Attempted to set an element on a list which is null");
         });
     }
+
+    @Test
+    public void testLetComparisonTransactionStatement() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, 2);\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (2, 3);\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                           "LET k2 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
+                           "IF k1.v < k2.v THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                           "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                           "COMMIT TRANSACTION";
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, 10);
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3664,7 +3664,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
-    public void testLetComparisonWithDifferentTypes() throws Throwable
+    public void testLetComparisonWithDifferentUDTFields() throws Throwable
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, customer person) WITH " + transactionalMode.asCqlParam(), cluster -> {
             Object personValue1 = CQLTester.userType("height", 74, "age", 37);

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3877,4 +3877,35 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, tuple(8, 8), tuple(3, 3));
         });
     }
+
+    @Test
+    public void testLetComparisonWithDescColumn() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, v int, z int, PRIMARY KEY (k, v)) WITH CLUSTERING ORDER BY (v DESC) AND " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v, z) VALUES (1, 3, 3);\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v, z) VALUES (2, 3, 3);\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1 AND v = 3);\n" +
+                           "LET k2 = (SELECT z FROM " + qualifiedAccordTableName + " WHERE k = 2 AND v = 3);\n" +
+                           "IF k1.v = k2.z THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET z = 8 WHERE k = 1 AND v = 3;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND v = 3;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+
+            assertThat(result).hasSize(1).contains(1, 3, 8);
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3634,7 +3634,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
-    public void testLetComparisonTransactionStatement() throws Throwable
+    public void testLetComparison() throws Throwable
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
             String insert = "BEGIN TRANSACTION\n" +
@@ -3788,6 +3788,62 @@ public abstract class AccordCQLTestBase extends AccordTestBase
                           "COMMIT TRANSACTION";
 
             assertRowEqualsWithPreemptedRetry(cluster, new Object[] { 1, ImmutableList.of(7, 8)}, read);
+        });
+    }
+
+    @Test
+    public void testUseLetVariableInConditionGuard() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v boolean) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, true);\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                           "IF k1.v THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET v = false WHERE k = 1;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, false);
+        });
+    }
+
+    @Test
+    public void testUseNegationOfLetVariableInConditionGuard() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v boolean) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, false);\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                           "IF !k1.v THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET v = true WHERE k = 1;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, true);
         });
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3634,4 +3634,30 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, 10);
         });
     }
+
+    @Test
+    public void testLetComparisonWithDifferentTypesFails() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int, c text) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                String query = "BEGIN TRANSACTION\n" +
+                               "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                               "LET k2 = (SELECT c FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
+                               "IF k1.v < k2.c THEN \n" +
+                               "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
+                               "END IF\n" +
+                               "COMMIT TRANSACTION";
+
+
+                cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals("Row reference (k1.v) must have the same type as row reference (k2.c)", t.getMessage());
+            }
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3761,4 +3761,33 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(10);
         });
     }
+
+    @Test
+    public void testLetComparisonWithFrozenCollections() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v list<int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
+
+            String insert = "BEGIN TRANSACTION\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (0, [9, 5]);\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, [2, 8]);\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.ANY);
+
+            String update = "BEGIN TRANSACTION\n" +
+                            "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 0);\n" +
+                            "LET k2 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                            "IF k1.v[0] > k2.v[1] THEN \n" +
+                            "    UPDATE " + qualifiedAccordTableName + " SET v = [7, 8] WHERE k = 1;\n" +
+                            "END IF\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            assertRowEqualsWithPreemptedRetry(cluster, new Object[] { 1, ImmutableList.of(7, 8)}, read);
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3629,6 +3629,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             String read = "BEGIN TRANSACTION\n" +
                            "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
                            "COMMIT TRANSACTION";
+
             SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
             assertThat(result).hasSize(1).contains(1, 10);
         });

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3848,7 +3848,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
-    public void testLetComparisonWithTwoRowsOfSameType() throws Throwable
+    public void testLetComparisonWithTwoColumnsOfTheSameType() throws Throwable
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v tuple<int, int>, z tuple<int, int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
             String insert = "BEGIN TRANSACTION\n" +

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3732,4 +3732,33 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, personBuffer1);
         });
     }
+
+    @Test
+    public void testLetComparisonWithMap() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v map<int, int>) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (0, {1:3});\n" +
+                            "  INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, {0:5});\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.ANY);
+
+            String update = "BEGIN TRANSACTION\n" +
+                            "LET k1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 0);\n" +
+                            "LET k2 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                            "IF k1.v[1] < k2.v[0] THEN \n" +
+                            "    UPDATE " + qualifiedAccordTableName + " SET v = {1:10} WHERE k = 1;\n" +
+                            "END IF\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT v[1] FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(10);
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3633,4 +3633,34 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, 10);
         });
     }
+
+    @Test
+    public void testLetComparisionWithDifferingTypes() throws Throwable
+    {
+
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            String insert = "BEGIN TRANSACTION\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, 2);\n" +
+                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (2, 3);\n" +
+                            "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
+
+            String query = "BEGIN TRANSACTION\n" +
+                           "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                           "LET k2 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
+                           "IF k1.v < k2.v THEN \n" +
+                           "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
+                           "END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, 10);
+        });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3633,34 +3633,4 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             assertThat(result).hasSize(1).contains(1, 10);
         });
     }
-
-    @Test
-    public void testLetComparisionWithDifferingTypes() throws Throwable
-    {
-
-        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
-            String insert = "BEGIN TRANSACTION\n" +
-                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, 2);\n" +
-                            "INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (2, 3);\n" +
-                            "COMMIT TRANSACTION";
-
-            cluster.coordinator(1).executeWithResult(insert, ConsistencyLevel.SERIAL);
-
-            String query = "BEGIN TRANSACTION\n" +
-                           "LET k1 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
-                           "LET k2 = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 2);\n" +
-                           "IF k1.v < k2.v THEN \n" +
-                           "    UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1;\n" +
-                           "END IF\n" +
-                           "COMMIT TRANSACTION";
-
-            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.SERIAL);
-
-            String read = "BEGIN TRANSACTION\n" +
-                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
-                          "COMMIT TRANSACTION";
-            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
-            assertThat(result).hasSize(1).contains(1, 10);
-        });
-    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3628,7 +3628,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
             catch (Throwable t)
             {
                 assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
-                assertEquals("Invalid type comparison: cannot compare type text with type int", t.getMessage());
+                assertEquals("Row reference (k1.k) must have the same type as row reference (k2.customer.height)", t.getMessage());
             }
         });
     }

--- a/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
@@ -572,7 +572,7 @@ public class TransactionStatementTest
                        "COMMIT TRANSACTION";
 
         Assertions.assertThatThrownBy(() -> prepare(query))
-                  .isInstanceOf(IllegalStateException.class)
+                  .isInstanceOf(InvalidRequestException.class)
                   .hasMessageContaining("Row reference (row1) can only be used with IS NULL/IS NOT NULL conditions");
     }
 
@@ -587,7 +587,7 @@ public class TransactionStatementTest
                        "COMMIT TRANSACTION";
 
         Assertions.assertThatThrownBy(() -> prepare(query))
-                  .isInstanceOf(IllegalStateException.class)
+                  .isInstanceOf(InvalidRequestException.class)
                   .hasMessageContaining("Row reference (row1) can only be used with IS NULL/IS NOT NULL conditions");
     }
 

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
@@ -68,12 +68,6 @@ import org.apache.cassandra.utils.CassandraGenerators;
 import org.apache.cassandra.utils.Generators;
 
 import static accord.utils.Property.qt;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.EQUAL_REF;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.GREATER_THAN_REF;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.LESS_THAN_REF;
-import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.NOT_EQUAL_REF;
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
 import static org.apache.cassandra.utils.Generators.toGen;
 
@@ -153,9 +147,6 @@ public class TxnConditionTest
     private static Gen<TxnCondition.Kind> VALUE_KIND_GEN = Gens.pick(TxnCondition.Kind.EQUAL, TxnCondition.Kind.NOT_EQUAL,
                                                                      TxnCondition.Kind.GREATER_THAN, TxnCondition.Kind.GREATER_THAN_OR_EQUAL,
                                                                      TxnCondition.Kind.LESS_THAN, TxnCondition.Kind.LESS_THAN_OR_EQUAL);
-    private static Gen<TxnCondition.Kind> VALUE_KIND_REF_GEN = Gens.pick(EQUAL_REF, NOT_EQUAL_REF,
-                                                                         TxnCondition.Kind.GREATER_THAN_REF, TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF,
-                                                                         TxnCondition.Kind.LESS_THAN_REF, TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF);
     private static Gen<ProtocolVersion> PROTOCOL_VERSION_GEN = Gens.enums().all(ProtocolVersion.class);
     private static Gen<ColumnMetadata> COLUM_METADATA_GEN = toGen(CassandraGenerators.columnMetadataGen()).map(cm -> {
         SCHEMA.add(cm);
@@ -505,6 +496,7 @@ public class TxnConditionTest
             List<ByteBuffer> complexValueRHS = type.isMultiCell() ? split(type, valueRHS) : null;
             Clustering<?> clusteringRHS = BufferClustering.make(valueRHS);
             SimplePartition partitionRHS = new SimplePartition(metadata, metadata.partitioner.decorateKey(valueRHS));
+
             for (TxnCondition.Kind kind : TxnCondition.Value.supported())
             {
                 for (ProtocolVersion version : ProtocolVersion.SUPPORTED)
@@ -515,7 +507,7 @@ public class TxnConditionTest
                         TxnReference refRHS = TxnReference.column(1, metadata, column);
 
                         TxnCondition.Value value = new TxnCondition.Value(refLHS.asColumn(), kind, valueRHS, version);
-                        TxnCondition.Reference condition = new TxnCondition.Reference(refLHS.asColumn(), convertKindToReferenceKind(kind), refRHS.asColumn(), version);
+                        TxnCondition.Reference condition = new TxnCondition.Reference(refLHS.asColumn(), kind, refRHS.asColumn(), version);
 
                         partitionLHS.clear().addEmptyAndLive(clusteringLHS);
                         partitionRHS.clear().addEmptyAndLive(clusteringRHS);
@@ -595,26 +587,12 @@ public class TxnConditionTest
                 case 0: return TxnCondition.none();
                 case 1: return new TxnCondition.Exists(TXN_REF_GEN.next(rs), EXISTS_KIND_GEN.next(rs));
                 case 2: return new TxnCondition.Value(TXN_REF_GEN.next(rs).asColumn(), VALUE_KIND_GEN.next(rs), BYTES_GEN.next(rs), PROTOCOL_VERSION_GEN.next(rs));
-                case 3: return new TxnCondition.Reference(TXN_REF_GEN.next(rs).asColumn(), VALUE_KIND_REF_GEN.next(rs), TXN_REF_GEN.next(rs).asColumn(), PROTOCOL_VERSION_GEN.next(rs));
+                case 3: return new TxnCondition.Reference(TXN_REF_GEN.next(rs).asColumn(), VALUE_KIND_GEN.next(rs), TXN_REF_GEN.next(rs).asColumn(), PROTOCOL_VERSION_GEN.next(rs));
                 case 4: return new TxnCondition.ColumnConditionsAdapter(CLUSTERING_GEN.next(rs), Gens.lists(BOUND_GEN).ofSizeBetween(0, 3).next(rs));
                 case 5: return new TxnCondition.BooleanGroup(BOOLEAN_KIND_GEN.next(rs), Gens.lists(txnConditionGen()).ofSizeBetween(0, 3).next(rs));
                 default: throw new AssertionError();
             }
         };
-    }
-
-    private TxnCondition.Kind convertKindToReferenceKind(TxnCondition.Kind kind)
-    {
-        switch (kind)
-        {
-            case EQUAL: return EQUAL_REF;
-            case NOT_EQUAL: return NOT_EQUAL_REF;
-            case GREATER_THAN: return GREATER_THAN_REF;
-            case GREATER_THAN_OR_EQUAL: return GREATER_THAN_OR_EQUAL_REF;
-            case LESS_THAN: return LESS_THAN_REF;
-            case LESS_THAN_OR_EQUAL: return LESS_THAN_OR_EQUAL_REF;
-            default: throw new UnsupportedOperationException(kind.name());
-        }
     }
 
     private interface IsNullTest // jdk16+ lets this be in-lined with the test method rather than be here

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
@@ -497,7 +497,7 @@ public class TxnConditionTest
             Clustering<?> clusteringRHS = BufferClustering.make(valueRHS);
             SimplePartition partitionRHS = new SimplePartition(metadata, metadata.partitioner.decorateKey(valueRHS));
 
-            for (TxnCondition.Kind kind : TxnCondition.Value.supported())
+            for (TxnCondition.Kind kind : TxnCondition.Reference.supported())
             {
                 for (ProtocolVersion version : ProtocolVersion.SUPPORTED)
                 {

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
@@ -554,6 +554,8 @@ public class TxnConditionTest
                                         .build();
                         }
 
+                        data = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered())).merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
+
                         Assertions.assertThat(condition.applies(data))
                                   .describedAs("column=%s, type=%s, kind=%s", column.name, type.asCQL3Type(), kind.name())
                                   .isEqualTo(value.applies(data));

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
@@ -68,6 +68,12 @@ import org.apache.cassandra.utils.CassandraGenerators;
 import org.apache.cassandra.utils.Generators;
 
 import static accord.utils.Property.qt;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.EQUAL_REF;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.GREATER_THAN_REF;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.LESS_THAN_REF;
+import static org.apache.cassandra.service.accord.txn.TxnCondition.Kind.NOT_EQUAL_REF;
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
 import static org.apache.cassandra.utils.Generators.toGen;
 
@@ -147,6 +153,9 @@ public class TxnConditionTest
     private static Gen<TxnCondition.Kind> VALUE_KIND_GEN = Gens.pick(TxnCondition.Kind.EQUAL, TxnCondition.Kind.NOT_EQUAL,
                                                                      TxnCondition.Kind.GREATER_THAN, TxnCondition.Kind.GREATER_THAN_OR_EQUAL,
                                                                      TxnCondition.Kind.LESS_THAN, TxnCondition.Kind.LESS_THAN_OR_EQUAL);
+    private static Gen<TxnCondition.Kind> VALUE_KIND_REF_GEN = Gens.pick(EQUAL_REF, NOT_EQUAL_REF,
+                                                                         TxnCondition.Kind.GREATER_THAN_REF, TxnCondition.Kind.GREATER_THAN_OR_EQUAL_REF,
+                                                                         TxnCondition.Kind.LESS_THAN_REF, TxnCondition.Kind.LESS_THAN_OR_EQUAL_REF);
     private static Gen<ProtocolVersion> PROTOCOL_VERSION_GEN = Gens.enums().all(ProtocolVersion.class);
     private static Gen<ColumnMetadata> COLUM_METADATA_GEN = toGen(CassandraGenerators.columnMetadataGen()).map(cm -> {
         SCHEMA.add(cm);
@@ -471,6 +480,89 @@ public class TxnConditionTest
         });
     }
 
+    @Test
+    public void reference()
+    {
+        Gen<AbstractType<?>> typeGen = toGen(new AbstractTypeGenerators.TypeGenBuilder()
+                                             .withoutUnsafeEquality()
+                                             .build());
+        qt().check(rs -> {
+            AbstractType<?> type = typeGen.next(rs);
+            TableMetadata metadata = TableMetadata.builder("ks", "tbl")
+                                                  .addPartitionKeyColumn("pk", type.freeze())
+                                                  .addClusteringColumn("ck", type.freeze())
+                                                  .addRegularColumn("r", type)
+                                                  .addStaticColumn("s", type)
+                                                  .partitioner(Murmur3Partitioner.instance)
+                                                  .build();
+
+            ByteBuffer valueLHS = toGen(AbstractTypeGenerators.getTypeSupport(type).bytesGen()).next(rs);
+            List<ByteBuffer> complexValueLHS = type.isMultiCell() ? split(type, valueLHS) : null;
+            Clustering<?> clusteringLHS = BufferClustering.make(valueLHS);
+            SimplePartition partitionLHS = new SimplePartition(metadata, metadata.partitioner.decorateKey(valueLHS));
+
+            ByteBuffer valueRHS = toGen(AbstractTypeGenerators.getTypeSupport(type).bytesGen()).next(rs);
+            List<ByteBuffer> complexValueRHS = type.isMultiCell() ? split(type, valueRHS) : null;
+            Clustering<?> clusteringRHS = BufferClustering.make(valueRHS);
+            SimplePartition partitionRHS = new SimplePartition(metadata, metadata.partitioner.decorateKey(valueRHS));
+            for (TxnCondition.Kind kind : TxnCondition.Value.supported())
+            {
+                for (ProtocolVersion version : ProtocolVersion.SUPPORTED)
+                {
+                    for (ColumnMetadata column : metadata.columns())
+                    {
+                        TxnReference refLHS = TxnReference.column(0, metadata, column);
+                        TxnReference refRHS = TxnReference.column(1, metadata, column);
+
+                        TxnCondition.Value value = new TxnCondition.Value(refLHS.asColumn(), kind, valueRHS, version);
+                        TxnCondition.Reference condition = new TxnCondition.Reference(refLHS.asColumn(), convertKindToReferenceKind(kind), refRHS.asColumn(), version);
+
+                        partitionLHS.clear().addEmptyAndLive(clusteringLHS);
+                        partitionRHS.clear().addEmptyAndLive(clusteringRHS);
+
+                        TxnData data = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered())).merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
+
+                        Assertions.assertThat(condition.applies(data))
+                                  .describedAs("column=%s, type=%s, kind=%s", column.name, type.asCQL3Type(), kind.name())
+                                  .isEqualTo(value.applies(data));
+
+                        if (column.isPrimaryKeyColumn()) continue;
+
+                        // with value
+                        if (type.isMultiCell())
+                        {
+                            partitionLHS.clear()
+                                     .add(column.isStatic() ? Clustering.STATIC_CLUSTERING : clusteringLHS)
+                                     .addComplex(column, complexValueLHS)
+                                     .build();
+
+                            partitionRHS.clear()
+                                        .add(column.isStatic() ? Clustering.STATIC_CLUSTERING : clusteringRHS)
+                                        .addComplex(column, complexValueRHS)
+                                        .build();
+                        }
+                        else
+                        {
+                            partitionLHS.clear()
+                                     .add(column.isStatic() ? Clustering.STATIC_CLUSTERING : clusteringLHS)
+                                     .add(column, valueLHS)
+                                     .build();
+
+                            partitionRHS.clear()
+                                        .add(column.isStatic() ? Clustering.STATIC_CLUSTERING : clusteringRHS)
+                                        .add(column, valueRHS)
+                                        .build();
+                        }
+
+                        Assertions.assertThat(condition.applies(data))
+                                  .describedAs("column=%s, type=%s, kind=%s", column.name, type.asCQL3Type(), kind.name())
+                                  .isEqualTo(value.applies(data));
+                    }
+                }
+            }
+        });
+    }
+
     private static List<ByteBuffer> split(AbstractType<?> type, ByteBuffer value)
     {
         type = type.unwrap();
@@ -494,16 +586,31 @@ public class TxnConditionTest
     private Gen<TxnCondition> txnConditionGen()
     {
         return rs -> {
-            switch (rs.nextInt(1, 5))
+            switch (rs.nextInt(1, 6))
             {
                 case 0: return TxnCondition.none();
                 case 1: return new TxnCondition.Exists(TXN_REF_GEN.next(rs), EXISTS_KIND_GEN.next(rs));
                 case 2: return new TxnCondition.Value(TXN_REF_GEN.next(rs).asColumn(), VALUE_KIND_GEN.next(rs), BYTES_GEN.next(rs), PROTOCOL_VERSION_GEN.next(rs));
-                case 3: return new TxnCondition.ColumnConditionsAdapter(CLUSTERING_GEN.next(rs), Gens.lists(BOUND_GEN).ofSizeBetween(0, 3).next(rs));
-                case 4: return new TxnCondition.BooleanGroup(BOOLEAN_KIND_GEN.next(rs), Gens.lists(txnConditionGen()).ofSizeBetween(0, 3).next(rs));
+                case 3: return new TxnCondition.Reference(TXN_REF_GEN.next(rs).asColumn(), VALUE_KIND_REF_GEN.next(rs), TXN_REF_GEN.next(rs).asColumn(), PROTOCOL_VERSION_GEN.next(rs));
+                case 4: return new TxnCondition.ColumnConditionsAdapter(CLUSTERING_GEN.next(rs), Gens.lists(BOUND_GEN).ofSizeBetween(0, 3).next(rs));
+                case 5: return new TxnCondition.BooleanGroup(BOOLEAN_KIND_GEN.next(rs), Gens.lists(txnConditionGen()).ofSizeBetween(0, 3).next(rs));
                 default: throw new AssertionError();
             }
         };
+    }
+
+    private TxnCondition.Kind convertKindToReferenceKind(TxnCondition.Kind kind)
+    {
+        switch (kind)
+        {
+            case EQUAL: return EQUAL_REF;
+            case NOT_EQUAL: return NOT_EQUAL_REF;
+            case GREATER_THAN: return GREATER_THAN_REF;
+            case GREATER_THAN_OR_EQUAL: return GREATER_THAN_OR_EQUAL_REF;
+            case LESS_THAN: return LESS_THAN_REF;
+            case LESS_THAN_OR_EQUAL: return LESS_THAN_OR_EQUAL_REF;
+            default: throw new UnsupportedOperationException(kind.name());
+        }
     }
 
     private interface IsNullTest // jdk16+ lets this be in-lined with the test method rather than be here

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnConditionTest.java
@@ -520,11 +520,12 @@ public class TxnConditionTest
                         partitionLHS.clear().addEmptyAndLive(clusteringLHS);
                         partitionRHS.clear().addEmptyAndLive(clusteringRHS);
 
-                        TxnData data = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered())).merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
+                        TxnData dataLHS = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered()));
+                        TxnData data = dataLHS.merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
 
                         Assertions.assertThat(condition.applies(data))
                                   .describedAs("column=%s, type=%s, kind=%s", column.name, type.asCQL3Type(), kind.name())
-                                  .isEqualTo(value.applies(data));
+                                  .isEqualTo(value.applies(dataLHS));
 
                         if (column.isPrimaryKeyColumn()) continue;
 
@@ -554,11 +555,12 @@ public class TxnConditionTest
                                         .build();
                         }
 
-                        data = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered())).merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
+                        dataLHS = TxnData.of(0, new TxnDataKeyValue(partitionLHS.filtered()));
+                        data = dataLHS.merge(TxnData.of(1, new TxnDataKeyValue(partitionRHS.filtered())));
 
                         Assertions.assertThat(condition.applies(data))
                                   .describedAs("column=%s, type=%s, kind=%s", column.name, type.asCQL3Type(), kind.name())
-                                  .isEqualTo(value.applies(data));
+                                  .isEqualTo(value.applies(dataLHS));
                     }
                 }
             }

--- a/test/unit/org/apache/cassandra/utils/ASTGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/ASTGenerators.java
@@ -1366,27 +1366,32 @@ public class ASTGenerators
         {
             Gen<Boolean> boolGen = SourceDSL.booleans().all();
             return rnd -> {
-                var pk = partitionKeyValuesGen.generate(rnd);
-                var mutation = mutationGen(rs, pk).generate(rnd);
+                var pk1 = partitionKeyValuesGen.generate(rnd);
+                var pk2 = partitionKeyValuesGen.generate(rnd);
+                var mutation = mutationGen(rs, pk1).generate(rnd);
 
-                Select select = select(metadata, pk).withLimit(1);
-                var columns = model.columns(select);
+                Select select1 = select(metadata, pk1).withLimit(1);
+                Select select2 = select(metadata, pk2).withLimit(1);
+                var columns = model.columns(select1);
                 Txn.Builder builder = Txn.builder();
-                builder.addLet("r1", select);
-                Reference ref = Reference.of(Symbol.unknownType("r1"));
+                builder.addLet("r1", select1);
+                Reference ref1 = Reference.of(Symbol.unknownType("r1"));
+                builder.addLet("r2", select1);
+                Reference ref2 = Reference.of(Symbol.unknownType("r2"));
 
-                builder.addReturn(select(metadata, pk));
+                builder.addReturn(select(metadata, pk1));
 
                 Conditional.Builder condition = Conditional.builder();
                 for (var col : columns)
                 {
                     if (boolGen.generate(rnd)) continue;
-                    Reference colRef = ref.add(col);
+                    Reference colRef1 = ref1.add(col);
+                    Reference colRef2 = ref2.add(col);
                     if (boolGen.generate(rnd))
-                        condition.is(colRef, SourceDSL.arbitrary().enumValues(Conditional.Is.Kind.class).generate(rnd));
+                        condition.is(colRef1, SourceDSL.arbitrary().enumValues(Conditional.Is.Kind.class).generate(rnd));
                     if (boolGen.generate(rnd))
                     {
-                        Expression lhs = colRef;
+                        Expression lhs = colRef1;
                         Expression rhs = value(rnd, getTypeSupport(lhs.type()).bytesGen().generate(rnd), lhs.type());
                         if (boolGen.generate(rnd))
                         {
@@ -1396,6 +1401,11 @@ public class ASTGenerators
                         }
                         Conditional.Where.Inequality inequality = SourceDSL.arbitrary().enumValues(Conditional.Where.Inequality.class).generate(rnd);
                         condition.where(lhs, inequality, rhs);
+                    }
+                    if (boolGen.generate(rnd))
+                    {
+                        Conditional.Where.Inequality inequality = SourceDSL.arbitrary().enumValues(Conditional.Where.Inequality.class).generate(rnd);
+                        condition.where(colRef1, inequality, colRef2);
                     }
                 }
                 if (condition.isEmpty())

--- a/test/unit/org/apache/cassandra/utils/ASTGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/ASTGenerators.java
@@ -1376,7 +1376,7 @@ public class ASTGenerators
                 Txn.Builder builder = Txn.builder();
                 builder.addLet("r1", select1);
                 Reference ref1 = Reference.of(Symbol.unknownType("r1"));
-                builder.addLet("r2", select1);
+                builder.addLet("r2", select2);
                 Reference ref2 = Reference.of(Symbol.unknownType("r2"));
 
                 builder.addReturn(select(metadata, pk1));


### PR DESCRIPTION
Update serializers to allow comparison between two LET variables

patch by Alan Wang;

reviewed by for [CASSANDRA-21458](https://issues.apache.org/jira/browse/CASSANDRA-21458)

Co-authored-by: Name1
Co-authored-by: Name2