### PR TITLE
CASSANDRA-21423: CQLSSTableWriter produces empty bloom filter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Size the Bloom filter of CQLSSTableWriter-produced SSTables for the real partition count (CASSANDRA-21423)
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
  * Support pluggable default role initialization (CASSANDRA-21546)
  * Add prepared statement cache stats to nodetool info (CASSANDRA-14366)

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -38,11 +39,19 @@ import org.apache.cassandra.db.compression.CompressionDictionary;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.index.Index;
+import org.apache.cassandra.io.sstable.format.FilterComponent;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableReaderLoadingBuilder;
+import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
+import org.apache.cassandra.io.sstable.format.StatsComponent;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.utils.FilterFactory;
+import org.apache.cassandra.utils.IFilter;
 
 /**
  * Base class for the sstable writers used by CQLSSTableWriter.
@@ -115,12 +124,59 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
         sstableProducedListener.accept(sstables);
     }
 
-    protected SSTableTxnWriter createWriter(SSTable.Owner owner) throws IOException
+    /**
+     * Rebuilds the Bloom filter of a finished SSTable at the correct size and swaps it into any opened readers.
+     */
+    protected Collection<SSTableReader> rebuildBloomFilter(SSTableTxnWriter writer, Collection<SSTableReader> produced) throws IOException
+    {
+        TableMetadata tableMetadata = metadata.getLocal();
+        double fpChance = tableMetadata.params.bloomFilterFpChance;
+        if (!FilterComponent.shouldUseBloomFilter(fpChance))
+            return produced;
+
+        // output directory does not have to follow the keyspace/table layout, so do not validate it
+        Descriptor descriptor = Descriptor.fromFileWithComponent(new File(writer.getFilename()), false).left;
+        long partitionCount = StatsComponent.load(descriptor, MetadataType.STATS).statsMetadata().estimatedPartitionSize.count();
+        SSTableReaderLoadingBuilder<?, ?> loader = descriptor.getFormat().getReaderFactory().loadingBuilder(descriptor, metadata, null);
+
+        try (IFilter filter = FilterFactory.getFilter(partitionCount, fpChance);
+             KeyReader keys = loader.buildKeyReader(null))
+        {
+            while (!keys.isExhausted())
+            {
+                filter.add(tableMetadata.partitioner.decorateKey(keys.key())); // token is unused
+                keys.advance();
+            }
+            FilterComponent.save(filter, descriptor, true);
+
+            List<SSTableReader> result = new ArrayList<>(produced.size());
+            for (SSTableReader reader : produced)
+            {
+                if (reader instanceof SSTableReaderWithFilter)
+                {
+                    result.add(((SSTableReaderWithFilter) reader).cloneAndReplace(filter.sharedCopy()));
+                    reader.selfRef().release();
+                }
+                else
+                {
+                    result.add(reader);
+                }
+            }
+            return result;
+        }
+        catch (IOException | RuntimeException | Error e)
+        {
+            descriptor.fileFor(SSTableFormat.Components.FILTER).deleteIfExists();
+            throw e;
+        }
+    }
+
+    protected SSTableTxnWriter createWriter(SSTable.Owner owner, long keyCount) throws IOException
     {
         SerializationHeader header = new SerializationHeader(true, metadata.get(), columns, EncodingStats.NO_STATS);
 
         if (makeRangeAware)
-            return SSTableTxnWriter.createRangeAware(metadata, 0, ActiveRepairService.UNREPAIRED_SSTABLE, ActiveRepairService.NO_PENDING_REPAIR, false, format, header);
+            return SSTableTxnWriter.createRangeAware(metadata, keyCount, ActiveRepairService.UNREPAIRED_SSTABLE, ActiveRepairService.NO_PENDING_REPAIR, false, format, header);
 
 
         SSTable.Owner effectiveOwner;
@@ -138,7 +194,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
 
         return SSTableTxnWriter.create(metadata,
                                        createDescriptor(directory, metadata.keyspace, metadata.name, format),
-                                       0,
+                                       keyCount,
                                        ActiveRepairService.UNREPAIRED_SSTABLE,
                                        ActiveRepairService.NO_PENDING_REPAIR,
                                        false,

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -225,7 +225,7 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
                     if (b == SENTINEL)
                         return;
 
-                    try (SSTableTxnWriter writer = createWriter(null))
+                    try (SSTableTxnWriter writer = createWriter(null, b.size()))
                     {
                         for (Map.Entry<DecoratedKey, PartitionUpdate.Builder> entry : b.entrySet())
                             writer.append(entry.getValue().build().unfilteredIterator());

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -109,7 +109,7 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
     }
 
     @Override
-    public void close()
+    public void close() throws IOException
     {
         writeLastPartitionUpdate(update);
         maybeCloseWriter(writer);
@@ -132,7 +132,7 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
         if (shouldSwitchToNewWriter())
         {
             maybeCloseWriter(writer);
-            writer = createWriter(null);
+            writer = createWriter(null, 0); // partition count unknown upfront
         }
 
         return writer;
@@ -153,15 +153,15 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
         }
     }
 
-    private void maybeCloseWriter(SSTableTxnWriter writer)
+    private void maybeCloseWriter(SSTableTxnWriter writer) throws IOException
     {
+        if (writer == null)
+            return;
+
+        Collection<SSTableReader> finished;
         try
         {
-            if (writer == null)
-                return;
-
-            Collection<SSTableReader> finished = writer.finish(shouldOpenSSTables());
-            notifySSTableProduced(finished);
+            finished = writer.finish(shouldOpenSSTables());
         }
         catch (Throwable t)
         {
@@ -169,6 +169,9 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
             Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
+
+        // the sstable is committed at this point, so a failure here must not attempt to abort the writer
+        notifySSTableProduced(rebuildBloomFilter(writer, finished));
     }
 
     private void writePartition(PartitionUpdate update) throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
@@ -134,7 +134,7 @@ public class FilterComponent
         return filter;
     }
 
-    static boolean shouldUseBloomFilter(double fpChance)
+    public static boolean shouldUseBloomFilter(double fpChance)
     {
         return !(Math.abs(1 - fpChance) <= filterFPChanceTolerance);
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -554,7 +553,6 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
         return b;
     }
 
-    @VisibleForTesting
     @Override
     public SSTableReaderWithFilter cloneAndReplace(IFilter filter)
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -392,7 +391,6 @@ public class BtiTableReader extends SSTableReaderWithFilter
             return new SSTableIterator(this, dataFileInput, key, indexEntry, slices, selectedColumns, rowIndexFile);
     }
 
