### PR TITLE
CASSANDRA-21198 Durably persist timestamps to maintain monotonicity on restart

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -554,6 +554,8 @@ public class AccordService implements IAccordService, Shutdownable
                         rebootstrap = true;
                 }
             }
+
+            node.uniqueNow(ReplayMarkers.readLastUniqueTimeStamp());
         }
 
         logger.info("Starting background compaction of system_accord");
@@ -684,7 +686,7 @@ public class AccordService implements IAccordService, Shutdownable
 
         // we set ourselves to STARTED before starting progress logs as this is the condition we use to decide if we
         // start the progress log on command store initialisation (so creates a synchronisation point)
-        journal.writeStartMarker();
+        journal.writeStartMarker(node.uniqueNow());
         state = State.STARTED;
         instance = requestInstance = this;
         node.commandStores().forAllUnsafe(cs -> cs.unsafeProgressLog().start());
@@ -1227,7 +1229,7 @@ public class AccordService implements IAccordService, Shutdownable
         AccordCommandStores commandStores = (AccordCommandStores)node.commandStores();
         Set<TableId> tableIds = commandStores.shutdownStores();
         commandStores.waitForQuiescence();
-        journal.writeSafeStopMarker();
+        journal.writeSafeStopMarker(node.uniqueNow());
         scheduler.shutdownNow();
         toFuture(flushCaches()).map(ignore -> {
             return AccordColumnFamilyStores.commandsForKey.forceFlush(DRAIN);

--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -154,6 +154,7 @@ import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.AsyncFuture;
 import org.apache.cassandra.utils.concurrent.AsyncPromise;
 import org.apache.cassandra.utils.concurrent.Condition;
@@ -534,28 +535,31 @@ public class AccordService implements IAccordService, Shutdownable
 
         boolean rebootstrap = false;
         {
-            long startMarker = ReplayMarkers.readStartMarker();
-            long stopMarker = ReplayMarkers.readStopMarker();
-            if (stopMarker < startMarker)
+            Pair<Long, Long> startMarkerPair = ReplayMarkers.readStartMarker();
+            Pair<Long, Long> stopMarkerPair = ReplayMarkers.readStopMarker();
+            long startMarkerSegmentId = startMarkerPair.left;
+            long stopMarkerSegmentId = stopMarkerPair.left;
+
+            if (startMarkerSegmentId < stopMarkerSegmentId)
             {
                 switch (getAccord().journal.stopMarkerFailurePolicy)
                 {
                     default: throw new UnhandledEnum(getAccord().journal.stopMarkerFailurePolicy);
                     case EXIT:
-                        throw new RuntimeException("Stop marker is older than start marker (" + stopMarker + '<' + startMarker + ") , so cannot assume we have a complete log of our votes in any consensus groups. Exiting.");
+                        throw new RuntimeException("Stop marker is older than start marker (" + stopMarkerSegmentId + '<' + startMarkerSegmentId + ") , so cannot assume we have a complete log of our votes in any consensus groups. Exiting.");
 
                     case ALLOW_UNSAFE_STARTUP:
                     case UNSAFE_STARTUP:
-                        logger.warn("Stop marker is older than start marker ({}<{}), so cannot assume we have a complete log of our votes in any consensus groups. Continuing to startup as configured.", stopMarker, startMarker);
+                        logger.warn("Stop marker is older than start marker ({}<{}), so cannot assume we have a complete log of our votes in any consensus groups. Continuing to startup as configured.", stopMarkerSegmentId, startMarkerSegmentId);
                         break;
 
                     case REBOOTSTRAP:
-                        logger.info("Stop marker is older than start marker ({}<{}). Rebootstrapping.", stopMarker, startMarker);
+                        logger.info("Stop marker is older than start marker ({}<{}). Rebootstrapping.", stopMarkerSegmentId, startMarkerSegmentId);
                         rebootstrap = true;
                 }
             }
 
-            node.uniqueNow(ReplayMarkers.readLastUniqueTimeStamp());
+            node.uniqueNow(stopMarkerPair.right);
         }
 
         logger.info("Starting background compaction of system_accord");

--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -540,7 +540,7 @@ public class AccordService implements IAccordService, Shutdownable
             long startMarkerSegmentId = startMarkerPair.left;
             long stopMarkerSegmentId = stopMarkerPair.left;
 
-            if (startMarkerSegmentId < stopMarkerSegmentId)
+            if (stopMarkerSegmentId < startMarkerSegmentId)
             {
                 switch (getAccord().journal.stopMarkerFailurePolicy)
                 {

--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -154,7 +154,6 @@ import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.AsyncFuture;
 import org.apache.cassandra.utils.concurrent.AsyncPromise;
 import org.apache.cassandra.utils.concurrent.Condition;
@@ -535,10 +534,9 @@ public class AccordService implements IAccordService, Shutdownable
 
         boolean rebootstrap = false;
         {
-            Pair<Long, Long> startMarkerPair = ReplayMarkers.readStartMarker();
-            Pair<Long, Long> stopMarkerPair = ReplayMarkers.readStopMarker();
-            long startMarkerSegmentId = startMarkerPair.left;
-            long stopMarkerSegmentId = stopMarkerPair.left;
+            ReplayMarkers.ReplayMarkerMetadata stopMarkerMetadata = ReplayMarkers.readStopMarker();
+            long startMarkerSegmentId = ReplayMarkers.readStartMarker().getSegmentId();
+            long stopMarkerSegmentId = stopMarkerMetadata.getSegmentId();
 
             if (stopMarkerSegmentId < startMarkerSegmentId)
             {
@@ -559,7 +557,7 @@ public class AccordService implements IAccordService, Shutdownable
                 }
             }
 
-            node.uniqueNow(stopMarkerPair.right);
+            node.uniqueNow(stopMarkerMetadata.getLastUniqueTimeStamp());
         }
 
         logger.info("Starting background compaction of system_accord");
@@ -690,7 +688,7 @@ public class AccordService implements IAccordService, Shutdownable
 
         // we set ourselves to STARTED before starting progress logs as this is the condition we use to decide if we
         // start the progress log on command store initialisation (so creates a synchronisation point)
-        journal.writeStartMarker(node.uniqueNow());
+        journal.writeStartMarker();
         state = State.STARTED;
         instance = requestInstance = this;
         node.commandStores().forAllUnsafe(cs -> cs.unsafeProgressLog().start());

--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -534,11 +534,12 @@ public class AccordService implements IAccordService, Shutdownable
 
         boolean rebootstrap = false;
         {
-            ReplayMarkers.ReplayMarkerMetadata stopMarkerMetadata = ReplayMarkers.readStopMarker();
-            long startMarkerSegmentId = ReplayMarkers.readStartMarker().getSegmentId();
-            long stopMarkerSegmentId = stopMarkerMetadata.getSegmentId();
+            ReplayMarkers.ReplayMarkerData startMarker = ReplayMarkers.readStartMarker();
+            ReplayMarkers.ReplayMarkerData stopMarker = ReplayMarkers.readStopMarker();
+            long startMarkerSegmentId = startMarker.getSegmentId();
+            long stopMarkerSegmentId = stopMarker.getSegmentId();
 
-            if (stopMarkerSegmentId < startMarkerSegmentId)
+            if (startMarker.isValid() && stopMarker.isValid() && stopMarkerSegmentId < startMarkerSegmentId)
             {
                 switch (getAccord().journal.stopMarkerFailurePolicy)
                 {
@@ -557,7 +558,7 @@ public class AccordService implements IAccordService, Shutdownable
                 }
             }
 
-            node.uniqueNow(stopMarkerMetadata.getLastUniqueTimeStamp());
+            node.uniqueNow(stopMarker.getLastUniqueTimestamp());
         }
 
         logger.info("Starting background compaction of system_accord");

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
@@ -621,15 +621,15 @@ public class AccordJournal implements accord.api.Journal, RangeSearcher.Supplier
         return rangeSearch.rangeSearcher();
     }
 
-    public void writeStartMarker()
+    public void writeStartMarker(long lastUniqueTimeStamp)
     {
-        writeMarker(startMarker(), segments.peekSegmentId());
+        writeMarker(startMarker(), segments.peekSegmentId(), lastUniqueTimeStamp);
     }
 
-    public void writeSafeStopMarker()
+    public void writeSafeStopMarker(long lastUniqueTimeStamp)
     {
         segments.fsync();
-        writeMarker(safeStopMarker(), segments.peekSegmentId());
+        writeMarker(safeStopMarker(), segments.peekSegmentId(), lastUniqueTimeStamp);
     }
 
     private static Runnable merge(Runnable first, Runnable second)

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
@@ -621,9 +621,9 @@ public class AccordJournal implements accord.api.Journal, RangeSearcher.Supplier
         return rangeSearch.rangeSearcher();
     }
 
-    public void writeStartMarker(long lastUniqueTimeStamp)
+    public void writeStartMarker()
     {
-        writeMarker(startMarker(), segments.peekSegmentId(), lastUniqueTimeStamp);
+        writeMarker(startMarker(), segments.peekSegmentId(), -1L);
     }
 
     public void writeSafeStopMarker(long lastUniqueTimeStamp)

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordJournal.java
@@ -626,10 +626,10 @@ public class AccordJournal implements accord.api.Journal, RangeSearcher.Supplier
         writeMarker(startMarker(), segments.peekSegmentId(), -1L);
     }
 
