### PR TITLE
CASSANDRA-21519: Return CorruptSSTableException if chunk metadata and file size are out of sync

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,7 @@ Merged from 6.0:
  * Introduce minimum_threshold for data resurrection startup check (CASSANDRA-21293)
  * Synchronously publish changes to local gossip state following metadata updates (CASSANDRA-21239)
 Merged from 5.0:
+ * Allow setCompressedReadAheadBufferSizeInKb(0) to disable read-ahead buffer (CASSANDRA-21522)
  * Support Python 3.12 and 3.13 in cqlsh (CASSANDRA-20997)
  * Make synchronization on VectorMemoryIndex inserts more granular (CASSANDRA-21160)
  * Fix RequestFailureReason serializer and nits in a few others (CASSANDRA-21437)

--- a/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
@@ -104,8 +104,10 @@ public class ThreadLocalReadAheadBuffer implements Closeable
     {
         Block block = getBlock();
         ByteBuffer blockBuffer = block.buffer;
-        long realPosition = Math.min(channelSize, position);
-        int blockNo = (int) (realPosition / bufferSize);
+        if (position >= channelSize)
+            throw new CorruptSSTableException(null, channel.filePath());
+
+        int blockNo = (int) (position / bufferSize);
         long blockPosition = blockNo * (long) bufferSize;
 
         long remaining = channelSize - blockPosition;
@@ -119,7 +121,7 @@ public class ThreadLocalReadAheadBuffer implements Closeable
 
         blockBuffer.flip();
         blockBuffer.limit(sizeToRead);
-        blockBuffer.position((int) (realPosition - blockPosition));
+        blockBuffer.position((int) (position - blockPosition));
     }
 
     protected void loadBlock(ByteBuffer blockBuffer, long blockPosition, int sizeToRead)

--- a/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
@@ -101,13 +101,12 @@ public class ThreadLocalReadAheadBuffer implements Closeable
         return blockMap.get().computeIfAbsent(channel.filePath(), k -> new Block());
     }
 
-    public void fill(long position)
+    public void fill(long position) throws CorruptBlockException
     {
         Block block = getBlock();
         ByteBuffer blockBuffer = block.buffer;
         if (position >= channelSize)
-            throw new CorruptSSTableException(new CorruptBlockException(channel.filePath(), position, bufferSize),
-                                              channel.filePath());
+            throw new CorruptBlockException(channel.filePath(), position, bufferSize);
 
         int blockNo = (int) (position / bufferSize);
         long blockPosition = blockNo * (long) bufferSize;

--- a/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
@@ -18,13 +18,13 @@
 
 package org.apache.cassandra.io.util;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.compress.CorruptBlockException;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.utils.Closeable;
 import org.apache.cassandra.utils.memory.MemoryUtil;
@@ -106,9 +106,8 @@ public class ThreadLocalReadAheadBuffer implements Closeable
         Block block = getBlock();
         ByteBuffer blockBuffer = block.buffer;
         if (position >= channelSize)
-            throw new CorruptSSTableException(new IOException(String.format("Chunk read past EOF: requested position %d must be less than file size %d",
-                                                                              position, channelSize)),
-                                                channel.filePath());
+            throw new CorruptSSTableException(new CorruptBlockException(channel.filePath(), position, bufferSize),
+                                              channel.filePath());
 
         int blockNo = (int) (position / bufferSize);
         long blockPosition = blockNo * (long) bufferSize;

--- a/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/ThreadLocalReadAheadBuffer.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.io.util;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -105,7 +106,9 @@ public class ThreadLocalReadAheadBuffer implements Closeable
         Block block = getBlock();
         ByteBuffer blockBuffer = block.buffer;
         if (position >= channelSize)
-            throw new CorruptSSTableException(null, channel.filePath());
+            throw new CorruptSSTableException(new IOException(String.format("Chunk read past EOF: requested position %d must be less than file size %d",
+                                                                              position, channelSize)),
+                                                channel.filePath());
 
         int blockNo = (int) (position / bufferSize);
         long blockPosition = blockNo * (long) bufferSize;

--- a/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
@@ -130,7 +130,7 @@ public class StandardCompressedChunkReaderTest extends CompressedChunkReaderTest
 
         long longsToWrite = 600; // 4800 uncompressed bytes -> 2 compressed chunks (second one partial)
         CompressionMetadata metadata;
-        try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, offsets, digest, writerOption, params,new MetadataCollector(new ClusteringComparator())))
+        try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, offsets, digest, writerOption, params, new MetadataCollector(new ClusteringComparator())))
         {
             for (long i = 0; i < longsToWrite; i++)
                 writer.writeLong(i);
@@ -139,9 +139,7 @@ public class StandardCompressedChunkReaderTest extends CompressedChunkReaderTest
             metadata = writer.open(0);
         }
 
