### PR TITLE
CASSANDRA-21522: Allow setCompressedReadAheadBufferSizeInKb(0) to disable RAB

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -69,6 +69,7 @@ Merged from 6.0:
  * Introduce minimum_threshold for data resurrection startup check (CASSANDRA-21293)
  * Synchronously publish changes to local gossip state following metadata updates (CASSANDRA-21239)
 Merged from 5.0:
+ * Allow setCompressedReadAheadBufferSizeInKb(0) to disable read-ahead buffer (CASSANDRA-21522)
  * Fix ThreadLocalReadAheadBuffer#fill() to throw a CorruptBlockException if chunk metadata and file size are out of sync (CASSANDRA-21519)
  * Support Python 3.12 and 3.13 in cqlsh (CASSANDRA-20997)
  * Make synchronization on VectorMemoryIndex inserts more granular (CASSANDRA-21160)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -3072,7 +3072,7 @@ public class DatabaseDescriptor
 
     public static void setCompressedReadAheadBufferSizeInKb(int sizeInKb)
     {
-        if (sizeInKb != 0 && sizeInKb < 256)
+        if (sizeInKb < 0 || (sizeInKb > 0 && sizeInKb < 256))
             throw new IllegalArgumentException("compressed_read_ahead_buffer_size_in_kb must be at least 256KiB (set to 0 to disable)");
 
         conf.compressed_read_ahead_buffer_size = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(sizeInKb, "compressed_read_ahead_buffer_size");

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -3072,8 +3072,8 @@ public class DatabaseDescriptor
 
     public static void setCompressedReadAheadBufferSizeInKb(int sizeInKb)
     {
-        if (sizeInKb < 256)
-            throw new IllegalArgumentException("compressed_read_ahead_buffer_size_in_kb must be at least 256KiB");
+        if (sizeInKb != 0 && sizeInKb < 256)
+            throw new IllegalArgumentException("compressed_read_ahead_buffer_size_in_kb must be at least 256KiB (set to 0 to disable)");
 
         conf.compressed_read_ahead_buffer_size = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(sizeInKb, "compressed_read_ahead_buffer_size");
     }

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -1212,4 +1212,28 @@ public class DatabaseDescriptorTest
             conf.local_system_data_file_directory = savedLocalSystemDir;
         }
     }
+
+    @Test
+    public void testSetCompressedReadAheadBufferSizeInKb()
+    {
+        int original = DatabaseDescriptor.getCompressedReadAheadBufferSizeInKB();
+        try
+        {
+            // 0 should be a legal value, and represents disabling read-ahead buffer
+            DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(0);
+            assertEquals(0, DatabaseDescriptor.getCompressedReadAheadBufferSizeInKB());
+            assertEquals(0, DatabaseDescriptor.getCompressedReadAheadBufferSize());
+
+            Assertions.assertThatThrownBy(() -> DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(255))
+                      .isInstanceOf(IllegalArgumentException.class)
+                      .hasMessage("compressed_read_ahead_buffer_size_in_kb must be at least 256KiB (set to 0 to disable)");
+
+            DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(256);
+            assertEquals(256, DatabaseDescriptor.getCompressedReadAheadBufferSizeInKB());
+        }
+        finally
+        {
+            DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(original);
+        }
+    }
 }


### PR DESCRIPTION
In DatabaseDescriptor:1132, the exception states: `compressed_read_ahead_buffer_size must be at least 256KiB (set to 0 to disable)`. But, if an operator ever later tries to disable the buffer by following this message and setting sizeInKb to 0, `setCompressedReadAheadBufferSizeInKb()` will throw an error that sizeInKb < 256. 

This PR explicitly allows a value of 0 in setCompressedReadAheadBufferSizeInKb (I’ve traced that 0 is handled in every other place that reads this value). 

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21522)

