### PR TITLE
CASSANDRA-18216: Allow sharding of the SAI in-memory index

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
+++ b/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
@@ -18,12 +18,18 @@
 package org.apache.cassandra.db.memtable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.tcm.Epoch;
 
@@ -45,8 +51,12 @@ public class ShardBoundaries
     // - the default partitioner doesn't support splitting
     // - the keyspace is local system keyspace
     public static final ShardBoundaries NONE = new ShardBoundaries(EMPTY_TOKEN_ARRAY, Epoch.EMPTY);
+    private static final Range<PartitionPosition>[] EMPTY_RANGE_ARRAY = new Range[0];
+    private static final List<Integer> EMPTY_BOUNDARIES_SHARDS = Collections.singletonList(0);
 
     private final Token[] boundaries;
+    private final Range<PartitionPosition>[] ranges;
+    private final List<Integer> allShards;
     public final Epoch epoch;
 
     @VisibleForTesting
@@ -54,6 +64,29 @@ public class ShardBoundaries
     {
         this.boundaries = boundaries;
         this.epoch = epoch;
+        this.ranges = precomputeRanges();
+        this.allShards = IntStream.range(0, boundaries.length + 1).boxed().collect(Collectors.toList());
+    }
+
+    private Range<PartitionPosition>[] precomputeRanges()
+    {
+        if (boundaries.length == 0)
+            return EMPTY_RANGE_ARRAY;
+
+        Range<PartitionPosition>[]  ranges = new Range[boundaries.length + 1];
+        int rangeIndex = 0;
+        PartitionPosition minimum = DatabaseDescriptor.getPartitioner().getMinimumToken().minKeyBound();
+
+        for (Token boundary : boundaries)
+        {
+            PartitionPosition boundaryPosition = boundary.maxKeyBound();
+            ranges[rangeIndex++] = new Range<>(minimum, boundaryPosition);
+            minimum = boundaryPosition;
+        }
+
+        ranges[rangeIndex] = new Range<>(minimum, DatabaseDescriptor.getPartitioner().getMaximumTokenForSplitting().maxKeyBound());
+
+        return ranges;
     }
 
     public ShardBoundaries(List<Token> boundaries, Epoch epoch)
@@ -85,6 +118,20 @@ public class ShardBoundaries
 
         assert (key.getPartitioner() == boundaries[0].getPartitioner());
         return getShardForToken(key.getToken());
+    }
+
+    public List<Integer> getShardsForRange(AbstractBounds<PartitionPosition> keyRange)
+    {
+        if (boundaries.length == 0)
+            return EMPTY_BOUNDARIES_SHARDS;
+
+        // If the keyRange tokens match and are minimum then it represents the entire token ring
+        // then we need to return all the shards.
+        if (keyRange.right.isMinimum() && keyRange.left.compareTo(keyRange.right) == 0)
+            return allShards;
+
+        // Otherwise we need to return all the shards whose range intersects the keyrange
+        return allShards.stream().filter(s -> ranges[s].intersects(keyRange)).collect(Collectors.toList());
     }
 
     public Token getShardStartBoundary(int shardId)

--- a/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
+++ b/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
@@ -65,7 +65,7 @@ public class ShardBoundaries
         this.boundaries = boundaries;
         this.epoch = epoch;
         this.ranges = precomputeRanges();
-        this.allShards = IntStream.range(0, boundaries.length + 1).boxed().collect(Collectors.toList());
+        this.allShards = IntStream.range(0, boundaries.length + 1).boxed().collect(Collectors.toUnmodifiableList());
     }
 
     private Range<PartitionPosition>[] precomputeRanges()

--- a/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
+++ b/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
@@ -25,10 +25,10 @@ import java.util.stream.IntStream;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.tcm.Epoch;
@@ -73,9 +73,10 @@ public class ShardBoundaries
         if (boundaries.length == 0)
             return EMPTY_RANGE_ARRAY;
 
+        IPartitioner partitioner = boundaries[0].getPartitioner();
         Range<PartitionPosition>[]  ranges = new Range[boundaries.length + 1];
         int rangeIndex = 0;
-        PartitionPosition minimum = DatabaseDescriptor.getPartitioner().getMinimumToken().minKeyBound();
+        PartitionPosition minimum = partitioner.getMinimumToken().minKeyBound();
 
         for (Token boundary : boundaries)
         {
@@ -84,7 +85,7 @@ public class ShardBoundaries
             minimum = boundaryPosition;
         }
 
-        ranges[rangeIndex] = new Range<>(minimum, DatabaseDescriptor.getPartitioner().getMaximumTokenForSplitting().maxKeyBound());
+        ranges[rangeIndex] = new Range<>(minimum, partitioner.getMaximumTokenForSplitting().maxKeyBound());
 
         return ranges;
     }

--- a/src/java/org/apache/cassandra/dht/Range.java
+++ b/src/java/org/apache/cassandra/dht/Range.java
@@ -178,7 +178,33 @@ public class Range<T extends RingPosition<T>> extends AbstractBounds<T> implemen
             return intersects((Range<T>) that);
         if (that instanceof Bounds)
             return intersects((Bounds<T>) that);
+        if (that instanceof ExcludingBounds)
+            return intersects((ExcludingBounds<T>) that);
+        if (that instanceof IncludingExcludingBounds)
+            return intersects((IncludingExcludingBounds<T>) that);
         throw new UnsupportedOperationException("Intersection is only supported for Bounds and Range objects; found " + that.getClass());
+    }
+
+    public boolean intersects(IncludingExcludingBounds<T> that)
+    {
+        if (!isWrapAround() && !that.right.isMinimum() && (this.left.compareTo(that.right) == 0))
+            return false;
+        else if (isWrapAround() && !that.right.isMinimum() && (this.right.compareTo(that.right) == 0))
+            return false;
+        return contains(that.left) || (!that.left.equals(that.right) && intersects(new Range<T>(that.left, that.right)));
+    }
+
+    public boolean intersects(ExcludingBounds<T> that)
+    {
+        if (!isWrapAround() &&
+            ((!that.right.isMinimum() && (this.left.compareTo(that.right) == 0)) ||
+             (this.right.compareTo(that.left) == 0)))
+            return false;
+        else if (isWrapAround() &&
+                 ((this.left.compareTo(that.left) == 0) ||
+                  (!that.right.isMinimum() && (this.right.compareTo(that.right) == 0))))
+            return false;
+        return contains(that.left) || (!that.left.equals(that.right) && intersects(new Range<T>(that.left, that.right)));
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -88,6 +88,7 @@ import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.memory.MemtableIndexManager;
+import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.utils.IndexIdentifier;
@@ -159,7 +160,8 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.OPTIMIZE_FOR,
                                                                      NonTokenizingOptions.CASE_SENSITIVE,
                                                                      NonTokenizingOptions.NORMALIZE,
-                                                                     NonTokenizingOptions.ASCII);
+                                                                     NonTokenizingOptions.ASCII,
+                                                                     ShardedMemtableIndex.SHARDS_OPTION);
 
     public static final Set<CQL3Type> SUPPORTED_TYPES = ImmutableSet.of(CQL3Type.Native.ASCII, CQL3Type.Native.BIGINT, CQL3Type.Native.DATE,
                                                                         CQL3Type.Native.DOUBLE, CQL3Type.Native.FLOAT, CQL3Type.Native.INT,
@@ -276,6 +278,10 @@ public class StorageAttachedIndex implements Index
         }
 
         IndexTermType indexTermType = IndexTermType.create(target.left, metadata.partitionKeyColumns(), target.right);
+        String shardsOption = options.get(ShardedMemtableIndex.SHARDS_OPTION);
+        if (shardsOption != null && indexTermType.isVector())
+            throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
+
         AbstractAnalyzer.fromOptions(indexTermType, analysisOptions);
         IndexWriterConfig config = IndexWriterConfig.fromOptions(null, indexTermType, options);
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -279,9 +279,22 @@ public class StorageAttachedIndex implements Index
 
         IndexTermType indexTermType = IndexTermType.create(target.left, metadata.partitionKeyColumns(), target.right);
         String shardsOption = options.get(ShardedMemtableIndex.SHARDS_OPTION);
-        if (shardsOption != null && indexTermType.isVector())
-            throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
+        if (shardsOption != null)
+        {
+            if (indexTermType.isVector())
+                throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
 
+            try
+            {
+                int shardCount = Integer.parseInt(shardsOption);
+                if (shardCount <= 0)
+                    throw new InvalidRequestException("Shard count for a storage-attached index must be a positive integer, was " + shardCount);
+            }
+            catch (NumberFormatException e)
+            {
+                throw new InvalidRequestException("Shard count for a storage-attached index must be a valid integer, got '" + shardsOption + "'");
+            }
+        }
         AbstractAnalyzer.fromOptions(indexTermType, analysisOptions);
         IndexWriterConfig config = IndexWriterConfig.fromOptions(null, indexTermType, options);
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -284,9 +284,22 @@ public class StorageAttachedIndex implements Index
 
         IndexTermType indexTermType = IndexTermType.create(target.left, metadata.partitionKeyColumns(), target.right);
         String shardsOption = options.get(ShardedMemtableIndex.SHARDS_OPTION);
-        if (shardsOption != null && indexTermType.isVector())
-            throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
+        if (shardsOption != null)
+        {
+            if (indexTermType.isVector())
+                throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
 
+            try
+            {
+                int shardCount = Integer.parseInt(shardsOption);
+                if (shardCount <= 0)
+                    throw new InvalidRequestException("Shard count for a storage-attached index must be a positive integer, was " + shardCount);
+            }
+            catch (NumberFormatException e)
+            {
+                throw new InvalidRequestException("Shard count for a storage-attached index must be a valid integer, got '" + shardsOption + "'");
+            }
+        }
         AbstractAnalyzer.fromOptions(indexTermType, analysisOptions);
         IndexWriterConfig config = IndexWriterConfig.fromOptions(null, indexTermType, options);
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -171,6 +171,9 @@ public class StorageAttachedIndex implements Index
                                                                         CQL3Type.Native.VARINT, CQL3Type.Native.DECIMAL, CQL3Type.Native.BOOLEAN,
                                                                         CQL3Type.Native.BLOB);
 
+    // Upper bound on the shards option to prevent runaway per-shard allocations at first-write.
+    public static final int MAX_SHARD_COUNT = 256;
+
     private static final Set<Class<? extends IPartitioner>> ILLEGAL_PARTITIONERS =
             ImmutableSet.of(OrderPreservingPartitioner.class, LocalPartitioner.class, ByteOrderedPartitioner.class, RandomPartitioner.class);
 
@@ -294,6 +297,8 @@ public class StorageAttachedIndex implements Index
                 int shardCount = Integer.parseInt(shardsOption);
                 if (shardCount <= 0)
                     throw new InvalidRequestException("Shard count for a storage-attached index must be a positive integer, was " + shardCount);
+                if (shardCount > MAX_SHARD_COUNT)
+                    throw new InvalidRequestException("Shard count for a storage-attached index must not exceed " + MAX_SHARD_COUNT + ", was " + shardCount);
             }
             catch (NumberFormatException e)
             {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -88,6 +88,7 @@ import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.memory.MemtableIndexManager;
+import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.utils.IndexIdentifier;
@@ -159,7 +160,8 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.OPTIMIZE_FOR,
                                                                      NonTokenizingOptions.CASE_SENSITIVE,
                                                                      NonTokenizingOptions.NORMALIZE,
-                                                                     NonTokenizingOptions.ASCII);
+                                                                     NonTokenizingOptions.ASCII,
+                                                                     ShardedMemtableIndex.SHARDS_OPTION);
 
     public static final Set<CQL3Type> SUPPORTED_TYPES = ImmutableSet.of(CQL3Type.Native.ASCII, CQL3Type.Native.BIGINT, CQL3Type.Native.DATE,
                                                                         CQL3Type.Native.DOUBLE, CQL3Type.Native.FLOAT, CQL3Type.Native.INT,
@@ -281,6 +283,10 @@ public class StorageAttachedIndex implements Index
         }
 
         IndexTermType indexTermType = IndexTermType.create(target.left, metadata.partitionKeyColumns(), target.right);
+        String shardsOption = options.get(ShardedMemtableIndex.SHARDS_OPTION);
+        if (shardsOption != null && indexTermType.isVector())
+            throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
+
         AbstractAnalyzer.fromOptions(indexTermType, analysisOptions);
         IndexWriterConfig config = IndexWriterConfig.fromOptions(null, indexTermType, options);
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -189,6 +189,7 @@ public class StorageAttachedIndex implements Index
     private final MemtableIndexManager memtableIndexManager;
     private final IndexMetrics indexMetrics;
     private final MaxThreshold maxTermSizeGuardrail;
+    private final int shardCount;
 
     // Tracks whether we've started the index build on initialization.
     private volatile boolean initBuildStarted = false;
@@ -220,6 +221,8 @@ public class StorageAttachedIndex implements Index
             maxTermSizeGuardrail = Guardrails.saiBlobTermSize;
         else
             maxTermSizeGuardrail = Guardrails.saiStringTermSize;
