### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -11,9 +11,9 @@ jobs:
 
         steps:
           - name: Checkout code
-            uses: actions/checkout@v3
+            uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
           - name: JDK 11
-            uses: actions/setup-java@v3
+            uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
             with:
               java-version: '11'
               distribution: 'temurin'
@@ -25,9 +25,9 @@ jobs:
 
         steps:
           - name: Checkout code
-            uses: actions/checkout@v3
+            uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
           - name: JDK 17
-            uses: actions/setup-java@v3
+            uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
             with:
               java-version: '17'
               distribution: 'temurin'


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions