### PR TITLE
CASSANDRA-21479 Allow calculations with let variables within update statements

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -2111,7 +2111,7 @@ normalColumnOperation[UpdateStatement.OperationCollector operations, ColumnIdent
               addRecognitionError("Only expressions of the form X = X " + ($i.text.charAt(0) == '-' ? '-' : '+') + " <value> are supported.");
           addRawUpdate(operations, key, new Operation.Addition(Constants.Literal.integer($i.text)));
       }
-     | {isParsingTxn}? r=dottedRowDataReference (sig=('+'|'-') t=term)?
+     | {isParsingTxn}? r=dottedRowDataReference (sig=('+'|'-') t=term)? // Todo: This parses row1.v + 2, but we still need to handle the case for 2 + row1.v and also key + row1.v
        {
            if (t == null)
            {

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -807,7 +807,7 @@ rowDataReference returns [RowDataReference.Raw rawRef]
     : t=sident ('.' s=referenceSelection)? { tuple = t; selectable = s; }
     ;
 
-dottedRowDataReference returns [RowDataReference.Raw rawRef]
+indexedRowDataReference returns [RowDataReference.Raw rawRef]
     @init { Selectable.RawIdentifier tuple = null; Selectable.Raw selectable = null; }
     @after { $rawRef = newRowDataReference(tuple, selectable); }
     : t=sident '.' s=referenceSelection { tuple = t; selectable = s; }
@@ -2111,7 +2111,7 @@ normalColumnOperation[UpdateStatement.OperationCollector operations, ColumnIdent
               addRecognitionError("Only expressions of the form X = X " + ($i.text.charAt(0) == '-' ? '-' : '+') + " <value> are supported.");
           addRawUpdate(operations, key, new Operation.Addition(Constants.Literal.integer($i.text)));
       }
-     | {isParsingTxn}? r=dottedRowDataReference (sig=('+'|'-') t=term)? // Todo: This parses row1.v + 2, but we still need to handle the case for 2 + row1.v and also key + row1.v
+     | {isParsingTxn}? r=indexedRowDataReference (sig=('+'|'-') t=term)? 
        {
            if (t == null)
            {

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -807,6 +807,12 @@ rowDataReference returns [RowDataReference.Raw rawRef]
     : t=sident ('.' s=referenceSelection)? { tuple = t; selectable = s; }
     ;
 
+dottedRowDataReference returns [RowDataReference.Raw rawRef]
+    @init { Selectable.RawIdentifier tuple = null; Selectable.Raw selectable = null; }
+    @after { $rawRef = newRowDataReference(tuple, selectable); }
+    : t=sident '.' s=referenceSelection { tuple = t; selectable = s; }
+    ;
+
 referenceSelection returns [Selectable.Raw s]
     : g=referenceSelectionWithoutField m=selectorModifier[g] {$s = m;}
     ;
@@ -2105,9 +2111,16 @@ normalColumnOperation[UpdateStatement.OperationCollector operations, ColumnIdent
               addRecognitionError("Only expressions of the form X = X " + ($i.text.charAt(0) == '-' ? '-' : '+') + " <value> are supported.");
           addRawUpdate(operations, key, new Operation.Addition(Constants.Literal.integer($i.text)));
       }
-     | {isParsingTxn}? r=rowDataReference
+     | {isParsingTxn}? r=dottedRowDataReference (sig=('+'|'-') t=term)?
        {
-           addRawReferenceOperation(operations, key, new ReferenceOperation.Raw(new Operation.SetValue(r), key, new ReferenceValue.Substitution.Raw(r)));
+           if (t == null)
+           {
+               addRawReferenceOperation(operations, key, new ReferenceOperation.Raw(new Operation.SetValue(r), key, new ReferenceValue.Substitution.Raw(r)));
+           }
+           else
+           {
+               addRawReferenceOperation(operations, key, new ReferenceOperation.Raw($sig.text.equals("+") ? new Operation.Addition(t) : new Operation.Substraction(t), key, new ReferenceValue.Substitution.Raw(r)));
+           }
        }
     ;
 

--- a/src/java/org/apache/cassandra/cql3/Operation.java
+++ b/src/java/org/apache/cassandra/cql3/Operation.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.cql3;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.cassandra.cql3.functions.Function;
@@ -119,6 +120,11 @@ public abstract class Operation
      * @param builder      parameters of the update.
      */
     public abstract void execute(DecoratedKey partitionKey, RowUpdateBuilder builder) throws InvalidRequestException;
+
+    public void execute(DecoratedKey partitionKey, RowUpdateBuilder builder, ByteBuffer term) throws InvalidRequestException
+    {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * A parsed raw UPDATE operation.

--- a/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
@@ -214,7 +214,7 @@ public class UpdateStatement extends ModificationStatement
                 {
                     ReferenceValue.Raw raw = (ReferenceValue.Raw) value;
                     ReferenceValue referenceValue = raw.prepare(def, bindVariables);
-                    ReferenceOperation operation = new ReferenceOperation(def, metadata, TxnReferenceOperation.Kind.setterFor(def), null, null, referenceValue);
+                    ReferenceOperation operation = new ReferenceOperation(def, metadata, TxnReferenceOperation.Kind.setterFor(def), null, null, null, referenceValue);
                     operations.add(def, operation);
                 }
                 else

--- a/src/java/org/apache/cassandra/cql3/terms/Constants.java
+++ b/src/java/org/apache/cassandra/cql3/terms/Constants.java
@@ -21,6 +21,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
+import accord.utils.Invariants;
+
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.ColumnSpecification;
@@ -550,6 +552,30 @@ public abstract class Constants
                 builder.addCell(column, newValue);
             }
         }
+
+        public void execute(DecoratedKey partitionKey, RowUpdateBuilder builder, ByteBuffer constant) throws InvalidRequestException
+        {
+            Invariants.require(constant != null);
+            if (column.type instanceof NumberType<?>)
+            {
+                @SuppressWarnings("unchecked") NumberType<Number> type = (NumberType<Number>) column.type;
+                ByteBuffer increment = type.sanitize(t.bindAndGet(builder));
+                if (increment == null)
+                    return;
+                ByteBuffer newValue = type.add(type.compose(constant), type.compose(increment));
+                builder.addCell(column, newValue);
+            }
+            else if (column.type instanceof StringType)
+            {
+                ByteBuffer left = t.bindAndGet(builder);
+                if (left == null)
+                    return;
+                ByteBuffer newValue = ByteBuffer.allocate(left.remaining() + constant.remaining());
+                FastByteOperations.copy(left, left.position(), newValue, newValue.position(), left.remaining());
+                FastByteOperations.copy(constant, constant.position(), newValue, newValue.position() + left.remaining(), constant.remaining());
+                builder.addCell(column, newValue);
+            }
+        }
     }
 
     public static class Substracter extends Operation
@@ -591,6 +617,20 @@ public abstract class Constants
                 if (current == null)
                     return;
                 ByteBuffer newValue = type.substract(type.compose(current), type.compose(increment));
+                builder.addCell(column, newValue);
+            }
+        }
+
+        public void execute(DecoratedKey partitionKey, RowUpdateBuilder builder, ByteBuffer constant) throws InvalidRequestException
+        {
+            Invariants.require(constant != null);
+            if (column.type instanceof NumberType<?>)
+            {
+                @SuppressWarnings("unchecked") NumberType<Number> type = (NumberType<Number>) column.type;
+                ByteBuffer increment = type.sanitize(t.bindAndGet(builder));
+                if (increment == null)
+                    return;
+                ByteBuffer newValue = type.substract(type.compose(increment), type.compose(constant));
                 builder.addCell(column, newValue);
             }
         }