+        String shardsOption = indexMetadata.options.get(ShardedMemtableIndex.SHARDS_OPTION);
+        shardCount = shardsOption == null ? 1 : Integer.parseInt(shardsOption);
     }
 
     /**
@@ -356,6 +359,11 @@ public class StorageAttachedIndex implements Index
     public IndexMetadata getIndexMetadata()
     {
         return indexMetadata;
+    }
+
+    public int shardCount()
+    {
+        return shardCount;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -118,6 +118,7 @@ import org.apache.cassandra.utils.concurrent.OpOrder;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
 import static org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig.MAX_TOP_K;
 
 public class StorageAttachedIndex implements Index
@@ -176,6 +177,8 @@ public class StorageAttachedIndex implements Index
 
     private static final Set<Class<? extends IPartitioner>> ILLEGAL_PARTITIONERS =
             ImmutableSet.of(OrderPreservingPartitioner.class, LocalPartitioner.class, ByteOrderedPartitioner.class, RandomPartitioner.class);
+    private static final int DEFAULT_SHARD_COUNT = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
+    private static final String AUTO_SHARDS_OPTION = "auto";
 
     private final ColumnFamilyStore baseCfs;
     private final IndexMetadata indexMetadata;
@@ -222,7 +225,12 @@ public class StorageAttachedIndex implements Index
         else
             maxTermSizeGuardrail = Guardrails.saiStringTermSize;
         String shardsOption = indexMetadata.options.get(ShardedMemtableIndex.SHARDS_OPTION);
-        shardCount = shardsOption == null ? 1 : Integer.parseInt(shardsOption);
+        if (shardsOption == null)
+            shardCount = 1;
+        else if (shardsOption.equalsIgnoreCase(AUTO_SHARDS_OPTION))
+            shardCount = DEFAULT_SHARD_COUNT;
+        else
+            shardCount = Integer.parseInt(shardsOption);
     }
 
     /**
@@ -295,17 +303,20 @@ public class StorageAttachedIndex implements Index
             if (indexTermType.isVector())
                 throw new InvalidRequestException("A storage-attached index on a vector column does not support sharding");
 
-            try
+            if (!shardsOption.equalsIgnoreCase(AUTO_SHARDS_OPTION))
             {
-                int shardCount = Integer.parseInt(shardsOption);
-                if (shardCount <= 0)
-                    throw new InvalidRequestException("Shard count for a storage-attached index must be a positive integer, was " + shardCount);
-                if (shardCount > MAX_SHARD_COUNT)
-                    throw new InvalidRequestException("Shard count for a storage-attached index must not exceed " + MAX_SHARD_COUNT + ", was " + shardCount);
-            }
-            catch (NumberFormatException e)
-            {
-                throw new InvalidRequestException("Shard count for a storage-attached index must be a valid integer, got '" + shardsOption + "'");
+                try
+                {
+                    int shardCount = Integer.parseInt(shardsOption);
+                    if (shardCount <= 0)
+                        throw new InvalidRequestException("Shard count for a storage-attached index must be a positive integer, was " + shardCount);
+                    if (shardCount > MAX_SHARD_COUNT)
+                        throw new InvalidRequestException("Shard count for a storage-attached index must not exceed " + MAX_SHARD_COUNT + ", was " + shardCount);
+                }
+                catch (NumberFormatException e)
+                {
+                    throw new InvalidRequestException("Shard count for a storage-attached index must be a valid integer, got '" + shardsOption + "'");
+                }
             }
         }
         AbstractAnalyzer.fromOptions(indexTermType, analysisOptions);

--- a/src/java/org/apache/cassandra/index/sai/disk/RowMapping.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RowMapping.java
@@ -105,7 +105,7 @@ public class RowMapping
     {
         assert complete : "RowMapping is not built.";
 
-        Iterator<Pair<ByteComparable, PrimaryKeys>> iterator = index.iterator(minKey.partitionKey(), maxKey.partitionKey());
+        Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator = index.iterator(minKey.partitionKey(), maxKey.partitionKey());
         return new AbstractGuavaIterator<>()
         {
             @Override
@@ -113,10 +113,10 @@ public class RowMapping
             {
                 while (iterator.hasNext())
                 {
-                    Pair<ByteComparable, PrimaryKeys> pair = iterator.next();
+                    Pair<ByteComparable, Iterator<PrimaryKey>> pair = iterator.next();
 
                     LongArrayList postings = null;
-                    Iterator<PrimaryKey> primaryKeys = pair.right.iterator();
+                    Iterator<PrimaryKey> primaryKeys = pair.right;
 
                     while (primaryKeys.hasNext())
                     {

--- a/src/java/org/apache/cassandra/index/sai/disk/RowMapping.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RowMapping.java
@@ -52,7 +52,7 @@ public class RowMapping
     public static final RowMapping DUMMY = new RowMapping()
     {
         @Override
-        public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index) { return Collections.emptyIterator(); }
+        public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index, PrimaryKey minKey, PrimaryKey maxKey) { return Collections.emptyIterator(); }
 
         @Override
         public void complete() {}
@@ -99,11 +99,13 @@ public class RowMapping
      *
      * @return an iterator of term -> postings list {@link Pair}s
      */
-    public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index)
+    public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index,
+                                                               PrimaryKey minKey,
+                                                               PrimaryKey maxKey)
     {
         assert complete : "RowMapping is not built.";
 
-        Iterator<Pair<ByteComparable, PrimaryKeys>> iterator = index.iterator();
+        Iterator<Pair<ByteComparable, PrimaryKeys>> iterator = index.iterator(minKey.partitionKey(), maxKey.partitionKey());
         return new AbstractGuavaIterator<>()
         {
             @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -145,7 +145,7 @@ public class MemtableIndexWriter implements PerColumnIndexWriter
             }
             else
             {
-                final Iterator<Pair<ByteComparable, LongArrayList>> iterator = rowMapping.merge(memtable);
+                final Iterator<Pair<ByteComparable, LongArrayList>> iterator = rowMapping.merge(memtable, minKey, maxKey);
 
                 long cellCount = 0;
                 if (iterator.hasNext())

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -66,16 +66,21 @@ public interface MemtableIndex extends MemtableOrdering
     KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     /**
-     * NOTE: Returned data may contain keys outside [minKey, maxKey].
-     * Bounds are used for shard selection only; implementations
-     * without sharding may ignore them.
+     * Returns an iterator over the in-memory index in ascending term order.
+     * <p>
+     * Returned data may contain keys outside [minKey, maxKey]. The bounds
+     * are used for shard selection only; implementations without sharding may
+     * ignore them.
+     * <p>
+     * Callers should invoke this method only when the source Memtable is no longer accepting
+     * writes. Otherwise, concurrent inserts may be observed partway through iteration.
      */
     Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max);
 
     /** Implementation only for Vector Indexes */
     default SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,
-                                                     IndexIdentifier indexIdentifier,
-                                                     Function<PrimaryKey, Integer> postingTransformer) throws IOException
+                                                             IndexIdentifier indexIdentifier,
+                                                             Function<PrimaryKey, Integer> postingTransformer) throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import org.apache.cassandra.db.Clustering;
@@ -31,7 +30,6 @@ import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.QueryContext;
-import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.segment.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v1.vector.PrimaryKeyWithScore;
@@ -44,91 +42,54 @@ import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
-public class MemtableIndex implements MemtableOrdering
+public interface MemtableIndex extends MemtableOrdering
 {
-    private final MemoryIndex memoryIndex;
-    private final LongAdder writeCount = new LongAdder();
-    private final LongAdder estimatedMemoryUsed = new LongAdder();
-    private final Memtable memtable;
+    long writeCount();
 
-    public MemtableIndex(StorageAttachedIndex index, Memtable memtable)
+    long estimatedMemoryUsed();
+
+    boolean isEmpty();
+
+    Memtable getMemtable();
+
+    ByteBuffer getMinTerm();
+
+    ByteBuffer getMaxTerm();
+
+    long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value);
+
+    /** Implementation only for Vector Indexes */
+    default long update(DecoratedKey key, Clustering<?> clustering, ByteBuffer oldValue, ByteBuffer newValue)
     {
-        this.memoryIndex = index.termType().isVector() ? new VectorMemoryIndex(index, memtable) : new TrieMemoryIndex(index);
-        this.memtable = memtable;
+        throw new UnsupportedOperationException();
     }
 
-    public long writeCount()
-    {
-        return writeCount.sum();
-    }
+    KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
-    public long estimatedMemoryUsed()
-    {
-        return estimatedMemoryUsed.sum();
-    }
+    /**
+     * NOTE: Returned data may contain keys outside [minKey, maxKey].
+     * Bounds are used for shard selection only; implementations
+     * without sharding may ignore them.
+     */
+    Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max);
 