-    @VisibleForTesting
     @Override
     public BtiTableReader cloneAndReplace(IFilter filter)
     {

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -63,11 +63,13 @@ import org.apache.cassandra.cql3.functions.types.LocalDate;
 import org.apache.cassandra.cql3.functions.types.TypeCodec;
 import org.apache.cassandra.cql3.functions.types.UDTValue;
 import org.apache.cassandra.cql3.functions.types.UserType;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.compression.CompressionDictionary;
 import org.apache.cassandra.db.compression.CompressionDictionary.DictId;
 import org.apache.cassandra.db.compression.ZstdCompressionDictionary;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.SimpleDateType;
 import org.apache.cassandra.db.marshal.TimeType;
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -78,8 +80,10 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.utils.IndexIdentifier;
+import org.apache.cassandra.io.sstable.format.FilterComponent;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
 import org.apache.cassandra.io.sstable.format.big.BigFormat;
 import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
 import org.apache.cassandra.io.util.File;
@@ -94,6 +98,8 @@ import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.CompressionDictionaryHelper;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.FilterFactory;
+import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.JavaDriverUtils;
 import org.apache.cassandra.utils.OutputHandler;
 
@@ -201,6 +207,150 @@ public abstract class CQLSSTableWriterTest
                 assertEquals(12, row.getInt("v2"));
             }
         }
