### PR TITLE
Allow unreserved keywords as user and identity names in USER and IDENTITY statements

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -2363,12 +2363,14 @@ vector_type returns [CQL3Type.Raw vt]
 username
     : IDENT
     | STRING_LITERAL
+    | unreserved_keyword
     | QUOTED_NAME { addRecognitionError("Quoted strings are are not supported for user names and USER is deprecated, please use ROLE");}
     ;
 
 identity
     : IDENT
     | STRING_LITERAL
+    | unreserved_keyword
     | QUOTED_NAME { addRecognitionError("Quoted strings are are not supported for identity");}
     ;
 

--- a/test/unit/org/apache/cassandra/cql3/ReservedKeywordsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/ReservedKeywordsTest.java
@@ -68,11 +68,42 @@ public class ReservedKeywordsTest
         asserts.assertAll();
     }
 
+    /**
+     * Legacy USER and IDENTITY statements must accept unreserved keywords as names, just like
+     * role statements do ({@code roleName} accepts {@code unreserved_keyword}). Otherwise adding
+     * a new keyword to the grammar breaks existing deployments with a user or identity of that name.
+     */
+    @Test
+    public void testUnreservedKeywordsAsUserNameAndIdentity()
+    {
+        SoftAssertions asserts = new SoftAssertions();
+        for (var f : Cql_Lexer.class.getDeclaredFields())
+        {
+            if (!Modifier.isStatic(f.getModifiers())) continue;
+            if (!f.getName().startsWith("K_")) continue;
+            String keyword = f.getName().replaceFirst("K_", "");
+            if (ReservedKeywords.isReserved(keyword)) continue;
+
+            for (String statement : new String[]{ "DROP USER %s", "DROP IDENTITY %s" })
+            {
+                asserts.assertThat(parses(String.format(statement, keyword)))
+                       .describedAs(String.format(statement, keyword))
+                       .isTrue();
+            }
+        }
+        asserts.assertAll();
+    }
+
     private static boolean isAllowed(String keyword)
+    {
+        return parses(String.format("ALTER TABLE ks.t ADD %s TEXT", keyword));
+    }
+
+    private static boolean parses(String cql)
     {
         try
         {
-            QueryProcessor.parseStatement(String.format("ALTER TABLE ks.t ADD %s TEXT", keyword));
+            QueryProcessor.parseStatement(cql);
             return true;
         }
         catch (SyntaxException ignore)


### PR DESCRIPTION
patch by Maxim Muzafarov; reviewed by <Reviewer> for CASSANDRA-21510

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