-    public boolean isEmpty()
+    /** Implementation only for Vector Indexes */
+    default SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,
+                                                     IndexIdentifier indexIdentifier,
+                                                     Function<PrimaryKey, Integer> postingTransformer) throws IOException
     {
-        return memoryIndex.isEmpty();
-    }
-
-    public Memtable getMemtable()
-    {
-        return memtable;
-    }
-
-    public ByteBuffer getMinTerm()
-    {
-        return memoryIndex.getMinTerm();
-    }
-
-    public ByteBuffer getMaxTerm()
-    {
-        return memoryIndex.getMaxTerm();
-    }
-
-    public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)
-    {
-        if (value == null || (value.remaining() == 0 && memoryIndex.index.termType().skipsEmptyValue()))
-            return 0;
-
-        long ram = memoryIndex.add(key, clustering, value);
-        writeCount.increment();
-        estimatedMemoryUsed.add(ram);
-        return ram;
-    }
-
-    public long update(DecoratedKey key, Clustering<?> clustering, ByteBuffer oldValue, ByteBuffer newValue)
-    {
-        return memoryIndex.update(key, clustering, oldValue, newValue);
-    }
-
-    public KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange)
-    {
-        return memoryIndex.search(queryContext, expression, keyRange);
-    }
-
-    public Iterator<Pair<ByteComparable, PrimaryKeys>> iterator()
-    {
-        return memoryIndex.iterator();
-    }
-
-    public SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,
-                                                            IndexIdentifier indexIdentifier,
-                                                            Function<PrimaryKey, Integer> postingTransformer) throws IOException
-    {
-        return memoryIndex.writeDirect(indexDescriptor, indexIdentifier, postingTransformer);
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public CloseableIterator<PrimaryKeyWithScore> orderBy(QueryContext queryContext, Expression orderer, AbstractBounds<PartitionPosition> keyRange)
+    default CloseableIterator<PrimaryKeyWithScore> orderBy(QueryContext queryContext, Expression orderer, AbstractBounds<PartitionPosition> keyRange)
     {
-        return memoryIndex.orderBy(queryContext, orderer, keyRange);
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public CloseableIterator<PrimaryKeyWithScore> orderResultsBy(QueryContext queryContext, List<PrimaryKey> results, Expression orderer)
+    default CloseableIterator<PrimaryKeyWithScore> orderResultsBy(QueryContext queryContext, List<PrimaryKey> results, Expression orderer)
     {
-        return memoryIndex.orderResultsBy(queryContext, results, orderer);
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.IndexIdentifier;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
-import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -71,7 +70,7 @@ public interface MemtableIndex extends MemtableOrdering
      * Bounds are used for shard selection only; implementations
      * without sharding may ignore them.
      */
-    Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max);
+    Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max);
 
     /** Implementation only for Vector Indexes */
     default SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
@@ -61,7 +61,7 @@ public class MemtableIndexManager
     {
         MemtableIndex current = liveMemtableIndexMap.get(mt);
 
-        // We expect the relevant IndexMemtable to be present most of the time, so only make the
+        // We expect the relevant MemtableIndex to be present most of the time, so only make the
         // call to computeIfAbsent() if it's not. (see https://bugs.openjdk.java.net/browse/JDK-8161372)
         return current != null ? current
                                : liveMemtableIndexMap.computeIfAbsent(mt, memtable -> {

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
@@ -64,7 +64,16 @@ public class MemtableIndexManager
         // We expect the relevant IndexMemtable to be present most of the time, so only make the
         // call to computeIfAbsent() if it's not. (see https://bugs.openjdk.java.net/browse/JDK-8161372)
         return current != null ? current
-                               : liveMemtableIndexMap.computeIfAbsent(mt, memtable -> new MemtableIndex(index, memtable));
+                               : liveMemtableIndexMap.computeIfAbsent(mt, memtable -> {
+            String shardsOption = index.getIndexMetadata().options.get(ShardedMemtableIndex.SHARDS_OPTION);
+            if (shardsOption != null)
+            {
+                Integer shardCount = Integer.parseInt(shardsOption);
+                if (shardCount > 1)
+                    return new ShardedMemtableIndex(index, index.baseCfs(), shardCount, memtable);
+            }
+            return new UnshardedMemtableIndex(index, memtable);
+        });
     }
 
     public long index(DecoratedKey key, Row row, Memtable mt)

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndexManager.java
@@ -65,13 +65,9 @@ public class MemtableIndexManager
         // call to computeIfAbsent() if it's not. (see https://bugs.openjdk.java.net/browse/JDK-8161372)
         return current != null ? current
                                : liveMemtableIndexMap.computeIfAbsent(mt, memtable -> {
-            String shardsOption = index.getIndexMetadata().options.get(ShardedMemtableIndex.SHARDS_OPTION);
-            if (shardsOption != null)
-            {
-                Integer shardCount = Integer.parseInt(shardsOption);
-                if (shardCount > 1)
-                    return new ShardedMemtableIndex(index, index.baseCfs(), shardCount, memtable);
-            }
+            int shardCount = index.shardCount();
+            if (shardCount > 1)
+                return new ShardedMemtableIndex(index, index.baseCfs(), shardCount, memtable);
             return new UnshardedMemtableIndex(index, memtable);
         });
     }

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -93,21 +93,25 @@ public class ShardedMemtableIndex implements MemtableIndex
         return shards.length;
     }
 
+    @Override
     public long writeCount()
     {
         return writeCount.sum();
     }
 
+    @Override
     public boolean isEmpty()
     {
         return getMinTerm() == null;
     }
 
+    @Override
     public Memtable getMemtable()
     {
         return memtable;
     }
 
+    @Override
     public long estimatedMemoryUsed()
     {
         return estimatedMemoryUsed.sum();
@@ -126,6 +130,7 @@ public class ShardedMemtableIndex implements MemtableIndex
      *
      * @return the minimum indexed term across all shards, or {@code null} if the index is empty.
      */
+    @Override
     @Nullable
     public ByteBuffer getMinTerm()
     {
@@ -148,6 +153,7 @@ public class ShardedMemtableIndex implements MemtableIndex
      *
      * @return the maximum indexed term across all shards, or {@code null} if the index is empty
      */
+    @Override
     @Nullable
     public ByteBuffer getMaxTerm()
     {
@@ -157,6 +163,7 @@ public class ShardedMemtableIndex implements MemtableIndex
         return result;
     }
 
+    @Override
     public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)
     {
         if (value == null || (value.remaining() == 0 && index.termType().skipsEmptyValue()))
@@ -168,6 +175,7 @@ public class ShardedMemtableIndex implements MemtableIndex
         return ram;
     }
 
+    @Override
     public KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         List<Integer> shardsForRange = boundaries.getShardsForRange(keyRange);

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.LongAdder;
 
 import javax.annotation.Nullable;
@@ -35,7 +34,6 @@ import com.google.common.base.Preconditions;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.memtable.ShardBoundaries;
 import org.apache.cassandra.dht.AbstractBounds;
@@ -57,7 +55,6 @@ public class ShardedMemtableIndex implements MemtableIndex
 {
     private final ShardBoundaries boundaries;
     private final MemoryIndex[] shards;
-    private final AbstractType<?> comparator;
     private final StorageAttachedIndex index;
     private final LongAdder writeCount = new LongAdder();
     private final LongAdder estimatedMemoryUsed = new LongAdder();
@@ -72,7 +69,6 @@ public class ShardedMemtableIndex implements MemtableIndex
                                 Memtable memtable)
     {
         this.index = index;
-        this.comparator = index.termType().indexType();
         int shardCount = (null == shardCountOption) ? defaultShardCount: shardCountOption;
         this.boundaries = owner.localRangeSplits(shardCount);
         this.shards = generateShards(boundaries.shardCount(), index);
@@ -126,11 +122,10 @@ public class ShardedMemtableIndex implements MemtableIndex
     // didn't receive any terms within the token range of the shard
     @Nullable
     public ByteBuffer getMinTerm() {
-        return Arrays.stream(shards)
-               .map(MemoryIndex::getMinTerm)
-               .filter(Objects::nonNull)
-               .min(comparator)
-               .orElse(null);
+        ByteBuffer result = null;
+        for (MemoryIndex shard : shards)
+            result = index.termType().min(shard.getMinTerm(), result);
+        return result;
     }
 
     // Returns the maximum indexed term in the combined memory indexes.
@@ -141,11 +136,10 @@ public class ShardedMemtableIndex implements MemtableIndex
     // didn't receive any terms within the token range of the shard
     @Nullable
     public ByteBuffer getMaxTerm() {
-        return Arrays.stream(shards)
-                     .map(MemoryIndex::getMaxTerm)
-                     .filter(Objects::nonNull)
-                     .max(comparator)
-                     .orElse(null);
+        ByteBuffer result = null;
+        for (MemoryIndex shard : shards)
+            result = index.termType().max(shard.getMaxTerm(), result);
+        return result;
     }
 
     public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -60,7 +60,7 @@ public class ShardedMemtableIndex implements MemtableIndex
     private final LongAdder estimatedMemoryUsed = new LongAdder();
     private final Memtable memtable;
 
-    private static volatile int defaultShardCount = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
+    private static final int DEFAULT_SHARD_COUNT = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
     public static final String SHARDS_OPTION = "shards";
 
     public ShardedMemtableIndex(StorageAttachedIndex index,
@@ -69,14 +69,13 @@ public class ShardedMemtableIndex implements MemtableIndex
                                 Memtable memtable)
     {
         this.index = index;
-        int shardCount = (null == shardCountOption) ? defaultShardCount: shardCountOption;
+        int shardCount = (null == shardCountOption) ? DEFAULT_SHARD_COUNT : shardCountOption;
         this.boundaries = owner.localRangeSplits(shardCount);
         this.shards = generateShards(boundaries.shardCount(), index);
         this.memtable = memtable;
     }
 
-    private MemoryIndex[] generateShards(int splits,
-                                         StorageAttachedIndex index)
+    private MemoryIndex[] generateShards(int splits, StorageAttachedIndex index)
     {
         MemoryIndex[] generatedShards = new MemoryIndex[splits];
 
@@ -114,28 +113,44 @@ public class ShardedMemtableIndex implements MemtableIndex
         return estimatedMemoryUsed.sum();
     }
 
-    // Returns the minimum indexed term in the combined memory indexes.
-    // This can be null if the indexed memtable was empty. Users of the
-    // {@code MemtableIndex} requiring a non-null minimum term should
-    // use the {@link MemtableIndex#isEmpty} method.
-    // Note: Individual index shards can return null here if the index
-    // didn't receive any terms within the token range of the shard
+    /**
+     * Returns the minimum indexed term in the combined memory indexes.
+     * This can be {@code null} if the indexed memtable was empty. Users of the
+     * {@code MemtableIndex} requiring a non-null minimum term should
+     * use the {@link MemtableIndex#isEmpty} method.
+     *
+     * <p>
+     * <b>Note:</b> Individual index shards can return {@code null} here if the index
+     *      didn't receive any terms within the token range of the shard
+     * </p>
+     *
+     * @return the minimum indexed term across all shards, or {@code null} if the index is empty.
+     */
     @Nullable
-    public ByteBuffer getMinTerm() {
+    public ByteBuffer getMinTerm()
+    {
         ByteBuffer result = null;
         for (MemoryIndex shard : shards)
             result = index.termType().min(shard.getMinTerm(), result);
         return result;
     }
 
-    // Returns the maximum indexed term in the combined memory indexes.
-    // This can be null if the indexed memtable was empty. Users of the
-    // {@code MemtableIndex} requiring a non-null maximum term should
-    // use the {@link MemtableIndex#isEmpty} method.
-    // Note: Individual index shards can return null here if the index
-    // didn't receive any terms within the token range of the shard
+    /**
+     *  Returns the maximum indexed term in the combined memory indexes.
+     *  This can be {@code null} if the indexed memtable was empty. Users of the
+     *  {@code MemtableIndex} requiring a non-null maximum term should
+     *  use the {@link MemtableIndex#isEmpty} method.
+     *
+     *  <p>
+     *  <b>Note:</b> Individual index shards can return {@code null} here if the index
+     *      didn't receive any terms within the token range of the shard
+     *  </p>
+     *
+     * @return the maximum indexed term across all shards, or {@code null} if the index is empty
+     */
     @Nullable
-    public ByteBuffer getMaxTerm() {
+    public ByteBuffer getMaxTerm()
+    {
         ByteBuffer result = null;
         for (MemoryIndex shard : shards)
             result = index.termType().max(shard.getMaxTerm(), result);
@@ -167,6 +182,7 @@ public class ShardedMemtableIndex implements MemtableIndex
         return builder.build();
     }
 
+    @Override
     public Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max)
     {
         int minSubrange = min == null ? 0 : boundaries.getShardForKey(min);
@@ -183,10 +199,12 @@ public class ShardedMemtableIndex implements MemtableIndex
                                  new PrimaryKeysMergeReducer(rangeIterators.size()));
     }
 
-    // The PrimaryKeysMergeReducer receives the range iterators from each of the shards selected based on the
-    // min and max keys passed to the iterator method. It doesn't strictly do any reduction because the terms in each
-    // shard are unique. It will receive at most one shard entry per selected shard before getReduced
-    // is called.
+    /**
+     *  The PrimaryKeysMergeReducer receives the range iterators from each of the shards selected based on the
+     *  min and max keys passed to the iterator method. It doesn't strictly do any reduction because the terms in each
+     *  shard are unique. It will receive at most one shard entry per selected shard before {@link #getReduced}
+     *  is called.
+     */
     private static class PrimaryKeysMergeReducer extends MergeIterator.Reducer<Pair<ByteComparable, PrimaryKeys>, Pair<ByteComparable, Iterator<PrimaryKey>>>
     {
         private final Pair<ByteComparable, PrimaryKeys>[] shardEntriesToMerge;
@@ -202,9 +220,14 @@ public class ShardedMemtableIndex implements MemtableIndex
             this.comparator = PrimaryKey::compareTo;
         }
 
+        /**
+         * Receive the term entry for a shard. This should only be called once for each
+         * shard before reduction.
+         *
+         * @param idx the index of the shard contributing this entry
+         * @param current the term and its associated primary keys from the shard
+         */
         @Override
-        // Receive the term entry for a shard. This should only be called once for each
-        // shard before reduction.
         public void reduce(int idx, Pair<ByteComparable, PrimaryKeys> current)
         {
             Preconditions.checkArgument(shardEntriesToMerge[idx] == null, "Terms should be unique in the memory index");

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -173,7 +173,7 @@ public class ShardedMemtableIndex implements MemtableIndex
         return builder.build();
     }
 
-    public Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max)
+    public Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max)
     {
         int minSubrange = min == null ? 0 : boundaries.getShardForKey(min);
         int maxSubrange = max == null ? shards.length - 1 : boundaries.getShardForKey(max);
@@ -193,7 +193,7 @@ public class ShardedMemtableIndex implements MemtableIndex
     // min and max keys passed to the iterator method. It doesn't strictly do any reduction because the terms in each
     // shard are unique. It will receive at most one shard entry per selected shard before getReduced
     // is called.
-    private static class PrimaryKeysMergeReducer extends MergeIterator.Reducer<Pair<ByteComparable, PrimaryKeys>, Pair<ByteComparable, PrimaryKeys>>
+    private static class PrimaryKeysMergeReducer extends MergeIterator.Reducer<Pair<ByteComparable, PrimaryKeys>, Pair<ByteComparable, Iterator<PrimaryKey>>>
     {
         private final Pair<ByteComparable, PrimaryKeys>[] shardEntriesToMerge;
         private final Comparator<PrimaryKey> comparator;
@@ -221,16 +221,16 @@ public class ShardedMemtableIndex implements MemtableIndex
         }
 
         @Override
-        protected Pair<ByteComparable, PrimaryKeys> getReduced()
+        protected Pair<ByteComparable, Iterator<PrimaryKey>> getReduced()
         {
             Preconditions.checkArgument(term != null, "The term must exist in memory index");
 
-            PrimaryKeys primaryKeys = new PrimaryKeys();
+            List<Iterator<PrimaryKey>> keyIterators = new ArrayList<>(shardEntriesToMerge.length);
             for (Pair<ByteComparable, PrimaryKeys> p : shardEntriesToMerge)
                 if (p != null && p.right != null && !p.right.isEmpty())
-                    for (PrimaryKey pk : p.right)
-                        primaryKeys.add(pk);
+                    keyIterators.add(p.right.iterator());
 
+            Iterator<PrimaryKey> primaryKeys = MergeIterator.get(keyIterators, comparator, new MergeIterator.Reducer.Trivial<>());
             return Pair.create(term, primaryKeys);
         }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.LongAdder;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.db.memtable.ShardBoundaries;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.iterators.KeyRangeConcatIterator;
+import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.index.sai.utils.PrimaryKeys;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.MergeIterator;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
+
+public class ShardedMemtableIndex implements MemtableIndex
+{
+    private final ShardBoundaries boundaries;
+    private final MemoryIndex[] shards;
+    private final AbstractType<?> comparator;
+    private final StorageAttachedIndex index;
+    private final LongAdder writeCount = new LongAdder();
+    private final LongAdder estimatedMemoryUsed = new LongAdder();
+    private final Memtable memtable;
+
+    private static volatile int defaultShardCount = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
+    public static final String SHARDS_OPTION = "shards";
+
+    public ShardedMemtableIndex(StorageAttachedIndex index,
+                                Memtable.Owner owner,
+                                Integer shardCountOption,
+                                Memtable memtable)
+    {
+        this.index = index;
+        this.comparator = index.termType().indexType();
+        int shardCount = (null == shardCountOption) ? defaultShardCount: shardCountOption;
+        this.boundaries = owner.localRangeSplits(shardCount);
+        this.shards = generateShards(boundaries.shardCount(), index);
+        this.memtable = memtable;
+    }
+
+    private MemoryIndex[] generateShards(int splits,
+                                         StorageAttachedIndex index)
+    {
+        MemoryIndex[] generatedShards = new MemoryIndex[splits];
+
+        for (int shard = 0; shard < boundaries.shardCount(); shard++)
+        {
+            generatedShards[shard] = new TrieMemoryIndex(index);
+        }
+
+        return generatedShards;
+    }
+
+    @VisibleForTesting
+    public int shardCount()
+    {
+        return shards.length;
+    }
+
+    public long writeCount()
+    {
+        return writeCount.sum();
+    }
+
+    public boolean isEmpty()
+    {
+        return getMinTerm() == null;
+    }
+
+    public Memtable getMemtable()
+    {
+        return memtable;
+    }
+
+    public long estimatedMemoryUsed()
+    {
+        return estimatedMemoryUsed.sum();
+    }
+
+    // Returns the minimum indexed term in the combined memory indexes.
+    // This can be null if the indexed memtable was empty. Users of the
+    // {@code MemtableIndex} requiring a non-null minimum term should
+    // use the {@link MemtableIndex#isEmpty} method.
+    // Note: Individual index shards can return null here if the index
+    // didn't receive any terms within the token range of the shard
+    @Nullable
+    public ByteBuffer getMinTerm() {
+        return Arrays.stream(shards)
+               .map(MemoryIndex::getMinTerm)
+               .filter(Objects::nonNull)
+               .min(comparator)
+               .orElse(null);
+    }
+
+    // Returns the maximum indexed term in the combined memory indexes.
+    // This can be null if the indexed memtable was empty. Users of the
+    // {@code MemtableIndex} requiring a non-null maximum term should
+    // use the {@link MemtableIndex#isEmpty} method.
+    // Note: Individual index shards can return null here if the index
+    // didn't receive any terms within the token range of the shard
+    @Nullable
+    public ByteBuffer getMaxTerm() {
+        return Arrays.stream(shards)
+                     .map(MemoryIndex::getMaxTerm)
+                     .filter(Objects::nonNull)
+                     .max(comparator)
+                     .orElse(null);
+    }
+
+    public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)
+    {
+        if (value == null || (value.remaining() == 0 && index.termType().skipsEmptyValue()))
+            return 0;
+
+        long ram = shards[boundaries.getShardForKey(key)].add(key, clustering, value);
+        writeCount.increment();
+        estimatedMemoryUsed.add(ram);
+        return ram;
+    }
+
+    public KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    {
+        List<Integer> shardsForRange = boundaries.getShardsForRange(keyRange);
+        KeyRangeConcatIterator.Builder builder = KeyRangeConcatIterator.builder(shardsForRange.size());
+
+        for (int shard: shardsForRange)
+        {
+            assert shards[shard] != null;
+            builder.add(shards[shard].search(queryContext, expression, keyRange));
+        }
+
+        return builder.build();
+    }
+
+    public Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max)
+    {
+        int minSubrange = min == null ? 0 : boundaries.getShardForKey(min);
+        int maxSubrange = max == null ? shards.length - 1 : boundaries.getShardForKey(max);
+
+        List<Iterator<Pair<ByteComparable, PrimaryKeys>>> rangeIterators = new ArrayList<>(maxSubrange - minSubrange + 1);
+
+        for (int i = minSubrange; i <= maxSubrange; i++)
+            rangeIterators.add(shards[i].iterator());
+
+        return MergeIterator.get(rangeIterators,
+                                 (o1, o2) -> ByteComparable.compare(o1.left, o2.left,
+                                                                    ByteComparable.Version.OSS50),
+                                 new PrimaryKeysMergeReducer(rangeIterators.size()));
+    }
+
+    // The PrimaryKeysMergeReducer receives the range iterators from each of the shards selected based on the
+    // min and max keys passed to the iterator method. It doesn't strictly do any reduction because the terms in each
+    // shard are unique. It will receive at most one shard entry per selected shard before getReduced
+    // is called.
+    private static class PrimaryKeysMergeReducer extends MergeIterator.Reducer<Pair<ByteComparable, PrimaryKeys>, Pair<ByteComparable, PrimaryKeys>>
+    {
+        private final Pair<ByteComparable, PrimaryKeys>[] shardEntriesToMerge;
+        private final Comparator<PrimaryKey> comparator;
+
+        private ByteComparable term;
+
+        @SuppressWarnings("unchecked")
+            // The size represents the number of shards that have been selected for the merger
+        PrimaryKeysMergeReducer(int size)
+        {
+            this.shardEntriesToMerge = new Pair[size];
+            this.comparator = PrimaryKey::compareTo;
+        }
+
+        @Override
+        // Receive the term entry for a shard. This should only be called once for each
+        // shard before reduction.
+        public void reduce(int idx, Pair<ByteComparable, PrimaryKeys> current)
+        {
+            Preconditions.checkArgument(shardEntriesToMerge[idx] == null, "Terms should be unique in the memory index");
+
+            shardEntriesToMerge[idx] = current;
+            if (current != null && term == null)
+                term = current.left;
+        }
+
+        @Override
+        protected Pair<ByteComparable, PrimaryKeys> getReduced()
+        {
+            Preconditions.checkArgument(term != null, "The term must exist in memory index");
+
+            PrimaryKeys primaryKeys = new PrimaryKeys();
+            for (Pair<ByteComparable, PrimaryKeys> p : shardEntriesToMerge)
+                if (p != null && p.right != null && !p.right.isEmpty())
+                    for (PrimaryKey pk : p.right)
+                        primaryKeys.add(pk);
+
+            return Pair.create(term, primaryKeys);
+        }
+
+        @Override
+        protected void onKeyChange()
+        {
+            Arrays.fill(shardEntriesToMerge, null);
+            term = null;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.memory;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
@@ -30,6 +29,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
 
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
@@ -200,15 +200,14 @@ public class ShardedMemtableIndex implements MemtableIndex
                                     "iterator(min, max) requires min <= max but got min shard %s > max shard %s",
                                     minSubrange, maxSubrange);
 
-        List<Iterator<Pair<ByteComparable, PrimaryKeys>>> rangeIterators = new ArrayList<>(maxSubrange - minSubrange + 1);
+        List<Iterator<Pair<ByteComparable, PrimaryKeys>>> shardIterators = new ArrayList<>(maxSubrange - minSubrange + 1);
 
         for (int i = minSubrange; i <= maxSubrange; i++)
-            rangeIterators.add(shards[i].iterator());
+            shardIterators.add(shards[i].iterator());
 
-        return MergeIterator.get(rangeIterators,
-                                 (o1, o2) -> ByteComparable.compare(o1.left, o2.left,
-                                                                    ByteComparable.Version.OSS50),
-                                 new PrimaryKeysMergeReducer(rangeIterators.size()));
+        return MergeIterator.get(shardIterators,
+                                 (o1, o2) -> ByteComparable.compare(o1.left, o2.left, ByteComparable.Version.OSS50),
+                                 new PrimaryKeysMergeReducer(shardIterators.size()));
     }
 
     /**
@@ -219,17 +218,17 @@ public class ShardedMemtableIndex implements MemtableIndex
      */
     private static class PrimaryKeysMergeReducer extends MergeIterator.Reducer<Pair<ByteComparable, PrimaryKeys>, Pair<ByteComparable, Iterator<PrimaryKey>>>
     {
-        private final Pair<ByteComparable, PrimaryKeys>[] shardEntriesToMerge;
-        private final Comparator<PrimaryKey> comparator;
+        private final Pair<ByteComparable, PrimaryKeys>[] perShardTermToKeys;
+        private final List<Iterator<PrimaryKey>> currentTermKeys;
 
-        private ByteComparable term;
+        private ByteComparable currentTerm;
+        private Iterator<PrimaryKey> lastReturnedIterator;
 
         @SuppressWarnings("unchecked")
-            // The size represents the number of shards that have been selected for the merger
-        PrimaryKeysMergeReducer(int size)
+        PrimaryKeysMergeReducer(int shards)
         {
-            this.shardEntriesToMerge = new Pair[size];
-            this.comparator = PrimaryKey::compareTo;
+            this.perShardTermToKeys = new Pair[shards];
+            this.currentTermKeys = new ArrayList<>(shards);
         }
 
         /**
@@ -242,32 +241,37 @@ public class ShardedMemtableIndex implements MemtableIndex
         @Override
         public void reduce(int idx, Pair<ByteComparable, PrimaryKeys> current)
         {
-            Preconditions.checkArgument(shardEntriesToMerge[idx] == null, "Terms should be unique in the memory index");
+            Preconditions.checkArgument(perShardTermToKeys[idx] == null, "Terms should be unique in the memory index");
 
-            shardEntriesToMerge[idx] = current;
-            if (current != null && term == null)
-                term = current.left;
+            perShardTermToKeys[idx] = current;
+
+            if (current != null && currentTerm == null)
+                currentTerm = current.left;
         }
 
         @Override
         protected Pair<ByteComparable, Iterator<PrimaryKey>> getReduced()
         {
-            Preconditions.checkArgument(term != null, "The term must exist in memory index");
+            Preconditions.checkArgument(currentTerm != null, "The term must exist in memory index");
 
-            List<Iterator<PrimaryKey>> keyIterators = new ArrayList<>(shardEntriesToMerge.length);
-            for (Pair<ByteComparable, PrimaryKeys> p : shardEntriesToMerge)
+            for (Pair<ByteComparable, PrimaryKeys> p : perShardTermToKeys)
                 if (p != null && p.right != null && !p.right.isEmpty())
-                    keyIterators.add(p.right.iterator());
+                    currentTermKeys.add(p.right.iterator());
 
-            Iterator<PrimaryKey> primaryKeys = MergeIterator.get(keyIterators, comparator, new MergeIterator.Reducer.Trivial<>());
-            return Pair.create(term, primaryKeys);
+            lastReturnedIterator = Iterators.concat(currentTermKeys.iterator());
+            return Pair.create(currentTerm, lastReturnedIterator);
         }
 
         @Override
         protected void onKeyChange()
         {
-            Arrays.fill(shardEntriesToMerge, null);
-            term = null;
+            Preconditions.checkState(lastReturnedIterator == null || !lastReturnedIterator.hasNext(),
+                                     "Previous per-term Iterator<PrimaryKey> was not drained before the outer iterator advanced");
+
+            Arrays.fill(perShardTermToKeys, null);
+            currentTermKeys.clear();
+            currentTerm = null;
+            lastReturnedIterator = null;
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -44,12 +44,9 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeys;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
-
-import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
 
 public class ShardedMemtableIndex implements MemtableIndex
 {
@@ -60,16 +57,14 @@ public class ShardedMemtableIndex implements MemtableIndex
     private final LongAdder estimatedMemoryUsed = new LongAdder();
     private final Memtable memtable;
 
-    private static final int DEFAULT_SHARD_COUNT = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
     public static final String SHARDS_OPTION = "shards";
 
     public ShardedMemtableIndex(StorageAttachedIndex index,
                                 Memtable.Owner owner,
-                                Integer shardCountOption,
+                                int shardCount,
                                 Memtable memtable)
     {
         this.index = index;
-        int shardCount = (null == shardCountOption) ? DEFAULT_SHARD_COUNT : shardCountOption;
         this.boundaries = owner.localRangeSplits(shardCount);
         this.shards = generateShards(boundaries.shardCount(), index);
         this.memtable = memtable;

--- a/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/ShardedMemtableIndex.java
@@ -196,6 +196,10 @@ public class ShardedMemtableIndex implements MemtableIndex
         int minSubrange = min == null ? 0 : boundaries.getShardForKey(min);
         int maxSubrange = max == null ? shards.length - 1 : boundaries.getShardForKey(max);
 
+        Preconditions.checkArgument(minSubrange <= maxSubrange,
+                                    "iterator(min, max) requires min <= max but got min shard %s > max shard %s",
+                                    minSubrange, maxSubrange);
+
         List<Iterator<Pair<ByteComparable, PrimaryKeys>>> rangeIterators = new ArrayList<>(maxSubrange - minSubrange + 1);
 
         for (int i = minSubrange; i <= maxSubrange; i++)

--- a/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
@@ -57,36 +57,43 @@ public class UnshardedMemtableIndex implements MemtableIndex
         this.memtable = memtable;
     }
 
+    @Override
     public long writeCount()
     {
         return writeCount.sum();
     }
 
+    @Override
     public long estimatedMemoryUsed()
     {
         return estimatedMemoryUsed.sum();
     }
 
+    @Override
     public boolean isEmpty()
     {
         return memoryIndex.isEmpty();
     }
 
+    @Override
     public Memtable getMemtable()
     {
         return memtable;
     }
 
+    @Override
     public ByteBuffer getMinTerm()
     {
         return memoryIndex.getMinTerm();
     }
 
+    @Override
     public ByteBuffer getMaxTerm()
     {
         return memoryIndex.getMaxTerm();
     }
 
+    @Override
     public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)
     {
         if (value == null || (value.remaining() == 0 && memoryIndex.index.termType().skipsEmptyValue()))
@@ -99,16 +106,19 @@ public class UnshardedMemtableIndex implements MemtableIndex
     }
 
     /** Used only for Vector Indexes */
+    @Override
     public long update(DecoratedKey key, Clustering<?> clustering, ByteBuffer oldValue, ByteBuffer newValue)
     {
         return memoryIndex.update(key, clustering, oldValue, newValue);
     }
 
+    @Override
     public KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         return memoryIndex.search(queryContext, expression, keyRange);
     }
 
+    @Override
     public Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max)
     {
         Iterator<Pair<ByteComparable, PrimaryKeys>> memoryIndexIterator = memoryIndex.iterator();
@@ -131,6 +141,7 @@ public class UnshardedMemtableIndex implements MemtableIndex
     }
 
     /** Used only for Vector Indexes */