--- a/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
@@ -64,7 +64,7 @@ public class ReferenceOperation
     }
 
     /**
-     * Creates a {@link ReferenceOperation} from the given {@link  Operation} for the purpose of defering execution
+     * Creates a {@link ReferenceOperation} from the given {@link Operation} for the purpose of defering execution
      * within a transaction. When the language sees an Operation using a reference one is created already, but for cases
      * that needs to defer execution (such as when {@link Operation#requiresRead()} is true), this method can be used.
      */
@@ -77,7 +77,6 @@ public class ReferenceOperation
         ReferenceValue value = new ReferenceValue.Constant(operation.term());
         Term key = extractKeyOrIndex(operation);
         FieldIdentifier field = extractField(operation);
-        // Chore: Maybe we should change the semantics of this?
         return new ReferenceOperation(receiver, table, kind, key, field, null, value);
     }
 

--- a/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
@@ -48,16 +48,18 @@ public class ReferenceOperation
     private final TableMetadata table;
     private final TxnReferenceOperation.Kind kind;
     private final FieldIdentifier field;
+    private final Term constant;
     private final Term key;
     private final ReferenceValue value;
 
-    public ReferenceOperation(ColumnMetadata receiver, TableMetadata table, TxnReferenceOperation.Kind kind, Term key, FieldIdentifier field, ReferenceValue value)
+    public ReferenceOperation(ColumnMetadata receiver, TableMetadata table, TxnReferenceOperation.Kind kind, Term key, FieldIdentifier field, Term constant, ReferenceValue value)
     {
         this.receiver = receiver;
         this.table = table;
         this.kind = kind;
         this.key = key;
         this.field = field;
+        this.constant = constant;
         this.value = value;
     }
 
