### PR TITLE
CASSANDRA-15904: Add compound primary key example to nodetool getendp…

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/GetReplicas.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetReplicas.java
@@ -44,7 +44,7 @@ public class GetReplicas extends AbstractCommand
     @Parameters(index = "1", arity = "0..1", description = "The table for which we need to find the replica")
     private String table;
 
-    @Parameters(index = "2", arity = "0..1", description = "The partition key for which we need to find the replica")
+    @Parameters(index = "2", arity = "0..1", description = "The partition key for which we need to find the replica (e.g., pk1:pk2:pk3 for compound keys)")
     private String key;
 
     @Mixin

--- a/test/resources/nodetool/help/getendpoints
+++ b/test/resources/nodetool/help/getendpoints
@@ -35,4 +35,4 @@ OPTIONS
 
         <keyspace> <table> <key>
             The keyspace, the table, and the partition key for which we need to
-            find the replica
+            find the replica (e.g., pk1:pk2:pk3 for compound keys)

--- a/test/resources/nodetool/help/getreplicas
+++ b/test/resources/nodetool/help/getreplicas
@@ -34,4 +34,4 @@ OPTIONS
 
         <keyspace> <table> <key>
             The keyspace, the table, and the partition key for which we need to
-            find the replica
+            find the replica (e.g., pk1:pk2:pk3 for compound keys)


### PR DESCRIPTION
### Description

DOC - nodetool getendpoints man page improvements

This PR updates the help documentation for the `nodetool getendpoints` command to clarify how to use compound primary keys. The backend already handles colon-separated compound keys correctly, but users were unaware of the syntax. This patch adds a clear example (`pk1:pk2:pk3`) directly into the CLI help text to improve operability and user experience as requested in CASSANDRA-15904.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-15904