+    @Override
     public SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,
                                                             IndexIdentifier indexIdentifier,
                                                             Function<PrimaryKey, Integer> postingTransformer) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
@@ -109,9 +109,25 @@ public class UnshardedMemtableIndex implements MemtableIndex
         return memoryIndex.search(queryContext, expression, keyRange);
     }
 
-    public Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max)
+    public Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator(DecoratedKey min, DecoratedKey max)
     {
-        return memoryIndex.iterator();
+        Iterator<Pair<ByteComparable, PrimaryKeys>> memoryIndexIterator = memoryIndex.iterator();
+
+        return new Iterator<>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return memoryIndexIterator.hasNext();
+            }
+
+            @Override
+            public Pair<ByteComparable, Iterator<PrimaryKey>> next()
+            {
+                Pair<ByteComparable, PrimaryKeys> p = memoryIndexIterator.next();
+                return Pair.create(p.left, p.right.iterator());
+            }
+        };
     }
 
     /** Used only for Vector Indexes */

--- a/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/UnshardedMemtableIndex.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.v1.segment.SegmentMetadata;
+import org.apache.cassandra.index.sai.disk.v1.vector.PrimaryKeyWithScore;
+import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.IndexIdentifier;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.index.sai.utils.PrimaryKeys;
+import org.apache.cassandra.utils.CloseableIterator;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+public class UnshardedMemtableIndex implements MemtableIndex
+{
+    private final MemoryIndex memoryIndex;
+    private final LongAdder writeCount = new LongAdder();
+    private final LongAdder estimatedMemoryUsed = new LongAdder();
+    private final Memtable memtable;
+
+    public UnshardedMemtableIndex(StorageAttachedIndex index, Memtable memtable)
+    {
+        this.memoryIndex = index.termType().isVector() ? new VectorMemoryIndex(index, memtable) : new TrieMemoryIndex(index);
+        this.memtable = memtable;
+    }
+
+    public long writeCount()
+    {
+        return writeCount.sum();
+    }
+
+    public long estimatedMemoryUsed()
+    {
+        return estimatedMemoryUsed.sum();
+    }
+
+    public boolean isEmpty()
+    {
+        return memoryIndex.isEmpty();
+    }
+
+    public Memtable getMemtable()
+    {
+        return memtable;
+    }
+
+    public ByteBuffer getMinTerm()
+    {
+        return memoryIndex.getMinTerm();
+    }
+
+    public ByteBuffer getMaxTerm()
+    {
+        return memoryIndex.getMaxTerm();
+    }
+
+    public long index(DecoratedKey key, Clustering<?> clustering, ByteBuffer value)
+    {
+        if (value == null || (value.remaining() == 0 && memoryIndex.index.termType().skipsEmptyValue()))
+            return 0;
+
+        long ram = memoryIndex.add(key, clustering, value);
+        writeCount.increment();
+        estimatedMemoryUsed.add(ram);
+        return ram;
+    }
+
+    /** Used only for Vector Indexes */
+    public long update(DecoratedKey key, Clustering<?> clustering, ByteBuffer oldValue, ByteBuffer newValue)
+    {
+        return memoryIndex.update(key, clustering, oldValue, newValue);
+    }
+
+    public KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    {
+        return memoryIndex.search(queryContext, expression, keyRange);
+    }
+
+    public Iterator<Pair<ByteComparable, PrimaryKeys>> iterator(DecoratedKey min, DecoratedKey max)
+    {
+        return memoryIndex.iterator();
+    }
+
+    /** Used only for Vector Indexes */
+    public SegmentMetadata.ComponentMetadataMap writeDirect(IndexDescriptor indexDescriptor,
+                                                            IndexIdentifier indexIdentifier,
+                                                            Function<PrimaryKey, Integer> postingTransformer) throws IOException
+    {
+        return memoryIndex.writeDirect(indexDescriptor, indexIdentifier, postingTransformer);
+    }
+
+    /** Used only for Vector Indexes */
+    @Override
+    public CloseableIterator<PrimaryKeyWithScore> orderBy(QueryContext queryContext, Expression orderer, AbstractBounds<PartitionPosition> keyRange)
+    {
+        return memoryIndex.orderBy(queryContext, orderer, keyRange);
+    }
+
+    @Override
+    public CloseableIterator<PrimaryKeyWithScore> orderResultsBy(QueryContext queryContext, List<PrimaryKey> results, Expression orderer)
+    {
+        return memoryIndex.orderResultsBy(queryContext, results, orderer);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -95,6 +96,14 @@ public class SingleNodeTableWalkTest extends StatefulASTBase
                                                                                                                          .stream()
                                                                                                                          .filter(t -> !AbstractTypeGenerators.isUnsafeEquality(t))
                                                                                                                          .collect(Collectors.toList()));
+    private static final String SHARDS = "shards";
+    @SuppressWarnings("unchecked")
+    private static final Map<String, String>[] SHARD_OPTIONS = new Map[] {
+        Collections.emptyMap(),
+        Collections.singletonMap(SHARDS, "1"),
+        Collections.singletonMap(SHARDS, "4"),
+        Collections.singletonMap(SHARDS, "8")
+    };
     private static final Logger logger = LoggerFactory.getLogger(SingleNodeTableWalkTest.class);
 
     protected static boolean READ_AFTER_WRITE = false;
@@ -695,12 +704,18 @@ public class SingleNodeTableWalkTest extends StatefulASTBase
                     colExpression = new CreateIndexDDL.CollectionReference(CreateIndexDDL.CollectionReference.Kind.FULL, colExpression);
 
                 String name = "tbl_" + col.name;
+
+                Map<String, String> indexOptions = Collections.emptyMap();
+                // If indexer is of Kind SAI, we want to randomize shards for testing the ShardedMemtableIndex implementation.
+                if (indexer.kind() == CreateIndexDDL.Indexer.Kind.sai )
+                    indexOptions = rs.pick(SHARD_OPTIONS);
+
                 CreateIndexDDL ddl = new CreateIndexDDL(rs.pick(CreateIndexDDL.Version.values()),
                                                         indexer,
                                                         Optional.of(new Symbol(name, UTF8Type.instance)),
                                                         TableReference.from(metadata),
                                                         Collections.singletonList(colExpression),
-                                                        Collections.emptyMap());
+                                                        indexOptions);
                 String stmt = ddl.toCQL();
                 logger.info(stmt);
                 cluster.schemaChange(stmt);