@@ -75,7 +77,8 @@ public class ReferenceOperation
         ReferenceValue value = new ReferenceValue.Constant(operation.term());
         Term key = extractKeyOrIndex(operation);
         FieldIdentifier field = extractField(operation);
-        return new ReferenceOperation(receiver, table, kind, key, field, value);
+        // Chore: Maybe we should change the semantics of this?
+        return new ReferenceOperation(receiver, table, kind, key, field, null, value);
     }
 
     public TxnReferenceOperation.Kind getKind()
@@ -105,6 +108,7 @@ public class ReferenceOperation
                                          receiver, table,
                                          key != null ? key.bindAndGet(options) : null,
                                          field != null ? field.bytes : null,
+                                         constant != null ? constant.bindAndGet(options) : null,
                                          value.bindAndGet(options));
     }
 
@@ -157,7 +161,11 @@ public class ReferenceOperation
                 }
             }
 
-            return new ReferenceOperation(receiver, metadata, kind, key, field, value.prepare(valueReceiver, bindVariables));
+            ReferenceValue referenceValue = value.prepare(valueReceiver, bindVariables);
+
+            // operation.term().equals(referenceValue.getTerm()) covers the case where we have
+            // v += row1.c,
+            return new ReferenceOperation(receiver, metadata, kind, key, field, operation.term().equals(referenceValue.getTerm()) ? null : operation.term(), referenceValue);
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ReferenceOperation.java
@@ -163,8 +163,8 @@ public class ReferenceOperation
 
             ReferenceValue referenceValue = value.prepare(valueReceiver, bindVariables);
 
-            // operation.term().equals(referenceValue.getTerm()) covers the case where we have
-            // v += row1.c,
+            // When operation.term().equals(referenceValue.getTerm()), we are in the case where we have v += row1.c and
+            // when this is not true, we are in the case where we have v = row1.c + 3
             return new ReferenceOperation(receiver, metadata, kind, key, field, operation.term().equals(referenceValue.getTerm()) ? null : operation.term(), referenceValue);
         }
     }