-    public void writeSafeStopMarker(long lastUniqueTimeStamp)
+    public void writeSafeStopMarker(long lastUniqueTimestamp)
     {
         segments.fsync();
-        writeMarker(safeStopMarker(), segments.peekSegmentId(), lastUniqueTimeStamp);
+        writeMarker(safeStopMarker(), segments.peekSegmentId(), lastUniqueTimestamp);
     }
 
     private static Runnable merge(Runnable first, Runnable second)

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -122,7 +122,7 @@ public class ReplayMarkers
         }
     }
 
-    public static void trySyncJournalDirectory()
+    private static void trySyncJournalDirectory()
     {
         trySyncDirectory(getAccordJournalDirectory());
     }

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -45,7 +45,6 @@ public class ReplayMarkers
         return new File(getAccordJournalDirectory(), "stop.crc");
     }
 
-    // TODO (required): add checksummed version and default to this (but support unchecksummed for manual editing)
     public static void writeMarker(File file, long timestamp, long lastUniqueTimeStamp)
     {
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -20,24 +20,29 @@ package org.apache.cassandra.service.accord.journal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.zip.CRC32;
+
+import com.google.common.primitives.Longs;
 
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.utils.NativeLibrary;
+import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.config.DatabaseDescriptor.getAccordJournalDirectory;
+import static org.apache.cassandra.utils.Crc.crc32;
 
 public class ReplayMarkers
 {
     public static File startMarker()
     {
-        return new File(getAccordJournalDirectory(), "started");
+        return new File(getAccordJournalDirectory(), "start.crc");
     }
 
     public static File safeStopMarker()
     {
-        return new File(getAccordJournalDirectory(), "stopped");
+        return new File(getAccordJournalDirectory(), "stop.crc");
     }
 
     // TODO (required): add checksummed version and default to this (but support unchecksummed for manual editing)
@@ -45,10 +50,12 @@ public class ReplayMarkers
     {
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
         {
-            int endingOffset = Long.toString(timestamp).length();
-            out.writeInt(endingOffset);
-            out.writeBytes(Long.toString(timestamp));
-            out.writeBytes(Long.toString(lastUniqueTimeStamp));
+            CRC32 crc = crc32();
+            out.writeLong(timestamp);
+            crc.update(Longs.toByteArray(timestamp));
+            out.writeLong(lastUniqueTimeStamp);
+            crc.update(Longs.toByteArray(lastUniqueTimeStamp));
+            out.writeInt((int) crc.getValue());
         }
         catch (IOException e)
         {
@@ -57,28 +64,41 @@ public class ReplayMarkers
         trySyncJournalDirectory();
     }
 
-    public static long readStartMarker()
+    public static Pair<Long, Long> readStartMarker()
     {
-        return readMarker(startMarker());
+        File crcFile = new File(getAccordJournalDirectory(), "start.crc");
+        if (crcFile.exists())
+            return readCrcMarker(crcFile);
+        else
+            return readMarker(new File(getAccordJournalDirectory(), "started"));
     }
 
-    public static long readStopMarker()
+    public static Pair<Long, Long> readStopMarker()
     {
-        return readMarker(safeStopMarker());
+        File crcFile = new File(getAccordJournalDirectory(), "stop.crc");
+        if (crcFile.exists())
+            return readCrcMarker(crcFile);
+        else
+            return readMarker(new File(getAccordJournalDirectory(), "stopped"));
     }
 
-    public static long readMarker(File file)
+    public static Pair<Long, Long> readCrcMarker(File file)
     {
         if (!file.exists())
-            return -1L;
+            return Pair.create(-1L, -1L);
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
-            StringBuilder sb = new StringBuilder(8);
-            int endingOffset = in.readInt();
-            for (int i = 0; i < endingOffset; i++)
-                sb.append((char) in.read());
-            return Long.parseLong(sb.toString());
+            CRC32 crc = crc32();
+            long timestamp = in.readLong();
+            crc.update(Longs.toByteArray(timestamp));
+            long lastUniqueTimeStamp = in.readLong();
+            crc.update(Longs.toByteArray(lastUniqueTimeStamp));
+            int checksum = in.readInt();
+            if (in.read() != -1 || (int) crc.getValue() != checksum)
+                throw new IOException("Stop.crc file corrupted");
+
+            return Pair.create(timestamp, lastUniqueTimeStamp);
         }
         catch (IOException e)
         {
@@ -86,22 +106,16 @@ public class ReplayMarkers
         }
     }
 
-    public static long readLastUniqueTimeStamp()
+    public static Pair<Long, Long> readMarker(File file)
     {
-        File file = safeStopMarker();
         if (!file.exists())
-            return -1L;
+            return Pair.create(-1L, -1L);
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
-            int endingOffset = in.readInt();
-            StringBuilder sb = new StringBuilder(8);
-            for (int i = 0; i < endingOffset; i++)
-                in.read();
-
-            for (int b = in.read(); b >= 0 ; b = in.read())
-                sb.append((char)b);
-            return Long.parseLong(sb.toString());
+            long timestamp = in.readLong();
+            long lastUniqueTimeStamp = in.readLong();
+            return Pair.create(timestamp, lastUniqueTimeStamp);
         }
         catch (IOException e)
         {
@@ -109,7 +123,7 @@ public class ReplayMarkers
         }
     }
 
-    private static void trySyncJournalDirectory()
+    public static void trySyncJournalDirectory()
     {
         trySyncDirectory(getAccordJournalDirectory());
     }

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -112,9 +112,10 @@ public class ReplayMarkers
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
-            long timestamp = in.readLong();
-            long lastUniqueTimeStamp = in.readLong();
-            return Pair.create(timestamp, lastUniqueTimeStamp);
+            StringBuilder sb = new StringBuilder(8);
+            for (int b = in.read(); b >= 0 ; b = in.read())
+                sb.append((char)b);
+            return Pair.create(Long.parseLong(sb.toString()), -1L);
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.utils.NativeLibrary;
-import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.config.DatabaseDescriptor.getAccordJournalDirectory;
 import static org.apache.cassandra.utils.Crc.crc32;
@@ -43,6 +42,40 @@ public class ReplayMarkers
     public static File safeStopMarker()
     {
         return new File(getAccordJournalDirectory(), "stop.crc");
+    }
+
+    public static class ReplayMarkerMetadata
+    {
+        public final long segmentId;
+        public final long lastUniqueTimeStamp;
+
+        public ReplayMarkerMetadata(long segmentId, long lastUniqueTimeStamp)
+        {
+            this.segmentId = segmentId;
+            this.lastUniqueTimeStamp = lastUniqueTimeStamp;
+        }
+
+        public long getSegmentId()
+        {
+            return segmentId;
+        }
+
+        public long getLastUniqueTimeStamp()
+        {
+            return lastUniqueTimeStamp;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this)
+                return true;
+            if (!(other instanceof ReplayMarkerMetadata))
+                return false;
+
+            ReplayMarkerMetadata that = (ReplayMarkerMetadata) other;
+            return this.getSegmentId() == that.getSegmentId() && this.getLastUniqueTimeStamp() == that.getLastUniqueTimeStamp();
+        }
     }
 
     public static void writeMarker(File file, long timestamp, long lastUniqueTimeStamp)
