### PR TITLE
CASSANDRA-21532: Update Python version prerequisites in installation docs to support Python 3.13

### DIFF
--- a/doc/modules/cassandra/pages/installing/installing.adoc
+++ b/doc/modules/cassandra/pages/installing/installing.adoc
@@ -23,7 +23,7 @@ Deploying on older Linux versions is not recommended unless you have previous ex
 
 include::cassandra:partial$java_version.adoc[]
 
-* To use the CQL shell `cqlsh`, install the latest version of Python 3.8-3.11.
+* To use the CQL shell `cqlsh`, install the latest version of Python 3.8-3.13.
 
 To verify that you have the correct version of Python installed, type `python --version`.
 


### PR DESCRIPTION
### Summary of Changes
Following CASSANDRA-20997 `cqlsh` added support for Python versions up to Python 3.13.

This PR updates the prerequisite section in `doc/modules/cassandra/pages/installing/installing.adoc` to reflect that `cqlsh` supports Python 3.8–3.13 (previously listed as `3.8–3.11`).

### Changes Made
* Updated `doc/modules/cassandra/pages/installing/installing.adoc`:
  - Changed `Python 3.8-3.11` to `Python 3.8-3.13`.

patch by Manish M Pillai; reviewed by tbd for CASSANDRA-21532