--- a/src/java/org/apache/cassandra/cql3/transactions/ReferenceValue.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ReferenceValue.java
@@ -33,6 +33,8 @@ public abstract class ReferenceValue
 {
     public abstract TxnReferenceValue bindAndGet(FunctionContext context);
 
+    public abstract Term getTerm();
+
     public static abstract class Raw extends Term.Raw
     {
         public abstract ReferenceValue prepare(ColumnMetadata receiver, VariableSpecifications bindVariables);
@@ -51,6 +53,12 @@ public abstract class ReferenceValue
         public TxnReferenceValue bindAndGet(FunctionContext context)
         {
             return new TxnReferenceValue.Constant(term.bindAndGet(context));
+        }
+
+        @Override
+        public Term getTerm()
+        {
+            return term;
         }
 
         public static class Raw extends ReferenceValue.Raw
@@ -107,6 +115,12 @@ public abstract class ReferenceValue
         public TxnReferenceValue bindAndGet(FunctionContext context)
         {
             return new TxnReferenceValue.Substitution(reference.toTxnReference(context).asColumn());
+        }
+
+        @Override
+        public Term getTerm()
+        {
+            return reference;
         }
 
         public static class Raw extends ReferenceValue.Raw

--- a/src/java/org/apache/cassandra/cql3/transactions/RowDataReference.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/RowDataReference.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.transactions;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
@@ -99,6 +100,19 @@ public class RowDataReference extends Term.NonTerminal
     public void addFunctionsTo(List<Function> functions)
     {
         throw new UnsupportedOperationException("Functions are not currently supported w/ reference terms.");
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RowDataReference that = (RowDataReference) o;
+        return Objects.equals(txnDataName, that.txnDataName)
+               && Objects.equals(column, that.column)
+               && Objects.equals(table, that.table)
+               && Objects.equals(elementPath, that.elementPath)
+               && Objects.equals(fieldPath, that.fieldPath);
     }
 
     public ColumnMetadata toResultMetadata()

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperation.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperation.java
@@ -312,10 +312,16 @@ public class TxnReferenceOperation
 
     static final ParameterisedUnversionedSerializer<TxnReferenceOperation, TableMetadatas> serializer = new ParameterisedUnversionedSerializer<>()
     {
+        private static final int TOP_BIT = 0x40;
+
         @Override
         public void serialize(TxnReferenceOperation operation, TableMetadatas tables, DataOutputPlus out) throws IOException
         {
-            out.writeByte(operation.kind.id);
+            if (operation.constant != null)
+                out.writeUnsignedVInt32(operation.kind.id | TOP_BIT);
+            else
+                out.writeUnsignedVInt32(operation.kind.id);
+
             tables.serialize(operation.table, out);
             columnMetadataSerializer.serialize(operation.receiver, operation.table, out);
             TxnReferenceValue.serializer.serialize(operation.value, tables, out);
@@ -327,7 +333,12 @@ public class TxnReferenceOperation
             out.writeBoolean(operation.field != null);
             if (operation.field != null)
                 ByteBufferUtil.writeWithVIntLength(operation.field, out);
-            out.writeBoolean(operation.constant != null);
+
+            // The boolean for whether operation.constant is null is encoded
+            // in the TOP_BIT of operation.kind.id, this is to ensure that everything
+            // serialized by the new nodes can be deserialized by the old nodes modulo
+            // the new CQL syntax allowing calcuations with LET variables within
+            // the update statement
             if (operation.constant != null)
                 ByteBufferUtil.writeWithVIntLength(operation.constant, out);
         }
@@ -335,21 +346,28 @@ public class TxnReferenceOperation
         @Override
         public TxnReferenceOperation deserialize(TableMetadatas tables, DataInputPlus in) throws IOException
         {
-            Kind kind = Kind.from(in.readByte());
+            int flags = in.readUnsignedVInt32();
+            Kind kind;
+            if ((flags & TOP_BIT) != 0)
+                kind = Kind.from((byte) (flags ^ TOP_BIT));
+            else
+                kind = Kind.from((byte) (flags));
             TableMetadata table = tables.deserialize(in);
             ColumnMetadata receiver = columnMetadataSerializer.deserialize(table, in);
             TxnReferenceValue value = TxnReferenceValue.serializer.deserialize(tables, in);
             ByteBuffer key = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
             ByteBuffer field = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
-            ByteBuffer constant = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
+            ByteBuffer constant = null;
+            if ((flags & TOP_BIT) != 0)
+                constant = ByteBufferUtil.readWithVIntLength(in);
             return new TxnReferenceOperation(kind, receiver, table, key, field, constant, value);
         }
 
         @Override
         public long serializedSize(TxnReferenceOperation operation, TableMetadatas tables)
         {
-            long size = Byte.BYTES;
-            size +=  tables.serializedSize(operation.table);
+            long size = TypeSizes.sizeofUnsignedVInt(operation.kind.id | TOP_BIT);
+            size += tables.serializedSize(operation.table);
             size += columnMetadataSerializer.serializedSize(operation.receiver, operation.table);
             size += TxnReferenceValue.serializer.serializedSize(operation.value, tables);
 
@@ -361,7 +379,6 @@ public class TxnReferenceOperation
             if (operation.field != null)
                 size += ByteBufferUtil.serializedSizeWithVIntLength(operation.field);
 
-            size += TypeSizes.sizeof(operation.constant != null);
             if (operation.constant != null)
                 size += ByteBufferUtil.serializedSizeWithVIntLength(operation.constant);
 

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperation.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperation.java
@@ -170,18 +170,20 @@ public class TxnReferenceOperation
     public final TableMetadata table;
     private final @Nullable ByteBuffer keyOrIndex;
     private final @Nullable ByteBuffer field;
+    private final @Nullable ByteBuffer constant;
     private final TxnReferenceValue value;
     private final @Nullable AbstractType<?> keyOrIndexType;
     private final AbstractType<?> valueType;
 
     public TxnReferenceOperation(Kind kind, ColumnMetadata receiver, TableMetadata table,
-                                 @Nullable ByteBuffer keyOrIndex, @Nullable ByteBuffer field, TxnReferenceValue value)
+                                 @Nullable ByteBuffer keyOrIndex, @Nullable ByteBuffer field, @Nullable ByteBuffer constant, TxnReferenceValue value)
     {
         this.kind = kind;
         this.receiver = receiver;
         this.table = table;
         this.keyOrIndex = keyOrIndex;
         this.field = field;
+        this.constant = constant;
 
         // We don't expect operators on clustering keys, but unwrap just in case.
         AbstractType<?> receiverType = receiver.type.unwrap();
@@ -272,7 +274,11 @@ public class TxnReferenceOperation
     public void apply(TxnData data, DecoratedKey key, RowUpdateBuilder up)
     {
         Operation operation = toOperation(data);
-        operation.execute(key, up);
+        // When constant != null, we are performing a computation with a LET variable (i.e. row1.v + 2)
+        if (constant != null)
+            operation.execute(key, up, constant);
+        else
+            operation.execute(key, up);
     }
 
     @VisibleForTesting
@@ -321,6 +327,9 @@ public class TxnReferenceOperation
             out.writeBoolean(operation.field != null);
             if (operation.field != null)
                 ByteBufferUtil.writeWithVIntLength(operation.field, out);
+            out.writeBoolean(operation.constant != null);
+            if (operation.constant != null)
+                ByteBufferUtil.writeWithVIntLength(operation.constant, out);
         }
 
         @Override
@@ -332,7 +341,8 @@ public class TxnReferenceOperation
             TxnReferenceValue value = TxnReferenceValue.serializer.deserialize(tables, in);
             ByteBuffer key = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
             ByteBuffer field = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
-            return new TxnReferenceOperation(kind, receiver, table, key, field, value);
+            ByteBuffer constant = in.readBoolean() ? ByteBufferUtil.readWithVIntLength(in) : null;
+            return new TxnReferenceOperation(kind, receiver, table, key, field, constant, value);
         }
 
         @Override
@@ -350,6 +360,10 @@ public class TxnReferenceOperation
             size += TypeSizes.sizeof(operation.field != null);
             if (operation.field != null)
                 size += ByteBufferUtil.serializedSizeWithVIntLength(operation.field);
+
+            size += TypeSizes.sizeof(operation.constant != null);
+            if (operation.constant != null)
+                size += ByteBufferUtil.serializedSizeWithVIntLength(operation.constant);
 
             return size;
         }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3604,4 +3604,43 @@ public abstract class AccordCQLTestBase extends AccordTestBase
                       .hasMessage("Attempted to set an element on a list which is null");
         });
     }
