### PR TITLE
CASSANDRA-15904: Add compound primary key example to nodetool getendpoints help (6.0)

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
@@ -43,7 +43,7 @@ public class GetEndpoints extends AbstractCommand
     @Parameters(index = "1", arity = "0..1", description = "The table for which we need to find the endpoint")
     private String table;
 
-    @Parameters(index = "2", arity = "0..1", description = "The partition key for which we need to find the endpoint")
+    @Parameters(index = "2", arity = "0..1", description = "The partition key for which we need to find the endpoint (e.g., pk1:pk2:pk3 for compound keys)")
     private String key;
 
     @Mixin

--- a/test/resources/nodetool/help/getendpoints
+++ b/test/resources/nodetool/help/getendpoints
@@ -34,4 +34,4 @@ OPTIONS
 
         <keyspace> <table> <key>
             The keyspace, the table, and the partition key for which we need to
-            find the endpoint
+            find the endpoint (e.g., pk1:pk2:pk3 for compound keys)


### PR DESCRIPTION
CASSANDRA-15904: Add compound primary key example to nodetool getendpoints help

This is the `cassandra-6.0` backport for CASSANDRA-15904. It updates the help documentation and parameters for the `nodetool getendpoints` command to include a clear example of using compound primary keys (e.g., `pk1:pk2:pk3`), as requested by the reviewers.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-15904