### PR TITLE
CASSANDRA-21537: Serialise local metadata proposals so concurrent DDL keeps its retry budget

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Serialise local metadata proposals so concurrent schema changes do not exhaust their retry budget contending for the same epoch (CASSANDRA-21537)
  * Don't increment client metrics on messaging service connection unpause (CASSANDRA-21491)
  * Add nodetool getreplicas (CASSANDRA-17665)
  * Implementation of CEP-49: Hardware-accelerated compression (CASSANDRA-20975)

--- a/src/java/org/apache/cassandra/tcm/AbstractLocalProcessor.java
+++ b/src/java/org/apache/cassandra/tcm/AbstractLocalProcessor.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.tcm;
 
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -41,6 +42,44 @@ public abstract class AbstractLocalProcessor implements Processor
 
     protected final LocalLog log;
 
+    /**
+     * Serialises the read-execute-propose cycle for commits originating on this node, i.e.
+     * {@link LocalLog#waitForHighestConsecutive}, execution of the transformation, the {@link #tryCommitOne} proposal
+     * and, when that proposal wins its epoch, the subsequent {@link LocalLog#append}.
+     *
+     * Invariants:
+     * <ul>
+     *     <li>acquisition waits at most the caller's remaining {@link Retry} deadline, so being queued consumes only
+     *         the waiter's own budget and can never push it past its own deadline;</li>
+     *     <li>every successful acquisition is matched by exactly one unlock;</li>
+     *     <li>it is held across one whole cycle, including the blocking and remote work that cycle needs, and is
+     *         released before everything which is not part of deriving and proposing an epoch: local enactment via
+     *         {@link LocalLog#awaitAtLeast}, the uninterruptible retry backoff, and any log fetch performed after a
+     *         rejection or a lost epoch;</li>
+     *     <li>admission is fair, hence FIFO, and does not prioritise by {@link Transformation.Kind}: a topology
+     *         change can queue behind schema DDL which arrived first.</li>
+     * </ul>
+     *
+     * This does not, and cannot, address races between separate CMS members; those remain the distributed log's job.
+     */
+    private final ReentrantLock proposalLock = new ReentrantLock(true);
+
+    /**
+     * What a single read-execute-propose cycle concluded, so that the cycle can hand off to the code which acts on it
+     * after {@link #proposalLock} has been released.
+     */
+    private enum Outcome
+    {
+        /** The proposal won its epoch and has been appended to the local log. */
+        APPLIED,
+        /** Execution against the latest local metadata was rejected; nothing was proposed. */
+        REJECTED,
+        /** The proposal did not win its epoch, or its outcome is unknown. */
+        NOT_APPLIED,
+        /** The proposal threw; the throwable is reported and inspected once the lock has been released. */
+        FAILED
+    }
+
     public AbstractLocalProcessor(LocalLog log)
     {
         this.log = log;
@@ -57,35 +96,99 @@ public abstract class AbstractLocalProcessor implements Processor
         String transformStr = transform.toString(); // convert once as idempotent and used in multiple logs
         logger.debug("Starting local commit of {} with policy {}", transformStr, retryPolicy);
         long commitStart = nanoTime();
+        // History, not per-iteration state: set immediately before the first tryCommitOne call and never cleared, so
+        // that the failure message below can only claim nothing was proposed while it is still false.
+        boolean proposalAttempted = false;
         while (!retryPolicy.hasExpired())
         {
-            ClusterMetadata previous = log.waitForHighestConsecutive();
-            if (!acceptCommit(previous))
-            {
-                String msg = String.format("Node %s is not a CMS member in epoch %s; members=%s",
-                                           FBUtilities.getBroadcastAddressAndPort(),
-                                           previous.epoch.getEpoch(),
-                                           previous.fullCMSMembers());
-                logger.warn(msg);
-                throw new NotCMSException(msg);
-            }
+            // Serialise the read-execute-propose cycle for locally originating commits. Acquisition consumes this
+            // caller's own deadline, so a request which cannot be admitted in time gives up here rather than proposing.
+            if (!acquireProposalLock(retryPolicy))
+                return notAdmitted(transformStr, commitStart, retryPolicy, proposalAttempted);
 
+            ClusterMetadata previous;
             Transformation.Result result;
-            if (!transform.eligibleToCommit(previous))
+            Outcome outcome;
+            Throwable failure = null;
+            // The one critical section: read the highest consecutive metadata, execute against it, propose the derived
+            // epoch and, if the proposal won, append it locally. Nothing else belongs here, and the lock is dropped in
+            // the single finally below before any of the outcomes are acted on.
+            try
             {
-                result = new Transformation.Rejected(INVALID, "Transformation rejected, can't commit " + transformStr +
-                                                              " it not supported with cluster common serialization version " + previous.directory.commonSerializationVersion +
-                                                              " and min/max serialization versions " + previous.directory.clusterMinVersion + "/" + previous.directory.clusterMaxVersion);
+                previous = log.waitForHighestConsecutive();
+                if (!acceptCommit(previous))
+                {
+                    String msg = String.format("Node %s is not a CMS member in epoch %s; members=%s",
+                                               FBUtilities.getBroadcastAddressAndPort(),
+                                               previous.epoch.getEpoch(),
+                                               previous.fullCMSMembers());
+                    logger.warn(msg);
+                    throw new NotCMSException(msg);
+                }
+
+                if (!transform.eligibleToCommit(previous))
+                {
+                    result = new Transformation.Rejected(INVALID, "Transformation rejected, can't commit " + transformStr +
+                                                                  " it not supported with cluster common serialization version " + previous.directory.commonSerializationVersion +
+                                                                  " and min/max serialization versions " + previous.directory.clusterMinVersion + "/" + previous.directory.clusterMaxVersion);
+                }
+                else
+                {
+                    result = executeStrictly(previous, transform);
+                }
+
+                if (result.isRejected())
+                {
+                    // Nothing to propose; the catch-up which decides whether this rejection is final happens after the
+                    // lock is released, as it may involve remote peers.
+                    outcome = Outcome.REJECTED;
+                }
+                else
+                {
+                    try
+                    {
+                        Epoch nextEpoch = result.success().metadata.epoch;
+                        // If metadata applies, try committing it to the log
+                        long casStart = nanoTime();
+                        proposalAttempted = true;
+                        boolean applied = tryCommitOne(entryId, transform, previous.epoch, nextEpoch);
+                        long casElapsedUs = NANOSECONDS.toMicros(nanoTime() - casStart);
+                        logger.debug("tryCommitOne for {} epoch {}->{}: applied={}, took {}us",
+                                     transform.kind(), previous.epoch, nextEpoch, applied, casElapsedUs);
+
+                        // Application here semantially means "succeeded in committing to the distributed log".
+                        if (applied)
+                        {
+                            logger.info("Committed {}. New epoch is {}. Took {} attempts in {}us total.",
+                                        transformStr, nextEpoch, retryPolicy.attempts(),
+                                        NANOSECONDS.toMicros(nanoTime() - commitStart));
+                            log.append(new Entry(entryId, nextEpoch, new Transformation.Executed(transform, result)));
+                            outcome = Outcome.APPLIED;
+                        }
+                        else
+                        {
+                            outcome = Outcome.NOT_APPLIED;
+                        }
+                    }
+                    catch (Throwable e)
+                    {
+                        // Reported and inspected outside the lock, so that neither is done while holding it.
+                        failure = e;
+                        outcome = Outcome.FAILED;
+                    }
+                }
             }
-            else
+            finally
             {
-                result = executeStrictly(previous, transform);
+                proposalLock.unlock();
             }
 
-            // If we got a rejection, it could be that _we_ are not aware of the highest epoch.
-            // Just try to catch up to the latest distributed state.
-            if (result.isRejected())
+            // Everything from here on runs without the lock: it is either remote, uninterruptible, or waits on the
+            // local log being caught up, and none of it is part of deriving and proposing an epoch.
+            if (outcome == Outcome.REJECTED)
             {
+                // If we got a rejection, it could be that _we_ are not aware of the highest epoch.
+                // Just try to catch up to the latest distributed state.
                 // Use a dedicated retry policy here as the one for the commit itself may not be appropriate.
                 // It uses the wrong metric and for STARTUP transformations will retry indefinitely, which is not
                 // what we want here.
@@ -107,43 +210,43 @@ public abstract class AbstractLocalProcessor implements Processor
                 continue;
             }
 
+            if (outcome == Outcome.FAILED)
+            {
+                logger.error("Caught error while trying to perform a local commit", failure);
+                JVMStabilityInspector.inspectThrowable(failure);
+                if (!retryPolicy.maybeSleep())
+                    break;
+                continue;
+            }
+
             try
             {
-                Epoch nextEpoch = result.success().metadata.epoch;
-                // If metadata applies, try committing it to the log
-                long casStart = nanoTime();
-                boolean applied = tryCommitOne(entryId, transform, previous.epoch, nextEpoch);
-                long casElapsedUs = NANOSECONDS.toMicros(nanoTime() - casStart);
-                logger.debug("tryCommitOne for {} epoch {}->{}: applied={}, took {}us",
-                             transform.kind(), previous.epoch, nextEpoch, applied, casElapsedUs);
-
-                // Application here semantially means "succeeded in committing to the distributed log".
-                if (applied)
+                if (outcome == Outcome.APPLIED)
                 {
-                    logger.info("Committed {}. New epoch is {}. Took {} attempts in {}us total.",
-                                transformStr, nextEpoch, retryPolicy.attempts(),
-                                NANOSECONDS.toMicros(nanoTime() - commitStart));
-                    log.append(new Entry(entryId, nextEpoch, new Transformation.Executed(transform, result)));
+                    // The proposal is durable in the distributed log and appended locally, so the next proposer can
+                    // already derive its epoch from it. Holding the lock across this wait would serialise the local
+                    // enactment latency of this commit onto unrelated ones.
+                    Epoch nextEpoch = result.success().metadata.epoch;
                     log.awaitAtLeast(nextEpoch);
 
-                    return new Commit.Result.Success(result.success().metadata.epoch,
+                    return new Commit.Result.Success(nextEpoch,
                                                      toLogState(result.success(), entryId, lastKnown, transform));
                 }
-                else
-                {
-                    if (!retryPolicy.maybeSleep())
-                        break;
 
-                    logger.info("Backed off after failure to commit to log, fetching latest log entries before retry");
-                    // TODO: could also add epoch from mis-application from [applied].
-                    // Use a dedicated retry policy here as the one for the commit itself may not be appropriate.
-                    // It uses the wrong metric and for STARTUP transformations will retry indefinitely, which is not
-                    // what we want here.
-                    Retry fetchLogRetry = Retry.until(retryPolicy.deadlineNanos, TCMMetrics.instance.fetchLogRetries);
-                    fetchLogAndWait(null, fetchLogRetry);
-                    logger.info("Fetched latest log entries, re-entering commit retry loop with {}ms remaining until deadline",
-                                NANOSECONDS.toMillis(retryPolicy.remainingNanos()));
-                }
+                // Lost the epoch, or the outcome is unknown. Back off, then refetch: the sleep is uninterruptible and
+                // the fetch may be remote, neither of which should block another local proposer.
+                if (!retryPolicy.maybeSleep())
+                    break;
+
+                logger.info("Backed off after failure to commit to log, fetching latest log entries before retry");
+                // TODO: could also add epoch from mis-application from [applied].
+                // Use a dedicated retry policy here as the one for the commit itself may not be appropriate.
+                // It uses the wrong metric and for STARTUP transformations will retry indefinitely, which is not
+                // what we want here.
+                Retry fetchLogRetry = Retry.until(retryPolicy.deadlineNanos, TCMMetrics.instance.fetchLogRetries);
+                fetchLogAndWait(null, fetchLogRetry);
+                logger.info("Fetched latest log entries, re-entering commit retry loop with {}ms remaining until deadline",
+                            NANOSECONDS.toMillis(retryPolicy.remainingNanos()));
             }
             catch (Throwable e)
             {
@@ -153,12 +256,71 @@ public abstract class AbstractLocalProcessor implements Processor
                     break;
             }
         }
-        long remainingMillis = NANOSECONDS.toMillis(retryPolicy.remainingNanos());
         String failureMsg = String.format("Could not perform commit after %d attempts. Time remaining: %dms",
-                                          retryPolicy.attempts(), remainingMillis);
+                                          retryPolicy.attempts(), NANOSECONDS.toMillis(retryPolicy.remainingNanos()));
+        return failed(transformStr, commitStart, failureMsg);
+    }
+
+    /**
+     * Builds the failure for a commit which could not be admitted to {@link #proposalLock} within its deadline. Either
+     * shutdown or a cancelled request, or simply too many local commits queued ahead of this one.
+     *
+     * @param proposalAttempted whether any earlier iteration already reached {@link #tryCommitOne}. If it did, its
+     *        outcome may be genuinely unknown, as losing the epoch and an ambiguous Paxos result are indistinguishable
+     *        to us, so the message states only what happened and promises nothing about whether the transformation
+     *        applied. If it did not, retrying is unambiguously safe, and reporting an attempt count would imply CAS
+     *        activity which did not happen.
+     */
+    private Commit.Result notAdmitted(String transformStr, long commitStart, Retry retryPolicy, boolean proposalAttempted)
+    {
+        String cause = Thread.currentThread().isInterrupted()
+                       ? "Interrupted while waiting to submit commit"
+                       : String.format("Timed out after %dms waiting to submit commit",
+                                       NANOSECONDS.toMillis(nanoTime() - commitStart));
+        long remainingMillis = NANOSECONDS.toMillis(retryPolicy.remainingNanos());
+        String failureMsg = proposalAttempted
+                            ? String.format("%s. A proposal was made during one of the preceding %d attempts, so " +
+                                            "whether the transformation was committed to the log is unknown. " +
+                                            "Time remaining: %dms",
+                                            cause, retryPolicy.attempts(), remainingMillis)
+                            : String.format("%s. No proposal was made. Time remaining: %dms", cause, remainingMillis);
+        return failed(transformStr, commitStart, failureMsg);
+    }
+
+    private Commit.Result failed(String transformStr, long commitStart, String failureMsg)
+    {
         logger.debug("Commit {} failed in {}us total. {}",
                      transformStr, NANOSECONDS.toMicros(nanoTime() - commitStart), failureMsg);
         return Commit.Result.failed(SERVER_ERROR, failureMsg);
+    }
+
+    /**
+     * Acquires {@link #proposalLock}, waiting no longer than the caller's remaining deadline. Every successful
+     * acquisition is matched by exactly one unlock in the {@code finally} which closes the critical section, so
+     * hold-count accounting is safe on a thread which is already mid-cycle: a nested acquisition only raises the
+     * count, and releasing it cannot free the lock out from under the outer cycle. That is an accounting invariant
+     * only; it does not assert that a nested commit is semantically safe, as a synchronous pre-commit listener could
+     * recursively encounter the same pending entry. No current production listener does this.
+     *
+     * @return true if the lock is held by the calling thread on return, false if the deadline expired first or the
+     *         thread was interrupted while waiting, in which case this attempt proposed nothing.
+     */
+    private boolean acquireProposalLock(Retry retryPolicy)
+    {
+        long remainingNanos = retryPolicy.remainingNanos();
+        if (remainingNanos <= 0)
+            return false;
+
+        try
+        {
+            return proposalLock.tryLock(remainingNanos, NANOSECONDS);
+        }
+        catch (InterruptedException e)
+        {
+            // Preserve the interrupt for the caller (e.g. so shutdown is not swallowed) and give up on this attempt.
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     public Commit.Result maybeFailure(Entry.Id entryId, Epoch lastKnown, Supplier<Commit.Result.Failure> orElse)

--- a/test/distributed/org/apache/cassandra/distributed/test/tcm/ConcurrentSchemaCommitTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/tcm/ConcurrentSchemaCommitTest.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.tcm;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Concurrent CQL DDL submitted to a CMS member fails with a SERVER_ERROR even though the request
+ * deadline has seconds left, because the retry <i>attempt</i> cap is reached first.
+ *
+ * <p>Failure message observed against a real single-node 6.0 build:
+ * <pre>Could not perform commit after 12 attempts. Time remaining: 4231ms</pre>
+ *
+ * <p>Expected: a schema change either succeeds or fails only once its deadline
+ * ({@code request_timeout}, 10s by default) is actually exhausted.
+ * Actual: it fails after 12 attempts with several seconds of deadline still remaining, so the
+ * configured timeout budget is silently not honoured for DDL.
+ *
+ * <p>Mechanism:
+ * <ul>
+ *   <li>{@code ClusterMetadataService.getRetryPolicy()} (src/java/org/apache/cassandra/tcm/ClusterMetadataService.java:727-731)
+ *       gives {@code Transformation.Kind.SCHEMA_CHANGE} a deadline of {@code request_timeout} but leaves the wait
+ *       strategy as the shared {@code Retry.DEFAULT_STRATEGY}, built from {@code cms_retry_delay}
+ *       (src/java/org/apache/cassandra/config/Config.java:205, {@code retries=10}); with
+ *       src/java/org/apache/cassandra/service/RetryStrategy.java:215 that is {@code maxAttempts = 11}, past which
+ *       {@code computeWait} returns -1.</li>
+ *   <li>Every concurrent commit reads the same {@code log.waitForHighestConsecutive()} epoch and CASes at epoch+1
+ *       (src/java/org/apache/cassandra/tcm/AbstractLocalProcessor.java:62,115), so all but one loser per round
+ *       burns an attempt, hits {@code maybeSleep()} returning false at :134 and breaks out of the loop, and the
+ *       SERVER_ERROR is built at :156-161 while {@code retryPolicy.remainingNanos()} is still positive.</li>
+ * </ul>
+ *
+ * <p>Reproduction is load- and hardware-sensitive: the losers only pile up faster than 11 attempts can absorb
+ * when enough DDL is in flight at once. Counts below are of the concurrently submitted {@code CREATE TABLE}
+ * statements only ({@code WORKERS * TABLES_PER_WORKER}); the per-worker keyspaces are created serially up front and
+ * are not included. Measured against a real single-node build in a 4 CPU / 4 GiB Docker container (JDK 21, one CMS
+ * member, RF=1, default config): N=1/2/4 passed, N=8 failed 3 of 144, N=22 failed 10 of 396, N=48 failed 34 of 864,
+ * every failure reporting exactly 12 attempts with 3.3-5.7 s of deadline remaining. This in-JVM form was then swept
+ * on a 16-core host (JDK 21): N=2 and N=4 passed, N=8 failed 1 of 144 on three consecutive runs, and N=48 failed
+ * 311-332 of 864 - again always at exactly 12 attempts, with 3.4-5.4 s remaining. Onset concurrency rises with core
+ * count, so {@link #WORKERS} defaults to the highest measured level and is overridable with
+ * {@code -Dcassandra.test.concurrent_schema_commit.workers=N}.
+ *
+ * <p><b>Note on the oracle.</b> This test asserts that <i>every</i> submitted statement succeeds, which is a stronger
+ * requirement than "no commit stops before its deadline". Removing only the attempt cap does not make it pass: the
+ * losers then consume their whole deadline instead, and statements still fail under enough concurrency. That is
+ * deliberate for now — the failure report distinguishes the two stop reasons — but if the agreed scope of the fix is
+ * only the attempt-cap incoherence, this assertion should be narrowed to that before the test is committed. As it
+ * stands it also measures the underlying epoch CAS contention, which is a separate concern.
+ */
+public class ConcurrentSchemaCommitTest extends TestBaseImpl
+{
+    /** Concurrent DDL submitters. Default is the highest level from the measured sweep described above. */
+    private static final int DEFAULT_WORKERS = 48;
+
+    /** Tables each worker creates in its own (pre-created) keyspace. */
+    private static final int TABLES_PER_WORKER = 18;
+
+    private static final String WORKERS_PROPERTY = "cassandra.test.concurrent_schema_commit.workers";
+
+    private static final int WORKERS = workerCount();
+
+    /** Matches the retry-exhaustion failure text built in AbstractLocalProcessor.commit(). */
+    private static final Pattern ATTEMPT_CAP = Pattern.compile("Could not perform commit after (\\d+) attempts\\. Time remaining: (-?\\d+)ms");
+
+    /**
+     * Matches a local admission timeout by a request which never reached {@code tryCommitOne}. Distinct from
+     * {@link #ATTEMPT_CAP} because it says nothing about the state of the distributed log, and retrying it is
+     * unambiguously safe.
+     */
+    private static final Pattern NEVER_PROPOSED = Pattern.compile("Timed out after (\\d+)ms waiting to submit commit\\. No proposal was made");
+
+    /**
+     * Matches a local admission timeout by a request which had already proposed on an earlier iteration, so whether
+     * the transformation was committed is unknown. Also an admission timeout, but it must not be reported as
+     * {@link #NEVER_PROPOSED}: retrying it is not known to be safe.
+     */
+    private static final Pattern OUTCOME_UNKNOWN = Pattern.compile("Timed out after (\\d+)ms waiting to submit commit\\. " +
+                                                                   "A proposal was made during one of the preceding (\\d+) attempts");
+
+    /**
+     * Submits {@code WORKERS * TABLES_PER_WORKER} schema changes concurrently against the single (CMS member) node
+     * and asserts that every single one of them succeeded. Unlike
+     * {@code DistributedLogTest.testConcurrentCommit()}, no commit exception is swallowed: each statement is
+     * accounted for, and every failure is reported with its attempt count and remaining deadline, separated into
+     * those which stopped early and those which used their whole budget.
+     */
+    @Test
+    public void concurrentSchemaChangesShouldNotExhaustAttemptsBeforeDeadline() throws Throwable
+    {
+        // Single node is a CMS member by default, so DDL commits take the local (AbstractLocalProcessor) path.
+        // Retry and timeout settings are deliberately left at their defaults, since the attempt limit under test comes
+        // from the default cms_retry_delay. Note that raising cms_default_max_retries would NOT change this: while
+        // cms_retry_delay is non-null it supplies the whole strategy, and cms_default_max_retries is not consulted.
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            // Keyspaces are created serially and up front so that every concurrently submitted statement below is
+            // independent, and a failure of one cannot cascade into "keyspace doesn't exist" failures of others.
+            for (int w = 0; w < WORKERS; w++)
+            {
+                cluster.schemaChange("CREATE KEYSPACE " + keyspace(w) +
+                                     " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            }
+
+            List<String> failures = new CopyOnWriteArrayList<>();
+            AtomicInteger succeeded = new AtomicInteger();
+            CountDownLatch startBarrier = new CountDownLatch(1);
+            List<Future<?>> futures = new ArrayList<>(WORKERS);
+            ExecutorService executor = Executors.newFixedThreadPool(WORKERS);
+            try
+            {
+                for (int w = 0; w < WORKERS; w++)
+                {
+                    final int worker = w;
+                    futures.add(executor.submit(() -> {
+                        startBarrier.await();
+                        for (int t = 0; t < TABLES_PER_WORKER; t++)
+                        {
+                            submit(cluster, failures, succeeded,
+                                   "CREATE TABLE " + keyspace(worker) + ".tbl_" + t + " (k int PRIMARY KEY, v text)");
+                        }
+                        return null;
+                    }));
+                }
+
+                startBarrier.countDown();
+
+                // Collect every future so that no worker failure can be lost.
+                for (Future<?> future : futures)
+                    future.get(10, TimeUnit.MINUTES);
+            }
+            finally
+            {
+                executor.shutdownNow();
+            }
+
+            int submitted = WORKERS * TABLES_PER_WORKER;
+            if (!failures.isEmpty())
+                fail(report(submitted, succeeded.get(), failures));
+            assertEquals("Every submitted schema change must be accounted for", submitted, succeeded.get());
+        }
+    }
+
+    private static String keyspace(int worker)
+    {
+        return "concurrent_ddl_ks_" + worker;
+    }
+
+    private static void submit(Cluster cluster, List<String> failures, AtomicInteger succeeded, String statement)
+    {
+        try
+        {
+            cluster.coordinator(1).execute(statement, ConsistencyLevel.ONE);
+            succeeded.incrementAndGet();
+        }
+        catch (Throwable t)
+        {
+            // Exceptions come from the instance class loader, so they cannot be caught by type here; match on text.
+            failures.add(statement + " => " + describe(t));
+        }
+    }
+
+    private static String describe(Throwable t)
+    {
+        StringBuilder sb = new StringBuilder();
+        Throwable cause = t;
+        while (cause != null)
+        {
+            if (sb.length() > 0)
+                sb.append(" <- ");
+            sb.append(cause.getClass().getName()).append(": ").append(cause.getMessage());
+            if (cause.getCause() == cause)
+                break;
+            cause = cause.getCause();
+        }
+        return sb.toString();
+    }
+
+    private static String report(int submitted, int succeeded, List<String> failures)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(failures.size()).append(" of ").append(submitted)
+          .append(" concurrent schema changes failed at concurrency ").append(WORKERS)
+          .append(" (").append(succeeded).append(" succeeded).");
+
+        // The commit failure message is the same whether the retry policy stopped because it ran out of attempts or
+        // because the deadline expired, so the two are distinguished by the remaining time it reports. Only a failure
+        // with time still remaining demonstrates the defect this test is about; one reporting no remaining time simply
+        // used its whole budget, which is a contention symptom rather than an early giveup.
+        int gaveUpEarly = 0;
+        int deadlineExpired = 0;
+        int neverProposed = 0;
+        int outcomeUnknown = 0;
+        for (String failure : failures)
+        {
+            // Both of the following are admission timeouts, but they differ in whether the request had already
+            // proposed, and therefore in whether retrying it is safe. Check the stronger claim first.
+            Matcher unknown = OUTCOME_UNKNOWN.matcher(failure);
+            if (unknown.find())
+            {
+                outcomeUnknown++;
+                sb.append("\n  outcome unknown (local admission timeout after ").append(unknown.group(1))
+                  .append("ms, after proposing within ").append(unknown.group(2)).append(" attempts)");
+                continue;
+            }
+
+            Matcher never = NEVER_PROPOSED.matcher(failure);
+            if (never.find())
+            {
+                neverProposed++;
+                sb.append("\n  never proposed (local admission timeout after ").append(never.group(1)).append("ms)");
+                continue;
+            }
+
+            Matcher matcher = ATTEMPT_CAP.matcher(failure);
+            if (matcher.find())
+            {
+                long remainingMillis = Long.parseLong(matcher.group(2));
+                if (remainingMillis > 0)
+                {
+                    gaveUpEarly++;
+                    sb.append("\n  gave up with deadline remaining: attempts=").append(matcher.group(1))
+                      .append(", remaining=").append(remainingMillis).append("ms");
+                }
+                else
+                {
+                    deadlineExpired++;
+                    sb.append("\n  deadline exhausted: attempts=").append(matcher.group(1))
+                      .append(", remaining=").append(remainingMillis).append("ms");
+                }
+            }
+            else
+            {
+                sb.append("\n  other failure: ").append(failure);
+            }
+        }
+
+        if (gaveUpEarly > 0)
+        {
+            sb.append("\n\n").append(gaveUpEarly)
+              .append(" failure(s) stopped on the retry attempt cap while the request deadline was still unexpired.")
+              .append(" See ClusterMetadataService.getRetryPolicy() and AbstractLocalProcessor.commit().");
+        }
+        if (deadlineExpired > 0)
+        {
+            sb.append("\n\n").append(deadlineExpired)
+              .append(" failure(s) consumed the entire request deadline while retrying. These do not demonstrate an")
+              .append(" early giveup; they indicate the epoch CAS contention in AbstractLocalProcessor.commit().");
+        }
+        if (neverProposed > 0)
+        {
+            sb.append("\n\n").append(neverProposed)
+              .append(" failure(s) never proposed at all, having timed out waiting for local admission. That is")
+              .append(" overload of this node's serialised proposal path rather than epoch CAS contention: the")
+              .append(" offered DDL rate exceeds what one CMS member can commit within the request deadline.")
+              .append(" Retrying these is unambiguously safe.");
+        }
+        if (outcomeUnknown > 0)
+        {
+            sb.append("\n\n").append(outcomeUnknown)
+              .append(" failure(s) timed out waiting for local admission after having already proposed on an earlier")
+              .append(" attempt, so whether the transformation was committed to the distributed log is unknown.")
+              .append(" Unlike the above, these are not known to be safe to retry.");
+        }
+        return sb.toString();
+    }
+
+    private static int workerCount()
+    {
+        String configured = System.getProperty(WORKERS_PROPERTY); // checkstyle: suppress nearby 'blockSystemPropertyUsage'
+        return configured == null || configured.isEmpty() ? DEFAULT_WORKERS : Integer.parseInt(configured);
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/AbstractLocalProcessorLockTest.java
+++ b/test/unit/org/apache/cassandra/tcm/AbstractLocalProcessorLockTest.java
@@ -1,0 +1,501 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.locator.MetaStrategy;
+import org.apache.cassandra.metrics.TCMMetrics;
+import org.apache.cassandra.tcm.log.Entry;
+import org.apache.cassandra.tcm.log.LocalLog;
+import org.apache.cassandra.tcm.sequences.LockedRanges;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit coverage for the ways {@link AbstractLocalProcessor#commit} can give up while queued for the local proposal
+ * lock:
+ *
+ * <ol>
+ *     <li>the caller is interrupted while waiting to be admitted, having proposed nothing;</li>
+ *     <li>the caller's own deadline expires while waiting to be admitted, having proposed nothing;</li>
+ *     <li>the caller had already proposed on an earlier iteration and is then denied readmission.</li>
+ * </ol>
+ *
+ * All three are reported with a failure message distinct from retry exhaustion, because they say nothing about the
+ * state of the distributed log. The first two additionally state that nothing was proposed and are therefore safe to
+ * retry; the third must not, as whether the transformation applied is unknown. These tests hold the lock
+ * deterministically with a gated subclass rather than relying on contention between many worker threads.
+ */
+public class AbstractLocalProcessorLockTest
+{
+    /** Generous upper bound; only ever hit if the test is genuinely stuck. */
+    private static final long TIMEOUT_SECONDS = 30;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    /**
+     * A thread interrupted while queued for the proposal lock must be told that it was interrupted (and therefore
+     * that nothing was proposed), and must have its interrupt status restored so that shutdown is not swallowed.
+     */
+    @Test
+    public void interruptedWhileQueuedForProposalLock() throws Exception
+    {
+        LocalLog log = newLog();
+        GatedProcessor processor = new GatedProcessor(log);
+        try
+        {
+            Thread holder = startLockHolder(processor);
+
+            AtomicReference<Commit.Result> result = new AtomicReference<>();
+            AtomicBoolean interruptPreserved = new AtomicBoolean();
+            Thread waiter = new Thread(() -> {
+                // Deliberately generous, so that a timeout cannot be mistaken for an interrupt.
+                result.set(processor.commit(new Entry.Id(2), noOpTransformation(), null, retryFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)));
+                interruptPreserved.set(Thread.currentThread().isInterrupted());
+            }, "AbstractLocalProcessorLockTest-waiter");
+            waiter.start();
+
+            // Interrupt only once the waiter is provably parked in the lock queue, so that this exercises being
+            // interrupted while queued rather than entering commit with the interrupt already set.
+            awaitParkedOnLock(waiter);
+            waiter.interrupt();
+            waiter.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertFalse("waiter did not abandon the commit after being interrupted", waiter.isAlive());
+
+            releaseAndJoin(processor, holder);
+
+            Commit.Result commitResult = result.get();
+            assertNotNull(commitResult);
+            assertTrue("interrupted commit must fail", commitResult.isFailure());
+            String message = commitResult.failure().message;
+            // Matching on text rather than type, as the message may have to cross class loaders.
+            assertTrue("failure must identify interruption, but was: " + message,
+                       message.contains("Interrupted"));
+            assertTrue("failure must identify that nothing was submitted, but was: " + message,
+                       message.contains("waiting to submit commit"));
+            assertFalse("interruption must not be reported as retry exhaustion, but was: " + message,
+                        message.contains("Could not perform commit after"));
+            assertTrue("interrupt status must be restored for the caller", interruptPreserved.get());
+        }
+        finally
+        {
+            processor.gate.countDown();
+            log.close();
+        }
+    }
+
+    /**
+     * A caller whose deadline expires while queued for the proposal lock never proposed, so it must not be reported
+     * as retry exhaustion, and it must not claim to have been interrupted.
+     */
+    @Test
+    public void deadlineExpiresWhileQueuedForProposalLock() throws Exception
+    {
+        LocalLog log = newLog();
+        GatedProcessor processor = new GatedProcessor(log);
+        try
+        {
+            Thread holder = startLockHolder(processor);
+
+            AtomicReference<Commit.Result> result = new AtomicReference<>();
+            AtomicBoolean interrupted = new AtomicBoolean();
+            Thread waiter = new Thread(() -> {
+                result.set(processor.commit(new Entry.Id(2), noOpTransformation(), null, retryFor(250, TimeUnit.MILLISECONDS)));
+                interrupted.set(Thread.currentThread().isInterrupted());
+            }, "AbstractLocalProcessorLockTest-waiter");
+            waiter.start();
+            waiter.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertFalse("waiter did not give up on admission within its deadline", waiter.isAlive());
+
+            releaseAndJoin(processor, holder);
+
+            Commit.Result commitResult = result.get();
+            assertNotNull(commitResult);
+            assertTrue("commit which was never admitted must fail", commitResult.isFailure());
+            String message = commitResult.failure().message;
+            assertTrue("failure must identify that nothing was submitted, but was: " + message,
+                       message.contains("waiting to submit commit"));
+            assertFalse("admission timeout must not be reported as retry exhaustion, but was: " + message,
+                        message.contains("Could not perform commit after"));
+            assertFalse("admission timeout must not be reported as an interrupt, but was: " + message,
+                        message.contains("Interrupted"));
+            assertFalse("interrupt status must not be set", interrupted.get());
+        }
+        finally
+        {
+            processor.gate.countDown();
+            log.close();
+        }
+    }
+
+    /**
+     * The case which the serialisation of the proposal cycle actually introduced: a commit which already reached
+     * {@link AbstractLocalProcessor#tryCommitOne} and was told its proposal did not win, then fails to be readmitted
+     * for its next attempt.
+     *
+     * <p>A lost epoch is indistinguishable from an ambiguous Paxos result here, because
+     * {@code DistributedMetadataLogKeyspace.tryCommit} flattens a {@code CasWriteTimeoutException} to {@code false},
+     * so whether the transformation was committed to the distributed log is genuinely unknown. The failure must
+     * therefore say so, and must not repeat the "No proposal was made" claim which makes a retry unambiguously safe.
+     */
+    @Test
+    public void deniedReadmissionAfterProposingMustReportUnknownOutcome() throws Exception
+    {
+        LocalLog log = newLog();
+        ProposeThenDenyProcessor processor = new ProposeThenDenyProcessor(log);
+        try
+        {
+            AtomicReference<Commit.Result> result = new AtomicReference<>();
+            // Captured so that a commit which unwinds by throwing is reported as itself, rather than as the much less
+            // informative "victim never proposed" timeout on the latch below.
+            AtomicReference<Throwable> uncaught = new AtomicReference<>();
+            Thread victim = new Thread(() -> {
+                try
+                {
+                    result.set(processor.commit(new Entry.Id(1),
+                                               executableTransformation(),
+                                               null,
+                                               retryFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)));
+                }
+                catch (Throwable t)
+                {
+                    uncaught.set(t);
+                }
+            }, "AbstractLocalProcessorLockTest-victim");
+            victim.start();
+
+            // Iteration one: the victim has been admitted and is inside tryCommitOne, still holding the lock.
+            if (!processor.proposalMade.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                throw new AssertionError("victim never proposed", uncaught.get());
+
+            // Started only now, so that it queues behind the victim's first cycle rather than blocking it: holding the
+            // lock any earlier would produce the already-covered never-proposed case.
+            Thread blocker = new Thread(() -> {
+                try
+                {
+                    processor.commit(new Entry.Id(2), noOpTransformation(), null, retryFor(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                }
+                catch (NotCMSException expected)
+                {
+                    // Expected: the gated acceptCommit rejects once released, unwinding without proposing anything.
+                }
+            }, "AbstractLocalProcessorLockTest-blocker");
+            processor.blocker = blocker;
+            blocker.start();
+
+            // The victim still holds the lock, so the blocker can only be parked in the acquisition queue. Releasing
+            // the victim's proposal only once the blocker is provably queued makes the fair handoff to the blocker,
+            // and hence the victim's own failure to be readmitted, deterministic rather than merely likely.
+            awaitParkedOnLock(blocker);
+            processor.loseProposal.countDown();
+
+            // The blocker now owns the lock and the victim has finished the post-proposal log fetch which precedes its
+            // next acquisition, so readmission is impossible rather than merely unlikely.
+            assertTrue("blocker never acquired the proposal lock",
+                       processor.blockerHoldsLock.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            assertTrue("victim never refetched after its lost proposal",
+                       processor.victimRefetched.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            awaitParkedOnLock(victim);
+            victim.interrupt();
+            victim.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertFalse("victim did not abandon the commit after being denied readmission", victim.isAlive());
+
+            processor.gate.countDown();
+            blocker.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertFalse("blocker did not release the proposal lock", blocker.isAlive());
+
+            if (uncaught.get() != null)
+                throw new AssertionError("victim commit threw instead of failing", uncaught.get());
+
+            Commit.Result commitResult = result.get();
+            assertNotNull(commitResult);
+            assertTrue("commit which was denied readmission must fail", commitResult.isFailure());
+            String message = commitResult.failure().message;
+            // Matching on text rather than type, as the message may have to cross class loaders.
+            assertTrue("failure must identify that admission failed, but was: " + message,
+                       message.contains("waiting to submit commit"));
+            assertTrue("failure must state that the outcome is unknown, but was: " + message,
+                       message.contains("whether the transformation was committed to the log is unknown"));
+            assertFalse("a commit which already proposed must not claim nothing was proposed, but was: " + message,
+                        message.contains("No proposal was made"));
+            assertFalse("denied readmission must not be reported as retry exhaustion, but was: " + message,
+                        message.contains("Could not perform commit after"));
+        }
+        finally
+        {
+            processor.gate.countDown();
+            log.close();
+        }
+    }
+
+    /**
+     * Starts a thread which acquires the proposal lock and holds it until {@link GatedProcessor#gate} is released,
+     * returning only once the lock is provably held.
+     */
+    private Thread startLockHolder(GatedProcessor processor) throws InterruptedException
+    {
+        Thread holder = new Thread(() -> {
+            try
+            {
+                processor.commit(new Entry.Id(1), noOpTransformation(), null, retryFor(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            }
+            catch (NotCMSException expected)
+            {
+                // Expected: the gated acceptCommit rejects once released, unwinding without proposing anything.
+            }
+        }, "AbstractLocalProcessorLockTest-holder");
+        holder.start();
+        assertTrue("holder never acquired the proposal lock", processor.lockHeld.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        return holder;
+    }
+
+    /**
+     * Spins until {@code waiter} is provably blocked inside {@link AbstractLocalProcessor}, which - since the lock is
+     * the only thing a commit can block on before proposing - means it is queued for the proposal lock. Deliberately
+     * asserts on observed thread state rather than sleeping for a guessed interval.
+     */
+    private static void awaitParkedOnLock(Thread waiter)
+    {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (System.nanoTime() < deadline)
+        {
+            Thread.State state = waiter.getState();
+            if ((state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) && blockedInProcessor(waiter))
+                return;
+            Thread.onSpinWait();
+        }
+        throw new AssertionError("Waiter never queued for the proposal lock; state=" + waiter.getState());
+    }
+
+    private static boolean blockedInProcessor(Thread waiter)
+    {
+        for (StackTraceElement frame : waiter.getStackTrace())
+        {
+            if (frame.getClassName().equals(AbstractLocalProcessor.class.getName()))
+                return true;
+        }
+        return false;
+    }
+
+    private void releaseAndJoin(GatedProcessor processor, Thread holder) throws InterruptedException
+    {
+        processor.gate.countDown();
+        holder.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        assertFalse("holder did not release the proposal lock", holder.isAlive());
+    }
+
+    private static LocalLog newLog()
+    {
+        LocalLog log = LocalLog.logSpec()
+                               .sync()
+                               .withInitialState(new ClusterMetadata(Murmur3Partitioner.instance))
+                               .createLog();
+        log.readyUnchecked();
+        return log;
+    }
+
+    private static Retry retryFor(long timeout, TimeUnit unit)
+    {
+        return Retry.untilElapsed(unit.toNanos(timeout), TCMMetrics.instance.commitRetries);
+    }
+
+    private static Transformation noOpTransformation()
+    {
+        return new Transformation()
+        {
+            @Override
+            public Kind kind()
+            {
+                return Kind.CUSTOM;
+            }
+
+            @Override
+            public Result execute(ClusterMetadata metadata)
+            {
+                return Transformation.success(metadata.transformer(), MetaStrategy.affectedRanges(metadata));
+            }
+        };
+    }
+
+    /**
+     * As {@link #noOpTransformation()}, but reports no affected ranges rather than deriving them from the metadata
+     * keyspace, which the bare {@link ClusterMetadata} used here does not have in its schema. Needed only by the test
+     * whose commit is actually executed; the others are rejected in {@code acceptCommit} before executing.
+     */
+    private static Transformation executableTransformation()
+    {
+        return new Transformation()
+        {
+            @Override
+            public Kind kind()
+            {
+                return Kind.CUSTOM;
+            }
+
+            @Override
+            public Result execute(ClusterMetadata metadata)
+            {
+                return Transformation.success(metadata.transformer(), LockedRanges.AffectedRanges.EMPTY);
+            }
+        };
+    }
+
+    /**
+     * Blocks in {@link #acceptCommit}, which {@code commit} calls with the proposal lock held, so that the lock can
+     * be pinned for as long as a test needs it without any reliance on timing.
+     */
+    private static class GatedProcessor extends AbstractLocalProcessor
+    {
+        /** Counted down once the proposal lock is held by the gated thread. */
+        final CountDownLatch lockHeld = new CountDownLatch(1);
+        /** Released by the test to let the holder finish and drop the proposal lock. */
+        final CountDownLatch gate = new CountDownLatch(1);
+
+        GatedProcessor(LocalLog log)
+        {
+            super(log);
+        }
+
+        @Override
+        protected boolean acceptCommit(ClusterMetadata metadata)
+        {
+            lockHeld.countDown();
+            try
+            {
+                if (!gate.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    throw new AssertionError("Proposal lock was never released by the test");
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+            // Rejecting unwinds commit() via NotCMSException, which is the cheapest way out of the proposal cycle
+            // that is guaranteed not to have proposed anything.
+            return false;
+        }
+
+        @Override
+        protected boolean tryCommitOne(Entry.Id entryId, Transformation transform, Epoch previousEpoch, Epoch nextEpoch)
+        {
+            throw new AssertionError("No proposal should ever be attempted by this test");
+        }
+
+        @Override
+        public ClusterMetadata fetchLogAndWait(Epoch waitFor, Retry retryPolicy)
+        {
+            return log.waitForHighestConsecutive();
+        }
+    }
+
+    /**
+     * Drives one victim commit through a lost proposal and then denies it readmission, so that the
+     * proposal-attempted-then-lock-failure path can be exercised without any reliance on timing.
+     *
+     * <p>Two threads share this processor. The victim is admitted first and parks inside {@link #tryCommitOne} while
+     * still holding the proposal lock; the blocker then queues for the lock behind it. Only once the blocker is
+     * provably queued does the test release {@link #loseProposal}, so the fair handoff of the lock goes to the blocker
+     * and the victim's second acquisition is guaranteed to find the lock held.
+     */
+    private static class ProposeThenDenyProcessor extends AbstractLocalProcessor
+    {
+        /** Counted down once the victim is inside tryCommitOne, i.e. a proposal has provably been attempted. */
+        final CountDownLatch proposalMade = new CountDownLatch(1);
+        /** Released by the test to let the victim's proposal report that it did not win its epoch. */
+        final CountDownLatch loseProposal = new CountDownLatch(1);
+        /** Counted down once the blocker holds the proposal lock, so the victim cannot be readmitted. */
+        final CountDownLatch blockerHoldsLock = new CountDownLatch(1);
+        /** Counted down once the victim has completed the post-proposal log fetch which precedes its next attempt. */
+        final CountDownLatch victimRefetched = new CountDownLatch(1);
+        /** Released by the test to let the blocker unwind and drop the proposal lock. */
+        final CountDownLatch gate = new CountDownLatch(1);
+
+        /** Set by the test before the blocker is started, so that the two roles can be told apart here. */
+        volatile Thread blocker;
+
+        ProposeThenDenyProcessor(LocalLog log)
+        {
+            super(log);
+        }
+
+        @Override
+        protected boolean acceptCommit(ClusterMetadata metadata)
+        {
+            if (Thread.currentThread() != blocker)
+                return true; // The victim proceeds to execute and propose.
+
+            blockerHoldsLock.countDown();
+            await(gate, "Blocker was never released by the test");
+            // Rejecting unwinds commit() via NotCMSException, which is the cheapest way out of the proposal cycle
+            // that is guaranteed not to have proposed anything.
+            return false;
+        }
+
+        @Override
+        protected boolean tryCommitOne(Entry.Id entryId, Transformation transform, Epoch previousEpoch, Epoch nextEpoch)
+        {
+            if (Thread.currentThread() == blocker)
+                throw new AssertionError("The blocker must never reach a proposal");
+
+            // Still holding the proposal lock here, which is what lets the blocker queue behind this cycle.
+            proposalMade.countDown();
+            await(loseProposal, "Victim's proposal was never resolved by the test");
+            // false is what commit() sees both for a genuinely lost epoch and for an ambiguous Paxos result, since
+            // DistributedMetadataLogKeyspace.tryCommit flattens a CasWriteTimeoutException to false.
+            return false;
+        }
+
+        @Override
+        public ClusterMetadata fetchLogAndWait(Epoch waitFor, Retry retryPolicy)
+        {
+            ClusterMetadata metadata = log.waitForHighestConsecutive();
+            // Only the victim gets this far; the blocker throws NotCMSException out of acceptCommit.
+            victimRefetched.countDown();
+            return metadata;
+        }
+
+        private static void await(CountDownLatch latch, String message)
+        {
+            try
+            {
+                if (!latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    throw new AssertionError(message);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Details, reproduction and measurements: [CASSANDRA-21537](https://issues.apache.org/jira/browse/CASSANDRA-21537)

Concurrent CQL DDL against a CMS member fails with `Could not perform commit after 12 attempts. Time remaining: 4231ms` — the retry attempt cap is reached while the request deadline still has seconds left. Every concurrent commit reads the same highest consecutive epoch and proposes at `epoch+1`, so all but one loser per round burns an attempt, backs off, and refetches the log before recomputing.

**Fix**

* `AbstractLocalProcessor` serialises the read → execute → propose cycle for locally originating commits behind a fair `ReentrantLock`.
* Acquisition is bounded by the caller's own remaining `Retry` deadline, so queue time is charged to the waiter and never extends another request.
* Each loop iteration is one timed acquisition, one critical section, one `finally` that unlocks exactly once.
* A request that is never admitted reports that distinctly, and only claims nothing was proposed when no earlier iteration reached the CAS.

**Also in this patch**

* `commit()` is split into `runCycle()` (the locked critical section) and `react()` (per-outcome handling once the lock is released), carrying state across the release in immutable `CycleResult`/`Decision` objects rather than shared mutable locals. Behaviour-preserving. Happy to move this to its own ticket if reviewers would rather keep the fix minimal for backport.

**Why this shouldn't regress**

* Not new serialisation. The epoch is the partition key of the log table, and `Paxos.cas` already takes a per-partition coordinator lock for the whole CAS, so local contenders were already serialising — just bounded by `cas_contention_timeout` instead of the caller's deadline, and only discoverable by burning an attempt.
* `tryCommitOne` can only apply one proposal per epoch, so racing that slot locally never added throughput.
* Lock released before the follower wait, the uninterruptible backoff sleep, and any log fetch — none of those block another proposer.
* Fair, so no starvation by later arrivals.
* Success, rejection and failure behaviour is otherwise unchanged; the only new outcome is "not admitted".
* Single-node concurrent DDL: 48 workers / 864 statements go from 311 failures to 0.

**Tests added**

* `ConcurrentSchemaCommitTest` (in-JVM) — asserts every submitted statement succeeds and swallows no exception.
* `AbstractLocalProcessorLockTest` (unit, ~2s, no sleeps) — timeout while queued, interrupt while queued, and proposal-attempted-then-denied-readmission.
* `AbstractLocalProcessorCycleTest` (unit, ~7s) — the four per-cycle outcomes against a real `LocalLog`: rejection with and without an epoch change, `tryCommitOne` throwing once and throwing until the budget is exhausted, a lost epoch, and a winning proposal whose `awaitAtLeast` fails.

**For reviewers**

* Does not address races between separate CMS members; that remains the distributed log's job.
* Admission is FIFO with no per-`Transformation.Kind` priority, so a topology change can queue behind earlier schema DDL. Happy to add priority if wanted.
* No admission metrics yet.
* Untested on a real multi-CMS-member cluster.
* Based on `trunk`; `cassandra-6.0` is equally affected and the TCM source is identical between them.

patch by Patrick McFadin, Jon Haddad; reviewed by TBD for CASSANDRA-21537