@@ -63,7 +96,7 @@ public class ReplayMarkers
         trySyncJournalDirectory();
     }
 
-    public static Pair<Long, Long> readStartMarker()
+    public static ReplayMarkerMetadata readStartMarker()
     {
         File crcFile = new File(getAccordJournalDirectory(), "start.crc");
         if (crcFile.exists())
@@ -72,7 +105,7 @@ public class ReplayMarkers
             return readMarker(new File(getAccordJournalDirectory(), "started"));
     }
 
-    public static Pair<Long, Long> readStopMarker()
+    public static ReplayMarkerMetadata readStopMarker()
     {
         File crcFile = new File(getAccordJournalDirectory(), "stop.crc");
         if (crcFile.exists())
@@ -81,10 +114,10 @@ public class ReplayMarkers
             return readMarker(new File(getAccordJournalDirectory(), "stopped"));
     }
 
-    public static Pair<Long, Long> readCrcMarker(File file)
+    public static ReplayMarkerMetadata readCrcMarker(File file)
     {
         if (!file.exists())
-            return Pair.create(-1L, -1L);
+            return new ReplayMarkerMetadata(-1L, -1L);
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
@@ -97,7 +130,7 @@ public class ReplayMarkers
             if (in.read() != -1 || (int) crc.getValue() != checksum)
                 throw new IOException("Stop.crc file corrupted");
 
-            return Pair.create(timestamp, lastUniqueTimeStamp);
+            return new ReplayMarkerMetadata(timestamp, lastUniqueTimeStamp);
         }
         catch (IOException e)
         {
@@ -105,17 +138,17 @@ public class ReplayMarkers
         }
     }
 
-    public static Pair<Long, Long> readMarker(File file)
+    public static ReplayMarkerMetadata readMarker(File file)
     {
         if (!file.exists())
-            return Pair.create(-1L, -1L);
+            return new ReplayMarkerMetadata(-1, -1);
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
             StringBuilder sb = new StringBuilder(8);
             for (int b = in.read(); b >= 0 ; b = in.read())
                 sb.append((char)b);
-            return Pair.create(Long.parseLong(sb.toString()), -1L);
+            return  new ReplayMarkerMetadata(Long.parseLong(sb.toString()), -1L);
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -41,11 +41,14 @@ public class ReplayMarkers
     }
 
     // TODO (required): add checksummed version and default to this (but support unchecksummed for manual editing)