+
+    @Test
+    public void testRowReferenceDoesNotNPE() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH CLUSTERING ORDER BY (c DESC) AND transactional_mode='" + transactionalMode + "'",
+             cluster ->
+             {
+                 cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);
+
+                 String update = "BEGIN TRANSACTION\n" +
+                                 "  LET r = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
+                                 "  UPDATE " + qualifiedAccordTableName + " SET v = r WHERE k=1 AND c=1;\n" +
+                                 "COMMIT TRANSACTION";
+                 assertRowEqualsWithPreemptedRetry(cluster, new Object[]{1, 1, 1}, update);
+             });
+    }
+
+    @Test
+    public void testUseLetVariableForEvaluationInUpdateStatement() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH CLUSTERING ORDER BY (c DESC) AND transactional_mode='" + transactionalMode + "'",
+             cluster ->
+             {
+                 cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);
+
+                 String update = "BEGIN TRANSACTION\n" +
+                                 "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
+                                 "  UPDATE " + qualifiedAccordTableName + " SET v = row1.v + 2 WHERE k=1 AND c=1;\n" +
+                                 "COMMIT TRANSACTION";
+                 cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.ALL);
+
+                 String read = "BEGIN TRANSACTION\n" +
+                               "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                               "COMMIT TRANSACTION";
+
+                 SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+                 assertThat(result).hasSize(1).contains(1, 3);
+             });
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -3632,7 +3632,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     public void testUseLetVariableForEvaluationWithInt() throws Exception
     {
         test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
-            cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 6)", ConsistencyLevel.ALL);
+            cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 5)", ConsistencyLevel.ALL);
 
             String update = "BEGIN TRANSACTION\n" +
                             "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