--- a/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -93,6 +94,14 @@ public class SingleNodeTableWalkTest extends StatefulASTBase
                                                                                                                          .stream()
                                                                                                                          .filter(t -> !AbstractTypeGenerators.isUnsafeEquality(t))
                                                                                                                          .collect(Collectors.toList()));
+    private static final String SHARDS = "shards";
+    @SuppressWarnings("unchecked")
+    private static final Map<String, String>[] SHARD_OPTIONS = new Map[] {
+        Collections.emptyMap(),
+        Collections.singletonMap(SHARDS, "1"),
+        Collections.singletonMap(SHARDS, "4"),
+        Collections.singletonMap(SHARDS, "8")
+    };
     private static final Logger logger = LoggerFactory.getLogger(SingleNodeTableWalkTest.class);
 
     protected static boolean READ_AFTER_WRITE = false;
@@ -628,12 +637,18 @@ public class SingleNodeTableWalkTest extends StatefulASTBase
                     colExpression = new CreateIndexDDL.CollectionReference(CreateIndexDDL.CollectionReference.Kind.FULL, colExpression);
 
                 String name = "tbl_" + col.name;
+
+                Map<String, String> indexOptions = Collections.emptyMap();
+                // If indexer is of Kind SAI, we want to randomize shards for testing the ShardedMemtableIndex implementation.
+                if (indexer.kind() == CreateIndexDDL.Indexer.Kind.sai )
+                    indexOptions = rs.pick(SHARD_OPTIONS);
+
                 CreateIndexDDL ddl = new CreateIndexDDL(rs.pick(CreateIndexDDL.Version.values()),
                                                         indexer,
                                                         Optional.of(new Symbol(name, UTF8Type.instance)),
                                                         TableReference.from(metadata),
                                                         Collections.singletonList(colExpression),
-                                                        Collections.emptyMap());
+                                                        indexOptions);
                 String stmt = ddl.toCQL();
                 logger.info(stmt);
                 cluster.schemaChange(stmt);

--- a/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/cql3/SingleNodeTableWalkTest.java
@@ -102,7 +102,7 @@ public class SingleNodeTableWalkTest extends StatefulASTBase
         Collections.emptyMap(),
         Collections.singletonMap(SHARDS, "1"),
         Collections.singletonMap(SHARDS, "4"),
-        Collections.singletonMap(SHARDS, "8")
+        Collections.singletonMap(SHARDS, "auto")
     };
     private static final Logger logger = LoggerFactory.getLogger(SingleNodeTableWalkTest.class);
 

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/AbstractMemtableIndexBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/AbstractMemtableIndexBench.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sai;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.statements.schema.IndexTarget;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.memory.MemtableIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+
+public abstract class AbstractMemtableIndexBench extends CQLTester
+{
+    private static final int RANDOM_STRING_SIZE = 64 * 1024 * 1024;
+    private static String keyspace;
+
+    protected MemtableIndex memtableIndex;
+    protected DecoratedKey[] partitionKeys;
+    protected ByteBuffer[] terms;
+    protected StorageAttachedIndex index;
+
+    protected ColumnFamilyStore cfs;
+    protected String table;
+    private char[] randomChars = new char[RANDOM_STRING_SIZE];
+
+    public void setup(int numberOfTerms, int rowsPerPartition)
+    {
+        setupServer();
+        setupTableAndKeyspace();
+        setupCfsAndIndex();
+        setupPartitionKeys(numberOfTerms, rowsPerPartition);
+        setupTerms(numberOfTerms);
+    }
+
+    public void setupServer()
+    {
+        CQLTester.setUpClass();
+        DatabaseDescriptor.setAutoSnapshot(false);
+    }
+
+    public void setupTableAndKeyspace()
+    {
+        keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        table = createTable(keyspace,
+                            "CREATE TABLE %s ( partition_id text, value_text text, PRIMARY KEY(partition_id)) with compression = {'enabled': false}",
+                            "memtable_index");
+        execute("use " + keyspace + ";");
+    }
+
+    public void setupCfsAndIndex()
+    {
+        cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        Map<String, String> options = new HashMap<>();
+        options.put(IndexTarget.CUSTOM_INDEX_OPTION_NAME,
+                    StorageAttachedIndex.class.getCanonicalName());
+        options.put("target", "value_text");
+
+        IndexMetadata indexMetadata = IndexMetadata.fromSchemaMetadata("value_text_idx", IndexMetadata.Kind.CUSTOM, options);
+
+        index = new StorageAttachedIndex(cfs, indexMetadata);
+    }
+
+    public void setupPartitionKeys(int numberOfTerms, int rowsPerPartition)
+    {
+        TableMetadata tableMetadata = cfs.metadata();
+
+        int numberOfKeys = numberOfTerms / rowsPerPartition;
+
+        partitionKeys = new DecoratedKey[numberOfKeys];
+        for (int i = 0; i < numberOfKeys; i++)
+            partitionKeys[i] = tableMetadata.partitioner.decorateKey(tableMetadata.partitionKeyType.fromString("partition_" + i));
+    }
+
+    public void setupTerms(int numberOfTerms)
+    {
+        Random random = new Random();
+        for (int i = 0; i < RANDOM_STRING_SIZE; i++)
+            randomChars[i] = (char)('a' + random.nextInt(26));
+
+        int length = 64;
+        terms = new ByteBuffer[numberOfTerms];
+        for (int i = 0; i < numberOfTerms; i++)
+            terms[i] = UTF8Type.instance.decompose(generateRandomString(random, length));
+    }
+
+    private String generateRandomString(Random random, int length)
+    {
+        return new String(randomChars, random.nextInt(RANDOM_STRING_SIZE - length), length);
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexFlushBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexFlushBench.java
@@ -19,8 +19,8 @@
 package org.apache.cassandra.test.microbench.sai;
 
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,30 +36,26 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.marshal.UTF8Type;
-import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Bounds;
-import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
 import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
-import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
-@BenchmarkMode(Mode.Throughput)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 6, time = 3)
+@Warmup(iterations = 3, time = 2)
 @Measurement(iterations = 5, time = 5)
 @Fork(value = 1, jvmArgsAppend = { "-Xmx4G", "-Xms4G", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @State(Scope.Benchmark)
-public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
+public class MemtableIndexFlushBench extends AbstractMemtableIndexBench
 {
     // 1 Million partitionKeys
     private static final int NUM_PARTITION_KEYS = 1000000;
-    private static final int NUMBER_OF_SEARCHES = 1000;
     private static final int SMALL_POOL_SIZE = 8 * 1024;
 
     @Param({ "1", "4", "8"})
@@ -69,15 +65,6 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
     int numberOfTerms;
 
     private char[] smallPool = new char[SMALL_POOL_SIZE];
-    private Expression[] stringEqualityExpressions;
-    private QueryContext queryContext;
-    private AbstractBounds<PartitionPosition>[] keyRanges;
-
-    @State(Scope.Thread)
-    public static class ThreadState
-    {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-    }
 
     @Setup(Level.Trial)
     public void setup()
@@ -86,14 +73,7 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
         setupTableAndKeyspace();
         setupCfsAndIndex();
         setupPartitionKeys();
-        setupQueryContext();
         setupIndexesExpressionsAndTerms();
-    }
-
-    private void setupQueryContext()
-    {
-        // setup a dummy query context, interface signature needs it.
-        queryContext = new QueryContext(null, Long.MAX_VALUE);
     }
 
     public void setupPartitionKeys()
@@ -111,8 +91,7 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
                         new UnshardedMemtableIndex(index);
 
         setupTerms(numberOfTerms);
-        populateIndexDataAndKeyRanges();
-        populateExpressions();
+        populateIndexData();
     }
 
     @Override
@@ -126,19 +105,17 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
         terms = new ByteBuffer[numberOfTerms];
         for (int i = 0; i < numberOfTerms; i++)
             terms[i] = UTF8Type.instance.decompose(
-                new String(smallPool, random.nextInt(SMALL_POOL_SIZE - length), length));
+            new String(smallPool, random.nextInt(SMALL_POOL_SIZE - length), length));
     }
 
-    private void populateIndexDataAndKeyRanges()
+    private void populateIndexData()
     {
         int termCount = 0;
-        keyRanges = new AbstractBounds[NUM_PARTITION_KEYS];
 
         for (int i = 0; i < NUM_PARTITION_KEYS; i++)
         {
             DecoratedKey partitionKey = partitionKeys[i];
             memtableIndex.index(partitionKey, Clustering.EMPTY, terms[termCount]);
-            keyRanges[i] = new Bounds<>(partitionKey, partitionKey);
 
             if (++termCount == numberOfTerms)
             {
@@ -147,21 +124,20 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
         }
     }
 
-    private void populateExpressions()
-    {
-        Random random = new Random();
-        stringEqualityExpressions = new Expression[NUMBER_OF_SEARCHES];
-        for (int i = 0; i < NUMBER_OF_SEARCHES; i++)
-            stringEqualityExpressions[i] = Expression.create(index).add(Operator.EQ, terms[random.nextInt(terms.length)]);
-    }
-
     @Benchmark
-    public long stringEqualityPartitionRestrictedRangeSearch(ThreadState state)
+    public long flushBench()
     {
-        long size = 0;
-        memtableIndex.search(queryContext,
-                             stringEqualityExpressions[state.random.nextInt(stringEqualityExpressions.length)],
-                             keyRanges[state.random.nextInt(keyRanges.length)]);
-        return size;
+        Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> it = memtableIndex.iterator(null, null);
+        long count = 0;
+        while (it.hasNext())
+        {
+            Iterator<PrimaryKey> primaryKeyIterator = it.next().right;
+            while (primaryKeyIterator.hasNext())
+            {
+                primaryKeyIterator.next();
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexFlushBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexFlushBench.java
@@ -39,6 +39,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
 import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
@@ -86,9 +87,10 @@ public class MemtableIndexFlushBench extends AbstractMemtableIndexBench
     }
 
     public void setupIndexesExpressionsAndTerms() {
+        Memtable memtable = cfs.getCurrentMemtable();
         memtableIndex = (shardCount > 1)
-                        ? new ShardedMemtableIndex(index, cfs, shardCount) :
-                        new UnshardedMemtableIndex(index);
+                        ? new ShardedMemtableIndex(index, cfs, shardCount, memtable) :
+                        new UnshardedMemtableIndex(index, memtable);
 
         setupTerms(numberOfTerms);
         populateIndexData();

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexPartitionReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexPartitionReadBench.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sai;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Bounds;
+import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
+import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.schema.TableMetadata;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 6, time = 3)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 1, jvmArgsAppend = { "-Xmx4G", "-Xms4G", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@State(Scope.Benchmark)
+public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
+{
+    // 1 Million partitionKeys
+    private static final int NUM_PARTITION_KEYS = 1000000;
+    private static final int NUMBER_OF_SEARCHES = 1000;
+    private static final int SMALL_POOL_SIZE = 8 * 1024;
+
+    @Param({ "1", "4", "8"})
+    int shardCount;
+
+    @Param({"50", "100"})
+    int numberOfTerms;
+
+    private char[] smallPool = new char[SMALL_POOL_SIZE];
+    private Expression[] stringEqualityExpressions;
+    private QueryContext queryContext;
+    private AbstractBounds<PartitionPosition>[] keyRanges;
+
+    @State(Scope.Thread)
+    public static class ThreadState
+    {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+    }
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        setupServer();
+        setupTableAndKeyspace();
+        setupCfsAndIndex();
+        setupPartitionKeys();
+        setupQueryContext();
+        setupIndexesExpressionsAndTerms();
+    }
+
+    private void setupQueryContext()
+    {
+        // setup a dummy query context, interface signature needs it.
+        queryContext = new QueryContext(null, Long.MAX_VALUE);
+    }
+
+    public void setupPartitionKeys()
+    {
+        TableMetadata tableMetadata = cfs.metadata();
+
+        partitionKeys = new DecoratedKey[NUM_PARTITION_KEYS];
+        for (int i = 0; i < NUM_PARTITION_KEYS; i++)
+            partitionKeys[i] = tableMetadata.partitioner.decorateKey(tableMetadata.partitionKeyType.fromString("partition_" + i));
+    }
+
+    //@Setup(Level.Iteration)
+    public void setupIndexesExpressionsAndTerms() {
+        memtableIndex = (shardCount > 1)
+                        ? new ShardedMemtableIndex(index, cfs, shardCount) :
+                        new UnshardedMemtableIndex(index);
+
+        setupTerms(numberOfTerms);
+        populateIndexDataAndKeyRanges();
+        populateExpressions();
+    }
+
+    @Override
+    public void setupTerms(int numberOfTerms)
+    {
+        Random random = new Random();
+        for (int i = 0; i < SMALL_POOL_SIZE; i++)
+            smallPool[i] = (char)('a' + random.nextInt(26));
+
+        int length = 64;
+        terms = new ByteBuffer[numberOfTerms];
+        for (int i = 0; i < numberOfTerms; i++)
+            terms[i] = UTF8Type.instance.decompose(
+                new String(smallPool, random.nextInt(SMALL_POOL_SIZE - length), length));
+    }
+
+    private void populateIndexDataAndKeyRanges()
+    {
+        int termCount = 0;
+        keyRanges = new AbstractBounds[NUM_PARTITION_KEYS];
+
+        for (int i = 0; i < NUM_PARTITION_KEYS; i++)
+        {
+            DecoratedKey partitionKey = partitionKeys[i];
+            memtableIndex.index(partitionKey, Clustering.EMPTY, terms[termCount]);
+            keyRanges[i] = new Bounds<>(partitionKey, partitionKey);
+
+            if (++termCount == numberOfTerms)
+            {
+                termCount = 0;
+            }
+        }
+    }
+
+    private void populateExpressions()
+    {
+        Random random = new Random();
+        stringEqualityExpressions = new Expression[NUMBER_OF_SEARCHES];
+        for (int i = 0; i < NUMBER_OF_SEARCHES; i++)
+            stringEqualityExpressions[i] = Expression.create(index).add(Operator.EQ, terms[random.nextInt(terms.length)]);
+    }
+
+    @Benchmark
+    public long stringEqualityPartitionRestrictedRangeSearch(ThreadState state)
+    {
+        long size = 0;
+        memtableIndex.search(queryContext,
+                             stringEqualityExpressions[state.random.nextInt(stringEqualityExpressions.length)],
+                             keyRanges[state.random.nextInt(keyRanges.length)]);
+        return size;
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexPartitionReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexPartitionReadBench.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -106,9 +107,10 @@ public class MemtableIndexPartitionReadBench extends AbstractMemtableIndexBench
     }
 
     public void setupIndexesExpressionsAndTerms() {
+        Memtable memtable = cfs.getCurrentMemtable();
         memtableIndex = (shardCount > 1)
-                        ? new ShardedMemtableIndex(index, cfs, shardCount) :
-                        new UnshardedMemtableIndex(index);
+                        ? new ShardedMemtableIndex(index, cfs, shardCount, memtable) :
+                        new UnshardedMemtableIndex(index, memtable);
 
         setupTerms(numberOfTerms);
         populateIndexDataAndKeyRanges();

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexReadBench.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sai;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DataRange;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
+import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
+import org.apache.cassandra.index.sai.plan.Expression;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 1, jvmArgsAppend = { "-Xmx4G", "-Xms4G", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@State(Scope.Benchmark)
+public class MemtableIndexReadBench extends AbstractMemtableIndexBench
+{
+    private static final int NUMBER_OF_SEARCHES = 1000;
+    private static final AbstractBounds<PartitionPosition> ALL_DATA_RANGE = DataRange.allData(Murmur3Partitioner.instance).keyRange();
+
+    @Param({ "1", "4", "8"})
+    int shardCount;
+
+    @Param({"1000000" })
+    protected int numberOfTerms;
+
+    @Param({ "1", "10", "100"})
+    protected int rowsPerPartition;
+
+    private Expression[] stringEqualityExpressions;
+    private QueryContext queryContext;
+
+    @State(Scope.Thread)
+    public static class ThreadState
+    {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+    }
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        super.setup(numberOfTerms, rowsPerPartition);
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIndexesAndExpressions() {
+        memtableIndex = (shardCount > 1)
+                        ? new ShardedMemtableIndex(index, cfs, shardCount):
+                        new UnshardedMemtableIndex(index);
+
+        populateIndexData();
+        populateExpressions();
+        // setup a dummy query context, interface signature needs it.
+        queryContext = new QueryContext(null, Long.MAX_VALUE);
+    }
+
+    private void populateIndexData()
+    {
+        int rowCount = 0;
+        int keyCount = 0;
+        for (int i = 0; i < numberOfTerms; i++)
+        {
+            memtableIndex.index(partitionKeys[keyCount], Clustering.EMPTY, terms[i]);
+            if (++rowCount == rowsPerPartition)
+            {
+                rowCount = 0;
+                keyCount++;
+            }
+        }
+    }
+
+    private void populateExpressions()
+    {
+        Random random = new Random();
+        stringEqualityExpressions = new Expression[NUMBER_OF_SEARCHES];
+        for (int i = 0; i < NUMBER_OF_SEARCHES; i++)
+            stringEqualityExpressions[i] = Expression.create(index).add(Operator.EQ, terms[random.nextInt(terms.length)]);
+    }
+
+    @Benchmark
+    public long stringEqualitySearch(ThreadState state)
+    {
+        long size = 0;
+        memtableIndex.search(queryContext,
+            stringEqualityExpressions[state.random.nextInt(stringEqualityExpressions.length)],
+            ALL_DATA_RANGE);
+        return size;
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexReadBench.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -83,9 +84,10 @@ public class MemtableIndexReadBench extends AbstractMemtableIndexBench
 
     @Setup(Level.Iteration)
     public void setupIndexesAndExpressions() {
+        Memtable memtable = cfs.getCurrentMemtable();
         memtableIndex = (shardCount > 1)
-                        ? new ShardedMemtableIndex(index, cfs, shardCount):
-                        new UnshardedMemtableIndex(index);
+                        ? new ShardedMemtableIndex(index, cfs, shardCount, memtable):
+                        new UnshardedMemtableIndex(index, memtable);
 
         populateIndexData();
         populateExpressions();

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexWriteBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexWriteBench.java
@@ -39,6 +39,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
 import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
 
@@ -75,9 +76,10 @@ public class MemtableIndexWriteBench extends AbstractMemtableIndexBench
     @Setup(Level.Iteration)
     public void setupIndexes()
     {
+        Memtable memtable = cfs.getCurrentMemtable();
         memtableIndex = (shardCount > 1)
-                        ? new ShardedMemtableIndex(index, cfs, shardCount):
-                        new UnshardedMemtableIndex(index);
+                        ? new ShardedMemtableIndex(index, cfs, shardCount, memtable):
+                        new UnshardedMemtableIndex(index, memtable);
     }
 
     @Benchmark

--- a/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexWriteBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sai/MemtableIndexWriteBench.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sai;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.index.sai.memory.ShardedMemtableIndex;
+import org.apache.cassandra.index.sai.memory.UnshardedMemtableIndex;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 1, jvmArgsAppend = { "-Xmx4G", "-Xms4G", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Threads(8)
+@State(Scope.Benchmark)
+public class MemtableIndexWriteBench extends AbstractMemtableIndexBench
+{
+    @Param({ "1", "4", "8"})
+    int shardCount;
+
+    @Param({"1000000" })
+    protected int numberOfTerms;
+
+    @Param({ "1", "10", "100"})
+    protected int rowsPerPartition;
+
+    @State(Scope.Thread)
+    public static class ThreadState
+    {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+    }
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        super.setup(numberOfTerms, rowsPerPartition);
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIndexes()
+    {
+        memtableIndex = (shardCount > 1)
+                        ? new ShardedMemtableIndex(index, cfs, shardCount):
+                        new UnshardedMemtableIndex(index);
+    }
+
+    @Benchmark
+    public long write(ThreadState state)
+    {
+        return memtableIndex.index(partitionKeys[state.random.nextInt(partitionKeys.length)],
+                                   Clustering.EMPTY,
+                                   terms[state.random.nextInt(terms.length)]);
+    }
+    
+    @TearDown(Level.Trial)
+    public void teardown() throws InterruptedException
+    {
+        CommitLog.instance.shutdownBlocking();
+        CQLTester.tearDownClass();
+        CQLTester.cleanup();
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
+++ b/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import org.junit.Test;
+
+import org.apache.cassandra.dht.RandomPartitioner.BigIntegerToken;
+
+import org.apache.cassandra.CassandraTestBase;
+import org.apache.cassandra.CassandraTestBase.DDDaemonInitialization;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@DDDaemonInitialization
+public class RangeIntersectsBoundsTest extends CassandraTestBase
+{
+    @Test
+    public void rangeIntersectsBounds() throws Exception
+    {
+        Range<Token> all = new Range<>(new BigIntegerToken("0"), new BigIntegerToken("0"));
+        Range<Token> some = new Range<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        Range<Token> someWrapped = new Range<>(some.right, some.left);
+
+        // Coda:
+        // l - matches left token of some range
+        // r - matches right token of some range
+        // b - below left token of some range
+        // a - above right token of some range
+        // i - inside some range (above left and below right
+        Bounds<Token> lr = new Bounds<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        Bounds<Token> br = new Bounds<>(new BigIntegerToken("3"), new BigIntegerToken("8"));
+        Bounds<Token> bi = new Bounds<>(new BigIntegerToken("3"), new BigIntegerToken("7"));
+        Bounds<Token> ba = new Bounds<>(new BigIntegerToken("3"), new BigIntegerToken("9"));
+        Bounds<Token> la = new Bounds<>(new BigIntegerToken("4"), new BigIntegerToken("9"));
+        Bounds<Token> li = new Bounds<>(new BigIntegerToken("4"), new BigIntegerToken("7"));
+        Bounds<Token> ii = new Bounds<>(new BigIntegerToken("5"), new BigIntegerToken("7"));
+        Bounds<Token> ir = new Bounds<>(new BigIntegerToken("5"), new BigIntegerToken("8"));
+        Bounds<Token> bb = new Bounds<>(new BigIntegerToken("2"), new BigIntegerToken("3"));
+        Bounds<Token> aa = new Bounds<>(new BigIntegerToken("9"), new BigIntegerToken("10"));
+        Bounds<Token> bl = new Bounds<>(new BigIntegerToken("3"), new BigIntegerToken("4"));
+        Bounds<Token> ra = new Bounds<>(new BigIntegerToken("8"), new BigIntegerToken("9"));
+
+        assertTrue(all.intersects(lr));
+        assertTrue(all.intersects(br));
+        assertTrue(all.intersects(bi));
+        assertTrue(all.intersects(ba));
+        assertTrue(all.intersects(la));
+        assertTrue(all.intersects(li));
+        assertTrue(all.intersects(ii));
+        assertTrue(all.intersects(ir));
+        assertTrue(all.intersects(bb));
+        assertTrue(all.intersects(aa));
+        assertTrue(all.intersects(bl));
+        assertTrue(all.intersects(ra));
+
+        assertTrue(some.intersects(lr));
+        assertTrue(some.intersects(br));
+        assertTrue(some.intersects(bi));
+        assertTrue(some.intersects(ba));
+        assertTrue(some.intersects(la));
+        assertTrue(some.intersects(li));
+        assertTrue(some.intersects(ii));
+        assertTrue(some.intersects(ir));
+        assertFalse(some.intersects(bb));
+        assertFalse(some.intersects(aa));
+        assertFalse(some.intersects(bl));
+        assertTrue(some.intersects(ra));
+
+        assertTrue(someWrapped.intersects(lr));
+        assertTrue(someWrapped.intersects(br));
+        assertTrue(someWrapped.intersects(bi));
+        assertTrue(someWrapped.intersects(ba));
+        assertTrue(someWrapped.intersects(la));
+        assertTrue(someWrapped.intersects(li));
+        assertFalse(someWrapped.intersects(ii));
+        assertFalse(someWrapped.intersects(ir));
+        assertTrue(someWrapped.intersects(bb));
+        assertTrue(someWrapped.intersects(aa));
+        assertTrue(someWrapped.intersects(bl));
+        assertTrue(someWrapped.intersects(ra));
+    }
+
+    @Test
+    public void rangeIntersectsExcludingBounds() throws Exception
+    {
+        Range<Token> all = new Range<>(new BigIntegerToken("0"), new BigIntegerToken("0"));
+        Range<Token> some = new Range<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        Range<Token> someWrapped = new Range<>(some.right, some.left);
+
+        // Coda:
+        // l - matches left token of some range
+        // r - matches right token of some range
+        // b - below left token of some range
+        // a - above right token of some range
+        // i - inside some range (above left and below right
+        ExcludingBounds<Token> lr = new ExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        ExcludingBounds<Token> br = new ExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("8"));
+        ExcludingBounds<Token> bi = new ExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("7"));
+        ExcludingBounds<Token> ba = new ExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("9"));
+        ExcludingBounds<Token> la = new ExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("9"));
+        ExcludingBounds<Token> li = new ExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("7"));
+        ExcludingBounds<Token> ii = new ExcludingBounds<>(new BigIntegerToken("5"), new BigIntegerToken("7"));
+        ExcludingBounds<Token> ir = new ExcludingBounds<>(new BigIntegerToken("5"), new BigIntegerToken("8"));
+        ExcludingBounds<Token> bb = new ExcludingBounds<>(new BigIntegerToken("2"), new BigIntegerToken("3"));
+        ExcludingBounds<Token> aa = new ExcludingBounds<>(new BigIntegerToken("9"), new BigIntegerToken("10"));
+        ExcludingBounds<Token> bl = new ExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("4"));
+        ExcludingBounds<Token> ra = new ExcludingBounds<>(new BigIntegerToken("8"), new BigIntegerToken("9"));
+
+        assertTrue(all.intersects(lr));
+        assertTrue(all.intersects(br));
+        assertTrue(all.intersects(bi));
+        assertTrue(all.intersects(ba));
+        assertTrue(all.intersects(la));
+        assertTrue(all.intersects(li));
+        assertTrue(all.intersects(ii));
+        assertTrue(all.intersects(ir));
+        assertTrue(all.intersects(bb));
+        assertTrue(all.intersects(aa));
+        assertTrue(all.intersects(bl));
+        assertTrue(all.intersects(ra));
+
+        assertTrue(some.intersects(lr));
+        assertTrue(some.intersects(br));
+        assertTrue(some.intersects(bi));
+        assertTrue(some.intersects(ba));
+        assertTrue(some.intersects(la));
+        assertTrue(some.intersects(li));
+        assertTrue(some.intersects(ii));
+        assertTrue(some.intersects(ir));
+        assertFalse(some.intersects(bb));
+        assertFalse(some.intersects(aa));
+        assertFalse(some.intersects(bl));
+        assertFalse(some.intersects(ra));
+
+        assertTrue(someWrapped.intersects(lr));
+        assertTrue(someWrapped.intersects(br));
+        assertTrue(someWrapped.intersects(bi));
+        assertTrue(someWrapped.intersects(ba));
+        assertTrue(someWrapped.intersects(la));
+        assertTrue(someWrapped.intersects(li));
+        assertFalse(someWrapped.intersects(ii));
+        assertFalse(someWrapped.intersects(ir));
+        assertTrue(someWrapped.intersects(bb));
+        assertTrue(someWrapped.intersects(aa));
+        assertFalse(someWrapped.intersects(bl));
+        assertFalse(someWrapped.intersects(ra));
+
+        Range<Token> range = new Range<>(Murmur3Partitioner.MINIMUM, new Murmur3Partitioner.LongToken(-1));
+        ExcludingBounds<Token> bounds = new ExcludingBounds<>(new Murmur3Partitioner.LongToken(-3248873570005575792L), Murmur3Partitioner.MINIMUM);
+
+        assertTrue(range.intersects(bounds));
+
+        range = new Range<>(new Murmur3Partitioner.LongToken(-1), Murmur3Partitioner.MINIMUM);
+
+        assertTrue(range.intersects(bounds));
+
+    }
+
+    @Test
+    public void rangeIntersectsIncludingExcludingBounds()
+    {
+        Range<Token> all = new Range<>(new BigIntegerToken("0"), new BigIntegerToken("0"));
+        Range<Token> some = new Range<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        Range<Token> someWrapped = new Range<>(some.right, some.left);
+
+        // Coda:
+        // l - matches left token of some range
+        // r - matches right token of some range
+        // b - below left token of some range
+        // a - above right token of some range
+        // i - inside some range (above left and below right
+        IncludingExcludingBounds<Token> lr = new IncludingExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("8"));
+        IncludingExcludingBounds<Token> br = new IncludingExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("8"));
+        IncludingExcludingBounds<Token> bi = new IncludingExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("7"));
+        IncludingExcludingBounds<Token> ba = new IncludingExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("9"));
+        IncludingExcludingBounds<Token> la = new IncludingExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("9"));
+        IncludingExcludingBounds<Token> li = new IncludingExcludingBounds<>(new BigIntegerToken("4"), new BigIntegerToken("7"));
+        IncludingExcludingBounds<Token> ii = new IncludingExcludingBounds<>(new BigIntegerToken("5"), new BigIntegerToken("7"));
+        IncludingExcludingBounds<Token> ir = new IncludingExcludingBounds<>(new BigIntegerToken("5"), new BigIntegerToken("8"));
+        IncludingExcludingBounds<Token> bb = new IncludingExcludingBounds<>(new BigIntegerToken("2"), new BigIntegerToken("3"));
+        IncludingExcludingBounds<Token> aa = new IncludingExcludingBounds<>(new BigIntegerToken("9"), new BigIntegerToken("10"));
+        IncludingExcludingBounds<Token> bl = new IncludingExcludingBounds<>(new BigIntegerToken("3"), new BigIntegerToken("4"));
+        IncludingExcludingBounds<Token> ra = new IncludingExcludingBounds<>(new BigIntegerToken("8"), new BigIntegerToken("9"));
+
+        assertTrue(all.intersects(lr));
+        assertTrue(all.intersects(br));
+        assertTrue(all.intersects(bi));
+        assertTrue(all.intersects(ba));
+        assertTrue(all.intersects(la));
+        assertTrue(all.intersects(li));
+        assertTrue(all.intersects(ii));
+        assertTrue(all.intersects(ir));
+        assertTrue(all.intersects(bb));
+        assertTrue(all.intersects(aa));
+        assertTrue(all.intersects(bl));
+        assertTrue(all.intersects(ra));
+
+        assertTrue(some.intersects(lr));
+        assertTrue(some.intersects(br));
+        assertTrue(some.intersects(bi));
+        assertTrue(some.intersects(ba));
+        assertTrue(some.intersects(la));
+        assertTrue(some.intersects(li));
+        assertTrue(some.intersects(ii));
+        assertTrue(some.intersects(ir));
+        assertFalse(some.intersects(bb));
+        assertFalse(some.intersects(aa));
+        assertFalse(some.intersects(bl));
+        assertTrue(some.intersects(ra));
+
+        assertTrue(someWrapped.intersects(lr));
+        assertTrue(someWrapped.intersects(br));
+        assertTrue(someWrapped.intersects(bi));
+        assertTrue(someWrapped.intersects(ba));
+        assertTrue(someWrapped.intersects(la));
+        assertTrue(someWrapped.intersects(li));
+        assertFalse(someWrapped.intersects(ii));
+        assertFalse(someWrapped.intersects(ir));
+        assertTrue(someWrapped.intersects(bb));
+        assertTrue(someWrapped.intersects(aa));
+        assertFalse(someWrapped.intersects(bl));
+        assertTrue(someWrapped.intersects(ra));
+    }
+
+    /**
+     * Test that we handle partial bounds of the type x > n or x >= n which specifically have
+     * their right value as minimum.
+     */
+    @Test
+    public void rangeIntersectsPartialBounds()
+    {
+        Range<Token> range = new Range<>(Murmur3Partitioner.MINIMUM, new Murmur3Partitioner.LongToken(-1L));
+
+        Bounds<Token> boundsMatch = new Bounds<>(new Murmur3Partitioner.LongToken(-2L), Murmur3Partitioner.MINIMUM);
+        Bounds<Token> boundsNoMatch = new Bounds<>(new Murmur3Partitioner.LongToken(0L), Murmur3Partitioner.MINIMUM);
+
+        assertTrue(range.intersects(boundsMatch));
+        assertFalse(range.intersects(boundsNoMatch));
+
+        ExcludingBounds<Token> excBoundsMatch = new ExcludingBounds<>(new Murmur3Partitioner.LongToken(-2L), Murmur3Partitioner.MINIMUM);
+        ExcludingBounds<Token> excBoundsNoMatch = new ExcludingBounds<>(new Murmur3Partitioner.LongToken(-1L), Murmur3Partitioner.MINIMUM);
+
+        assertTrue(range.intersects(excBoundsMatch));
+        assertFalse(range.intersects(excBoundsNoMatch));
+
+        IncludingExcludingBounds<Token> incExcBoundsMatch = new IncludingExcludingBounds<>(new Murmur3Partitioner.LongToken(-2L), Murmur3Partitioner.MINIMUM);
+        IncludingExcludingBounds<Token> incExcBoundsNoMatch = new IncludingExcludingBounds<>(new Murmur3Partitioner.LongToken(0L), Murmur3Partitioner.MINIMUM);
+
+        assertTrue(range.intersects(incExcBoundsMatch));
+        assertFalse(range.intersects(incExcBoundsNoMatch));
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
+++ b/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
@@ -159,6 +159,11 @@ public class RangeIntersectsBoundsTest extends CassandraTestBase
         assertFalse(someWrapped.intersects(ir));
         assertTrue(someWrapped.intersects(bb));
         assertTrue(someWrapped.intersects(aa));
+        // TODO (CASSANDRA-18216): bl=(3,4) and ra=(8,9) are empty on integer tokens (no value between adjacent
+        // integers), so assertFalse is accidentally correct here. With PartitionPosition (where multiple keys can
+        // share a token), these intervals are non-empty and the wrapping range (8,4] would intersect them. The
+        // wrapping branch in Range.intersects(ExcludingBounds) returns false for these cases; revisit if
+        // ExcludingBounds is ever used with PartitionPosition on wrapping ranges.
         assertFalse(someWrapped.intersects(bl));
         assertFalse(someWrapped.intersects(ra));
 
@@ -235,6 +240,10 @@ public class RangeIntersectsBoundsTest extends CassandraTestBase
         assertFalse(someWrapped.intersects(ir));
         assertTrue(someWrapped.intersects(bb));
         assertTrue(someWrapped.intersects(aa));
+        // TODO (CASSANDRA-18216): bl=[3,4) includes 3, and (8,4] wrapping contains 3 — they intersect. This
+        // assertFalse matches the wrapping branch in Range.intersects(IncludingExcludingBounds) which returns
+        // false when this.right == that.right (both 4). The branch is semantically wrong for this case but is
+        // dead code for SAI (shard ranges never wrap). Ported as-is from DS fork PR #298.
         assertFalse(someWrapped.intersects(bl));
         assertTrue(someWrapped.intersects(ra));
     }

--- a/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
+++ b/test/unit/org/apache/cassandra/dht/RangeIntersectsBoundsTest.java
@@ -20,10 +20,9 @@ package org.apache.cassandra.dht;
 
 import org.junit.Test;
 
-import org.apache.cassandra.dht.RandomPartitioner.BigIntegerToken;
-
 import org.apache.cassandra.CassandraTestBase;
 import org.apache.cassandra.CassandraTestBase.DDDaemonInitialization;
+import org.apache.cassandra.dht.RandomPartitioner.BigIntegerToken;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -267,6 +267,16 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldRejectShardsOptionOnVectorIndex()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val vector<float, 3>)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '4' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("vector column does not support sharding");
+    }
+
+    @Test
     public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -277,6 +277,39 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldCreateIndexWithValidShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val1 text, val2 text)");