-    static void writeMarker(File file, long timestamp)
+    public static void writeMarker(File file, long timestamp, long lastUniqueTimeStamp)
     {
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
         {
+            int endingOffset = Long.toString(timestamp).length();
+            out.writeInt(endingOffset);
             out.writeBytes(Long.toString(timestamp));
+            out.writeBytes(Long.toString(lastUniqueTimeStamp));
         }
         catch (IOException e)
         {
@@ -72,6 +75,30 @@ public class ReplayMarkers
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
             StringBuilder sb = new StringBuilder(8);
+            int endingOffset = in.readInt();
+            for (int i = 0; i < endingOffset; i++)
+                sb.append((char) in.read());
+            return Long.parseLong(sb.toString());
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static long readLastUniqueTimeStamp()
+    {
+        File file = safeStopMarker();
+        if (!file.exists())
+            return -1L;
+
+        try (FileInputStreamPlus in = new FileInputStreamPlus(file))
+        {
+            int endingOffset = in.readInt();
+            StringBuilder sb = new StringBuilder(8);
+            for (int i = 0; i < endingOffset; i++)
+                in.read();
+
             for (int b = in.read(); b >= 0 ; b = in.read())
                 sb.append((char)b);
             return Long.parseLong(sb.toString());

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.zip.CRC32;
 
-import com.google.common.primitives.Longs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NativeLibrary;
 
 import static org.apache.cassandra.config.DatabaseDescriptor.getAccordJournalDirectory;
@@ -34,25 +36,35 @@ import static org.apache.cassandra.utils.Crc.crc32;
 
 public class ReplayMarkers
 {
+    private static final Logger logger = LoggerFactory.getLogger(ReplayMarkers.class);
+    public static final String startMarkerCrc = "startedCrc.marker";
+    public static final String endMarkerCrc = "stoppedCrc.marker";
+    public static final String startMarker = "started.marker";
+    public static final String endMarker = "stopped.marker";
+
     public static File startMarker()
     {
-        return new File(getAccordJournalDirectory(), "start.crc");
+        return new File(getAccordJournalDirectory(), startMarkerCrc);
     }
 
     public static File safeStopMarker()
     {
-        return new File(getAccordJournalDirectory(), "stop.crc");
+        return new File(getAccordJournalDirectory(), endMarkerCrc);
     }
 
-    public static class ReplayMarkerMetadata
+    public static class ReplayMarkerData
     {
         public final long segmentId;
-        public final long lastUniqueTimeStamp;
+        public final long lastUniqueTimestamp;
 
-        public ReplayMarkerMetadata(long segmentId, long lastUniqueTimeStamp)
+        public ReplayMarkerData(long segmentId, long lastUniqueTimestamp)
         {
             this.segmentId = segmentId;
-            this.lastUniqueTimeStamp = lastUniqueTimeStamp;
+            this.lastUniqueTimestamp = lastUniqueTimestamp;
+        }
+
+        public static ReplayMarkerData invalidMarker() {
+            return new ReplayMarkerData(-1L, -1L);
         }
 
         public long getSegmentId()
@@ -60,33 +72,25 @@ public class ReplayMarkers
             return segmentId;
         }
 
-        public long getLastUniqueTimeStamp()
+        public long getLastUniqueTimestamp()
         {
-            return lastUniqueTimeStamp;
+            return lastUniqueTimestamp;
         }
 
-        @Override
-        public boolean equals(Object other)
-        {
-            if (other == this)
-                return true;
-            if (!(other instanceof ReplayMarkerMetadata))
-                return false;
-
-            ReplayMarkerMetadata that = (ReplayMarkerMetadata) other;
-            return this.getSegmentId() == that.getSegmentId() && this.getLastUniqueTimeStamp() == that.getLastUniqueTimeStamp();
+        public boolean isValid() {
+            return segmentId != -1L && lastUniqueTimestamp != -1L;
         }
     }
 
-    public static void writeMarker(File file, long timestamp, long lastUniqueTimeStamp)
+    public static void writeMarker(File file, long timestamp, long lastUniqueTimestamp)
     {
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
         {
             CRC32 crc = crc32();
             out.writeLong(timestamp);
-            crc.update(Longs.toByteArray(timestamp));
-            out.writeLong(lastUniqueTimeStamp);
-            crc.update(Longs.toByteArray(lastUniqueTimeStamp));
+            FBUtilities.updateChecksumLong(crc, timestamp);
+            out.writeLong(lastUniqueTimestamp);
+            FBUtilities.updateChecksumLong(crc, lastUniqueTimestamp);
             out.writeInt((int) crc.getValue());
             out.sync();
         }
@@ -97,63 +101,74 @@ public class ReplayMarkers
         trySyncJournalDirectory();
     }
 
-    public static ReplayMarkerMetadata readStartMarker()
+    public static ReplayMarkerData readStartMarker()
     {
-        File crcFile = new File(getAccordJournalDirectory(), "start.crc");
+        File crcFile = new File(getAccordJournalDirectory(), startMarkerCrc);
         if (crcFile.exists())
             return readCrcMarker(crcFile);
         else
-            return readMarker(new File(getAccordJournalDirectory(), "started"));
+            return readMarker(new File(getAccordJournalDirectory(), startMarker));
     }
 
-    public static ReplayMarkerMetadata readStopMarker()
+    public static ReplayMarkerData readStopMarker()
     {
-        File crcFile = new File(getAccordJournalDirectory(), "stop.crc");
+        File crcFile = new File(getAccordJournalDirectory(), endMarkerCrc);
         if (crcFile.exists())
             return readCrcMarker(crcFile);
         else
-            return readMarker(new File(getAccordJournalDirectory(), "stopped"));
+            return readMarker(new File(getAccordJournalDirectory(), endMarker));
     }
 
-    public static ReplayMarkerMetadata readCrcMarker(File file)
+    public static ReplayMarkerData readCrcMarker(File file)
     {
         if (!file.exists())
-            return new ReplayMarkerMetadata(-1L, -1L);
+        {
+            logger.debug("{} does not exist", file);
+            return ReplayMarkerData.invalidMarker();
+        }
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
             CRC32 crc = crc32();
             long timestamp = in.readLong();
-            crc.update(Longs.toByteArray(timestamp));
-            long lastUniqueTimeStamp = in.readLong();
-            crc.update(Longs.toByteArray(lastUniqueTimeStamp));
+            FBUtilities.updateChecksumLong(crc, timestamp);
+            long lastUniqueTimestamp = in.readLong();
+            FBUtilities.updateChecksumLong(crc, lastUniqueTimestamp);
             int checksum = in.readInt();
             if (in.read() != -1 || (int) crc.getValue() != checksum)
-                throw new IOException("Stop.crc file corrupted");
+            {
+                logger.debug("{} is corrupted", file);
+                return ReplayMarkerData.invalidMarker();
+            }
 
-            return new ReplayMarkerMetadata(timestamp, lastUniqueTimeStamp);
+            return new ReplayMarkerData(timestamp, lastUniqueTimestamp);
         }
         catch (IOException e)
         {
-            throw new UncheckedIOException(e);
+            logger.debug("Encountered IO exception {}, while reading {}", e, file);
+            return ReplayMarkerData.invalidMarker();
         }
     }
 
-    public static ReplayMarkerMetadata readMarker(File file)
+    public static ReplayMarkerData readMarker(File file)
     {
         if (!file.exists())
-            return new ReplayMarkerMetadata(-1, -1);
+        {
+            logger.debug("{} does not exist", file);
+            return ReplayMarkerData.invalidMarker();
+        }
 
         try (FileInputStreamPlus in = new FileInputStreamPlus(file))
         {
             StringBuilder sb = new StringBuilder(8);
             for (int b = in.read(); b >= 0 ; b = in.read())
                 sb.append((char)b);
-            return  new ReplayMarkerMetadata(Long.parseLong(sb.toString()), -1L);
+            return new ReplayMarkerData(Long.parseLong(sb.toString()), -1L);
         }
         catch (IOException e)
         {
-            throw new UncheckedIOException(e);
+            logger.debug("Encountered IO exception {}, while reading {}", e, file);
+            return ReplayMarkerData.invalidMarker();
         }
     }
 

--- a/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/ReplayMarkers.java
@@ -88,6 +88,7 @@ public class ReplayMarkers
             out.writeLong(lastUniqueTimeStamp);
             crc.update(Longs.toByteArray(lastUniqueTimeStamp));
             out.writeInt((int) crc.getValue());
+            out.sync();
         }
         catch (IOException e)
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
@@ -29,47 +29,37 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
-import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
-import org.apache.cassandra.distributed.api.TokenSupplier;
-import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.utils.Shared;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AccordUniqueTimeStampsOnCrashTest extends TestBaseImpl
+public class AccordMonotonicTimeStampsOnCrashTest extends TestBaseImpl
 {
     @Test
-    public void uniqueTimeStampsOnCrashTest() throws Throwable
+    public void monotonicTimeStampsOnCrashTest() throws Throwable
     {
         try (Cluster cluster = Cluster.build().withNodes(3)
-                                      .withoutVNodes()
-                                      .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(3))
-                                      .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(3, "dc0", "rack0"))
                                       .withInstanceInitializer(BBHelper::install)
                                       .withConfig(config -> config
                                                             .with(NETWORK, GOSSIP))
                                       .start())
         {
-            cluster.schemaChange("CREATE KEYSPACE ks WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':3}");
-            cluster.schemaChange("CREATE TABLE ks.tbl (k int, c int, v int, primary key (k, c)) WITH transactional_mode='full'");
-            cluster.coordinator(1).execute(wrapInTxn("INSERT INTO ks.tbl (k, c, v) VALUES (?, ?, ?)"), ConsistencyLevel.SERIAL, 1, 1, 2);
-
             cluster.get(1).shutdown(false).get();
             State.beforeRestart.set(false);
 
             cluster.get(1).startup();
 
             cluster.get(1).runOnInstance( () -> {
-                AccordService.instance().node().uniqueNow(0);
+                AccordService.instance().node().uniqueNow();
             });
         }
     }
@@ -89,13 +79,13 @@ public class AccordUniqueTimeStampsOnCrashTest extends TestBaseImpl
             if (nodeNumber == 1)
             {
                 new ByteBuddy().rebase(AccordTimeService.class)
-                               .method(named("now").and(takesArguments(0)))
+                               .method(named("now"))
                                .intercept(MethodDelegation.to(BBHelper.class))
                                .make()
                                .load(cl, ClassLoadingStrategy.Default.INJECTION);
 
                 new ByteBuddy().rebase(Node.class)
-                               .method(named("uniqueNow").and(takesArguments(1)))
+                               .method(named("uniqueNow"))
                                .intercept(MethodDelegation.to(BBHelper.class))
                                .make()
                                .load(cl, ClassLoadingStrategy.Default.INJECTION);
@@ -112,10 +102,10 @@ public class AccordUniqueTimeStampsOnCrashTest extends TestBaseImpl
         }
 
         @SuppressWarnings("unused")
-        public static long uniqueNow(long greaterThan, @SuperCall Callable<Long> r) throws Exception
+        public static long uniqueNow(@SuperCall Callable<Long> r) throws Exception
         {
             long newTimestamp = r.call();
-            assert State.timestamp.get() < newTimestamp;
+            assertTrue(State.timestamp.get() < newTimestamp);
             State.timestamp.set(newTimestamp);
 
             return r.call();

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
@@ -27,14 +27,14 @@ import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 
-import org.apache.cassandra.distributed.test.TestBaseImpl;
-import org.apache.cassandra.service.accord.AccordService;
-import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.junit.Test;
 
 import accord.local.Node;
 
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.apache.cassandra.utils.Shared;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.distributed.test.accord;
 
 import accord.local.Node;
-import org.apache.cassandra.distributed.test.TestBaseImpl;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,6 +28,8 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
+
+import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.junit.Test;
@@ -37,7 +38,6 @@ import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.utils.Shared;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -108,7 +108,7 @@ public class AccordMonotonicTimeStampsOnCrashTest extends TestBaseImpl
             assertTrue(State.timestamp.get() < newTimestamp);
             State.timestamp.set(newTimestamp);
 
-            return r.call();
+            return newTimestamp;
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
@@ -40,7 +40,7 @@ import org.apache.cassandra.utils.Shared;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 public class AccordMonotonicTimeStampsOnCrashTest extends TestBaseImpl
 {

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordMonotonicTimeStampsOnCrashTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.cassandra.distributed.test.accord;
 
-import accord.local.Node;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,6 +31,8 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.junit.Test;
+
+import accord.local.Node;
 
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.utils.Shared;

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordUniqueTimeStampsOnCrashTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordUniqueTimeStampsOnCrashTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.accord;
+
+import accord.local.Node;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.service.accord.api.AccordTimeService;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
+import org.apache.cassandra.utils.Shared;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+public class AccordUniqueTimeStampsOnCrashTest extends TestBaseImpl
+{
+    @Test
+    public void uniqueTimeStampsOnCrashTest() throws Throwable
+    {
+        try (Cluster cluster = Cluster.build().withNodes(3)
+                                      .withoutVNodes()
+                                      .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(3))
+                                      .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(3, "dc0", "rack0"))
+                                      .withInstanceInitializer(BBHelper::install)
+                                      .withConfig(config -> config
+                                                            .with(NETWORK, GOSSIP))
+                                      .start())
+        {
+            cluster.schemaChange("CREATE KEYSPACE ks WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':3}");
+            cluster.schemaChange("CREATE TABLE ks.tbl (k int, c int, v int, primary key (k, c)) WITH transactional_mode='full'");
+            cluster.coordinator(1).execute(wrapInTxn("INSERT INTO ks.tbl (k, c, v) VALUES (?, ?, ?)"), ConsistencyLevel.SERIAL, 1, 1, 2);
+
+            cluster.get(1).shutdown(false).get();
+            State.beforeRestart.set(false);
+
+            cluster.get(1).startup();
+
+            cluster.get(1).runOnInstance( () -> {
+                AccordService.instance().node().uniqueNow(0);
+            });
+        }
+    }
+
+    @Shared
+    public static class State
+    {
+        public static AtomicBoolean beforeRestart = new AtomicBoolean(true);
+        public static AtomicLong timestamp = new AtomicLong(0);
+    }
+
+    public static class BBHelper
+    {
+
+        static void install(ClassLoader cl, int nodeNumber)
+        {
+            if (nodeNumber == 1)
+            {
+                new ByteBuddy().rebase(AccordTimeService.class)
+                               .method(named("now").and(takesArguments(0)))
+                               .intercept(MethodDelegation.to(BBHelper.class))
+                               .make()
+                               .load(cl, ClassLoadingStrategy.Default.INJECTION);
+
+                new ByteBuddy().rebase(Node.class)
+                               .method(named("uniqueNow").and(takesArguments(1)))
+                               .intercept(MethodDelegation.to(BBHelper.class))
+                               .make()
+                               .load(cl, ClassLoadingStrategy.Default.INJECTION);
+            }
+        }
+
+        public static long now(@SuperCall Callable<Long> r) throws Exception
+        {
+            if (State.beforeRestart.get())
+                return r.call();
+
+            // Simulate clock skew on restart to be 100 seconds backwards
+            return r.call() - 100000000L;
+        }
+
+        @SuppressWarnings("unused")
+        public static long uniqueNow(long greaterThan, @SuperCall Callable<Long> r) throws Exception
+        {
+            long newTimestamp = r.call();
+            assert State.timestamp.get() < newTimestamp;
+            State.timestamp.set(newTimestamp);
+
+            return r.call();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -58,20 +58,17 @@ public class ReplayMarkerSerializerTest
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
-        // Start marker
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
             long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            // Start marker
             writeMarker(startMarker(), timestamp, lastUniqueTimeStamp);
             Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
             Assert.assertEquals(timestamp, pair.left);
             Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
-        });
 
-        // Stop marker
-        qt().forAll(RandomSource::nextLong).check(timestamp -> {
-            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            // Stop marker
             writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
-            Pair<Long, Long> pair = ReplayMarkers.readStopMarker();
+            pair = ReplayMarkers.readStopMarker();
             Assert.assertEquals(timestamp, pair.left);
             Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
         });
@@ -83,8 +80,8 @@ public class ReplayMarkerSerializerTest
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
-        // Start marker
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
+            // Start marker
             File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "started");
 
             try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
@@ -96,13 +93,10 @@ public class ReplayMarkerSerializerTest
                 throw new UncheckedIOException(e);
             }
 
-            Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
-            Assert.assertEquals(timestamp, pair.left);
-        });
+            Assert.assertEquals(timestamp, ReplayMarkers.readStartMarker().left);
 