+    }
+
+    @Test
+    public void testBloomFilterSizedForKeyCountUnsortedBig() throws Exception
+    {
+        assertBloomFilterSizedForKeyCount(BigFormat.getInstance(), false);
+    }
+
+    @Test
+    public void testBloomFilterSizedForKeyCountUnsortedBti() throws Exception
+    {
+        assertBloomFilterSizedForKeyCount(new BtiFormat.BtiFormatFactory().getInstance(Collections.emptyMap()), false);
+    }
+
+    @Test
+    public void testBloomFilterSizedForKeyCountSortedBig() throws Exception
+    {
+        assertBloomFilterSizedForKeyCount(BigFormat.getInstance(), true);
+    }
+
+    @Test
+    public void testBloomFilterSizedForKeyCountSortedBti() throws Exception
+    {
+        assertBloomFilterSizedForKeyCount(new BtiFormat.BtiFormatFactory().getInstance(Collections.emptyMap()), true);
+    }
+
+    private void assertBloomFilterSizedForKeyCount(SSTableFormat<?, ?> format, boolean sorted) throws Exception
+    {
+        // Check the filter is sized for the real partition count, on disk and in the opened reader (CASSANDRA-21423)
+        int keyCount = 10_000;
+        double fpChance = 0.01;
+        List<SSTableReader> produced = new ArrayList<>();
+        String schema = "CREATE TABLE " + qualifiedTable + " (k int PRIMARY KEY, v int) WITH bloom_filter_fp_chance = " + fpChance;
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+        CQLSSTableWriter.Builder builder = CQLSSTableWriter.builder()
+                                                           .inDirectory(dataDir)
+                                                           .forTable(schema)
+                                                           .withFormat(format)
+                                                           .using(insert)
+                                                           .openSSTableOnProduced()
+                                                           .withSSTableProducedListener(produced::addAll);
+        if (sorted)
+            builder.sorted();
+        try (CQLSSTableWriter writer = builder.build())
+        {
+            for (int i = 0; i < keyCount; i++)
+                writer.addRow(i, i);
+        }
+
+        long expectedSize;
+        try (IFilter expected = FilterFactory.getFilter(keyCount, fpChance))
+        {
+            expectedSize = expected.offHeapSize();
+        }
+
+        List<Descriptor> descriptors = sstableDescriptors();
+        assertEquals(1, descriptors.size());
+        try (IFilter filter = FilterComponent.load(descriptors.get(0)))
+        {
+            assertEquals(expectedSize, filter.offHeapSize());
+            for (int i = 0; i < keyCount; i++)
+                assertTrue("key " + i + " should be present in the Bloom filter", filter.isPresent(key(i)));
+            assertNotSaturated(filter, keyCount, 2 * keyCount);
+        }
+
+        assertEquals(1, produced.size());
+        assertEquals(expectedSize, ((SSTableReaderWithFilter) produced.get(0)).getFilterOffHeapSize());
+        produced.forEach(reader -> reader.selfRef().release());
+    }
+
+    @Test
+    public void testNoBloomFilterWhenDisabled() throws Exception
+    {
+        String schema = "CREATE TABLE " + qualifiedTable + " (k int PRIMARY KEY, v int) WITH bloom_filter_fp_chance = 1.0";
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+        try (CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                       .inDirectory(dataDir)
+                                                       .forTable(schema)
+                                                       .using(insert)
+                                                       .sorted()
+                                                       .build())
+        {
+            for (int i = 0; i < 1_000; i++)
+                writer.addRow(i, i);
+        }
+
+        // bloom_filter_fp_chance = 1.0 disables the filter, so there must be no Filter.db to rebuild
+        List<Descriptor> descriptors = sstableDescriptors();
+        assertEquals(1, descriptors.size());
+        assertFalse(descriptors.get(0).fileFor(SSTableFormat.Components.FILTER).exists());
+    }
+
+    @Test
+    public void testBloomFilterSizedForEachRotatedSSTable() throws Exception
+    {
+        // Each rotated sstable is finished on its own, so each filter must be sized for its own partition count.
+        // Compression is disabled so the ~5 MiB payload crosses the 1 MiB cap several times.
+        int keyCount = 10_000;
+        String schema = "CREATE TABLE " + qualifiedTable + " (k int PRIMARY KEY, v text) WITH compression = {'enabled': 'false'}";
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+        String value = "x".repeat(512);
+        try (CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                       .inDirectory(dataDir)
+                                                       .forTable(schema)
+                                                       .using(insert)
+                                                       .sorted()
+                                                       .withMaxSSTableSizeInMiB(1)
+                                                       .build())
+        {
+            for (int i = 0; i < keyCount; i++)
+                writer.addRow(i, value);
+        }
+
+        List<Descriptor> descriptors = sstableDescriptors();
+        assertThat(descriptors.size()).as("expected the writer to roll over into multiple sstables").isGreaterThan(1);
+        for (Descriptor descriptor : descriptors)
+        {
+            try (IFilter filter = FilterComponent.load(descriptor))
+            {
+                assertNotSaturated(filter, keyCount, 2 * keyCount);
+            }
+        }
+    }
+
+    private List<Descriptor> sstableDescriptors() throws IOException
+    {
+        return Arrays.stream(dataDir.list(f -> f.name().endsWith(SSTableFormat.Components.DATA.type.repr)))
+                     .map(f -> Descriptor.fromFileWithComponent(f, false).left)
+                     .collect(Collectors.toList());
+    }
+
+    private static DecoratedKey key(int k)
+    {
+        return ByteOrderedPartitioner.instance.decorateKey(Int32Type.instance.decompose(k));
+    }
+
+    private static void assertNotSaturated(IFilter filter, int from, int to)
+    {
+        // a filter sized for 0 keys reports every key as present
+        int falsePositives = 0;
+        for (int i = from; i < to; i++)
+            if (filter.isPresent(key(i)))
+                falsePositives++;
+        assertThat(falsePositives).isLessThan((to - from) / 10);
     }
 
     @Test


