### PR TITLE
System peers tables may be incorrectly repaired during a rolling upgrade.

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -193,6 +193,7 @@ import org.apache.cassandra.streaming.StreamResultFuture;
 import org.apache.cassandra.streaming.StreamState;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.ClusterMetadataService;
+import org.apache.cassandra.tcm.Epoch;
 import org.apache.cassandra.tcm.MultiStepOperation;
 import org.apache.cassandra.tcm.RegistrationStatus;
 import org.apache.cassandra.tcm.Transformation;
@@ -858,7 +859,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         RegistrationStatus.instance.onRegistration();
         Startup.maybeExecuteStartupTransformation(self);
 
-        if (CassandraRelevantProperties.SYNC_SYSTEM_PEERS_TABLES_AT_STARTUP.getBoolean())
+        if (CassandraRelevantProperties.SYNC_SYSTEM_PEERS_TABLES_AT_STARTUP.getBoolean() && ClusterMetadata.current().epoch.isAfter(Epoch.FIRST))
             SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         try


### PR DESCRIPTION
During a rolling upgrade from 4.0.4 to 4.0.5, the system peers tables are expected to be temporarily divergent from ClusterMetadata. Nodes still on 4.0.4 have not yet registered with TCM, so their peer table entries are not fully reflected in ClusterMetadata.directory.

SystemPeersValidator.validateAndRepair() does not account for this window, making it possible for the peers tables to end up in an incorrect state where valid peer entries have been removed or overwritten.

patch by @minal-kyada ; reviewed by @beobal and @maedhroz for CASSANDRA-21503