+        createIndex("CREATE INDEX ON %s(val1) USING 'sai' WITH OPTIONS = { 'shards' : '1' }");
+        createIndex("CREATE INDEX ON %s(val2) USING 'sai' WITH OPTIONS = { 'shards' : '4' }");
+        assertEquals(2, saiCreationCounter.get());
+    }
+
+    @Test
+    public void shouldRejectNonIntegerShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : 'abc' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a valid integer");
+    }
+
+    @Test
+    public void shouldRejectNonPositiveShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '0' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a positive integer");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '-5' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a positive integer");
+    }
+
+    @Test
     public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -280,6 +280,39 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldCreateIndexWithValidShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val1 text, val2 text)");
+        createIndex("CREATE INDEX ON %s(val1) USING 'sai' WITH OPTIONS = { 'shards' : '1' }");
+        createIndex("CREATE INDEX ON %s(val2) USING 'sai' WITH OPTIONS = { 'shards' : '4' }");
+        assertEquals(2, saiCreationCounter.get());
+    }
+
+    @Test
+    public void shouldRejectNonIntegerShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : 'abc' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a valid integer");
+    }
+
+    @Test
+    public void shouldRejectNonPositiveShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '0' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a positive integer");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '-5' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must be a positive integer");
+    }
+
+    @Test
     public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -270,6 +270,16 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldRejectShardsOptionOnVectorIndex()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val vector<float, 3>)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '4' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("vector column does not support sharding");
+    }
+
+    @Test
     public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -313,6 +313,16 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldRejectShardsOptionGreaterThanMaxShardCount()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : '257' }"))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessageContaining("Shard count for a storage-attached index must not exceed");
+    }
+
+    @Test
     public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -82,9 +82,11 @@ import org.apache.cassandra.inject.InvokePointBuilder;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 
 import static java.util.Collections.singletonList;
+import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -296,6 +298,21 @@ public class StorageAttachedIndexDDLTest extends SAITester
         assertThatThrownBy(() -> executeNet("CREATE INDEX ON %s(val) USING 'sai' WITH OPTIONS = { 'shards' : 'abc' }"))
         .isInstanceOf(InvalidQueryException.class)
         .hasMessageContaining("Shard count for a storage-attached index must be a valid integer");