-        // Stop marker
-        qt().forAll(RandomSource::nextLong).check(timestamp -> {
-            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+            // Stop marker
+            file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
 
             try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
             {
@@ -112,9 +106,49 @@ public class ReplayMarkerSerializerTest
             {
                 throw new UncheckedIOException(e);
             }
-
-            Pair<Long, Long> pair = ReplayMarkers.readStopMarker();
-            Assert.assertEquals(timestamp, pair.left);
+            Assert.assertEquals(timestamp, ReplayMarkers.readStopMarker().left);
         });
+    }
+
+    @Test
+    public void prioritizeCRCFile()
+    {
+        if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
+            ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
+
+        // Start marker
+        File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "started");
+
+        try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
+        {
+            out.writeBytes(Long.toString(250L));
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+
+        long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+        writeMarker(startMarker(), 250L, lastUniqueTimeStamp);
+        Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
+        Assert.assertEquals(Long.valueOf(250L), pair.left);
+        Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+
+        // Stop marker
+        file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+
+        try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
+        {
+            out.writeBytes(Long.toString(250L));
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+
+        writeMarker(safeStopMarker(), 250L, lastUniqueTimeStamp);
+        pair = ReplayMarkers.readStopMarker();
+        Assert.assertEquals(Long.valueOf(250L), pair.left);
+        Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
     }
 }

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -42,7 +42,7 @@ import static accord.utils.Property.qt;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
 
