### PR TITLE
CASSANDRA-20611: Remove unused cassandra.boot_without_jna from cassandra-env.sh documentation (5.0)

### DIFF
--- a/doc/modules/cassandra/pages/managing/configuration/cass_env_sh_file.adoc
+++ b/doc/modules/cassandra/pages/managing/configuration/cass_env_sh_file.adoc
@@ -31,10 +31,6 @@ In a multi-instance deployment, multiple Cassandra instances will
 independently assume that all CPU processors are available to it. This
 setting allows you to specify a smaller set of processors.
 
-== `cassandra.boot_without_jna=true`
-
-If JNA fails to initialize, Cassandra fails to boot. Use this command to
-boot Cassandra without JNA.
 
 == `cassandra.config=<directory>`
 


### PR DESCRIPTION
Remove unused cassandra.boot_without_jna from `cassandra-env.sh` documentation

*(Backport of CASSANDRA-20611 for Cassandra 5.0)*
The `cassandra.boot_without_jna` property was removed from the codebase in CASSANDRA-9573, but it was still being documented in `cass_env_sh_file.adoc`. This patch removes the outdated reference to avoid user confusion.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-20611