### PR TITLE
Add security-model discoverability (AGENTS.md -> SECURITY.md -> security model)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,15 @@ General style conventions:
 - 🚫 Never run the full test suite — it takes hours. Run targeted tests only.
 - 🚫 Never bypass Checkstyle violations without a suppression comment explaining why.
 - ⚠️ Ask before modifying the CQL grammar (`src/antlr/Cql.g`) — changes cascade widely.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to the project's
+security model at
+[doc/modules/cassandra/pages/reference/security-model.adoc](./doc/modules/cassandra/pages/reference/security-model.adoc).
+
+Automated agents (security scanners, code analyzers) that scan this
+repository should consult that security model for the project's in-scope /
+out-of-scope declarations, trust boundaries, the security properties
+Cassandra provides and disclaims, and how findings are triaged, before
+reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities in Apache Cassandra
+privately to the Apache Security Team at <security@apache.org>, following the
+ASF process at <https://www.apache.org/security/>. Do not open public GitHub
+issues or pull requests for security reports.
+
+## Security Model
+
+Apache Cassandra's security model - what is in and out of scope, the trust
+boundaries it assumes, the security properties the project provides and
+disclaims, and how findings are triaged - is documented in-repo at
+[doc/modules/cassandra/pages/reference/security-model.adoc](./doc/modules/cassandra/pages/reference/security-model.adoc).


### PR DESCRIPTION
**This is a proposal for the PMC to review, own, and merge — please correct, reject, or discuss as needed.**

This wires the conventional `AGENTS.md → SECURITY.md → security model` discoverability chain so automated tooling (and contributors) can mechanically find the project's security model.

- Adds a `## Security` section to the existing `AGENTS.md` (no existing content removed).
- Adds a new `SECURITY.md`.

Both point at the in-repo security model (`doc/modules/cassandra/pages/reference/security-model.adoc`). No model content is added or changed here.

Context: the ASF Security team is preparing the Cassandra repositories for an automated agentic security scan we're piloting; such scans look for the model along this chain and run far less noisily when it resolves. The Security team has been in touch separately on the PMC's private list. This addresses the discoverability gap noted there (the model landed on trunk, but the `AGENTS.md → SECURITY.md` wiring didn't come with it).