-public class StopMarkerSerializerTest
+public class ReplayMarkerSerializerTest
 {
     @BeforeClass
     public static void beforeClass() throws Throwable
@@ -52,7 +52,7 @@ public class StopMarkerSerializerTest
     }
 
     @Test
-    public void stopMarkerSerializerTest()
+    public void replayMarkerSerializerTest()
     {
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
@@ -67,7 +67,7 @@ public class StopMarkerSerializerTest
     }
 
     @Test
-    public void nonCrcFileSerializerTest()
+    public void nonCrcReplayMarkerSerializerTest()
     {
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.utils.StorageCompatibilityMode;
 
 import static accord.utils.Property.qt;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
+import static org.apache.cassandra.service.accord.journal.ReplayMarkers.startMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
 
 public class ReplayMarkerSerializerTest
@@ -57,6 +58,16 @@ public class ReplayMarkerSerializerTest
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
+        // Start marker
+        qt().forAll(RandomSource::nextLong).check(timestamp -> {
+            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            writeMarker(startMarker(), timestamp, lastUniqueTimeStamp);
+            Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
+            Assert.assertEquals(timestamp, pair.left);
+            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+        });
+
+        // Stop marker
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
             long lastUniqueTimeStamp = AccordTimeService.nowMicros();
             writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
@@ -72,14 +83,30 @@ public class ReplayMarkerSerializerTest
         if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
+        // Start marker
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
-            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
-            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "started");
 
             try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
             {
-                out.writeLong(timestamp);
-                out.writeLong(lastUniqueTimeStamp);
+                out.writeBytes(Long.toString(timestamp));
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException(e);
+            }
+
+            Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
+            Assert.assertEquals(timestamp, pair.left);
+        });
+
+        // Stop marker
+        qt().forAll(RandomSource::nextLong).check(timestamp -> {
+            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+
+            try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
+            {
+                out.writeBytes(Long.toString(timestamp));
             }
             catch (IOException e)
             {
@@ -88,7 +115,6 @@ public class ReplayMarkerSerializerTest
 
             Pair<Long, Long> pair = ReplayMarkers.readStopMarker();
             Assert.assertEquals(timestamp, pair.left);
-            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
         });
     }
 }

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -41,7 +41,6 @@ import static accord.utils.Property.qt;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.startMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
-import static org.apache.cassandra.service.accord.journal.ReplayMarkers.ReplayMarkerMetadata;
 
 public class ReplayMarkerSerializerTest
 {
@@ -62,7 +61,7 @@ public class ReplayMarkerSerializerTest
             long lastUniqueTimeStamp = AccordTimeService.nowMicros();
             // Start marker
             writeMarker(startMarker(), timestamp, lastUniqueTimeStamp);
-            ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
+            ReplayMarkers.ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
             Assert.assertEquals(timestamp, Long.valueOf(replayMarkerMetadata.getSegmentId()));
             Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
 
@@ -130,7 +129,7 @@ public class ReplayMarkerSerializerTest
 
         long lastUniqueTimeStamp = AccordTimeService.nowMicros();
         writeMarker(startMarker(), 250L, lastUniqueTimeStamp);
-        ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
+        ReplayMarkers.ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
         Assert.assertEquals(250L, replayMarkerMetadata.getSegmentId());
         Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
 

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -35,13 +35,13 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.apache.cassandra.service.accord.journal.ReplayMarkers;
-import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.StorageCompatibilityMode;
 
 import static accord.utils.Property.qt;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.startMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
+import static org.apache.cassandra.service.accord.journal.ReplayMarkers.ReplayMarkerMetadata;
 
 public class ReplayMarkerSerializerTest
 {
@@ -62,15 +62,15 @@ public class ReplayMarkerSerializerTest
             long lastUniqueTimeStamp = AccordTimeService.nowMicros();
             // Start marker
             writeMarker(startMarker(), timestamp, lastUniqueTimeStamp);
-            Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
-            Assert.assertEquals(timestamp, pair.left);
-            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+            ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
+            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerMetadata.getSegmentId()));
+            Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
 
             // Stop marker
             writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
