### PR TITLE
Optimize RangeTombstoneList copying with copy-on-write array sharing (CASSANDRA-21492)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 7.0
  * Implementation of CEP-49: Hardware-accelerated compression (CASSANDRA-20975)
+ * Optimize RangeTombstoneList copying with copy-on-write array sharing (CASSANDRA-21492)
  * Avoid using ObjectUtils.getFirstNonNull in Schema (CASSANDRA-21394)
  * Allow nodetool garbagecollect to take a user defined list of SSTables (CASSANDRA-16767)
  * Add a guardrail for misprepared statements (CASSANDRA-21139)

--- a/src/java/org/apache/cassandra/db/RangeTombstoneList.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstoneList.java
@@ -48,6 +48,13 @@ import org.apache.cassandra.utils.memory.ByteBufferCloner;
  * <p>
  * The only use of the local deletion time is to know when a given tombstone can
  * be purged, which will be done by the purge() method.
+ * <p>
+ * <b>Copy-on-Write (COW) Invariant:</b>
+ * This class implements a copy-on-write optimization. The {@link #copy()} method creates a new instance 
+ * that shares the four parallel backing arrays ({@code starts}, {@code ends}, {@code markedAts}, 
+ * and {@code delTimesUnsignedIntegers}) with the original instance and marks both instances as shared ({@code shared = true}).
+ * To ensure safe copy independence, any operation that performs in-place mutation of these backing arrays 
+ * MUST call {@link #isolate()} before writing to them for the first time. All backing-array writes are guarded this way.
  */
 public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurableMemory
 {
@@ -64,6 +71,19 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
     private long boundaryHeapSize;
     private int size;
+    private boolean shared;
+
+    private void isolate()
+    {
+        if (shared)
+        {
+            starts = Arrays.copyOf(starts, starts.length);
+            ends = Arrays.copyOf(ends, ends.length);
+            markedAts = Arrays.copyOf(markedAts, markedAts.length);
+            delTimesUnsignedIntegers = Arrays.copyOf(delTimesUnsignedIntegers, delTimesUnsignedIntegers.length);
+            shared = false;
+        }
+    }
 
     private RangeTombstoneList(ClusteringComparator comparator,
                                ClusteringBound<?>[] starts,
@@ -103,14 +123,28 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         return comparator;
     }
 
+    /**
+     * Creates a copy-on-write duplicate of this list.
+     * <p>
+     * This method shares the four backing arrays ({@code starts}, {@code ends}, {@code markedAts}, and
+     * {@code delTimesUnsignedIntegers}) between the original list and the returned copy, marking both instances
+     * as shared ({@code shared = true}). To maintain independent states, any subsequent in-place mutation on
+     * either instance must first trigger {@link #isolate()} to copy and isolate the backing arrays before writing.
+     *
+     * @return a copy-on-write copy of this list.
+     */
     public RangeTombstoneList copy()
     {
-        return new RangeTombstoneList(comparator,
-                                      Arrays.copyOf(starts, size),
-                                      Arrays.copyOf(ends, size),
-                                      Arrays.copyOf(markedAts, size),
-                                      Arrays.copyOf(delTimesUnsignedIntegers, size),
-                                      boundaryHeapSize, size);
+        this.shared = true;
+        RangeTombstoneList copy = new RangeTombstoneList(comparator,
+                                                         starts,
+                                                         ends,
+                                                         markedAts,
+                                                         delTimesUnsignedIntegers,
+                                                         boundaryHeapSize,
+                                                         size);
+        copy.shared = true;
+        return copy;
     }
 
     public RangeTombstoneList clone(ByteBufferCloner cloner)
@@ -188,7 +222,14 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
         if (isEmpty())
         {
-            copyArrays(tombstones, this);
+            tombstones.shared = true;
+            this.starts = tombstones.starts;
+            this.ends = tombstones.ends;
+            this.markedAts = tombstones.markedAts;
+            this.delTimesUnsignedIntegers = tombstones.delTimesUnsignedIntegers;
+            this.size = tombstones.size;
+            this.boundaryHeapSize = tombstones.boundaryHeapSize;
+            this.shared = true;
             return;
         }
 
@@ -324,12 +365,14 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
     public void updateAllTimestamp(long timestamp)
     {
+        isolate();
         for (int i = 0; i < size; i++)
             markedAts[i] = timestamp;
     }
 
     public void updateAllTimestampAndLocalDeletionTime(long timestamp, long localDeletionTime)
     {
+        isolate();
         int unsignedLocalDeletionTime = Cell.deletionTimeLongToUnsignedInteger(localDeletionTime);
         for (int i = 0; i < size; i++)
         {
@@ -527,17 +570,6 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         return result;
     }
 
-    private static void copyArrays(RangeTombstoneList src, RangeTombstoneList dst)
-    {
-        dst.grow(src.size);
-        System.arraycopy(src.starts, 0, dst.starts, 0, src.size);
-        System.arraycopy(src.ends, 0, dst.ends, 0, src.size);
-        System.arraycopy(src.markedAts, 0, dst.markedAts, 0, src.size);
-        System.arraycopy(src.delTimesUnsignedIntegers, 0, dst.delTimesUnsignedIntegers, 0, src.size);
-        dst.size = src.size;
-        dst.boundaryHeapSize = src.boundaryHeapSize;
-    }
-
     /*
      * Inserts a new element starting at index i. This method assumes that:
      *    ends[i-1] <= start < ends[i]
@@ -552,6 +584,7 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
      */
     private void insertFrom(int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTimeUnsignedInternal)
     {
+        isolate();
         while (i < size)
         {
             assert start.isStart() && end.isEnd();
@@ -677,8 +710,12 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
         if (size == capacity())
             growToFree(i);
-        else if (i < size)
-            moveElements(i);
+        else
+        {
+            isolate();
+            if (i < size)
+                moveElements(i);
+        }
 
         setInternal(i, start, end, markedAt, delTimeUnsignedInteger);
         size++;
@@ -698,21 +735,13 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         grow(i, newLength);
     }
 
-    /*
-     * Grow the arrays to match newLength capacity.
-     */
-    private void grow(int newLength)
-    {
-        if (capacity() < newLength)
-            grow(-1, newLength);
-    }
-
     private void grow(int i, int newLength)
     {
         starts = grow(starts, size, newLength, i);
         ends = grow(ends, size, newLength, i);
         markedAts = grow(markedAts, size, newLength, i);
         delTimesUnsignedIntegers = grow(delTimesUnsignedIntegers, size, newLength, i);
+        shared = false;
     }
 
     private static ClusteringBound<?>[] grow(ClusteringBound<?>[] a, int size, int newLength, int i)

--- a/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneListBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneListBench.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.db.RangeTombstoneList;
+import org.apache.cassandra.db.Slice;
+import org.apache.cassandra.db.marshal.Int32Type;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
+@Threads(1)
+@State(Scope.Benchmark)
+public class RangeTombstoneListBench
+{
+    private ClusteringComparator comparator;
+    private RangeTombstoneList existing;
+    private RangeTombstone tombstone;
+
+    @Param({"10", "100", "1000"})
+    private int size;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        comparator = new ClusteringComparator(Int32Type.instance);
+        existing = new RangeTombstoneList(comparator, size);
+        for (int i = 0; i < size; i++)
+        {
+            existing.add(new RangeTombstone(Slice.make(comparator.make(i * 2), comparator.make(i * 2 + 1)), DeletionTime.build(1, 1)));
+        }
+        tombstone = new RangeTombstone(Slice.make(comparator.make(100000), comparator.make(100001)), DeletionTime.build(1, 1));
+    }
+
+    @Benchmark
+    public RangeTombstoneList benchCopyOnly()
+    {
+        return existing.copy();
+    }
+
+    @Benchmark
+    public RangeTombstoneList benchCopyAndAdd()
+    {
+        RangeTombstoneList copy = existing.copy();
+        copy.add(tombstone);
+        return copy;
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneListSize10Bench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneListSize10Bench.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.db.RangeTombstoneList;
+import org.apache.cassandra.db.Slice;
+import org.apache.cassandra.db.marshal.Int32Type;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
+@Threads(1)
+@State(Scope.Benchmark)
+public class RangeTombstoneListSize10Bench
+{
+    private ClusteringComparator comparator;
+    private RangeTombstoneList existing;
+    private RangeTombstone tombstone;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        comparator = new ClusteringComparator(Int32Type.instance);
+        existing = new RangeTombstoneList(comparator, 10);
+        for (int i = 0; i < 10; i++)
+        {
+            existing.add(new RangeTombstone(Slice.make(comparator.make(i * 2), comparator.make(i * 2 + 1)), DeletionTime.build(1, 1)));
+        }
+        tombstone = new RangeTombstone(Slice.make(comparator.make(100000), comparator.make(100001)), DeletionTime.build(1, 1));
+    }
+
+    @Benchmark
+    public RangeTombstoneList benchCopyOnly()
+    {
+        return existing.copy();
+    }
+
+    @Benchmark
+    public RangeTombstoneList benchCopyAndAdd()
+    {
+        RangeTombstoneList copy = existing.copy();
+        copy.add(tombstone);
+        return copy;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/RangeTombstoneListTest.java
+++ b/test/unit/org/apache/cassandra/db/RangeTombstoneListTest.java
@@ -629,6 +629,73 @@ public class RangeTombstoneListTest
         }
     }
 
+    @Test
+    public void testCopyIndependence()
+    {
+        RangeTombstoneList original = new RangeTombstoneList(cmp, 5);
+        original.add(rt(1, 5, 10));
+        original.add(rt(7, 10, 20));
+
+        RangeTombstoneList copy = original.copy();
+
+        original.add(rt(12, 15, 30));
+
+        assertEquals(3, original.size());
+        assertEquals(2, copy.size());
+
+        Iterator<RangeTombstone> origIter = original.iterator();
+        assertRT(rt(1, 5, 10), origIter.next());
+        assertRT(rt(7, 10, 20), origIter.next());
+        assertRT(rt(12, 15, 30), origIter.next());
+        assertFalse(origIter.hasNext());
+
+        Iterator<RangeTombstone> copyIter = copy.iterator();
+        assertRT(rt(1, 5, 10), copyIter.next());
+        assertRT(rt(7, 10, 20), copyIter.next());
+        assertFalse(copyIter.hasNext());
+
+        copy.add(rt(20, 25, 40));
+        assertEquals(3, original.size());
+        assertEquals(3, copy.size());
+
+        origIter = original.iterator();
+        assertRT(rt(1, 5, 10), origIter.next());
+        assertRT(rt(7, 10, 20), origIter.next());
+        assertRT(rt(12, 15, 30), origIter.next());
+        assertFalse(origIter.hasNext());
+
+        copyIter = copy.iterator();
+        assertRT(rt(1, 5, 10), copyIter.next());
+        assertRT(rt(7, 10, 20), copyIter.next());
+        assertRT(rt(20, 25, 40), copyIter.next());
+        assertFalse(copyIter.hasNext());
+
+        RangeTombstoneList other = new RangeTombstoneList(cmp, 1);
+        other.add(rt(30, 35, 50));
+        copy.addAll(other);
+        assertEquals(3, original.size());
+        assertEquals(4, copy.size());
+
+        copy.updateAllTimestamp(999);
+        origIter = original.iterator();
+        assertRT(rt(1, 5, 10), origIter.next());
+        assertRT(rt(7, 10, 20), origIter.next());
+        assertRT(rt(12, 15, 30), origIter.next());
+
+        copyIter = copy.iterator();
+        assertRT(rt(1, 5, 999), copyIter.next());
+        assertRT(rt(7, 10, 999), copyIter.next());
+        assertRT(rt(20, 25, 999), copyIter.next());
+        assertRT(rt(30, 35, 999), copyIter.next());
+
+        copy.updateAllTimestampAndLocalDeletionTime(888, 888);
+        origIter = original.iterator();
+        assertRT(rt(1, 5, 10), origIter.next());
+
+        copyIter = copy.iterator();
+        assertRT(rt(1, 5, 888, 888), copyIter.next());
+    }
+
     private void assertHasException(ThrowingRunnable block, Consumer<Throwable> verifier)
     {
         try


### PR DESCRIPTION
Optimize RangeTombstoneList copying with copy-on-write array sharing (CASSANDRA-21492)

### Description
Each memtable write carrying a range tombstone runs `BTreePartitionUpdater.merge` -> existing `DeletionInfo.mutableCopy()` -> `RangeTombstoneList.copy`, which unconditionally copies all four parallel arrays (starts, ends, markedAts, and delTimesUnsignedIntegers) of the existing list regardless of insert position.

Here, the variable `N` represents the number of range tombstones in the `RangeTombstoneList`. Under modeled production workloads, `N` typically ranges from small lists of size `N ~ 10` (for small partitions with light deletion traffic) to large lists of size `N >= 1000` (under heavy range-delete or partition-level tombstone-heavy workloads). Successive range-tombstone merges into one unflushed partition pay O(N^2) parallel array copying work on the mutation write path because unmutated lists are repeatedly re-copied. Duplicating these parallel arrays is highly expensive at scale due to array allocation and element-by-element copy overheads.

This optimization implements copy-on-write array sharing (starts, ends, markedAts, and delTimesUnsignedIntegers backing arrays) between copies, reducing unmutated copying to an O(1) pointer-sharing operation. This optimization introduces no behavior changes and preserves full copy independence under all mutating operations.

**Limits of the Mechanism**:
Because this is a copy-on-write mechanism, any subsequent mutation on a shared list forces an O(N) isolation copy (via `isolate()`) before the write occurs. This means that if mutations are performed immediately after copying, the parallel array copying cost is deferred rather than eliminated. However, in workloads where RangeTombstoneLists are copied but not subsequently mutated, the copying cost is entirely eliminated.

### Headline Win (benchCopyOnly)
- **Primary Win**: `RangeTombstoneListBench.benchCopyOnly` drops from `3362.5156478614854` ns/op to `9.018492886907715` ns/op (a **99.7318%** reduction in copying latency, n=10, p=1.08251e-05).

### Guardrails (Categorized as Held)
- `RangeTombstoneListBench.benchCopyAndAdd` (size N=1000): `8842.89307604306` ns/op -> `5485.592293470344` ns/op (**Held**, a **37.9661%** reduction, n=10, p=1.08251e-05)
- `RangeTombstoneListSize10Bench.benchCopyOnly` (size N=10): `56.7137252431266` ns/op -> `9.083180562797722` ns/op (**Held**, an **83.9842%** reduction, n=10, p=1.08251e-05)
- `RangeTombstoneListSize10Bench.benchCopyAndAdd` (size N=10): `186.2202636628365` ns/op -> `122.92588844176737` ns/op (**Held**, a **33.989%** reduction, n=10, p=1.08251e-05)

### Co-measured Ground-Truth Comparison
Measurements are co-measured. The baseline was measured at baseline commit tree with the benchmarks compiled in.
- **Baseline Commit**: `061749b0ae48d5b3be1f78754f177bdd745c7a1e`
- **Candidate Commit**: `ca5e7e41597ff05a09028d2e0f382df62db4620d` (shipped commit `ca5e7e41`)
- **Benchmark Provenance**: Microbenchmarks authored by the agent.

| Benchmark Selector | Metric | Baseline (Median) | Shipped Commit `ca5e7e41` (Median) | Delta (Median) | Outcome |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `RangeTombstoneListBench.benchCopyOnly` | ns/op | 3362.5156478614854 | 9.018492886907715 | -99.7318% | Won |
| `RangeTombstoneListBench.benchCopyAndAdd` | ns/op | 8842.89307604306 | 5485.592293470344 | -37.9661% | Held |
| `RangeTombstoneListSize10Bench.benchCopyOnly` | ns/op | 56.7137252431266 | 9.083180562797722 | -83.9842% | Held |
| `RangeTombstoneListSize10Bench.benchCopyAndAdd` | ns/op | 186.2202636628365 | 122.92588844176737 | -33.989% | Held |

### Correctness Verification
The following correctness checks and suites passed completely:
- `pairing`, `environment_consistent`, `baseline_valid`, `benchmark_passed`, `RangeTombstoneListTest` (verifies full copy independence under mutations), `StyleCheck`, `measurements_sane`, `metric_present`, `sample_sufficiency`, `sample_independence`.

### Reproduction
- **Environment**: linux/amd64/openjdk-21.0.11
- **Baseline Commit**: `061749b0ae48d5b3be1f78754f177bdd745c7a1e`
- **Candidate Commit**: `ca5e7e41597ff05a09028d2e0f382df62db4620d` (shipped commit `ca5e7e41`)
- **Compilation Command**:
  ```bash
  ant -lib /workspace/deps/m2/org/apache/ant/ant-junit/1.10.12/ant-junit-1.10.12.jar -Dno-build-accord=true -Dmaven.repo.local=/workspace/deps/m2 -Dlocal.repository=/workspace/deps/m2 build-test
  ```
- **Run Command**:
  ```bash
  java -Dcassandra.config=file://$(pwd)/test/conf/cassandra.yaml -cp "build/classes/main:build/test/classes:build/lib/jars/*:build/test/lib/jars/*:lib/*" org.openjdk.jmh.Main -f 1 -wi 3 -w 1s -i 1 -r 1s -bm avgt -tu ns -foe true -rf json -rff jmh.json -p size=1000 "^org\.apache\.cassandra\.test\.microbench\.RangeTombstoneListBench\.benchCopyOnly$"
  ```

### Full Proof
- **Case Page Link**: https://app.perfloop.ai/t/oss/case_w33wfzba46

---
This is an automated, human-reviewed Perfloop contribution opened by perfloop-agent. The body links to reproducible proof for the change. The change was benchmarked on perfloop/cassandra, an automation fork of apache/cassandra; the commit on this PR's head branch carries the proof.

Assisted-by: PerfloopAgent:gemini-3.5-flash