@@ -3645,7 +3645,7 @@ public abstract class AccordCQLTestBase extends AccordTestBase
                           "COMMIT TRANSACTION";
 
             SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
-            assertThat(result).hasSize(1).contains(1, 1, 11);
+            assertThat(result).hasSize(1).contains(1, 1, 8);
         });
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -84,6 +84,7 @@ import org.apache.cassandra.distributed.shared.AssertUtils;
 import org.apache.cassandra.distributed.test.sai.SAIUtil;
 import org.apache.cassandra.distributed.util.QueryResultUtil;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -3606,41 +3607,66 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
-    public void testRowReferenceDoesNotNPE() throws Exception
+    public void testLETVariableReferenceInUpdateFails() throws Exception
     {
-        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH CLUSTERING ORDER BY (c DESC) AND transactional_mode='" + transactionalMode + "'",
-             cluster ->
-             {
-                 cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);
+        // Regression test for prior NPE
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                String txn = "BEGIN TRANSACTION\n" +
+                             "  LET r = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
+                             "  UPDATE " + qualifiedAccordTableName + " SET v = r WHERE k=1 AND c=1;\n" +
+                             "COMMIT TRANSACTION";
 
-                 String update = "BEGIN TRANSACTION\n" +
-                                 "  LET r = (SELECT v FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
-                                 "  UPDATE " + qualifiedAccordTableName + " SET v = r WHERE k=1 AND c=1;\n" +
-                                 "COMMIT TRANSACTION";
-                 assertRowEqualsWithPreemptedRetry(cluster, new Object[]{1, 1, 1}, update);
-             });
+                cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(SyntaxException.class.getName(), t.getClass().getName());
+            }
+        });
     }
 
     @Test
-    public void testUseLetVariableForEvaluationInUpdateStatement() throws Exception
+    public void testUseLetVariableForEvaluationWithInt() throws Exception
     {
-        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH CLUSTERING ORDER BY (c DESC) AND transactional_mode='" + transactionalMode + "'",
-             cluster ->
-             {
-                 cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, PRIMARY KEY (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (1, 1, 6)", ConsistencyLevel.ALL);
 
-                 String update = "BEGIN TRANSACTION\n" +
-                                 "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
-                                 "  UPDATE " + qualifiedAccordTableName + " SET v = row1.v + 2 WHERE k=1 AND c=1;\n" +
-                                 "COMMIT TRANSACTION";
-                 cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.ALL);
+            String update = "BEGIN TRANSACTION\n" +
+                            "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
+                            "  UPDATE " + qualifiedAccordTableName + " SET v = row1.v + 3 WHERE k = 1 AND c = 1;\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.ALL);
 
-                 String read = "BEGIN TRANSACTION\n" +
-                               "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
-                               "COMMIT TRANSACTION";
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
 
-                 SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
-                 assertThat(result).hasSize(1).contains(1, 3);
-             });
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, 1, 11);
+        });
+    }
+
+    @Test
+    public void testUseLetVariableForEvaluationWithString() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v text, PRIMARY KEY (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (?, ?, ?)", ConsistencyLevel.ALL, 1, 1, "a");
+
+            String update = "BEGIN TRANSACTION\n" +
+                            "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1 AND c = 1);\n" +
+                            "  UPDATE " + qualifiedAccordTableName + " SET v = row1.v + ? WHERE k = 1 AND c = 1;\n" +
+                            "COMMIT TRANSACTION";
+            cluster.coordinator(1).executeWithResult(update, ConsistencyLevel.ALL, "m");
+
+            String read = "BEGIN TRANSACTION\n" +
+                          "SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1;\n" +
+                          "COMMIT TRANSACTION";
+
+            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(read, ConsistencyLevel.SERIAL);
+            assertThat(result).hasSize(1).contains(1, 1, "am");
+        });
     }
 }

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnReferenceOperationTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnReferenceOperationTest.java
@@ -55,9 +55,9 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.accord.serializers.TableMetadatas;
 import org.apache.cassandra.utils.AbstractTypeGenerators;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Generators;
 
 import static accord.utils.Property.qt;