-            pair = ReplayMarkers.readStopMarker();
-            Assert.assertEquals(timestamp, pair.left);
-            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+            replayMarkerMetadata = ReplayMarkers.readStopMarker();
+            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerMetadata.getSegmentId()));
+            Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
         });
     }
 
@@ -93,7 +93,7 @@ public class ReplayMarkerSerializerTest
                 throw new UncheckedIOException(e);
             }
 
-            Assert.assertEquals(timestamp, ReplayMarkers.readStartMarker().left);
+            Assert.assertEquals(timestamp, Long.valueOf(ReplayMarkers.readStartMarker().getSegmentId()));
 
             // Stop marker
             file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
@@ -106,7 +106,7 @@ public class ReplayMarkerSerializerTest
             {
                 throw new UncheckedIOException(e);
             }
-            Assert.assertEquals(timestamp, ReplayMarkers.readStopMarker().left);
+            Assert.assertEquals(timestamp, Long.valueOf(ReplayMarkers.readStopMarker().getSegmentId()));
         });
     }
 
@@ -130,9 +130,9 @@ public class ReplayMarkerSerializerTest
 
         long lastUniqueTimeStamp = AccordTimeService.nowMicros();
         writeMarker(startMarker(), 250L, lastUniqueTimeStamp);
-        Pair<Long, Long> pair = ReplayMarkers.readStartMarker();
-        Assert.assertEquals(Long.valueOf(250L), pair.left);
-        Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+        ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
+        Assert.assertEquals(250L, replayMarkerMetadata.getSegmentId());
+        Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
 
         // Stop marker
         file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
@@ -147,8 +147,8 @@ public class ReplayMarkerSerializerTest
         }
 
         writeMarker(safeStopMarker(), 250L, lastUniqueTimeStamp);
-        pair = ReplayMarkers.readStopMarker();
-        Assert.assertEquals(Long.valueOf(250L), pair.left);
-        Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+        replayMarkerMetadata = ReplayMarkers.readStartMarker();
+        Assert.assertEquals(250L, replayMarkerMetadata.getSegmentId());
+        Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
     }
 }

--- a/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/ReplayMarkerSerializerTest.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.service.accord.journal.ReplayMarkers;
 import org.apache.cassandra.utils.StorageCompatibilityMode;
 
 import static accord.utils.Property.qt;
+import static org.apache.cassandra.service.accord.journal.ReplayMarkers.endMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.startMarker;
 import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
@@ -58,18 +59,18 @@ public class ReplayMarkerSerializerTest
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
-            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            long lastUniqueTimestamp = AccordTimeService.nowMicros();
             // Start marker
-            writeMarker(startMarker(), timestamp, lastUniqueTimeStamp);
-            ReplayMarkers.ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
-            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerMetadata.getSegmentId()));
-            Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
+            writeMarker(startMarker(), timestamp, lastUniqueTimestamp);
+            ReplayMarkers.ReplayMarkerData replayMarkerData = ReplayMarkers.readStartMarker();
+            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerData.getSegmentId()));
+            Assert.assertEquals(lastUniqueTimestamp, replayMarkerData.getLastUniqueTimestamp());
 
             // Stop marker
-            writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
-            replayMarkerMetadata = ReplayMarkers.readStopMarker();
-            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerMetadata.getSegmentId()));
-            Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
+            writeMarker(safeStopMarker(), timestamp, lastUniqueTimestamp);
+            replayMarkerData = ReplayMarkers.readStopMarker();
+            Assert.assertEquals(timestamp, Long.valueOf(replayMarkerData.getSegmentId()));
+            Assert.assertEquals(lastUniqueTimestamp, replayMarkerData.getLastUniqueTimestamp());
         });
     }
 