-        // Sanity: read-ahead must actually engage for this test to exercise the scan path
-        Assert.assertTrue("read-ahead must be larger than chunk length for scanReader to be non-null",
-                          DatabaseDescriptor.getCompressedReadAheadBufferSize() > metadata.chunkLength());
+        DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(256);
 
         // Truncate file so that chunk metadata expects a chunk to extend further than the actual file size
         long originalSize = Files.size(f.toPath());

--- a/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
@@ -19,7 +19,9 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
@@ -33,6 +35,7 @@ import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.filesystem.ListenableFileSystem;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.utils.memory.MemoryUtil;
@@ -106,6 +109,60 @@ public class StandardCompressedChunkReaderTest extends CompressedChunkReaderTest
                 }
                 while (offset < maxOffset);
             }
+        }
+        finally
+        {
+            MemoryUtil.clean(buffer);
+        }
+    }
+
+
+    @Test(timeout = 10_000)
+    public void scanReaderShouldNotHangOnTruncatedFile() throws Exception
+    {
+        SequentialWriterOption writerOption = SequentialWriterOption.newBuilder().finishOnClose(false).bufferSize(1 << 10).build();
+        CompressionParams params = CompressionParams.snappy(4096, 1.1);
+
+        FileSystems.newGlobalInMemoryFileSystem();
+        File f = new File("/truncated_hang_repro.db");
+        File offsets = new File("/truncated_hang_repro.offset");
+        File digest = new File("/truncated_hang_repro.digest");
+
+        long longsToWrite = 600; // 4800 uncompressed bytes -> 2 compressed chunks (second one partial)
+        CompressionMetadata metadata;
+        try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, offsets, digest, writerOption, params,new MetadataCollector(new ClusteringComparator())))
+        {
+            for (long i = 0; i < longsToWrite; i++)
+                writer.writeLong(i);
+
+            writer.sync();
+            metadata = writer.open(0);
+        }
+
+        // Sanity: read-ahead must actually engage for this test to exercise the scan path
+        Assert.assertTrue("read-ahead must be larger than chunk length for scanReader to be non-null",
+                          DatabaseDescriptor.getCompressedReadAheadBufferSize() > metadata.chunkLength());
+
+        // Truncate file so that chunk metadata expects a chunk to extend further than the actual file size
+        long originalSize = Files.size(f.toPath());
+        long truncatedSize = originalSize - (params.chunkLength() / 2);
+        try (FileChannel fc = FileChannel.open(f.toPath(), StandardOpenOption.WRITE))
+        {
+            fc.truncate(truncatedSize);
+        }
+        long uncompressedTotal = longsToWrite * Long.BYTES;
+        long lastChunkUncompressedStart = ((uncompressedTotal - 1) / metadata.chunkLength()) * metadata.chunkLength();
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(metadata.chunkLength());
+        try (ChannelProxy channel = new ChannelProxy(f);
+             CompressedChunkReader reader = new CompressedChunkReader.Standard(channel, metadata, () -> 1.1);
+             metadata)
+        {
+            reader.forScan();
+
+            Assertions.assertThatThrownBy(() -> reader.readChunk(lastChunkUncompressedStart, buffer))
+                      .as("readChunk() reading past truncated EOF via the scan path")
+                      .isInstanceOf(CorruptSSTableException.class);
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/StandardCompressedChunkReaderTest.java
@@ -116,7 +116,6 @@ public class StandardCompressedChunkReaderTest extends CompressedChunkReaderTest
         }
     }
 
-
     @Test(timeout = 10_000)
     public void scanReaderShouldNotHangOnTruncatedFile() throws Exception
     {

--- a/test/unit/org/apache/cassandra/io/util/ThreadLocalReadAheadBufferTest.java
+++ b/test/unit/org/apache/cassandra/io/util/ThreadLocalReadAheadBufferTest.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DataStorageSpec;
 import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.compress.CorruptBlockException;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.utils.Pair;
 
@@ -125,7 +126,7 @@ public class ThreadLocalReadAheadBufferTest implements WithQuickTheories
                     copied += tlrab.read(buf2, tlrab.remaining());
             }
         }
-        catch (CorruptSSTableException e)
+        catch (CorruptSSTableException | CorruptBlockException e)
         {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
In ThreadLocalReadAheadBuffer, in the rare case that chunk metadata and file size are out of sync (e.g. bytes erased from the file after chunk metadata is calculated), we’d enter an infinite loop.
 
The proposed fix is to throw a CorruptBlockException if we’re trying to read past the end of a file, rather than clamping the read. 

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21519)