+    }
+
+    @Test
+    public void shouldCreateIndexWithAutoShardsOption()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val1 text, val2 text, val3 text)");
+        createIndex("CREATE INDEX auto_idx ON %s(val1) USING 'sai' WITH OPTIONS = { 'shards' : 'auto' }");
+        createIndex("CREATE INDEX ON %s(val2) USING 'sai' WITH OPTIONS = { 'shards' : 'Auto' }");
+        createIndex("CREATE INDEX ON %s(val3) USING 'sai' WITH OPTIONS = { 'shards' : 'AUTO' }");
+        assertEquals(3, saiCreationCounter.get());
+
+        SecondaryIndexManager sim = getCurrentColumnFamilyStore().indexManager;
+        StorageAttachedIndex index = (StorageAttachedIndex) sim.getIndexByName("auto_idx");
+        int expectedShardCount = MEMTABLE_SHARD_COUNT.getInt(FBUtilities.getAvailableProcessors());
+        assertEquals(expectedShardCount, index.shardCount());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexFlushTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import org.junit.Test;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.index.sai.utils.SAIRandomizedTester;
+
+public class ShardedMemtableIndexFlushTest extends SAIRandomizedTester
+{
+    @Test
+    public void flushShardedIndexWithReversedClustering()
+    {
+        createTable("CREATE TABLE %s (pk0 varint, ck0 bigint, ck1 text, v0 uuid, PRIMARY KEY (pk0, ck0, ck1)) WITH CLUSTERING ORDER BY (ck0 DESC, ck1 DESC)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(ck0) USING 'StorageAttachedIndex' WITH OPTIONS = {'shards': '4'}");
+        createIndex("CREATE CUSTOM INDEX ON %s(ck1) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk0, ck0, ck1, v0) VALUES (0, 3796795943589367651, 'apple', uuid()) USING TIMESTAMP 2");
+        execute("INSERT INTO %s (pk0, ck0, ck1, v0) VALUES (0, 5390896686766209114, 'banana', uuid()) USING TIMESTAMP 4");
+
+        execute("UPDATE %s USING TIMESTAMP 5 SET v0 = uuid() WHERE pk0 = 13271891 AND ck0 = 7466188966332780245 AND ck1 = 'cherry'");
+        execute("UPDATE %s USING TIMESTAMP 5 SET v0 = uuid() WHERE pk0 = 2081887771 AND ck0 = 7466188966332780245 AND ck1 = 'cherry'");
+
+        execute("UPDATE %s USING TIMESTAMP 6 SET v0 = uuid() WHERE pk0 = 0 AND ck0 = 8977613850235134686 AND ck1 = 'date'");
+        execute("UPDATE %s USING TIMESTAMP 6 SET v0 = uuid() WHERE pk0 = 4982 AND ck0 = 8977613850235134686 AND ck1 = 'date'");
+
+        // Verify data is visible before flush
+        UntypedResultSet beforeFlush = execute("SELECT * FROM %s WHERE ck0 = 8977613850235134686 AND ck1 = 'date' ALLOW FILTERING");
+        assertRowCount(beforeFlush, 2);
+
+        flush();
+
+        // After flush, same query should return same results
+        UntypedResultSet afterFlush = execute("SELECT * FROM %s WHERE ck0 = 8977613850235134686 AND ck1 = 'date' ALLOW FILTERING");
+        assertRowCount(afterFlush, 2);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexFlushTest.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.memory;
 
 import org.junit.Test;
+
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.utils.SAIRandomizedTester;
 

--- a/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.statements.schema.IndexTarget;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.index.sai.utils.SAIRandomizedTester;
+import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShardedMemtableIndexTest extends SAIRandomizedTester
+{
+    private ColumnFamilyStore cfs;
+    private IPartitioner partitioner;
+    private StorageAttachedIndex index;
+    private ShardedMemtableIndex memtableIndex;
+    private Map<DecoratedKey, Integer> keyMap;
+    private Map<Integer, Integer> rowMap;
+
+    @BeforeClass
+    public static void setShardCount() {
+        System.setProperty(MEMTABLE_SHARD_COUNT.getKey(), "8");
+    }
+
+    @Before
+    public void setup() throws Throwable
+    {
+        // CQLTester @BeforeClass already sets up server.
+        // Set up the keyspace and the table.
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        String table = createTable(keyspace,
+                                   "CREATE TABLE %s (pk int PRIMARY KEY, val int)",
+                            "memtable_index");
+        execute("use " + keyspace + ";");
+
+        setupCfsAndIndex(keyspace, table);
+
+        partitioner = cfs.getPartitioner();
+        keyMap = new TreeMap<>();
+        rowMap = new HashMap<>();
+    }
+
+    public void setupCfsAndIndex(String keyspace, String table)
+    {
+        cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        Map<String, String> options = new HashMap<>();
+        options.put(IndexTarget.CUSTOM_INDEX_OPTION_NAME,
+                    StorageAttachedIndex.class.getCanonicalName());
+        options.put("target", "val");
+
+        IndexMetadata indexMetadata = IndexMetadata.fromSchemaMetadata("val_idx", IndexMetadata.Kind.CUSTOM, options);
+
+        index = new StorageAttachedIndex(cfs, indexMetadata);
+    }
+
+    @Test
+    public void onHeapAllocationTest()
+    {
+        // Should take the system variable-based shard count here
+        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        assertEquals(8, memtableIndex.shardCount());
+
+        assertEquals(0L, memtableIndex.writeCount());
+
+        for (int row = 0; row < 100; row++)
+        {
+            addRow(row, row);
+        }
+
+        assertTrue(memtableIndex.writeCount() > 0);
+    }
+
+    @Test
+    public void randomQueryTest() throws Exception
+    {
+        // Should take the system variable-based shard count here
+        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        assertEquals(8, memtableIndex.shardCount());
+
+        for (int row = 0; row < getRandom().nextIntBetween(1000, 5000); row++)
+        {
+            int pk = getRandom().nextIntBetween(0, 10000);
+            while (rowMap.containsKey(pk))
+                pk = getRandom().nextIntBetween(0, 10000);
+            int value = getRandom().nextIntBetween(0, 100);
+            rowMap.put(pk, value);
+            addRow(pk, value);
+        }
+
+        List<DecoratedKey> keys = new ArrayList<>(keyMap.keySet());
+
+        for (int executionCount = 0; executionCount < 1000; executionCount++)
+        {
+            Expression expression = generateRandomExpression(index);
+
+            AbstractBounds<PartitionPosition> keyRange = generateRandomBounds(keys, partitioner);
+
+            Set<Integer> expectedKeys = keyMap.keySet()
+                                              .stream()
+                                              .filter(keyRange::contains)
+                                              .map(keyMap::get)
+                                              .filter(pk -> expression.isSatisfiedBy(Int32Type.instance.decompose(rowMap.get(pk))))
+                                              .collect(Collectors.toSet());
+
+            Set<Integer> foundKeys = new HashSet<>();
+
+            try (KeyRangeIterator iterator = memtableIndex.search(null, expression, keyRange))
+            {
+                while (iterator.hasNext())
+                {
+                    int key = Int32Type.instance.compose(iterator.next().partitionKey().getKey());
+                    assertFalse(foundKeys.contains(key));
+                    foundKeys.add(key);
+                }
+            }
+
+            assertEquals(expectedKeys, foundKeys);
+        }
+    }
+
+    @Test
+    public void indexIteratorTest()
+    {
+        // Should take the system variable-based shard count here
+        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        assertEquals(8, memtableIndex.shardCount());
+
+        Map<Integer, Set<DecoratedKey>> terms = buildTermMap();
+
+        terms.entrySet()
+             .stream()
+             .forEach(entry -> entry.getValue()
+                                    .forEach(pk -> addRow(Int32Type.instance.compose(pk.getKey()), entry.getKey())));
+
+        for (int executionCount = 0; executionCount < 1000; executionCount++)
+        {
+            // These keys have midrange tokens that select 3 of the 8 shards
+            DecoratedKey minimum = makeKey(cfs.metadata(), getRandom().nextIntBetween(0, 20000));
+            DecoratedKey temp = makeKey(cfs.metadata(), getRandom().nextIntBetween(0, 20000));
+            while (temp.compareTo(minimum) <= 0)
+                temp = makeKey(cfs.metadata(), getRandom().nextIntBetween(0, 20000));
+            DecoratedKey maximum = temp;
+
+            Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator = memtableIndex.iterator(minimum, maximum);
+
+            while (iterator.hasNext())
+            {
+                Pair<ByteComparable, Iterator<PrimaryKey>> termPair = iterator.next();
+                int term = termFromComparable(termPair.left);
+
+                // The iterator will return keys outside the range of min/max so we need to filter here to
+                // get the correct keys
+                List<DecoratedKey> expectedPks = terms.get(term)
+                                                      .stream()
+                                                      .filter(pk -> pk.compareTo(minimum) >= 0 && pk.compareTo(maximum) <= 0)
+                                                      .sorted()
+                                                      .collect(Collectors.toList());
+
+                List<DecoratedKey> termPks = new ArrayList<>();
+
+                while (termPair.right.hasNext())
+                {
+                    DecoratedKey pk = termPair.right.next().partitionKey();
+                    if (pk.compareTo(minimum) >= 0 && pk.compareTo(maximum) <= 0)
+                        termPks.add(pk);
+                }
+
+                assertEquals(expectedPks, termPks);
+            }
+        }
+    }
+
+    private int termFromComparable(ByteComparable comparable)
+    {
+        ByteSource.Peekable peekable = ByteSource.peekable(comparable.asComparableBytes(ByteComparable.Version.OSS50));
+        return Int32Type.instance.compose(Int32Type.instance.fromComparableBytes(peekable, ByteComparable.Version.OSS50));
+    }
+
+    private Map<Integer, Set<DecoratedKey>> buildTermMap()
+    {
+        Map<Integer, Set<DecoratedKey>> terms = new HashMap<>();
+
+        for (int count = 0; count < 10000; count++)
+        {
+            int term = getRandom().nextIntBetween(0, 100);
+            Set<DecoratedKey> pks;
+            if (terms.containsKey(term))
+                pks = terms.get(term);
+            else
+            {
+                pks = new HashSet<>();
+                terms.put(term, pks);
+            }
+            DecoratedKey key = makeKey(cfs.metadata(), getRandom().nextIntBetween(0, 20000));
+            while (pks.contains(key))
+                key = makeKey(cfs.metadata(), getRandom().nextIntBetween(0, 20000));
+            pks.add(key);
+        }
+
+        return terms;
+    }
+
+    private void addRow(int pk, int value)
+    {
+        DecoratedKey key = makeKey(cfs.metadata(), pk);
+        memtableIndex.index(key, Clustering.EMPTY, Int32Type.instance.decompose(value));
+        keyMap.put(key, pk);
+    }
+
+    private DecoratedKey makeKey(TableMetadata table, Integer partitionKey)
+    {
+        ByteBuffer key = table.partitionKeyType.fromString(partitionKey.toString());
+        return table.partitioner.decorateKey(key);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/ShardedMemtableIndexTest.java
@@ -30,7 +30,6 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -53,7 +52,6 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -66,11 +64,6 @@ public class ShardedMemtableIndexTest extends SAIRandomizedTester
     private ShardedMemtableIndex memtableIndex;
     private Map<DecoratedKey, Integer> keyMap;
     private Map<Integer, Integer> rowMap;
-
-    @BeforeClass
-    public static void setShardCount() {
-        System.setProperty(MEMTABLE_SHARD_COUNT.getKey(), "8");
-    }
 
     @Before
     public void setup() throws Throwable
@@ -108,8 +101,7 @@ public class ShardedMemtableIndexTest extends SAIRandomizedTester
     @Test
     public void onHeapAllocationTest()
     {
-        // Should take the system variable-based shard count here
-        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        memtableIndex = new ShardedMemtableIndex(index, cfs, 8, cfs.getCurrentMemtable());
         assertEquals(8, memtableIndex.shardCount());
 
         assertEquals(0L, memtableIndex.writeCount());
@@ -125,8 +117,7 @@ public class ShardedMemtableIndexTest extends SAIRandomizedTester
     @Test
     public void randomQueryTest() throws Exception
     {
-        // Should take the system variable-based shard count here
-        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        memtableIndex = new ShardedMemtableIndex(index, cfs, 8, cfs.getCurrentMemtable());
         assertEquals(8, memtableIndex.shardCount());
 
         for (int row = 0; row < getRandom().nextIntBetween(1000, 5000); row++)
@@ -173,8 +164,7 @@ public class ShardedMemtableIndexTest extends SAIRandomizedTester
     @Test
     public void indexIteratorTest()
     {
-        // Should take the system variable-based shard count here
-        memtableIndex = new ShardedMemtableIndex(index, cfs, null, cfs.getCurrentMemtable());
+        memtableIndex = new ShardedMemtableIndex(index, cfs, 8, cfs.getCurrentMemtable());
         assertEquals(8, memtableIndex.shardCount());
 
         Map<Integer, Set<DecoratedKey>> terms = buildTermMap();

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
@@ -33,7 +33,6 @@ import org.HdrHistogram.Histogram;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -43,11 +42,7 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Bounds;
-import org.apache.cassandra.dht.ExcludingBounds;
-import org.apache.cassandra.dht.IncludingExcludingBounds;
 import org.apache.cassandra.dht.Murmur3Partitioner;
-import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
@@ -110,9 +105,9 @@ public class TrieMemoryIndexTest extends SAIRandomizedTester
 
         for (int executionCount = 0; executionCount < 1000; executionCount++)
         {
-            Expression expression = generateRandomExpression();
+            Expression expression = generateRandomExpression(this.index);
 
-            AbstractBounds<PartitionPosition> keyRange = generateRandomBounds(keys);
+            AbstractBounds<PartitionPosition> keyRange = generateRandomBounds(keys, Murmur3Partitioner.instance);
 
             Set<Integer> expectedKeys = keyMap.keySet()
                                               .stream()
@@ -135,62 +130,6 @@ public class TrieMemoryIndexTest extends SAIRandomizedTester
 
             assertEquals(expectedKeys, foundKeys);
         }
-    }
-
-    private AbstractBounds<PartitionPosition> generateRandomBounds(List<DecoratedKey> keys)
-    {
-        PartitionPosition leftBound = getRandom().nextBoolean() ? Murmur3Partitioner.instance.getMinimumToken().minKeyBound()
-                                                                : keys.get(getRandom().nextIntBetween(0, keys.size() - 1)).getToken().minKeyBound();
-
-        PartitionPosition rightBound = getRandom().nextBoolean() ? Murmur3Partitioner.instance.getMinimumToken().minKeyBound()
-                                                                 : keys.get(getRandom().nextIntBetween(0, keys.size() - 1)).getToken().maxKeyBound();
-
-        AbstractBounds<PartitionPosition> keyRange;
-
-        if (leftBound.isMinimum() && rightBound.isMinimum())
-            keyRange = new Range<>(leftBound, rightBound);
-        else
-        {
-            if (AbstractBounds.strictlyWrapsAround(leftBound, rightBound))
-            {
-                PartitionPosition temp = leftBound;
-                leftBound = rightBound;
-                rightBound = temp;
-            }
-            if (getRandom().nextBoolean())
-                keyRange = new Bounds<>(leftBound, rightBound);
-            else if (getRandom().nextBoolean())
-                keyRange = new ExcludingBounds<>(leftBound, rightBound);
-            else
-                keyRange = new IncludingExcludingBounds<>(leftBound, rightBound);
-        }
-        return keyRange;
-    }
-
-    private Expression generateRandomExpression()
-    {
-        Expression expression = Expression.create(index);
-
-        int equality = getRandom().nextIntBetween(0, 100);
-        int lower = getRandom().nextIntBetween(0, 75);
-        int upper = getRandom().nextIntBetween(25, 100);
-        while (upper <= lower)
-            upper = getRandom().nextIntBetween(0, 100);
-
-        if (getRandom().nextBoolean())
-            expression.add(Operator.EQ, Int32Type.instance.decompose(equality));
-        else
-        {
-            boolean useLower = getRandom().nextBoolean();
-            boolean useUpper = getRandom().nextBoolean();
-            if (!useLower && !useUpper)
-                useLower = useUpper = true;
-            if (useLower)
-                expression.add(getRandom().nextBoolean() ? Operator.GT : Operator.GTE, Int32Type.instance.decompose(lower));
-            if (useUpper)
-                expression.add(getRandom().nextBoolean() ? Operator.LT : Operator.LTE, Int32Type.instance.decompose(upper));
-        }
-        return expression;
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/utils/SAIRandomizedTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SAIRandomizedTester.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.index.sai.utils;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.google.common.base.Preconditions;
 
@@ -28,11 +29,22 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Bounds;
+import org.apache.cassandra.dht.ExcludingBounds;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.IncludingExcludingBounds;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.io.IndexFileUtils;
+import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.postings.PostingList;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
@@ -198,5 +210,62 @@ public class SAIRandomizedTester extends SAITester
             array[i] = array[randomPosition];
             array[randomPosition] = temp;
         }
+    }
+
+    public static Expression generateRandomExpression(StorageAttachedIndex index)
+    {
+        Expression expression = Expression.create(index);
+
+        int equality = getRandom().nextIntBetween(0, 100);
+        int lower = getRandom().nextIntBetween(0, 75);
+        int upper = getRandom().nextIntBetween(25, 100);
+        while (upper <= lower)
+            upper = getRandom().nextIntBetween(0, 100);
+
+        if (getRandom().nextBoolean())
+            expression.add(Operator.EQ, Int32Type.instance.decompose(equality));
+        else
+        {
+            boolean useLower = getRandom().nextBoolean();
+            boolean useUpper = getRandom().nextBoolean();
+            if (!useLower && !useUpper)
+                useLower = useUpper = true;
+            if (useLower)
+                expression.add(getRandom().nextBoolean() ? Operator.GT : Operator.GTE, Int32Type.instance.decompose(lower));
+            if (useUpper)
+                expression.add(getRandom().nextBoolean() ? Operator.LT : Operator.LTE, Int32Type.instance.decompose(upper));
+        }
+        return expression;
+    }
+
+    public static AbstractBounds<PartitionPosition> generateRandomBounds(List<DecoratedKey> keys,
+                                                                         IPartitioner partitioner)
+    {
+        PartitionPosition leftBound = getRandom().nextBoolean() ? partitioner.getMinimumToken().minKeyBound()
+                                                                : keys.get(getRandom().nextIntBetween(0, keys.size() - 1)).getToken().minKeyBound();
+
+        PartitionPosition rightBound = getRandom().nextBoolean() ? partitioner.getMinimumToken().minKeyBound()
+                                                                 : keys.get(getRandom().nextIntBetween(0, keys.size() - 1)).getToken().maxKeyBound();
+
+        AbstractBounds<PartitionPosition> keyRange;
+
+        if (leftBound.isMinimum() && rightBound.isMinimum())
+            keyRange = new Range<>(leftBound, rightBound);
+        else
+        {
+            if (AbstractBounds.strictlyWrapsAround(leftBound, rightBound))
+            {
+                PartitionPosition temp = leftBound;
+                leftBound = rightBound;
+                rightBound = temp;
+            }
+            if (getRandom().nextBoolean())
+                keyRange = new Bounds<>(leftBound, rightBound);
+            else if (getRandom().nextBoolean())
+                keyRange = new ExcludingBounds<>(leftBound, rightBound);
+            else
+                keyRange = new IncludingExcludingBounds<>(leftBound, rightBound);
+        }
+        return keyRange;
     }
 }


### PR DESCRIPTION
CASSANDRA-18216: Allow sharding of the SAI in-memory index

- Refactor MemtableIndex from concrete class to interface
- Add UnshardedMemtableIndex preserving existing behavior
- Add ShardedMemtableIndex with token-range sharded TrieMemoryIndex[]
- Extend ShardBoundaries with precomputed partition ranges and shard-to-key-range intersection
- Add Range.intersects() overloads for IncludingExcludingBounds and ExcludingBounds
- Add MemtableIndexManager factory routing based on index options
- Sharding is opt-in via CREATE INDEX WITH OPTIONS = {'shards': '<count>'}
- Reject shards option on vector indexes at validation time

patch by Yash Nasery; reviewed by Caleb Rackliffe for [CASSANDRA-18216](https://issues.apache.org/jira/browse/CASSANDRA-18216)