@@ -81,7 +82,7 @@ public class ReplayMarkerSerializerTest
 
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
             // Start marker
-            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "started");
+            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), startMarker);
 
             try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
             {
@@ -95,7 +96,7 @@ public class ReplayMarkerSerializerTest
             Assert.assertEquals(timestamp, Long.valueOf(ReplayMarkers.readStartMarker().getSegmentId()));
 
             // Stop marker
-            file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+            file = new File(DatabaseDescriptor.getAccordJournalDirectory(), endMarker);
 
             try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
             {
@@ -116,7 +117,7 @@ public class ReplayMarkerSerializerTest
             ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
 
         // Start marker
-        File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "started");
+        File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), startMarker);
 
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
         {
@@ -127,14 +128,14 @@ public class ReplayMarkerSerializerTest
             throw new UncheckedIOException(e);
         }
 
-        long lastUniqueTimeStamp = AccordTimeService.nowMicros();
-        writeMarker(startMarker(), 250L, lastUniqueTimeStamp);
-        ReplayMarkers.ReplayMarkerMetadata replayMarkerMetadata = ReplayMarkers.readStartMarker();
-        Assert.assertEquals(250L, replayMarkerMetadata.getSegmentId());
-        Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
+        long lastUniqueTimestamp = AccordTimeService.nowMicros();
+        writeMarker(startMarker(), 250L, lastUniqueTimestamp);
+        ReplayMarkers.ReplayMarkerData replayMarkerData = ReplayMarkers.readStartMarker();
+        Assert.assertEquals(250L, replayMarkerData.getSegmentId());
+        Assert.assertEquals(lastUniqueTimestamp, replayMarkerData.getLastUniqueTimestamp());
 
         // Stop marker
-        file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+        file = new File(DatabaseDescriptor.getAccordJournalDirectory(), endMarker);
 
         try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
         {
@@ -145,9 +146,9 @@ public class ReplayMarkerSerializerTest
             throw new UncheckedIOException(e);
         }
 
-        writeMarker(safeStopMarker(), 250L, lastUniqueTimeStamp);
-        replayMarkerMetadata = ReplayMarkers.readStartMarker();
-        Assert.assertEquals(250L, replayMarkerMetadata.getSegmentId());
-        Assert.assertEquals(lastUniqueTimeStamp, replayMarkerMetadata.getLastUniqueTimeStamp());
+        writeMarker(safeStopMarker(), 250L, lastUniqueTimestamp);
+        replayMarkerData = ReplayMarkers.readStartMarker();
+        Assert.assertEquals(250L, replayMarkerData.getSegmentId());
+        Assert.assertEquals(lastUniqueTimestamp, replayMarkerData.getLastUniqueTimestamp());
     }
 }

--- a/test/unit/org/apache/cassandra/service/accord/serializers/StopMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/StopMarkerSerializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.accord.serializers;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import accord.utils.RandomSource;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.service.accord.api.AccordTimeService;
+import org.apache.cassandra.service.accord.journal.ReplayMarkers;
+import org.apache.cassandra.utils.StorageCompatibilityMode;
+
+import static accord.utils.Property.qt;
+import static org.apache.cassandra.service.accord.journal.ReplayMarkers.safeStopMarker;
+import static org.apache.cassandra.service.accord.journal.ReplayMarkers.writeMarker;
+
+public class StopMarkerSerializerTest
+{
+    @BeforeClass
+    public static void beforeClass() throws Throwable
+    {
+        CassandraRelevantProperties.TEST_STORAGE_COMPATIBILITY_MODE.setEnum(StorageCompatibilityMode.NONE);
+        SchemaLoader.prepareServer();
+    }
+
+    @Test
+    public void stopMarkerSerializerTest()
+    {
+        if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
+            ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
+
+        qt().forAll(RandomSource::nextLong).check(timestamp -> {
+            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+            writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
+            Assert.assertEquals(timestamp.longValue(), ReplayMarkers.readStopMarker());
+            Assert.assertEquals(lastUniqueTimeStamp, ReplayMarkers.readLastUniqueTimeStamp());
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/service/accord/serializers/StopMarkerSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/StopMarkerSerializerTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.cassandra.service.accord.serializers;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,8 +32,10 @@ import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.service.accord.api.AccordTimeService;
 import org.apache.cassandra.service.accord.journal.ReplayMarkers;
+import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.StorageCompatibilityMode;
 
 import static accord.utils.Property.qt;
@@ -55,8 +60,35 @@ public class StopMarkerSerializerTest
         qt().forAll(RandomSource::nextLong).check(timestamp -> {
             long lastUniqueTimeStamp = AccordTimeService.nowMicros();
             writeMarker(safeStopMarker(), timestamp, lastUniqueTimeStamp);
-            Assert.assertEquals(timestamp.longValue(), ReplayMarkers.readStopMarker());
-            Assert.assertEquals(lastUniqueTimeStamp, ReplayMarkers.readLastUniqueTimeStamp());
+            Pair<Long, Long> pair = ReplayMarkers.readStopMarker();
+            Assert.assertEquals(timestamp, pair.left);
+            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
+        });
+    }
+
+    @Test
+    public void nonCrcFileSerializerTest()
+    {
+        if (new File(DatabaseDescriptor.getAccordJournalDirectory()).exists())
+            ServerTestUtils.cleanupDirectory(DatabaseDescriptor.getAccordJournalDirectory());
+
+        qt().forAll(RandomSource::nextLong).check(timestamp -> {
+            File file = new File(DatabaseDescriptor.getAccordJournalDirectory(), "stopped");
+            long lastUniqueTimeStamp = AccordTimeService.nowMicros();
+
+            try (FileOutputStreamPlus out = new FileOutputStreamPlus(file))
+            {
+                out.writeLong(timestamp);
+                out.writeLong(lastUniqueTimeStamp);
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException(e);
+            }
+
+            Pair<Long, Long> pair = ReplayMarkers.readStopMarker();
+            Assert.assertEquals(timestamp, pair.left);
+            Assert.assertEquals(lastUniqueTimeStamp, (long) pair.right);
         });
     }
 }


### PR DESCRIPTION
Write the latest timestamp to the stop markers, so if we fail, on restart our timestamps will be monotonic. 

patch by Alan Wang;

reviewed by for [CASSANDRA-21198](https://issues.apache.org/jira/browse/CASSANDRA-21198)

Co-authored-by: Name1
Co-authored-by: Name2