-import static org.apache.cassandra.utils.Generators.toGen;
 
 public class TxnReferenceOperationTest
 {
@@ -110,7 +110,7 @@ public class TxnReferenceOperationTest
 
     private static Gen<TxnReferenceValue> valueGen(AbstractType<?> type)
     {
-        return toGen(AbstractTypeGenerators.getTypeSupport(type)
+        return Generators.toGen(AbstractTypeGenerators.getTypeSupport(type)
                                                       .bytesGen())
                          .map(TxnReferenceValue.Constant::new);
     }
@@ -140,7 +140,7 @@ public class TxnReferenceOperationTest
                 break;
                 case Discarder:
                 {
-                    CollectionType<?> type = (CollectionType<?>) toGen(AbstractTypeGenerators.builder()
+                    CollectionType<?> type = (CollectionType<?>) Generators.toGen(AbstractTypeGenerators.builder()
                                                                                                         .withMaxDepth(1)
                                                                                                         .withTypeKinds(AbstractTypeGenerators.TypeKind.LIST,
                                                                                                                        AbstractTypeGenerators.TypeKind.SET,
@@ -197,14 +197,14 @@ public class TxnReferenceOperationTest
                         receiver = table.getColumn(ColumnIdentifier.getInterned("col", true));
                         value = valueGen(type).next(rs);
                         if (rs.nextBoolean())
-                            constant = toGen(AbstractTypeGenerators.getTypeSupport(type).bytesGen()).next(rs);
+                            constant = Generators.toGen(AbstractTypeGenerators.getTypeSupport(type).bytesGen()).next(rs);
                         kind = group == Group.Adder ? TxnReferenceOperation.Kind.ConstantAdder : TxnReferenceOperation.Kind.ConstantSubtracter;
                     }
                 }
                 break;
                 case Setter:
                 {
-                    var type = toGen(AbstractTypeGenerators.builder()
+                    var type = Generators.toGen(AbstractTypeGenerators.builder()
                                                                       .withoutUnsafeEquality()
                                                                       .withMaxDepth(1)
                                                                       .build())

--- a/test/unit/org/apache/cassandra/service/accord/txn/TxnReferenceOperationTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/txn/TxnReferenceOperationTest.java
@@ -55,9 +55,9 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.accord.serializers.TableMetadatas;
 import org.apache.cassandra.utils.AbstractTypeGenerators;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.Generators;
 
 import static accord.utils.Property.qt;
+import static org.apache.cassandra.utils.Generators.toGen;
 
 public class TxnReferenceOperationTest
 {
@@ -110,7 +110,7 @@ public class TxnReferenceOperationTest
 
     private static Gen<TxnReferenceValue> valueGen(AbstractType<?> type)
     {
-        return Generators.toGen(AbstractTypeGenerators.getTypeSupport(type)
+        return toGen(AbstractTypeGenerators.getTypeSupport(type)
                                                       .bytesGen())
                          .map(TxnReferenceValue.Constant::new);
     }
@@ -123,6 +123,7 @@ public class TxnReferenceOperationTest
             TableMetadata table;
             @Nullable ByteBuffer keyOrIndex = null;
             @Nullable ByteBuffer field = null;
+            @Nullable ByteBuffer constant = null;
             TxnReferenceValue value;
             Group group = rs.pick(Group.values());
             switch (group)
@@ -139,7 +140,7 @@ public class TxnReferenceOperationTest
                 break;
                 case Discarder:
                 {
-                    CollectionType<?> type = (CollectionType<?>) Generators.toGen(AbstractTypeGenerators.builder()
+                    CollectionType<?> type = (CollectionType<?>) toGen(AbstractTypeGenerators.builder()
                                                                                                         .withMaxDepth(1)
                                                                                                         .withTypeKinds(AbstractTypeGenerators.TypeKind.LIST,
                                                                                                                        AbstractTypeGenerators.TypeKind.SET,
@@ -195,13 +196,15 @@ public class TxnReferenceOperationTest
                         table = table(type);
                         receiver = table.getColumn(ColumnIdentifier.getInterned("col", true));
                         value = valueGen(type).next(rs);
+                        if (rs.nextBoolean())
+                            constant = toGen(AbstractTypeGenerators.getTypeSupport(type).bytesGen()).next(rs);
                         kind = group == Group.Adder ? TxnReferenceOperation.Kind.ConstantAdder : TxnReferenceOperation.Kind.ConstantSubtracter;
                     }
                 }
                 break;
                 case Setter:
                 {
-                    var type = Generators.toGen(AbstractTypeGenerators.builder()
+                    var type = toGen(AbstractTypeGenerators.builder()
                                                                       .withoutUnsafeEquality()
                                                                       .withMaxDepth(1)
                                                                       .build())
@@ -276,7 +279,8 @@ public class TxnReferenceOperationTest
                 default:
                     throw new UnsupportedOperationException();
             }
-            return new TxnReferenceOperation(kind, receiver, table, keyOrIndex, field, value);
+
+            return new TxnReferenceOperation(kind, receiver, table, keyOrIndex, field, constant, value);
         };
     }
 


### PR DESCRIPTION
Allow calculations with let variables within update statements

patch by Alan Wang;

reviewed by for [CASSANDRA-21458](https://issues.apache.org/jira/browse/CASSANDRA-21479)

Co-authored-by: Name1
Co-authored-by: Name2