### PR DESCRIPTION
Issue: [CASSANDRA-21423](https://issues.apache.org/jira/browse/CASSANDRA-21423)

### Purpose

CQLSSTableWriter does not know the key count on INSERT and thus produces near-empty Filter.db files. This saturates every flushed SSTable's Bloom Filter and recalculation never gets triggered, causing unnecessary disk reads for every partition key lookup to tables written via CQLSSTableWriter.

### Context

CQLSSTableWriter allows callers to generate SSTable entries outside of a running Cassandra process.

CQLSSTableWriter initializes an AbstractSSTableSimpleWriter writer that gets instantiated to either SSTableSimpleWriter or an SSTableSimpleUnsortedWriter. Either writer implementation calls AbstractSSTableSimpleWriter.createWriter() which hardcodes a partition count of 0, as neither path passes the true key count.

### Problem

Hardcoded 0 flows into FilterFactory.getFilter(0, fpChance), which allocates a filter of 0 elements + BITSET_EXCESS (20 bits). Resulting Filter.db is ~16 bytes in size ([CASSANALYTICS-167](https://issues.apache.org/jira/browse/CASSANALYTICS-167)). Effectively every bloom filter check will fall into a disk read.

### Proposed Solution

SSTableSimpleUnsortedWriter knows the key count from its in-memory buffer, so it now passes it to createWriter() and the filter is sized correctly up front. SSTableSimpleWriter rotates SSTables by on-disk size, so the count is unknown up front; add AbstractSSTableSimpleWriter.rebuildBloomFilter(), which pulls the exact partition count from Statistics.db, then walks the on-disk primary index to repopulate the filter with every key, and overwrites Filter.db.

SSTableSimpleWriter calls rebuildBloomFilter() after each SSTable is produced before notifying sstableProducedListener. Because finish(openResult) may already have opened an SSTableReader holding a shared in-memory copy of the original (broken) filter before this method runs, independent of what gets written to disk afterward, the fix also swaps the corrected filter into any already-opened readers via cloneAndReplace, releasing the original.

Skips entirely when bloom filtering is disabled for the table. On rebuild failure, failed Filter.db is deleted so a node will safely rebuild on load instead.