### PR TITLE
CASSANDRA-21117: Fix unreliable metric "networking cache size" in nodetool info

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/Info.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Info.java
@@ -145,7 +145,7 @@ public class Info extends AbstractCommand
         try
         {
             out.printf("%-23s: size %s, overflow size: %s, capacity %s%n", "Network Cache",
-                       FileUtils.stringifyFileSize((long) probe.getBufferPoolMetric("networking", "Size")),
+                       FileUtils.stringifyFileSize((long) probe.getBufferPoolMetric("networking", "UsedSize")),
                        FileUtils.stringifyFileSize((long) probe.getBufferPoolMetric("networking", "OverflowSize")),
                        FileUtils.stringifyFileSize((long) probe.getBufferPoolMetric("networking", "Capacity")));
         }

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -882,16 +882,12 @@ public class BufferPool
         {
             Chunk chunk = Chunk.getParentChunk(buffer);
             int originalCapacity = buffer.capacity();
-            int size = originalCapacity - buffer.limit();
 
             if (chunk == null)
-            {
-                updateOverflowMemoryUsage(-size);
                 return;
-            }
 
             chunk.freeUnusedPortion(buffer);
-            // Calculate the actual freed bytes which may be different from `size` when pooling is involved
+            // The actual freed bytes may differ from (originalCapacity - limit) when pooling is involved
             memoryInUse.inc(buffer.capacity() - originalCapacity);
         }
 

--- a/test/unit/org/apache/cassandra/metrics/BufferPoolMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/BufferPoolMetricsTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.cassandra.metrics;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import org.junit.Before;
@@ -240,6 +243,50 @@ public class BufferPoolMetricsTest
         assertEquals(0, metrics.misses.getCount());
         assertThat(metrics.size.getValue()).isEqualTo(bufferPool.sizeInBytes())
                                            .isGreaterThanOrEqualTo(65536);
+    }
+
+    @Test
+    public void testOverflowAccountingBalancesAfterPutUnusedPortionAndPut()
+    {
+        assertEquals(0, metrics.overflowSize.getValue().longValue());
+        assertEquals(0, metrics.usedSize.getValue().longValue());
+
+        // Buffer larger than NORMAL_CHUNK_SIZE bypasses the pool and goes to overflow
+        int bufferSize = BufferPool.NORMAL_CHUNK_SIZE + 1;
+        ByteBuffer buffer = bufferPool.get(bufferSize, BufferType.OFF_HEAP);
+        assertEquals(bufferSize, metrics.overflowSize.getValue().longValue());
+
+        // Simulate partial use: caller only fills half the buffer
+        buffer.limit(bufferSize / 2);
+        bufferPool.putUnusedPortion(buffer);
+
+        // Full return — overflowSize must return to zero, not go negative
+        bufferPool.put(buffer);
+        assertEquals(0, metrics.overflowSize.getValue().longValue());
+        assertEquals(0, metrics.usedSize.getValue().longValue());
+    }
+
+    @Test
+    public void testUsedSizeIsZeroWhenPoolIsIdle()
+    {
+        assertEquals(0, metrics.usedSize.getValue().longValue());
+
+        // Allocate pooled buffers until the pool is fully expanded
+        int bufferSize = BufferPool.NORMAL_CHUNK_SIZE - 1;
+        List<ByteBuffer> buffers = new ArrayList<>();
+        while (bufferPool.sizeInBytes() < bufferPool.memoryUsageThreshold())
+            buffers.add(bufferPool.get(bufferSize, BufferType.OFF_HEAP));
+
+        assertThat(metrics.usedSize.getValue().longValue()).isGreaterThan(0);
+
+        // Return all buffers — pool stays expanded but usedSize must drop to zero
+        for (ByteBuffer buf : buffers)
+            bufferPool.put(buf);
+
+        assertEquals(0, metrics.usedSize.getValue().longValue());
+        // sizeInBytes remains at capacity (memoryAllocated is never decremented),
+        // confirming that usedSize and sizeInBytes measure different things
+        assertThat(bufferPool.sizeInBytes()).isGreaterThan(0);
     }
 
     private void tryRequestNegativeBufferSize()


### PR DESCRIPTION
nodetool info reported "Network Cache" size using BufferPool.sizeInBytes() which includes memoryAllocated - a monotonically non-decreasing counter that never drops below the pool's high-water mark. Switch to usedSizeInBytes() which tracks only currently checked-out buffers.

Additionally fix BufferPool.LocalPool.putUnusedPortion for non-pooled buffers: the chunk==null branch was decrementing overflowMemoryUsage by the unused portion, but the subsequent put() decremented by the full original capacity, causing overflowMemoryUsage to drift negative over time.
