### PR TITLE
21462 cursor compaction 6.0 stabilization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Stabilize cursor-based compaction (CASSANDRA-21462)
  * Stop using Java streams in CIDRPermissions.SubsetPermissions#canAccessFrom hot method (CASSANDRA-21588)
  * Enable trickle fsync by default (CASSANDRA-21572)
  * Protect uncaught_exceptions virtual table against the crash path (CASSANDRA-21578)

--- a/build.xml
+++ b/build.xml
@@ -707,6 +707,10 @@
         <gen-java-copy class="org.apache.cassandra.utils.MergeIterator" newName="RowMergeIterator"/>
         <gen-java-copy class="org.apache.cassandra.utils.MergeIterator" newName="UnfilteredMergeIterator"/>
         <gen-java-copy class="org.apache.cassandra.utils.MergeIterator" newName="ComplexCellMergeIterator"/>
+        <gen-java-copy class="org.apache.cassandra.db.compaction.PreSortedBubbleInsert" newName="PartitionKeyMergeSort"/>
+        <gen-java-copy class="org.apache.cassandra.db.compaction.PreSortedBubbleInsert" newName="RowClusteringMergeSort"/>
+        <gen-java-copy class="org.apache.cassandra.db.compaction.PreSortedBubbleInsert" newName="StaticMergeSort"/>
+        <gen-java-copy class="org.apache.cassandra.db.compaction.PreSortedBubbleInsert" newName="ColumnMergeSort"/>
     </target>
 
     <!-- create properties file with C version -->

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -688,6 +688,9 @@ commitlog_segment_size: 32MiB
 # The default setting is legacy when the storage compatibility is set to 4 or auto otherwise.
 commitlog_disk_access_mode: legacy
 
+# Experimental.  New garbage free compaction path.  Does not yet support collections, counters, BTI.
+cursor_compaction_enabled: false
+
 # Set the disk access mode for reading SSTables during compaction. The allowed values are:
 # - auto: inherit from disk_access_mode (default)
 # - direct: use direct I/O for compaction reads, bypassing the OS page cache

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -202,7 +202,8 @@ public enum CassandraRelevantProperties
     CONSISTENT_RANGE_MOVEMENT("cassandra.consistent.rangemovement", "true"),
     CONSISTENT_SIMULTANEOUS_MOVES_ALLOW("cassandra.consistent.simultaneousmoves.allow"),
     CRYPTO_PROVIDER_CLASS_NAME("cassandra.crypto_provider_class_name"),
-    CURSOR_COMPACTION_ENABLED("cassandra.cursor_compaction_enabled", "true"),
+    /** Experimental. */
+    CURSOR_COMPACTION_ENABLED("cassandra.cursor_compaction_enabled", "false"),
     CUSTOM_DISK_ERROR_HANDLER("cassandra.custom_disk_error_handler"),
     CUSTOM_GUARDRAILS_CONFIG_PROVIDER_CLASS("cassandra.custom_guardrails_config_provider_class"),
     CUSTOM_QUERY_HANDLER_CLASS("cassandra.custom_query_handler_class"),
@@ -633,6 +634,28 @@ public enum CassandraRelevantProperties
     TEST_COMPRESSION_ALGO("cassandra.test.compression.algo", "lz4"),
     TEST_DEBUG_REF_COUNT("cassandra.debugrefcount"),
     TEST_DEBUG_REF_EVENTS("cassandra.debug.refevents"),
+    /**
+     * Scale knobs for the cursor-vs-iterator differential compaction suite. The bigvolume and
+     * largepartition defaults reproduce their documented test/burn scale (40M rows / 20 sstables;
+     * a ~2.4GiB merged partition) -- override down for a quick local check.
+     */
+    TEST_DIFFERENTIAL_BIGVOLUME_PARTITIONS("cassandra.test.differential.bigvolume.partitions", "20000"),
+    TEST_DIFFERENTIAL_BIGVOLUME_ROUNDS("cassandra.test.differential.bigvolume.rounds", "20"),
+    TEST_DIFFERENTIAL_BIGVOLUME_ROWS_PER_ROUND("cassandra.test.differential.bigvolume.rows_per_round", "100"),
+    TEST_DIFFERENTIAL_BIGVOLUME_VALUE_PADDING("cassandra.test.differential.bigvolume.value_padding", "200"),
+    /** Number of generated examples the randomized differential soak runs; must be > 0. */
+    TEST_DIFFERENTIAL_EXAMPLES("cassandra.test.differential.examples"),
+    /**
+     * Preserves a failed differential comparison's captured sstables for post-mortem instead of deleting
+     * them. Off by default: the burn scenarios' captures are multi-GB and would fill a CI disk.
+     */
+    TEST_DIFFERENTIAL_KEEP_SCRATCH_ON_FAILURE("cassandra.test.differential.keep_scratch_on_failure", "false"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_CK_STRIDE("cassandra.test.differential.largepartition.ck_stride"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_ROWS_PER_SSTABLE("cassandra.test.differential.largepartition.rows_per_sstable", "1100000"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_SSTABLES("cassandra.test.differential.largepartition.sstables", "8"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_VALUE_PADDING("cassandra.test.differential.largepartition.value_padding", "240"),
+    /** Seed for the randomized differential soak; defaults to the wall clock, logged per example. */
+    TEST_DIFFERENTIAL_SEED("cassandra.test.differential.seed"),
     TEST_DRIVER_CONNECTION_TIMEOUT_MS("cassandra.test.driver.connection_timeout_ms", "5000"),
     TEST_DRIVER_READ_TIMEOUT_MS("cassandra.test.driver.read_timeout_ms", "12000"),
     TEST_ENCRYPTION("cassandra.test.encryption", "false"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -633,6 +633,19 @@ public enum CassandraRelevantProperties
     TEST_COMPRESSION_ALGO("cassandra.test.compression.algo", "lz4"),
     TEST_DEBUG_REF_COUNT("cassandra.debugrefcount"),
     TEST_DEBUG_REF_EVENTS("cassandra.debug.refevents"),
+    /** Scale knobs for the cursor-vs-iterator differential compaction suite. */
+    TEST_DIFFERENTIAL_BIGVOLUME_PARTITIONS("cassandra.test.differential.bigvolume.partitions", "2000"),
+    TEST_DIFFERENTIAL_BIGVOLUME_ROUNDS("cassandra.test.differential.bigvolume.rounds", "20"),
+    TEST_DIFFERENTIAL_BIGVOLUME_ROWS_PER_ROUND("cassandra.test.differential.bigvolume.rows_per_round", "50"),
+    TEST_DIFFERENTIAL_BIGVOLUME_VALUE_PADDING("cassandra.test.differential.bigvolume.value_padding", "0"),
+    /** Number of generated examples the randomized differential soak runs; must be > 0. */
+    TEST_DIFFERENTIAL_EXAMPLES("cassandra.test.differential.examples"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_CK_STRIDE("cassandra.test.differential.largepartition.ck_stride"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_ROWS_PER_SSTABLE("cassandra.test.differential.largepartition.rows_per_sstable", "250000"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_SSTABLES("cassandra.test.differential.largepartition.sstables", "4"),
+    TEST_DIFFERENTIAL_LARGEPARTITION_VALUE_PADDING("cassandra.test.differential.largepartition.value_padding", "120"),
+    /** Seed for the randomized differential soak; defaults to the wall clock, logged per example. */
+    TEST_DIFFERENTIAL_SEED("cassandra.test.differential.seed"),
     TEST_DRIVER_CONNECTION_TIMEOUT_MS("cassandra.test.driver.connection_timeout_ms", "5000"),
     TEST_DRIVER_READ_TIMEOUT_MS("cassandra.test.driver.read_timeout_ms", "12000"),
     TEST_ENCRYPTION("cassandra.test.encryption", "false"),

--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -183,6 +183,9 @@ public class ClusteringComparator implements Comparator<Clusterable>
         return compare(types, c1, c2, types.length);
     }
 
+    // 2-bit per-component flag in the wire clustering block: 0b00 valued, 0b01 empty, 0b10 null.
+    private static final int CLUSTERING_VALUE_FLAG_NULL = 0b10;
+
     private static int compare(AbstractType<?>[] types, ByteBuffer c1, ByteBuffer c2, int size)
     {
         long clusteringBlock1 = 0;
@@ -245,7 +248,17 @@ public class ClusteringComparator implements Comparator<Clusterable>
                     // compare swapped arguments to reverse the order
                     int cmp = Long.compare(v2Flags, v1Flags);
                     if (cmp != 0)
+                    {
+                        // Null ordering is type-independent: nulls sort first even on reversed
+                        // (DESC) columns, mirroring ClusteringComparator.compareComponent which
+                        // handles nulls before consulting the type. EMPTY vs VALUED, however, is
+                        // decided by the type: every base type sorts empty before values, so
+                        // ReversedType sorts empty AFTER values (it swaps operands around the
+                        // base comparison) — flip the flag-derived order for reversed columns.
+                        if ((v1Flags & CLUSTERING_VALUE_FLAG_NULL) == 0 && (v2Flags & CLUSTERING_VALUE_FLAG_NULL) == 0 && type.isReversed())
+                            cmp = -cmp;
                         return cmp;
+                    }
                     // null/empty == null/empty, continue...
                 }
                 clusteringBlock1 = clusteringBlock1 >>> 2;

--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -245,7 +245,17 @@ public class ClusteringComparator implements Comparator<Clusterable>
                     // compare swapped arguments to reverse the order
                     int cmp = Long.compare(v2Flags, v1Flags);
                     if (cmp != 0)
+                    {
+                        // Null ordering is type-independent: nulls sort first even on reversed
+                        // (DESC) columns, mirroring ClusteringComparator.compareComponent which
+                        // handles nulls before consulting the type. EMPTY vs VALUED, however, is
+                        // decided by the type: every base type sorts empty before values, so
+                        // ReversedType sorts empty AFTER values (it swaps operands around the
+                        // base comparison) — flip the flag-derived order for reversed columns.
+                        if ((v1Flags & 0b10) == 0 && (v2Flags & 0b10) == 0 && type.isReversed())
+                            cmp = -cmp;
                         return cmp;
+                    }
                     // null/empty == null/empty, continue...
                 }
                 clusteringBlock1 = clusteringBlock1 >>> 2;

--- a/src/java/org/apache/cassandra/db/DeletionPurger.java
+++ b/src/java/org/apache/cassandra/db/DeletionPurger.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.db;
 
+import org.apache.cassandra.db.rows.CellLivenessInfo;
+
 public interface DeletionPurger
 {
     DeletionPurger PURGE_ALL = (ts, ldt) -> true;
@@ -31,5 +33,16 @@ public interface DeletionPurger
     default boolean shouldPurge(LivenessInfo liveness, long nowInSec)
     {
         return !liveness.isLive(nowInSec) && shouldPurge(liveness.timestamp(), liveness.localExpirationTime());
+    }
+
+    /**
+     * The cell form, mirroring {@code AbstractCell.purge}. Separate from the row overload above because the
+     * two liveness contracts disagree on what "live" means; no call site can be ambiguous, since
+     * {@link org.apache.cassandra.db.rows.ReusableCellLivenessInfo} implements only one of the two interfaces
+     * and {@link org.apache.cassandra.db.rows.Cell} reaches {@code AbstractCell.purge} instead of this.
+     */
+    default boolean shouldPurge(CellLivenessInfo liveness, long nowInSec)
+    {
+        return !liveness.isLive(nowInSec) && shouldPurge(liveness.timestamp(), liveness.localDeletionTime());
     }
 }

--- a/src/java/org/apache/cassandra/db/DeletionTime.java
+++ b/src/java/org/apache/cassandra/db/DeletionTime.java
@@ -110,7 +110,7 @@ public abstract class DeletionTime implements Comparable<DeletionTime>, IMeasura
      */
     public boolean isLive()
     {
-        return markedForDeleteAt() == Long.MIN_VALUE && localDeletionTime() == Long.MAX_VALUE;
+        return markedForDeleteAt == Long.MIN_VALUE && localDeletionTimeUnsignedInteger == Cell.NO_DELETION_TIME_UNSIGNED_INTEGER;
     }
 
     public void digest(Digest digest)
@@ -138,7 +138,7 @@ public abstract class DeletionTime implements Comparable<DeletionTime>, IMeasura
         if(!(o instanceof DeletionTime))
             return false;
         DeletionTime that = (DeletionTime)o;
-        return markedForDeleteAt() == that.markedForDeleteAt() && localDeletionTime() == that.localDeletionTime();
+        return markedForDeleteAt == that.markedForDeleteAt && localDeletionTimeUnsignedInteger == that.localDeletionTimeUnsignedInteger;
     }
 
     @Override
@@ -168,12 +168,31 @@ public abstract class DeletionTime implements Comparable<DeletionTime>, IMeasura
      */
     public boolean supersedes(DeletionTime dt)
     {
-        return markedForDeleteAt() > dt.markedForDeleteAt() || (markedForDeleteAt() == dt.markedForDeleteAt() && localDeletionTime() > dt.localDeletionTime());
+        return markedForDeleteAt > dt.markedForDeleteAt || (markedForDeleteAt == dt.markedForDeleteAt && CassandraUInt.compare(localDeletionTimeUnsignedInteger, dt.localDeletionTimeUnsignedInteger) > 0);
     }
 
     public boolean deletes(LivenessInfo info)
     {
         return deletes(info.timestamp());
+    }
+
+    /**
+     * Whether this deletion shadows a cell written at {@code timestamp}. The LIVE short-circuit is
+     * load-bearing rather than an optimisation: {@link #deletes(long)} answers TRUE for
+     * {@link LivenessInfo#NO_TIMESTAMP}, because Long.MIN_VALUE is both that sentinel and LIVE's
+     * {@code markedForDeleteAt} — so a LIVE deletion would shadow a cell carrying it.
+     *
+     * {@link #deletes(LivenessInfo)} has no such guard, and must not grow one. Two reasons, and the second is
+     * the load-bearing one: for ROW liveness the answer is behaviour-neutral, since an empty row liveness has
+     * nothing to shadow and "deleted" and "absent" coincide; and the iterator path applies that same unguarded
+     * form to row liveness of its own accord ({@code Row.Merger.merge}, {@code BTreeRow}), so guarding it would
+     * move the reference as well as the cursor. The guard belongs to the cell contract alone, which is why
+     * {@link #deletes(Cell)} carries it too; that overload keeps its own copy because the check has to precede
+     * the virtual {@code timestamp()} read it guards.
+     */
+    public boolean deletesCellAt(long timestamp)
+    {
+        return markedForDeleteAt != MARKED_FOR_DELETE_AT_LIVE && timestamp <= markedForDeleteAt;
     }
 
     public boolean deletes(Cell<?> cell)
@@ -443,7 +462,13 @@ public abstract class DeletionTime implements Comparable<DeletionTime>, IMeasura
         public void reset(long markedForDeleteAt, long localDeletionTime)
         {
             this.markedForDeleteAt = markedForDeleteAt;
-            if (localDeletionTime < 0 || localDeletionTime > Cell.MAX_DELETION_TIME) // invalid
+            if (localDeletionTime == Cell.NO_DELETION_TIME)
+                // NO_DELETION_TIME (Long.MAX_VALUE) is the canonical "no deletion" long and must
+                // round-trip to the LIVE marker (deletionTimeLongToUnsignedInteger semantics);
+                // classifying it as invalid made reset(LIVE.markedForDeleteAt(),
+                // LIVE.localDeletionTime()) produce a NON-live deletion
+                this.localDeletionTimeUnsignedInteger = LOCAL_DELETION_TIME_LIVE;
+            else if (localDeletionTime < 0 || localDeletionTime > Cell.MAX_DELETION_TIME) // invalid
                 this.localDeletionTimeUnsignedInteger = Cell.MAX_DELETION_TIME_UNSIGNED_INTEGER + 1;
             else
                 this.localDeletionTimeUnsignedInteger = Cell.deletionTimeLongToUnsignedInteger(localDeletionTime);

--- a/src/java/org/apache/cassandra/db/DeletionTime.java
+++ b/src/java/org/apache/cassandra/db/DeletionTime.java
@@ -443,7 +443,13 @@ public abstract class DeletionTime implements Comparable<DeletionTime>, IMeasura
         public void reset(long markedForDeleteAt, long localDeletionTime)
         {
             this.markedForDeleteAt = markedForDeleteAt;
-            if (localDeletionTime < 0 || localDeletionTime > Cell.MAX_DELETION_TIME) // invalid
+            if (localDeletionTime == Cell.NO_DELETION_TIME)
+                // NO_DELETION_TIME (Long.MAX_VALUE) is the canonical "no deletion" long and must
+                // round-trip to the LIVE marker (deletionTimeLongToUnsignedInteger semantics);
+                // classifying it as invalid made reset(LIVE.markedForDeleteAt(),
+                // LIVE.localDeletionTime()) produce a NON-live deletion
+                this.localDeletionTimeUnsignedInteger = LOCAL_DELETION_TIME_LIVE;
+            else if (localDeletionTime < 0 || localDeletionTime > Cell.MAX_DELETION_TIME) // invalid
                 this.localDeletionTimeUnsignedInteger = Cell.MAX_DELETION_TIME_UNSIGNED_INTEGER + 1;
             else
                 this.localDeletionTimeUnsignedInteger = Cell.deletionTimeLongToUnsignedInteger(localDeletionTime);

--- a/src/java/org/apache/cassandra/db/ReusableLivenessInfo.java
+++ b/src/java/org/apache/cassandra/db/ReusableLivenessInfo.java
@@ -43,10 +43,16 @@ public class ReusableLivenessInfo implements LivenessInfo
         return localExpirationTime;
     }
 
+    /**
+     * "Has a TTL", as specified by {@link LivenessInfo#isExpiring()} and implemented by every other
+     * liveness type ({@link LivenessInfo.ExpiringLivenessInfo}, {@link org.apache.cassandra.db.rows.AbstractCell#isExpiring()}).
+     * Note this is NOT "has an expiration time": cell liveness held here can be a tombstone, which
+     * carries a local deletion time with no TTL.
+     */
     @Override
     public boolean isExpiring()
     {
-        return localExpirationTime != NO_EXPIRATION_TIME;
+        return ttl != NO_TTL;
     }
 
     @Override
@@ -56,29 +62,28 @@ public class ReusableLivenessInfo implements LivenessInfo
     }
 
     /**
-     * {@link org.apache.cassandra.db.rows.AbstractCell#isTombstone()}
+     * The ROW contract, matching the row references: empty liveness is not live
+     * ({@link LivenessInfo#EMPTY}, whose {@code isLive} is {@code !isEmpty()}), an
+     * {@link #EXPIRED_LIVENESS_TTL} marker is never live ({@link LivenessInfo.ExpiredLivenessInfo}), and
+     * otherwise an expiring liveness is live until its expiration second.
+     *
+     * It differs from the cell contract on three inputs, which is why cell liveness has its own type;
+     * {@code ReusableCellLivenessInfo} carries that reading.
+     *
+     * The old code here read the CELL contract instead, treating an {@code EXPIRED_LIVENESS_TTL} marker
+     * (view maintenance's PK-shadow tombstone) as live until its expiration second rather than never. The
+     * flip is inert on this branch: the marker's {@code localExpirationTime} is stamped with
+     * {@code nowInSec} when the view mutation is applied, and compaction only observes the row after that
+     * mutation has been applied and flushed, so compaction-time {@code nowInSec} is never less than the
+     * stamped one — the old read could never actually return {@code true} for it either. Exercised by
+     * {@code MaterializedViewDifferentialCompactionTest}.
      */
-    public boolean isTombstone()
-    {
-        return localExpirationTime != NO_EXPIRATION_TIME && ttl == NO_TTL;
-    }
-
     @Override
     public boolean isLive(long nowInSec)
     {
-        return localExpirationTime == NO_EXPIRATION_TIME || ttl != NO_TTL && !isExpired(nowInSec);
-    }
-
-    public boolean isExpired(long nowInSec)
-    {
-        return nowInSec >= localExpirationTime;
-    }
-
-    public void ttlToTombstone()
-    {
-        // LET/LDT is now the time the TTL would have expired
-        localExpirationTime = localExpirationTime - ttl;
-        ttl = NO_TTL;
+        if (isEmpty() || isExpired())
+            return false;
+        return !isExpiring() || nowInSec < localExpirationTime;
     }
 
     public void reset(long timestamp, int ttl, long localExpirationTime)

--- a/src/java/org/apache/cassandra/db/ReusableLivenessInfo.java
+++ b/src/java/org/apache/cassandra/db/ReusableLivenessInfo.java
@@ -43,10 +43,16 @@ public class ReusableLivenessInfo implements LivenessInfo
         return localExpirationTime;
     }
 
+    /**
+     * "Has a TTL", as specified by {@link LivenessInfo#isExpiring()} and implemented by every other
+     * liveness type ({@link LivenessInfo.ExpiringLivenessInfo}, {@link org.apache.cassandra.db.rows.AbstractCell#isExpiring()}).
+     * Note this is NOT "has an expiration time": cell liveness held here can be a tombstone, which
+     * carries a local deletion time with no TTL.
+     */
     @Override
     public boolean isExpiring()
     {
-        return localExpirationTime != NO_EXPIRATION_TIME;
+        return ttl != NO_TTL;
     }
 
     @Override
@@ -63,6 +69,15 @@ public class ReusableLivenessInfo implements LivenessInfo
         return localExpirationTime != NO_EXPIRATION_TIME && ttl == NO_TTL;
     }
 
+    /**
+     * The cell contract, {@link org.apache.cassandra.db.rows.Cell#isLive(long)}: liveness with no
+     * expiration time is live, otherwise it must carry a TTL that has not lapsed. Cell liveness
+     * needs that reading, and it differs from the row references twice over. Row callers gate on
+     * {@link #isEmpty()}, which covers the first: empty liveness reports live here, where
+     * {@link LivenessInfo#EMPTY} does not. Nothing covers the second: liveness carrying
+     * {@link #EXPIRED_LIVENESS_TTL} reports live until its expiration second, where
+     * {@link LivenessInfo.ExpiredLivenessInfo} never reports live at all.
+     */
     @Override
     public boolean isLive(long nowInSec)
     {

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionPipeline.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionPipeline.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db.compaction;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.AbstractCompactionController;
@@ -31,6 +32,21 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.TimeUUID;
 
 abstract class AbstractCompactionPipeline extends CompactionInfo.Holder implements AutoCloseable {
+    // Which pipeline each compaction selected, as a delta across one compaction. Read by
+    // CompactionPipelineCounts (test), which documents why supportability alone cannot establish it.
+    private static final LongAdder CURSOR_PIPELINES_CREATED = new LongAdder();
+    private static final LongAdder ITERATOR_PIPELINES_CREATED = new LongAdder();
+
+    static long cursorPipelinesCreated()
+    {
+        return CURSOR_PIPELINES_CREATED.sum();
+    }
+
+    static long iteratorPipelinesCreated()
+    {
+        return ITERATOR_PIPELINES_CREATED.sum();
+    }
+
     static AbstractCompactionPipeline create(
         CompactionTask task,
         OperationType type,
@@ -42,9 +58,11 @@ abstract class AbstractCompactionPipeline extends CompactionInfo.Holder implemen
         if (DatabaseDescriptor.cursorCompactionEnabled()) {
             if (CursorCompactor.isSupported(scanners, controller))
             {
+                CURSOR_PIPELINES_CREATED.increment();
                 return new CursorCompactionPipeline(task, type, scanners, controller, nowInSec, compactionId);
             }
         }
+        ITERATOR_PIPELINES_CREATED.increment();
         return new IteratorCompactionPipeline(task, type, scanners, controller, nowInSec, compactionId);
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -88,6 +89,7 @@ public class CompactionTask extends AbstractCompactionTask
     protected final boolean keepOriginals;
     protected static long totalBytesCompacted = 0;
     private ActiveCompactionsTracker activeCompactions;
+    private LongSupplier nowInSecondsSupplier = FBUtilities::nowInSeconds;
 
     public CompactionTask(ColumnFamilyStore cfs, ILifecycleTransaction txn, long gcBeforeSeconds)
     {
@@ -99,6 +101,13 @@ public class CompactionTask extends AbstractCompactionTask
         super(cfs, txn);
         this.gcBeforeSeconds = gcBeforeSeconds;
         this.keepOriginals = keepOriginals;
+    }
+
+    /** Test hook: overrides FBUtilities.nowInSeconds() for TTL-expiration decisions during this task's merge. */
+    public CompactionTask setNowInSecondsSupplier(LongSupplier nowInSecondsSupplier)
+    {
+        this.nowInSecondsSupplier = nowInSecondsSupplier;
+        return this;
     }
 
     public static synchronized long addToTotalBytesCompacted(long bytesCompacted)
@@ -258,7 +267,7 @@ public class CompactionTask extends AbstractCompactionTask
             Range<Token> tokenRange = tokenRange();
             List<Range<Token>> rangeList = tokenRange != null ? ImmutableList.of(tokenRange) : null;
 
-            long nowInSec = FBUtilities.nowInSeconds();
+            long nowInSec = nowInSecondsSupplier.getAsLong();
             try (Refs<SSTableReader> refs = Refs.ref(actuallyCompact);
                  AbstractCompactionStrategy.ScannerList scanners = strategy.getScanners(actuallyCompact, rangeList);
                  AbstractCompactionPipeline ci = AbstractCompactionPipeline.create(this, compactionType, scanners, controller, nowInSec, taskId))

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -22,7 +22,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.LongPredicate;
 
@@ -35,25 +34,28 @@ import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.AbstractCompactionController;
 import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionPurger;
 import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.DeletionTime.ReusableDeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
-import org.apache.cassandra.db.ReusableLivenessInfo;
-import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
 import org.apache.cassandra.db.rows.BTreeRow;
 import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellLivenessInfo;
+import org.apache.cassandra.db.rows.CellLivenessInfo.Resolution;
 import org.apache.cassandra.db.rows.Cells;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
+import org.apache.cassandra.db.rows.ReusableCellLivenessInfo;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.UnfilteredRowIterators;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
-import org.apache.cassandra.dht.ReusableDecoratedKey;
+import org.apache.cassandra.io.sstable.ClusteringDescriptor;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.PartitionDescriptor;
 import org.apache.cassandra.io.sstable.SSTableCursorReader;
@@ -79,9 +81,8 @@ import static org.apache.cassandra.db.ClusteringPrefix.Kind.EXCL_START_BOUND;
 import static org.apache.cassandra.db.ClusteringPrefix.Kind.INCL_END_BOUND;
 import static org.apache.cassandra.db.ClusteringPrefix.Kind.INCL_END_EXCL_START_BOUNDARY;
 import static org.apache.cassandra.db.ClusteringPrefix.Kind.INCL_START_BOUND;
-import static org.apache.cassandra.db.compaction.CursorCompactor.CellResolution.COMPARE;
-import static org.apache.cassandra.db.compaction.CursorCompactor.CellResolution.LEFT;
-import static org.apache.cassandra.db.compaction.CursorCompactor.CellResolution.RIGHT;
+import static org.apache.cassandra.db.rows.CellLivenessInfo.Resolution.LEFT;
+import static org.apache.cassandra.db.rows.CellLivenessInfo.Resolution.RIGHT;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_END;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_HEADER_START;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_VALUE_START;
@@ -104,13 +105,16 @@ import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.isState;
  *   <li>Purge gc-able tombstones if possible (see PurgeFunction below).</li>
  *   <li>Invalidate cached partitions that are empty post-compaction. This avoids keeping partitions with
  *       only purgable tombstones in the row cache.</li>
- *   <li>Keep tracks of the compaction progress.</li>
+ *   <li>Keeps track of the compaction progress.</li>
  * </ul>
- * This compaction implementation does not support 2ndary indexes or trie indexes at this time.
+ * This compaction implementation does not support 2ndary indexes, trie (BTI) sstable output,
+ * complex (collection/UDT) columns, or counter columns, and it stands aside for a compaction that
+ * ignores gc grace for a key; see {@link #isSupported} and {@link #unsupportedMetadata} for the full
+ * set of gates.
  * <p>
-*     This compaction implmentation avoids garbage creation per partition/row/cell by utilizing reader/writer code
-*     which supports reusable copies of sstable entry components. The implementation consolidates and duplicates code
- *    from various classes to support the use of these reusable structures.
+ *     This compaction implementation avoids garbage creation per partition/row/cell by utilizing reader/writer code
+ *     which supports reusable copies of sstable entry components. The implementation consolidates and duplicates code
+ *     from various classes to support the use of these reusable structures.
  * </p>
  */
 public class CursorCompactor extends CompactionInfo.Holder
@@ -136,18 +140,36 @@ public class CursorCompactor extends CompactionInfo.Holder
                     if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Older sstable versions are not supported. version=" + version);
                     return false;
                 }
+                if (unsupportedHeaderColumns(metadata, reader))
+                    return false;
             }
         }
         // BTI index writing is not supported yet
         if (!(DatabaseDescriptor.getSelectedSSTableFormat() instanceof BigFormat))
         {
-            if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Only BIG sstable output format is supported. format=" + DatabaseDescriptor.getSelectedSSTableFormat());
+            if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Only the BIG sstable output format is supported. format=" + DatabaseDescriptor.getSelectedSSTableFormat());
             return false;
         }
         // TODO: Implement CompactionIterator.GarbageSkipper like functionality
         if (controller.tombstoneOption != CompactionParams.TombstoneOption.NONE)
         {
             if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Garbage skipping not implemented. controller.tombstoneOption=" + controller.tombstoneOption);
+            return false;
+        }
+        // ColumnFamilyStore.forceCompactionKeysIgnoringGcGrace, whose shipped caller is nodetool
+        // forcecompact, is the only thing that puts a key in this set, and so the only way a purge is
+        // decided with localDeletionTime >= gcBefore (see Purger.shouldPurge). That is the case the cursor
+        // cannot reproduce. BTreeRow.purge returns the row untouched whenever nowInSec is below the row's
+        // minimum local deletion time, so the iterator settles row-level purging all-or-nothing over the
+        // whole row before touching a cell, while a streaming cursor commits to the row's deletion and
+        // liveness before it has walked the row's cells. Under an ordinary gcBefore that short-circuit
+        // costs nothing, because such a row holds nothing purgeable either way.
+        // The set is per-table and lives for the whole force compaction, so a background compaction that
+        // starts inside that window falls back as well. Coarse, but the fallback is to the reference
+        // implementation, so it costs throughput and not correctness.
+        if (controller.cfs.shouldIgnoreGcGraceForAnyKey())
+        {
+            if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Ignoring gc_grace_seconds for a key is not supported (nodetool forcecompact).");
             return false;
         }
         if (LOGGER.isDebugEnabled()) LOGGER.debug("Cursor compaction for table: " + metadata.name + " keyspace: " + metadata.keyspace + " is supported.");
@@ -196,6 +218,47 @@ public class CursorCompactor extends CompactionInfo.Holder
         return false;
     }
 
+    /**
+     * {@link #unsupportedSchema} only sees the columns the table has NOW. Dropping a column
+     * removes it from {@link TableMetadata#regularAndStaticColumns()}, but every sstable written
+     * before the drop still lists it in that sstable's own serialization header, with its original
+     * type intact — {@code TableMetadata.recordColumnDrop} stores {@code type.expandUserTypes()},
+     * so a dropped non-frozen collection is still a multi-cell column there. The reader builds its
+     * column arrays from the header, not from the schema, so such a column reaches the cell cursor,
+     * which reads a single cell where the complex framing
+     * ({@code [complex deletion?][vint cellsCount][cells]}) requires a count-led run, and misparses
+     * the row.
+     *
+     * Whether that misparse then surfaces at all is not something the reader can decide sensibly:
+     * {@link #mergeCells} rejects complex columns outright, but reaching it depends on the
+     * dropped-column filter, and the timestamp that filter compares against the drop horizon was
+     * itself decoded from the misread framing rather than written by any cell. So the column is
+     * discarded silently or rejected loudly according to bytes that mean nothing here — neither
+     * outcome can be relied on, which is why the screening belongs at the gate.
+     *
+     * Dropping a non-frozen collection is legal and cursor compaction is on by default, so the
+     * schema check alone lets that misparse through. Screen the columns the readers will actually
+     * present. The fallback is permanent for this table: the ghost column stays in those headers
+     * until the pre-drop sstables are rewritten by the iterator path.
+     */
+    private static boolean unsupportedHeaderColumns(TableMetadata metadata, SSTableReader reader)
+    {
+        // RegularAndStaticColumns iterates statics then regulars, so this covers both
+        for (ColumnMetadata column : reader.header.columns())
+        {
+            // the header records its own type for any column whose type has since changed, so ask
+            // it as well as the schema: that is the type the reader will decode against
+            AbstractType<?> diskType = reader.header.getType(column);
+            if (column.isComplex() || column.isCounterColumn()
+                || (diskType != null && (diskType.isMultiCell() || diskType.isCounter())))
+            {
+                if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Complex and counter columns are not supported, and " + reader.descriptor + " still carries one in its header (dropped from the schema?). column=" + column);
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static void logDebugReason(TableMetadata metadata, String reason)
     {
         LOGGER.debug("Cursor compaction for table: " + metadata.name + " keyspace: " + metadata.keyspace + " is not supported. REASON: " + reason);
@@ -215,6 +278,16 @@ public class CursorCompactor extends CompactionInfo.Holder
     private final boolean[] sstableCursorsEqualsNext;
     private final boolean hasStaticColumns;
     private final boolean enforceStrictLiveness;
+
+    /**
+     * Scratch for {@link #anyMergedCellDeadAtNow}, which walks a row's cells and then puts the cursors
+     * back: the cursor ORDER and the equals-next flags its sorts overwrite, and the per-cursor state it
+     * needs to know which cursors to rewind. Null unless the table enforces strict liveness, so a
+     * non-view compaction does not allocate them at all.
+     */
+    private final StatefulCursor[] probeCursorOrder;
+    private final boolean[] probeEqualsNext;
+    private final int[] probeCursorState;
 
     // Keep targetDirectory for compactions, needed for `nodetool compactionstats`
     private volatile String targetDirectory;
@@ -242,7 +315,44 @@ public class CursorCompactor extends CompactionInfo.Holder
     final Purger purger;
 
     private StatefulCursor lastSource = null;
-    private final ReusableDecoratedKey detachedLastWrittenKey;
+    /**
+     * The PartitionDescriptor instance holding the last WRITTEN partition's header, owned by the write side.
+     * Obtained by swapping this field's previous contents into the writing cursor's prev slot, so the key is
+     * never copied. Non-final: it IS the floater, and every steal exchanges it.
+     */
+    private PartitionDescriptor lastWrittenPartition;
+    /**
+     * The cursor whose partition was written most recently, and from which the steal is still owed. Cleared by
+     * the steal, so a skipped partition leaves nothing to take and the held instance keeps describing the last
+     * partition actually written.
+     */
+    private StatefulCursor lastWrittenPartitionSource = null;
+    /** {@link StatefulCursor#partitionSwaps()} on that cursor at the moment the write happened. */
+    private long lastWrittenPartitionSourceSwaps = 0;
+    /**
+     * The UnfilteredDescriptor instance holding the last unfiltered WRITTEN to the current output partition,
+     * owned by the write side.
+     *
+     * sstableCursors[*].unfiltered() descriptors are reusable: a cursor overwrites its descriptor in place as
+     * soon as it reads its next unfiltered — including unfiltereds that then merge away or purge and never
+     * reach the output — so a reference borrowed during the merge loop can, by the time the partition closes,
+     * describe a clustering that was never written. This instance is obtained instead by swapping the field's
+     * previous contents into the writing cursor's slot, so the clustering is never copied. Non-final: it IS
+     * the floater, and every steal exchanges it.
+     */
+    private UnfilteredDescriptor lastWrittenUnfiltered;
+    /**
+     * Unfiltereds written to the current output partition, reset once per partition in
+     * {@link #mergePartitions}, immediately before the unfiltered loop rather than inside it.
+     *
+     * The zero case is load-bearing rather than an optimisation, because the instance above is
+     * compaction-global: for a partition written from only a partition-level deletion and/or a static row it
+     * still describes a PREVIOUS partition's unfiltered, so feeding it to the covered-clustering update would
+     * widen this output's Statistics.db slice to a clustering no partition of it holds there. On the very
+     * first partition it describes nothing at all — a fresh ClusteringDescriptor leaves its kind null, which
+     * would NPE in MetadataCollector rather than widen anything.
+     */
+    private int unfilteredsWrittenToPartition = 0;
 
     // Partition state. Writes can be delayed if the deletion is purged, or live and partition is empty -> LIVE deletion.
     PartitionDescriptor partitionDescriptor;
@@ -265,7 +375,14 @@ public class CursorCompactor extends CompactionInfo.Holder
     {
         this.controller = controller;
         this.type = type;
-        this.nowInSec = nowInSec;
+        // mirror CompactionIterator.purger(): accord-enabled (and accord-migrating) tables
+        // purge and expire relative to gcBefore — derived from accord's durability bounds by
+        // CompactionTask.getCompactionController — retaining data accord may still read at
+        // earlier timestamps; every nowInSec use below is a purge/expiry decision
+        TableMetadata tableMetadata = controller.cfs.metadata();
+        this.nowInSec = tableMetadata.isAccordEnabled() || tableMetadata.migratingFromAccord()
+                        ? controller.gcBefore
+                        : nowInSec;
         this.compactionId = compactionId;
 
         long inputBytes = 0;
@@ -290,7 +407,14 @@ public class CursorCompactor extends CompactionInfo.Holder
         this.activeCompactions.beginCompaction(this); // note that CompactionTask also calls this, but CT only creates CompactionIterator with a NOOP ActiveCompactions
 
         TableMetadata metadata = metadata();
-        this.hasStaticColumns = metadata.hasStaticColumns();
+        // the INPUT headers decide whether static rows can occur in this merge (and the output
+        // header, SerializationHeader.make, is their union): after ALTER TABLE ... DROP of the
+        // last static column, current metadata has no static columns but older sstables
+        // legitimately still carry static rows
+        boolean anyStaticColumns = false;
+        for (SSTableReader sstable : this.sstables)
+            anyStaticColumns |= sstable.header.hasStatic();
+        this.hasStaticColumns = anyStaticColumns;
         /**
          * Pipeline should end up similar to the one in {@link CompactionIterator}:
          * [MERGED -> ?TopPartitionTracker -> GarbageSkipper -> Purger -> org.apache.cassandra.db.transform.DuplicateRowChecker -> Abortable] -> next()
@@ -307,10 +431,41 @@ public class CursorCompactor extends CompactionInfo.Holder
         this.sstableCursors = convertScannersToCursors(scanners, sstables, DatabaseDescriptor.getCompactionReadDiskAccessMode());
         this.sstableCursorsEqualsNext = new boolean[sstables.size()];
         this.enforceStrictLiveness = controller.cfs.metadata.get().enforceStrictLiveness();
+        this.probeCursorOrder = enforceStrictLiveness ? new StatefulCursor[sstableCursors.length] : null;
+        this.probeEqualsNext = enforceStrictLiveness ? new boolean[sstableCursors.length] : null;
+        this.probeCursorState = enforceStrictLiveness ? new int[sstableCursors.length] : null;
 
-        purger = new Purger(type, controller, nowInSec);
+        purger = new Purger(type, controller);
 
-        detachedLastWrittenKey = metadata.partitioner.createReusableKey(128);
+        lastWrittenPartition = new PartitionDescriptor(metadata.partitioner.createReusableKey(0));
+        lastWrittenUnfiltered = new UnfilteredDescriptor(metadata.comparator.subtypes().toArray(AbstractType[]::new));
+        // The unfiltered steal hands one cursor's descriptor to another, and to the write side's instance built
+        // from the table comparator above, so all of them must PARSE a clustering identically. A descriptor
+        // parses with its OWN clusteringTypes and reads exactly two things from them, per column: whether the
+        // value is fixed-length, and how long (SSTableCursorReader.readUnfilteredClustering). That is what the
+        // assert covers.
+        assert clusteringParsingAgrees() : "the cursors disagree on how to parse a clustering: " + metadata;
+    }
+
+    /** @see #lastWrittenUnfiltered */
+    private boolean clusteringParsingAgrees()
+    {
+        AbstractType<?>[] writeSide = lastWrittenUnfiltered.clusteringTypes();
+        for (StatefulCursor cursor : sstableCursors)
+        {
+            AbstractType<?>[] readSide = cursor.unfiltered().clusteringTypes();
+            if (readSide.length != writeSide.length)
+                return false;
+            for (int i = 0; i < readSide.length; i++)
+            {
+                if (readSide[i].isValueLengthFixed() != writeSide[i].isValueLengthFixed())
+                    return false;
+                if (readSide[i].isValueLengthFixed()
+                    && readSide[i].valueLengthIfFixed() != writeSide[i].valueLengthIfFixed())
+                    return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -334,6 +489,10 @@ public class CursorCompactor extends CompactionInfo.Holder
             throw new CompactionInterruptedException(getCompactionInfo());
 
         int partitionMergeLimit = prepareAndSortForPartitionMerge();
+        // The round's slot advances have happened, so the steal owed by the last written partition is due. This
+        // sits ahead of the finish() exit because that path consumes the value too, through writerRollover's
+        // setLast; on it the advance came from resetAfterDone rather than from a read.
+        takeOwedPartitionSteal();
         if (partitionMergeLimit == 0)
         {
             finish();
@@ -347,7 +506,10 @@ public class CursorCompactor extends CompactionInfo.Holder
         try
         {
             DecoratedKey key = partitionDescriptor.key();
-            if (lastSource != null && currSource != lastSource && lastWrittenKey().compareTo(key) >= 0)
+            // The check begins once a partition has been written, because there is nothing to check against
+            // before that: no output exists to be out of order with, and no writer is created until the first
+            // write, so setLast is unreachable in that window.
+            if (hasWrittenPartition() && lastSource != null && currSource != lastSource && lastWrittenKey().compareTo(key) >= 0)
                 throw new IllegalStateException(String.format("Last written key %s >= current key %s", lastWrittenKey(), key));
 
             // needed if we actually write a partition, not used otherwise
@@ -358,15 +520,12 @@ public class CursorCompactor extends CompactionInfo.Holder
             if (!written)
             {
                 purger.onEmptyPartitionPostPurge();
-                // skipping a partition means the prevPartition on the lastSource is no longer stable, copy it
-                if (detachedLastWrittenKey.getKeyLength() == 0 && lastSource != null)
-                    detachedLastWrittenKey.copyKey(lastSource.prevKey().getKey());
             }
             else
             {
-                // last source has will have the prev key recorded, reset the copy
-                if (detachedLastWrittenKey.getKeyLength() != 0)
-                    detachedLastWrittenKey.reset();
+                // the steal is owed by this cursor, and lands one round later — see detachPrevPartition
+                lastWrittenPartitionSource = currSource;
+                lastWrittenPartitionSourceSwaps = currSource.partitionSwaps();
             }
             return written;
         }
@@ -403,7 +562,20 @@ public class CursorCompactor extends CompactionInfo.Holder
             int staticRowMergeLimit = prepareAndSortStaticForMerge(partitionMergeLimit);
             if (staticRowMergeLimit != 0)
             {
+                // No steal here, because this call's return value is not consumed -- but the consumed
+                // static descriptor is still in cursor 0's slot when the unfiltered loop below opens, and
+                // STATIC_CLUSTERING sorts ahead of every row, so that loop's first round calls mergeRows on
+                // it again, inside the branch that DOES steal; see the assert there for why that round
+                // writes nothing.
                 mergeRows(staticRowMergeLimit, activeDeletion, true, false);
+                // Without this, a cursor that had a static row is left at UNFILTERED_END with its
+                // unfiltered() descriptor still showing STATIC_CLUSTERING -- which sorts ahead of every
+                // real row -- so the normal-row loop below would sort it first and spuriously re-merge
+                // the same, already-fully-consumed position as a phantom regular row. Harmless to
+                // output (the phantom row has no new liveness/deletion, so it's dropped unwritten), but
+                // it inflates rowMergeCounters once per static-row partition, feeding
+                // system.compaction_history.rows_merged and the logged totalSourceRows.
+                continueReadingAfterMerge(staticRowMergeLimit, UNFILTERED_END);
             }
             if (isPartitionStarted())
             {
@@ -415,8 +587,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         // Merge any common normal rows
         int unfilteredMergeLimit = partitionMergeLimit;
         boolean isFirstUnfiltered = true;
-        int unfilteredCount = 0;
-        UnfilteredDescriptor lastClustering = null;
+        unfilteredsWrittenToPartition = 0;
         while (true)
         {
             unfilteredMergeLimit = prepareAndSortUnfilteredForMerge(partitionMergeLimit, unfilteredMergeLimit);
@@ -427,9 +598,24 @@ public class CursorCompactor extends CompactionInfo.Holder
             {
                 if (mergeRows(unfilteredMergeLimit, activeDeletion, false, isFirstUnfiltered))
                 {
+                    // The static descriptor reaches this loop — STATIC_CLUSTERING sorts ahead of every row —
+                    // and must never be WRITTEN from it: its clustering has length 0, so it belongs in neither
+                    // the covered-clustering slice nor an index block. What keeps it out is that the round
+                    // writes nothing, and it writes nothing only because CQL gives a static row no
+                    // primary-key liveness: UpdateStatement adds liveness inside updatesRegularRows(), and
+                    // DeleteStatement's static branch emits cell tombstones only, so the row is dropped.
+                    //
+                    // That is a property of the write path, not of this one, which is why it is asserted.
+                    // A static row that does carry liveness — PartitionUpdate.simpleBuilder's row() with no
+                    // clustering values produces one — reaches the write and hands the covered-clustering
+                    // max a STATIC_CLUSTERING, which fails in MetadataCollector.finalizeMetadata when the
+                    // sstable is closed. That failure predates the detach; the assert only moves it to the
+                    // point where the cause is still on the stack.
+                    assert sstableCursors[0].unfiltered().clusteringKind() != ClusteringPrefix.Kind.STATIC_CLUSTERING
+                         : "a static descriptor was written from the unfiltered loop";
                     isFirstUnfiltered = false;
-                    unfilteredCount++;
-                    lastClustering = sstableCursors[0].unfiltered();
+                    unfilteredsWrittenToPartition++;
+                    detachWrittenUnfiltered();
                 }
             }
             else if (UnfilteredSerializer.isTombstoneMarker(flags)) {
@@ -437,8 +623,8 @@ public class CursorCompactor extends CompactionInfo.Holder
                 if (mergeRangeTombstones(unfilteredMergeLimit, mergedDeletion, isFirstUnfiltered))
                 {
                     isFirstUnfiltered = false;
-                    unfilteredCount++;
-                    lastClustering = sstableCursors[0].unfiltered();
+                    unfilteredsWrittenToPartition++;
+                    detachWrittenUnfiltered();
                 }
                 if (activeOpenRangeDeletion == DeletionTime.LIVE) {
                     activeDeletion = mergedDeletion;
@@ -457,10 +643,15 @@ public class CursorCompactor extends CompactionInfo.Holder
         boolean partitionWritten = isPartitionStarted();
         if (partitionWritten)
         {
-            ssTableCursorWriter.writePartitionEnd(partitionDescriptor.keyBytes(), partitionDescriptor.keyLength(), toWritePartitionDeletion, partitionHeaderLength);
-            // update metadata tracking of min/max clustering on last unfiltered
-            if (unfilteredCount > 1) {
-                ssTableCursorWriter.updateClusteringMetadata(lastClustering);
+            // The trailing index block's last name and the covered-clustering max are the same value, the
+            // clustering of the last unfiltered written here; a partition that wrote none has no trailing
+            // block to cut, hence null.
+            ClusteringDescriptor lastName = unfilteredsWrittenToPartition > 0 ? lastWrittenClustering() : null;
+            ssTableCursorWriter.writePartitionEnd(partitionDescriptor.keyBytes(), partitionDescriptor.keyLength(), toWritePartitionDeletion, partitionHeaderLength, lastName);
+            // update metadata tracking of min/max clustering on last unfiltered. The count guard is
+            // load-bearing rather than an optimisation — see unfilteredsWrittenToPartition.
+            if (unfilteredsWrittenToPartition > 1) {
+                ssTableCursorWriter.updateClusteringMetadata(lastName);
             }
         }
         // move along
@@ -529,6 +720,11 @@ public class CursorCompactor extends CompactionInfo.Holder
 
         LivenessInfo mergedRowInfo = row.livenessInfo();
         DeletionTime mergedRowDeletion = row.deletionTime();
+        // Row.Deletion.isShadowable(): deprecated (CASSANDRA-11500), reachable only on old
+        // Materialized View data. Tracked alongside mergedRowDeletion because the shadowing step
+        // below reads it, and because it has to survive to the output write attached to whichever
+        // deletion wins.
+        boolean mergedRowShadowable = row.isShadowableDeletion();
 
         for (int i = 1; i < rowMergeLimit; i++)
         {
@@ -538,26 +734,77 @@ public class CursorCompactor extends CompactionInfo.Holder
             if (row.livenessInfo().supersedes(mergedRowInfo))
                 mergedRowInfo = row.livenessInfo();
             if (row.deletionTime().supersedes(mergedRowDeletion))
+            {
                 mergedRowDeletion = row.deletionTime();
+                mergedRowShadowable = row.isShadowableDeletion();
+            }
+        }
+
+        /**
+         * {@link Row.Deletion#isShadowedBy(LivenessInfo)}, applied where
+         * {@link Row.Merger#merge(DeletionTime)} applies it: after the N-way merge and BEFORE the
+         * active-deletion comparison below. A shadowable deletion yields to a primary-key liveness that
+         * postdates it, so the row keeps the cells the deletion would otherwise shadow — and the output
+         * carries neither the deletion nor its {@code HAS_SHADOWABLE_DELETION} extension flag.
+         *
+         * Safe against exposing a cell the deletion itself shadowed: {@code BTreeRow.Builder} drops such
+         * cells at write time, so no on-disk row carries one for this step to uncover.
+         */
+        if (mergedRowShadowable && mergedRowInfo.timestamp() > mergedRowDeletion.markedForDeleteAt())
+        {
+            mergedRowDeletion = DeletionTime.LIVE;
+            mergedRowShadowable = false; // a live deletion is never shadowable
         }
 
         /**
          * See: {@link BTreeRow#purge(DeletionPurger, long, boolean)}
          */
         DeletionTime rowActiveDeletion = partitionActiveDeletion;
+        // Whether BTreeRow.purge's hasDeletion(nowInSec) guard would be open for reasons OTHER than the
+        // row's cells; see the strict-liveness branch below for why only the purger's two clearances
+        // count here.
+        boolean rowHasDeletionAtNow = false;
         if (mergedRowDeletion.supersedes(rowActiveDeletion))
         {
             rowActiveDeletion = mergedRowDeletion; // deletion is in effect before purge takes effect
-            mergedRowDeletion = purger.shouldPurge(mergedRowDeletion) ? DeletionTime.LIVE : mergedRowDeletion;
+            if (purger.shouldPurge(mergedRowDeletion))
+            {
+                mergedRowDeletion = DeletionTime.LIVE;
+                mergedRowShadowable = false; // a live deletion is never shadowable
+                rowHasDeletionAtNow = true;
+            }
         }
         else
         {
             // partition delete takes over
             mergedRowDeletion = DeletionTime.LIVE;
+            mergedRowShadowable = false; // a live deletion is never shadowable
         }
 
-        if (rowActiveDeletion.deletes(mergedRowInfo) || purger.shouldPurge(mergedRowInfo, nowInSec))
+        // Split from the single disjunction it reads as so the strict-liveness branch below can tell the
+        // two clearances apart: the reference's minLocalDeletionTime is computed AFTER the active
+        // deletion has emptied the liveness and BEFORE the purger runs, so only a purger clearance is
+        // visible to it. Splitting is behaviour-neutral, the assignment of the EMPTY singleton over an
+        // already-empty liveness included: an empty liveness carries NO_TIMESTAMP, which is
+        // Long.MIN_VALUE, so DeletionTime.deletes reports every deletion as deleting it and the first
+        // branch is always the one taken.
+        if (rowActiveDeletion.deletes(mergedRowInfo))
         {
+            mergedRowInfo = LivenessInfo.EMPTY;
+        }
+        else if (purger.shouldPurge(mergedRowInfo, nowInSec))
+        {
+            // A purged liveness contributed a reference term at or below nowInSec, so the guard is open.
+            // Not because "not live at nowInSec" implies an expiration at or below it -- an
+            // EXPIRED_LIVENESS_TTL move marker is not live at any nowInSec while its localExpirationTime
+            // can be above it, and ReusableLivenessInfo.isLive answers on that flag. It is because
+            // shouldPurge requires localDeletionTime < gcBefore, and gcBefore <= nowInSec on every path
+            // that reaches here: gcBefore is now - gc_grace with gc_grace non-negative, and an
+            // accord-enabled table takes nowInSec := gcBefore outright. The one escape from
+            // localDeletionTime < gcBefore is ignoreGcGraceSeconds -- and isSupported refuses the table
+            // while any key ignores gc grace, so that gate is load-bearing for this arm too, which is
+            // why it is named here.
+            rowHasDeletionAtNow |= !mergedRowInfo.isEmpty();
             mergedRowInfo = LivenessInfo.EMPTY;
         }
 
@@ -565,10 +812,37 @@ public class CursorCompactor extends CompactionInfo.Holder
 
         if (!isRowDropped)
         {
-            lateStartRow(mergedRowInfo, mergedRowDeletion, isStatic);
+            lateStartRow(mergedRowInfo, mergedRowDeletion, mergedRowShadowable, isStatic);
         }
 
-        if (isRowDropped && enforceStrictLiveness)
+        /**
+         * Strict liveness ({@link org.apache.cassandra.schema.TableMetadata#enforceStrictLiveness}, true
+         * only for a view whose primary key holds a base non-PK column) drops a row with no primary-key
+         * liveness and no row deletion -- but {@link BTreeRow#purge} reaches that drop only past its
+         * opening {@code if (!hasDeletion(nowInSec)) return this;}, i.e. only when
+         * {@code nowInSec >= minLocalDeletionTime} of the MERGED row. Without that precondition the
+         * cursor deleted rows the iterator returns untouched, cells included.
+         *
+         * {@code minLocalDeletionTime} is the minimum of three terms, all taken on the merged row as
+         * {@link Row.Merger#merge} leaves it -- after the active deletion has emptied the liveness and
+         * cleared the deletion it does not outrank, and before the purger runs:
+         *
+         *   liveness: {@code isExpiring() ? localExpirationTime() : Cell.MAX_DELETION_TIME}
+         *   deletion: {@code isLive() ? Cell.MAX_DELETION_TIME : Long.MIN_VALUE}
+         *   cells:    {@code Long.MIN_VALUE} for a tombstone, else the cell's local deletion time
+         *
+         * Reaching this branch at all means the post-purge deletion is live and the post-purge liveness
+         * empty, which collapses the first two terms to the purger's own two clearances. If the purger
+         * cleared the deletion, the pre-purge deletion was not live and the deletion term is
+         * {@code Long.MIN_VALUE}. If it cleared the liveness, the liveness was not live at
+         * {@code nowInSec}, which for a non-empty liveness means expiring and expired, so the liveness
+         * term is at or below {@code nowInSec}. Either way the guard is open. Otherwise both terms are
+         * {@code Cell.MAX_DELETION_TIME} and the cells decide it alone -- which is what
+         * {@link #anyMergedCellDeadAtNow} answers, and why it is only consulted when neither clearance
+         * fired.
+         */
+        if (isRowDropped && enforceStrictLiveness
+            && (rowHasDeletionAtNow || anyMergedCellDeadAtNow(rowMergeLimit, rowActiveDeletion, isStatic)))
         {
             skipRowsOnStrictLiveness(rowMergeLimit, isStatic);
         }
@@ -620,6 +894,97 @@ public class CursorCompactor extends CompactionInfo.Holder
         }
     }
 
+    /**
+     * Whether the merged row carries any cell that is not live at {@code nowInSec} — a cell tombstone,
+     * or an expiring cell already past its expiry. That is the cells' contribution to
+     * {@link BTreeRow#purge}'s {@code hasDeletion(nowInSec)} guard: {@code Cell.minDeletionTime()} is
+     * {@code Long.MIN_VALUE} for a tombstone and the local deletion time otherwise, and
+     * {@code Cell.NO_DELETION_TIME} for a plain live cell, so "at or below {@code nowInSec}" and "not
+     * live at {@code nowInSec}" name the same cells.
+     *
+     * Only the merge WINNER of each column counts, because only the winner reaches the reference's
+     * merged row, and only if it survives the active deletion — which the reference applies before
+     * reconciling. Taking the winner across all cells and then testing it against the active deletion is
+     * the same answer: the winner carries the greatest timestamp, so if the active deletion deletes it,
+     * it deletes every cell of that column and the column contributes nothing. The winner is decided by
+     * {@link CellLivenessInfo#resolve} alone, and its {@code COMPARE} verdict never leaves the two sides
+     * disagreeing about being live: it is returned either because both carry
+     * {@code Cell.NO_DELETION_TIME}, which makes both live outright, or because they agree on timestamp,
+     * deletion time and TTL. So the value comparison this skips cannot move the answer.
+     *
+     * <b>Walks the row's cells and rewinds every cursor it moved</b>, so the caller's own cell loop runs
+     * against the state it would have seen had the probe not run — the cursor ORDER and the equals-next
+     * flags included, which the cell sorts below overwrite; restoring both is defensive rather than
+     * provably needed, since the real loop's first sort re-sorts the whole group anyway. Only reached
+     * under {@code enforceStrictLiveness}, so no non-view compaction pays for the second walk or its
+     * scratch. Decided as soon as one dead cell is found, so this is the one walk that always runs to
+     * the end of the row.
+     */
+    private boolean anyMergedCellDeadAtNow(int rowMergeLimit, DeletionTime rowActiveDeletion, boolean isStatic)
+    {
+        System.arraycopy(sstableCursors, 0, probeCursorOrder, 0, rowMergeLimit);
+        System.arraycopy(sstableCursorsEqualsNext, 0, probeEqualsNext, 0, rowMergeLimit);
+        for (int i = 0; i < rowMergeLimit; i++)
+            probeCursorState[i] = sstableCursors[i].state();
+
+        boolean anyDead = false;
+        int cellMergeLimit = rowMergeLimit;
+        while (!anyDead)
+        {
+            for (int i = 0; i < cellMergeLimit; i++)
+            {
+                if (sstableCursors[i].state() == CELL_HEADER_START)
+                    sstableCursors[i].readCellHeader();
+            }
+            cellMergeLimit = prepareAndSortCellsForMerge(rowMergeLimit, cellMergeLimit);
+            if (cellMergeLimit == 0)
+                break;
+
+            ReusableCellLivenessInfo winner = sstableCursors[0].cellCursor().cellLiveness;
+            for (int i = 1; i < cellMergeLimit; i++)
+            {
+                ReusableCellLivenessInfo challenger = sstableCursors[i].cellCursor().cellLiveness;
+                if (CellLivenessInfo.resolve(winner, challenger) == RIGHT)
+                    winner = challenger;
+            }
+            anyDead = !rowActiveDeletion.deletesCellAt(winner.timestamp()) && !winner.isLive(nowInSec);
+
+            for (int i = 0; i < cellMergeLimit; i++)
+            {
+                if (sstableCursors[i].state() == CELL_VALUE_START)
+                    sstableCursors[i].skipCellValue();
+            }
+            continueReadingAfterMerge(cellMergeLimit, CELL_END);
+        }
+
+        System.arraycopy(probeCursorOrder, 0, sstableCursors, 0, rowMergeLimit);
+        System.arraycopy(probeEqualsNext, 0, sstableCursorsEqualsNext, 0, rowMergeLimit);
+        for (int i = 0; i < rowMergeLimit; i++)
+        {
+            // Every member of the group is at CELL_HEADER_START if it has a cell in this row, else
+            // UNFILTERED_END: the row-header loaders return only those two, and every member has been
+            // through one. It is the sort ORDER that keeps other states out, not a throw -- both
+            // comparators pass PARTITION_END and sort it to the back, so it either empties the group or
+            // ends it before itself; and compareByStatic sorts STATIC_ROW_START ahead of every non-static
+            // cursor, so a static group is all-static and prepareAndSortStaticForMerge has loaded every
+            // member of it.
+            // Only the first state needs rewinding, and only the first CAN be -- rewindRowCells restores
+            // the walk to the row's FIRST cell, so a cursor recorded mid-row would have its earlier cells
+            // re-presented to the merge. Asserted rather than tolerated for that reason. With assertions
+            // off a mid-row cursor is left where the probe put it, and the cell-desync check catches that
+            // only when the probe's walk had RUN OUT the row, which clears unfilteredEnd; on the
+            // early-exit path -- the one a dropped row usually takes -- the second walk consumes to the
+            // same declared end and the missing cells go unreported. That asymmetry is the reason the
+            // assert is here rather than a tolerated branch.
+            int recordedState = probeCursorState[i];
+            assert recordedState == CELL_HEADER_START || recordedState == UNFILTERED_END
+                 : "unexpected merge-group state before the strict-liveness probe: " + sstableCursors[i];
+            if (recordedState == CELL_HEADER_START)
+                sstableCursors[i].rewindRowCells(isStatic);
+        }
+        return anyDead;
+    }
+
     private DataOutputBuffer tempCellBuffer1 = new DataOutputBuffer();
     private DataOutputBuffer tempCellBuffer2 = new DataOutputBuffer();
     private final byte[] copyColumnValueBuffer = new byte[4096]; // used to copy cell contents (maybe piecemeal if very large, since we don't have a direct read option)
@@ -636,7 +1001,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         // TODO: handle counters/complex cells
         StatefulCursor cellSource = sstableCursors[0];
         SSTableCursorReader.CellCursor cellCursor = cellSource.cellCursor();
-        ReusableLivenessInfo cellLiveness = cellCursor.cellLiveness;
+        ReusableCellLivenessInfo cellLiveness = cellCursor.cellLiveness;
         DataOutputBuffer tempCellBuffer = null;
 
         if (cellCursor.cellColumn.isComplex())
@@ -645,14 +1010,17 @@ public class CursorCompactor extends CompactionInfo.Holder
             throw new UnsupportedOperationException("TODO: Not ready for counter cells.");
 
         /** See: {@link Cells#reconcile(Cell, Cell)} */
-        // Find latest cell value/delete info, only one cell can win(for now... same timestamp handling awaits)!
+        // Find the winning cell across sources: CellLivenessInfo.resolve is the full decision the reference
+        // path takes, including the same-timestamp tie-breaks (deleted/expiring beats live, greater deletion
+        // time, lower TTL), and COMPARE is the value comparison it defers to us. No narrowing needed here,
+        // unlike Cells.resolveRegular: ReusableCellLivenessInfo has no subclasses to pollute the profile.
         for (int i = 1; i < cellMergeLimit; i++)
         {
             StatefulCursor oCellSource = sstableCursors[i];
             SSTableCursorReader.CellCursor oCellCursor = oCellSource.cellCursor();
-            ReusableLivenessInfo oCellLiveness = oCellCursor.cellLiveness;
+            ReusableCellLivenessInfo oCellLiveness = oCellCursor.cellLiveness;
 
-            CellResolution cellResolution = resolveRegular(cellLiveness, oCellLiveness);
+            Resolution cellResolution = CellLivenessInfo.resolve(cellLiveness, oCellLiveness);
             if (cellResolution == LEFT) {
                 if (oCellSource.state() == CELL_VALUE_START) oCellSource.skipCellValue();
             }
@@ -664,7 +1032,7 @@ public class CursorCompactor extends CompactionInfo.Holder
                 tempCellBuffer = null;
             }
             else { // COMPARE
-                if (activeDeletion.deletes(oCellLiveness)) {
+                if (activeDeletion.deletesCellAt(oCellLiveness.timestamp())) {
                     if (oCellSource.state() == CELL_VALUE_START) oCellSource.skipCellValue();
                 }
                 else {
@@ -690,9 +1058,25 @@ public class CursorCompactor extends CompactionInfo.Holder
                     if (oCellSource.state() == CELL_VALUE_START)
                         oCellSource.copyCellValue(tempCellBuffer2, copyColumnValueBuffer);
 
-                    int compare = Arrays.compareUnsigned(tempCellBuffer1.getData(), 0, tempCellBuffer1.getLength(), tempCellBuffer2.getData(), 0, tempCellBuffer2.getLength());
-                    if (compare >= 0) {
-                        // swap the buffers
+                    // Matches Cells.resolveRegular: left (the current winner) wins ties, the
+                    // challenger only wins with a strictly greater value
+                    // (compareValues(left, right) >= 0 ? left : right). The reference
+                    // comparison is over the RAW value bytes (ValueAccessor.compare, plain
+                    // unsigned lexicographic): these buffers hold the WIRE form, which for
+                    // variable-length types carries a leading length vint — comparing that
+                    // prefix orders by LENGTH first (the vint's leading byte encodes it) and
+                    // picks the wrong winner for ties between different-length values.
+                    // Fixed-length types carry no vint (and equal lengths).
+                    int skip1 = 0, skip2 = 0;
+                    if (cellCursor.cellType.valueLengthIfFixed() < 0)
+                    {
+                        skip1 = tempCellBuffer1.getLength() == 0 ? 0 : wireVintSize(tempCellBuffer1.getData()[0]);
+                        skip2 = tempCellBuffer2.getLength() == 0 ? 0 : wireVintSize(tempCellBuffer2.getData()[0]);
+                    }
+                    int compare = Arrays.compareUnsigned(tempCellBuffer1.getData(), skip1, tempCellBuffer1.getLength(),
+                                                         tempCellBuffer2.getData(), skip2, tempCellBuffer2.getLength());
+                    if (compare < 0) {
+                        // challenger wins: swap buffers so tempCellBuffer1 holds the winner's value
                         tempCellBuffer = tempCellBuffer1;
                         tempCellBuffer1 = tempCellBuffer2;
                         tempCellBuffer2 = tempCellBuffer;
@@ -737,7 +1121,7 @@ public class CursorCompactor extends CompactionInfo.Holder
             }
         }
 
-        if (activeDeletion.deletes(cellLiveness) || purger.shouldPurge(cellLiveness, nowInSec))
+        if (activeDeletion.deletesCellAt(cellLiveness.timestamp()) || purger.shouldPurge(cellLiveness, nowInSec))
         {
             if (Cell.Serializer.hasValue(cellFlags))
             {
@@ -763,17 +1147,19 @@ public class CursorCompactor extends CompactionInfo.Holder
                 isRowDropped = false;
                 lateStartRow(isStatic);
             }
-            /** {@link org.apache.cassandra.db.rows.Cell.Serializer#serialize(Cell, ColumnMetadata, DataOutputPlus, LivenessInfo, SerializationHeader)} */
+            /** {@link org.apache.cassandra.db.rows.Cell.Serializer#serialize(Cell, ColumnMetadata, DataOutputPlus, LivenessInfo, org.apache.cassandra.db.SerializationHeader)} */
             boolean isDeleted = cellLiveness.isTombstone();
+            // Cell.Serializer treats deleted/expiring as mutually exclusive (else-if below), so a
+            // tombstone must never carry IS_EXPIRING or a TTL field.
             boolean isExpiring = cellLiveness.isExpiring();
             boolean useRowTimestamp = !rowLiveness.isEmpty() && cellLiveness.timestamp() == rowLiveness.timestamp();
             boolean useRowTTL = isExpiring && rowLiveness.isExpiring() &&
                                 cellLiveness.ttl() == rowLiveness.ttl() &&
-                                cellLiveness.localExpirationTime() == rowLiveness.localExpirationTime();
+                                cellLiveness.localDeletionTime() == rowLiveness.localExpirationTime();
             // Re-write cell flags to reflect resulting contents
             cellFlags &= Cell.Serializer.HAS_EMPTY_VALUE_MASK;
             if (isDeleted) cellFlags |= Cell.Serializer.IS_DELETED_MASK;
-            if (isExpiring) cellFlags |= Cell.Serializer.IS_EXPIRING_MASK;
+            else if (isExpiring) cellFlags |= Cell.Serializer.IS_EXPIRING_MASK;
             if (useRowTimestamp) cellFlags |= Cell.Serializer.USE_ROW_TIMESTAMP_MASK;
             if (useRowTTL) cellFlags |= Cell.Serializer.USE_ROW_TTL_MASK;
             ssTableCursorWriter.writeCellHeader(cellFlags, cellLiveness, cellSource.cellCursor().cellColumn);
@@ -797,50 +1183,15 @@ public class CursorCompactor extends CompactionInfo.Holder
         return isRowDropped;
     }
 
-    enum CellResolution
+    /**
+     * Byte length of the leading unsigned vint in a wire-form variable-length value:
+     * non-negative first byte = single-byte vint (VIntCoding's own callers guard the same
+     * way before consulting numberOfExtraBytesToRead, which expects the SIGNED byte).
+     */
+    private static int wireVintSize(byte firstByte)
     {
-        LEFT, RIGHT, COMPARE
-    }
-
-    private static CellResolution resolveRegular(LivenessInfo left, LivenessInfo right)
-    {
-        long leftTimestamp = left.timestamp();
-        long rightTimestamp = right.timestamp();
-        if (leftTimestamp != rightTimestamp)
-            return leftTimestamp > rightTimestamp ? LEFT : RIGHT;
-
-        long leftLocalDeletionTime = left.localExpirationTime();
-        long rightLocalDeletionTime = right.localExpirationTime();
-
-        boolean leftIsExpiringOrTombstone = leftLocalDeletionTime != Cell.NO_DELETION_TIME;
-        boolean rightIsExpiringOrTombstone = rightLocalDeletionTime != Cell.NO_DELETION_TIME;
-
-        if (leftIsExpiringOrTombstone | rightIsExpiringOrTombstone)
-        {
-            // Tombstones always win reconciliation with live cells of the same timstamp
-            // CASSANDRA-14592: for consistency of reconciliation, regardless of system clock at time of reconciliation
-            // this requires us to treat expiring cells (which will become tombstones at some future date) the same wrt regular cells
-            if (leftIsExpiringOrTombstone != rightIsExpiringOrTombstone)
-                return leftIsExpiringOrTombstone ? LEFT : RIGHT;
-
-            // for most historical consistency, we still prefer tombstones over expiring cells.
-            // While this leads to an inconsistency over which is chosen
-            // (i.e. before expiry, the pure tombstone; after expiry, whichever is more recent)
-            // this inconsistency has no user-visible distinction, as at this point they are both logically tombstones
-            // (the only possible difference is the time at which the cells become purgeable)
-            boolean leftIsTombstone = !left.isExpiring(); // !isExpiring() == isTombstone(), but does not need to consider localDeletionTime()
-            boolean rightIsTombstone = !right.isExpiring();
-            if (leftIsTombstone != rightIsTombstone)
-                return leftIsTombstone ? LEFT : RIGHT;
-
-            // ==> (leftIsExpiring && rightIsExpiring) or (leftIsTombstone && rightIsTombstone)
-            // if both are expiring, we do not want to consult the value bytes if we can avoid it, as like with C-14592
-            // the value bytes implicitly depend on the system time at reconciliation, as a
-            // would otherwise always win (unless it had an empty value), until it expired and was translated to a tombstone
-            if (leftLocalDeletionTime != rightLocalDeletionTime)
-                return leftLocalDeletionTime > rightLocalDeletionTime ? LEFT : RIGHT;
-        }
-        return COMPARE;
+        return firstByte >= 0 ? 1
+               : 1 + org.apache.cassandra.utils.vint.VIntCoding.numberOfExtraBytesToRead(firstByte);
     }
 
     DeletionTime activeOpenRangeDeletion = DeletionTime.LIVE;
@@ -1090,16 +1441,16 @@ public class CursorCompactor extends CompactionInfo.Holder
 
     private void lateStartRow(boolean isStatic) throws IOException
     {
-        lateStartRow(LivenessInfo.EMPTY, DeletionTime.LIVE, isStatic);
+        lateStartRow(LivenessInfo.EMPTY, DeletionTime.LIVE, false, isStatic);
     }
 
-    private void lateStartRow(LivenessInfo livenessInfo, DeletionTime deletionTime, boolean isStatic) throws IOException
+    private void lateStartRow(LivenessInfo livenessInfo, DeletionTime deletionTime, boolean isShadowable, boolean isStatic) throws IOException
     {
         if (isPartitionStartDelayed())
         {
             lateStartPartition(isStatic);
         }
-        ssTableCursorWriter.writeRowStart(livenessInfo, deletionTime, isStatic);
+        ssTableCursorWriter.writeRowStart(livenessInfo, deletionTime, isShadowable, isStatic);
     }
 
     private void lateStartPartition(boolean isStatic) throws IOException
@@ -1147,12 +1498,60 @@ public class CursorCompactor extends CompactionInfo.Holder
         ssTableCursorWriter = null;
     }
 
+    private boolean hasWrittenPartition()
+    {
+        return lastWrittenPartition.keyLength() != 0;
+    }
+
     private DecoratedKey lastWrittenKey()
     {
-        if (detachedLastWrittenKey.getKeyLength() != 0)
-            return detachedLastWrittenKey;
-        else
-            return lastSource.prevKey();
+        assert hasWrittenPartition() : "no partition has been written yet";
+        return lastWrittenPartition.key();
+    }
+
+    /**
+     * Takes the owed steal, if any. Called at the top of a round, after the prepare-and-sort that performs the
+     * round's reads and before either consumer of the value: the writer-order check below, and
+     * {@code writerRollover}'s setLast reached from startPartition or from finish().
+     *
+     * The deferral is what makes it correct. On the cursor that wrote key k1, the round that reads k2 has
+     * already swapped k1 into prev and compared it against k2, so prev is consumed and can be taken; the next
+     * round swaps k2 into prev and loads k3 into the floater we handed back. Exactly one read must have
+     * happened in between, which the assert states.
+     */
+    private void takeOwedPartitionSteal()
+    {
+        if (lastWrittenPartitionSource == null)
+            return;
+        assert lastWrittenPartitionSource.partitionSwaps() == lastWrittenPartitionSourceSwaps + 1
+             : "the partition steal is not one slot advance behind its write: now "
+               + lastWrittenPartitionSource.partitionSwaps() + ", was " + lastWrittenPartitionSourceSwaps;
+        lastWrittenPartition = lastWrittenPartitionSource.detachPrevPartition(lastWrittenPartition);
+        lastWrittenPartitionSource = null;
+    }
+
+    /**
+     * Takes the instance describing the unfiltered just written from the cursor it was read into, handing that
+     * cursor the floater in exchange.
+     *
+     * sstableCursors[0] is the source because it is the instance the output was written from: the merged group
+     * shares one clustering, mergeRows writes cursor 0's descriptor, and mergeRangeTombstones stomps the
+     * clustering kind on that same instance before writing it — which the covered-clustering update then keys
+     * its boundary skip on.
+     *
+     * Immediate, not deferred by a round like the partition steal — see
+     * {@link StatefulCursor#detachUnfiltered} for why that is safe with a single slot.
+     */
+    private void detachWrittenUnfiltered()
+    {
+        lastWrittenUnfiltered = sstableCursors[0].detachUnfiltered(lastWrittenUnfiltered);
+    }
+
+    /** The clustering of the last unfiltered written to the current output partition. */
+    private ClusteringDescriptor lastWrittenClustering()
+    {
+        assert unfilteredsWrittenToPartition > 0 : "no unfiltered has been written to this partition";
+        return lastWrittenUnfiltered;
     }
 
     // SORT AND COMPARE
@@ -1220,7 +1619,7 @@ public class CursorCompactor extends CompactionInfo.Holder
             return 0;
         }
 
-        sortPerturbedCursors(perturbedCursors, sstableCursors.length, CursorCompactor::compareByPartitionKey);
+        PARTITION_KEY_SORT.sortPerturbed(sstableCursors, sstableCursorsEqualsNext, perturbedCursors, sstableCursors.length);
         // top cursor is DONE -> all cursors are DONE
         int state = sstableCursors[0].state();
         if(state == DONE)
@@ -1260,7 +1659,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         }
 
         // Sort rows by their clustering
-        sortPerturbedCursors(prevMergeLimit, partitionMergeLimit, CursorCompactor::compareByRowClustering);
+        ROW_CLUSTERING_SORT.sortPerturbed(sstableCursors, sstableCursorsEqualsNext, prevMergeLimit, partitionMergeLimit);
         int state = sstableCursors[0].state();
         if (state == PARTITION_END)
         {
@@ -1278,7 +1677,7 @@ public class CursorCompactor extends CompactionInfo.Holder
 
     private int prepareAndSortStaticForMerge(int partitionMergeLimit) throws IOException
     {
-        sortPerturbedCursors(partitionMergeLimit, partitionMergeLimit, CursorCompactor::compareByStatic);
+        STATIC_SORT.sortPerturbed(sstableCursors, sstableCursorsEqualsNext, partitionMergeLimit, partitionMergeLimit);
         int state = sstableCursors[0].state();
         if (state != STATIC_ROW_START)
         {
@@ -1304,7 +1703,7 @@ public class CursorCompactor extends CompactionInfo.Holder
 
     private int prepareAndSortCellsForMerge(int rowMergeLimit, int prevCellMergeLimit)
     {
-        sortPerturbedCursors(prevCellMergeLimit, rowMergeLimit, CursorCompactor::compareByColumn);
+        COLUMN_SORT.sortPerturbed(sstableCursors, sstableCursorsEqualsNext, prevCellMergeLimit, rowMergeLimit);
         // next row/partition/done
         if (sstableCursors[0].state() == UNFILTERED_END)
             return 0;
@@ -1321,6 +1720,19 @@ public class CursorCompactor extends CompactionInfo.Holder
         }
         return cellMergeLimit;
     }
+
+    // One dedicated, separately-compiled sort per comparison kind (see PreSortedBubbleInsert's
+    // javadoc): each singleton is only ever constructed with its own compareByXxx reference, so
+    // its copy's comparator.compare() call site stays monomorphic/inlinable instead of megamorphic
+    // across all 4 comparators sharing one call site.
+    private static final PartitionKeyMergeSort<StatefulCursor> PARTITION_KEY_SORT =
+        new PartitionKeyMergeSort<>(CursorCompactor::compareByPartitionKey);
+    private static final RowClusteringMergeSort<StatefulCursor> ROW_CLUSTERING_SORT =
+        new RowClusteringMergeSort<>(CursorCompactor::compareByRowClustering);
+    private static final StaticMergeSort<StatefulCursor> STATIC_SORT =
+        new StaticMergeSort<>(CursorCompactor::compareByStatic);
+    private static final ColumnMergeSort<StatefulCursor> COLUMN_SORT =
+        new ColumnMergeSort<>(CursorCompactor::compareByColumn);
 
     private static int compareByPartitionKey(StatefulCursor c1, StatefulCursor c2)
     {
@@ -1393,8 +1805,6 @@ public class CursorCompactor extends CompactionInfo.Holder
      */
     static class Purger implements DeletionPurger
     {
-        private final long nowInSec;
-
         private final long oldestUnrepairedTombstone;
         private final boolean onlyPurgeRepairedTombstones;
         private final boolean shouldIgnoreGcGraceForAnyKey;
@@ -1408,12 +1818,11 @@ public class CursorCompactor extends CompactionInfo.Holder
 
         private long compactedUnfiltered;
 
-        Purger(OperationType type, AbstractCompactionController controller, long nowInSec)
+        Purger(OperationType type, AbstractCompactionController controller)
         {
             oldestUnrepairedTombstone = controller.compactingRepaired() ? Long.MAX_VALUE : Integer.MIN_VALUE;
             onlyPurgeRepairedTombstones = controller.cfs.getCompactionStrategyManager().onlyPurgeRepairedTombstones();
             shouldIgnoreGcGraceForAnyKey = controller.cfs.shouldIgnoreGcGraceForAnyKey();
-            this.nowInSec = nowInSec;
             this.controller = controller;
             this.type = type;
         }
@@ -1611,66 +2020,4 @@ public class CursorCompactor extends CompactionInfo.Holder
         }
     }
 
-    private void sortPerturbedCursors(int perturbedLimit, int mergeLimit, Comparator<? super StatefulCursor> comparator) {
-        for (; perturbedLimit > 0; perturbedLimit--) {
-            bubbleInsertElementToPreSorted(sstableCursors, sstableCursorsEqualsNext, perturbedLimit, mergeLimit, comparator);
-        }
-    }
-
-    /**
-     * Use bubble sort to insert the <code>sortedFrom - 1</code> element into a pre-sorted array, and track element
-     * equality to next element to help in finding merge ranges.
-     * </p>
-     * We use this method to sort the cursor array on 3 levels:
-     * <ul>
-     *     <li>Partition - insert sort the newly read partitions into the full list, comparing on pKey</li>
-     *     <li>Unfiltered - insert sort the newly read rows into the sub-list of merging partitions, comparing on clustering</li>
-     *     <li>Cell - insert sort the newly read cells into the sub-list of merging rows, comparing on column</li>
-     * </ul>
-     *
-     * @param preSortedArray partially pre-sorted array of elements to be sorted in place
-     * @param equalsNext tracking the equality between each element and the next in the sorted array
-     * @param sortedFrom elements from <code>sortedFrom</code> are assumed sorted
-     * @param sortedTo the limit of our sort effort
-     * @param comparator comparing elements in the array
-     * @param <T> element type
-     */
-    public static <T> void bubbleInsertElementToPreSorted(T[] preSortedArray,
-                                                          boolean[] equalsNext,
-                                                          int sortedFrom,
-                                                          int sortedTo,
-                                                          Comparator<T> comparator)
-    {
-        int insertInto = sortedFrom - 1;
-        T newElement = preSortedArray[insertInto];
-        for (; insertInto < sortedTo - 1; insertInto++)
-        {
-            int cmp = comparator.compare(newElement, preSortedArray[insertInto + 1]);
-            if (cmp < 0)
-            {
-                equalsNext[insertInto] = false;
-                break;
-            }
-            else if (cmp == 0) {
-                equalsNext[insertInto] = true;
-                break;
-            }
-            else
-            {
-                // skip the section of equal elements who are smaller than the new element
-                for (; insertInto < sortedTo - 1; insertInto++)
-                {
-                    if (!equalsNext[insertInto + 1])
-                    {
-                        break;
-                    }
-                    preSortedArray[insertInto] = preSortedArray[insertInto + 1];
-                    equalsNext[insertInto] = true;
-                }
-                preSortedArray[insertInto] = preSortedArray[insertInto + 1];
-                equalsNext[insertInto] = false;
-            }
-        }
-        preSortedArray[insertInto] = newElement;
-    }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -837,8 +837,15 @@ public class CursorCompactor extends CompactionInfo.Holder
             // (i.e. before expiry, the pure tombstone; after expiry, whichever is more recent)
             // this inconsistency has no user-visible distinction, as at this point they are both logically tombstones
             // (the only possible difference is the time at which the cells become purgeable)
-            boolean leftIsTombstone = !left.isExpiring(); // !isExpiring() == isTombstone(), but does not need to consider localDeletionTime()
-            boolean rightIsTombstone = !right.isExpiring();
+            // NOTE: ReusableLivenessInfo.isExpiring() means "has an expiration time", which is
+            // also true for tombstones — !isExpiring() would be false for BOTH sides here (both
+            // have an expiration time once we are past the presence check above), making this
+            // tie-break dead and letting the localDeletionTime comparison below pick an expiring
+            // cell over a tombstone. Tombstone semantics need AbstractCell.isTombstone():
+            // within this block both sides have localExpirationTime set, so ttl == NO_TTL is
+            // exactly "is a tombstone" (mirrors Cells.resolveRegular's !left.isExpiring()).
+            boolean leftIsTombstone = left.ttl() == LivenessInfo.NO_TTL;
+            boolean rightIsTombstone = right.ttl() == LivenessInfo.NO_TTL;
             if (leftIsTombstone != rightIsTombstone)
                 return leftIsTombstone ? LEFT : RIGHT;
 

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -104,13 +104,15 @@ import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.isState;
  *   <li>Purge gc-able tombstones if possible (see PurgeFunction below).</li>
  *   <li>Invalidate cached partitions that are empty post-compaction. This avoids keeping partitions with
  *       only purgable tombstones in the row cache.</li>
- *   <li>Keep tracks of the compaction progress.</li>
+ *   <li>Keeps track of the compaction progress.</li>
  * </ul>
- * This compaction implementation does not support 2ndary indexes or trie indexes at this time.
+ * This compaction implementation does not support 2ndary indexes, trie (BTI) sstable output,
+ * complex (collection/UDT) columns, or counter columns; see {@link #isSupported} and
+ * {@link #unsupportedMetadata} for the full set of gates.
  * <p>
-*     This compaction implmentation avoids garbage creation per partition/row/cell by utilizing reader/writer code
-*     which supports reusable copies of sstable entry components. The implementation consolidates and duplicates code
- *    from various classes to support the use of these reusable structures.
+ *     This compaction implementation avoids garbage creation per partition/row/cell by utilizing reader/writer code
+ *     which supports reusable copies of sstable entry components. The implementation consolidates and duplicates code
+ *     from various classes to support the use of these reusable structures.
  * </p>
  */
 public class CursorCompactor extends CompactionInfo.Holder

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
 import org.apache.cassandra.db.rows.BTreeRow;
 import org.apache.cassandra.db.rows.Cell;
@@ -54,6 +55,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.UnfilteredRowIterators;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
 import org.apache.cassandra.dht.ReusableDecoratedKey;
+import org.apache.cassandra.io.sstable.ClusteringDescriptor;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.PartitionDescriptor;
 import org.apache.cassandra.io.sstable.SSTableCursorReader;
@@ -245,6 +247,13 @@ public class CursorCompactor extends CompactionInfo.Holder
 
     private StatefulCursor lastSource = null;
     private final ReusableDecoratedKey detachedLastWrittenKey;
+    // Snapshot of the clustering of the last unfiltered WRITTEN to the current output partition.
+    // sstableCursors[*].unfiltered() descriptors are reusable: a cursor overwrites its descriptor
+    // in place as soon as it reads its next unfiltered — including unfiltereds that then merge
+    // away or purge and never reach the output — so a reference captured during the merge loop
+    // can, by the time the partition closes, describe a clustering that was never written. A copy
+    // per written unfiltered keeps the true last written clustering for the min/max metadata.
+    private final ClusteringDescriptor lastWrittenClustering;
 
     // Partition state. Writes can be delayed if the deletion is purged, or live and partition is empty -> LIVE deletion.
     PartitionDescriptor partitionDescriptor;
@@ -327,6 +336,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         purger = new Purger(type, controller);
 
         detachedLastWrittenKey = metadata.partitioner.createReusableKey(128);
+        lastWrittenClustering = new ClusteringDescriptor(metadata.comparator.subtypes().toArray(AbstractType[]::new));
     }
 
     /**
@@ -432,7 +442,6 @@ public class CursorCompactor extends CompactionInfo.Holder
         int unfilteredMergeLimit = partitionMergeLimit;
         boolean isFirstUnfiltered = true;
         int unfilteredCount = 0;
-        UnfilteredDescriptor lastClustering = null;
         while (true)
         {
             unfilteredMergeLimit = prepareAndSortUnfilteredForMerge(partitionMergeLimit, unfilteredMergeLimit);
@@ -445,7 +454,7 @@ public class CursorCompactor extends CompactionInfo.Holder
                 {
                     isFirstUnfiltered = false;
                     unfilteredCount++;
-                    lastClustering = sstableCursors[0].unfiltered();
+                    lastWrittenClustering.copy(sstableCursors[0].unfiltered());
                 }
             }
             else if (UnfilteredSerializer.isTombstoneMarker(flags)) {
@@ -454,7 +463,7 @@ public class CursorCompactor extends CompactionInfo.Holder
                 {
                     isFirstUnfiltered = false;
                     unfilteredCount++;
-                    lastClustering = sstableCursors[0].unfiltered();
+                    lastWrittenClustering.copy(sstableCursors[0].unfiltered());
                 }
                 if (activeOpenRangeDeletion == DeletionTime.LIVE) {
                     activeDeletion = mergedDeletion;
@@ -476,7 +485,7 @@ public class CursorCompactor extends CompactionInfo.Holder
             ssTableCursorWriter.writePartitionEnd(partitionDescriptor.keyBytes(), partitionDescriptor.keyLength(), toWritePartitionDeletion, partitionHeaderLength);
             // update metadata tracking of min/max clustering on last unfiltered
             if (unfilteredCount > 1) {
-                ssTableCursorWriter.updateClusteringMetadata(lastClustering);
+                ssTableCursorWriter.updateClusteringMetadata(lastWrittenClustering);
             }
         }
         // move along

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -141,7 +141,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         // BTI index writing is not supported yet
         if (!(DatabaseDescriptor.getSelectedSSTableFormat() instanceof BigFormat))
         {
-            if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Only BIG sstable output format is supported. format=" + DatabaseDescriptor.getSelectedSSTableFormat());
+            if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Only the BIG sstable output format is supported. format=" + DatabaseDescriptor.getSelectedSSTableFormat());
             return false;
         }
         // TODO: Implement CompactionIterator.GarbageSkipper like functionality
@@ -645,7 +645,9 @@ public class CursorCompactor extends CompactionInfo.Holder
             throw new UnsupportedOperationException("TODO: Not ready for counter cells.");
 
         /** See: {@link Cells#reconcile(Cell, Cell)} */
-        // Find latest cell value/delete info, only one cell can win(for now... same timestamp handling awaits)!
+        // Find the winning cell across sources: resolveRegular implements the full
+        // Cells.resolveRegular decision table, including the same-timestamp tie-breaks
+        // (deleted/expiring beats live, greater deletion time, lower TTL, greater value)
         for (int i = 1; i < cellMergeLimit; i++)
         {
             StatefulCursor oCellSource = sstableCursors[i];

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -297,7 +297,14 @@ public class CursorCompactor extends CompactionInfo.Holder
         this.activeCompactions.beginCompaction(this); // note that CompactionTask also calls this, but CT only creates CompactionIterator with a NOOP ActiveCompactions
 
         TableMetadata metadata = metadata();
-        this.hasStaticColumns = metadata.hasStaticColumns();
+        // the INPUT headers decide whether static rows can occur in this merge (and the output
+        // header, SerializationHeader.make, is their union): after ALTER TABLE ... DROP of the
+        // last static column, current metadata has no static columns but older sstables
+        // legitimately still carry static rows
+        boolean anyStaticColumns = false;
+        for (SSTableReader sstable : this.sstables)
+            anyStaticColumns |= sstable.header.hasStatic();
+        this.hasStaticColumns = anyStaticColumns;
         /**
          * Pipeline should end up similar to the one in {@link CompactionIterator}:
          * [MERGED -> ?TopPartitionTracker -> GarbageSkipper -> Purger -> org.apache.cassandra.db.transform.DuplicateRowChecker -> Abortable] -> next()

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -719,8 +719,21 @@ public class CursorCompactor extends CompactionInfo.Holder
 
                     // Matches Cells.resolveRegular: left (the current winner) wins ties, the
                     // challenger only wins with a strictly greater value
-                    // (compareValues(left, right) >= 0 ? left : right).
-                    int compare = Arrays.compareUnsigned(tempCellBuffer1.getData(), 0, tempCellBuffer1.getLength(), tempCellBuffer2.getData(), 0, tempCellBuffer2.getLength());
+                    // (compareValues(left, right) >= 0 ? left : right). The reference
+                    // comparison is over the RAW value bytes (ValueAccessor.compare, plain
+                    // unsigned lexicographic): these buffers hold the WIRE form, which for
+                    // variable-length types carries a leading length vint — comparing that
+                    // prefix orders by LENGTH first (the vint's leading byte encodes it) and
+                    // picks the wrong winner for ties between different-length values.
+                    // Fixed-length types carry no vint (and equal lengths).
+                    int skip1 = 0, skip2 = 0;
+                    if (cellCursor.cellType.valueLengthIfFixed() < 0)
+                    {
+                        skip1 = tempCellBuffer1.getLength() == 0 ? 0 : wireVintSize(tempCellBuffer1.getData()[0]);
+                        skip2 = tempCellBuffer2.getLength() == 0 ? 0 : wireVintSize(tempCellBuffer2.getData()[0]);
+                    }
+                    int compare = Arrays.compareUnsigned(tempCellBuffer1.getData(), skip1, tempCellBuffer1.getLength(),
+                                                         tempCellBuffer2.getData(), skip2, tempCellBuffer2.getLength());
                     if (compare < 0) {
                         // challenger wins: swap buffers so tempCellBuffer1 holds the winner's value
                         tempCellBuffer = tempCellBuffer1;
@@ -829,6 +842,17 @@ public class CursorCompactor extends CompactionInfo.Holder
 
         }
         return isRowDropped;
+    }
+
+    /**
+     * Byte length of the leading unsigned vint in a wire-form variable-length value:
+     * non-negative first byte = single-byte vint (VIntCoding's own callers guard the same
+     * way before consulting numberOfExtraBytesToRead, which expects the SIGNED byte).
+     */
+    private static int wireVintSize(byte firstByte)
+    {
+        return firstByte >= 0 ? 1
+               : 1 + org.apache.cassandra.utils.vint.VIntCoding.numberOfExtraBytesToRead(firstByte);
     }
 
     enum CellResolution

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.DeletionTime.ReusableDeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
 import org.apache.cassandra.db.ReusableLivenessInfo;
-import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -140,6 +139,8 @@ public class CursorCompactor extends CompactionInfo.Holder
                     if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Older sstable versions are not supported. version=" + version);
                     return false;
                 }
+                if (unsupportedHeaderColumns(metadata, reader))
+                    return false;
             }
         }
         // BTI index writing is not supported yet
@@ -194,6 +195,47 @@ public class CursorCompactor extends CompactionInfo.Holder
             else if (column.isCounterColumn())
             {
                 if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Counter columns are not supported. column=" + column);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@link #unsupportedSchema} only sees the columns the table has NOW. Dropping a column
+     * removes it from {@link TableMetadata#regularAndStaticColumns()}, but every sstable written
+     * before the drop still lists it in that sstable's own serialization header, with its original
+     * type intact — {@code TableMetadata.recordColumnDrop} stores {@code type.expandUserTypes()},
+     * so a dropped non-frozen collection is still a multi-cell column there. The reader builds its
+     * column arrays from the header, not from the schema, so such a column reaches the cell cursor,
+     * which reads a single cell where the complex framing
+     * ({@code [complex deletion?][vint cellsCount][cells]}) requires a count-led run, and misparses
+     * the row.
+     *
+     * Whether that misparse then surfaces at all is not something the reader can decide sensibly:
+     * {@link #mergeCells} rejects complex columns outright, but reaching it depends on the
+     * dropped-column filter, and the timestamp that filter compares against the drop horizon was
+     * itself decoded from the misread framing rather than written by any cell. So the column is
+     * discarded silently or rejected loudly according to bytes that mean nothing here — neither
+     * outcome can be relied on, which is why the screening belongs at the gate.
+     *
+     * Dropping a non-frozen collection is legal and cursor compaction is on by default, so the
+     * schema check alone lets that misparse through. Screen the columns the readers will actually
+     * present. The fallback is permanent for this table: the ghost column stays in those headers
+     * until the pre-drop sstables are rewritten by the iterator path.
+     */
+    private static boolean unsupportedHeaderColumns(TableMetadata metadata, SSTableReader reader)
+    {
+        // RegularAndStaticColumns iterates statics then regulars, so this covers both
+        for (ColumnMetadata column : reader.header.columns())
+        {
+            // the header records its own type for any column whose type has since changed, so ask
+            // it as well as the schema: that is the type the reader will decode against
+            AbstractType<?> diskType = reader.header.getType(column);
+            if (column.isComplex() || column.isCounterColumn()
+                || (diskType != null && (diskType.isMultiCell() || diskType.isCounter())))
+            {
+                if (LOGGER.isDebugEnabled()) logDebugReason(metadata, "Complex and counter columns are not supported, and " + reader.descriptor + " still carries one in its header (dropped from the schema?). column=" + column);
                 return true;
             }
         }
@@ -806,13 +848,11 @@ public class CursorCompactor extends CompactionInfo.Holder
                 isRowDropped = false;
                 lateStartRow(isStatic);
             }
-            /** {@link org.apache.cassandra.db.rows.Cell.Serializer#serialize(Cell, ColumnMetadata, DataOutputPlus, LivenessInfo, SerializationHeader)} */
+            /** {@link org.apache.cassandra.db.rows.Cell.Serializer#serialize(Cell, ColumnMetadata, DataOutputPlus, LivenessInfo, org.apache.cassandra.db.SerializationHeader)} */
             boolean isDeleted = cellLiveness.isTombstone();
-            // NOTE: ReusableLivenessInfo.isExpiring() means "has an expiration time", which is
-            // also true for tombstones. Cell flag semantics need AbstractCell.isExpiring(),
-            // i.e. ttl set — and Cell.Serializer treats deleted/expiring as mutually exclusive
-            // (else-if), so a tombstone must never carry IS_EXPIRING or a TTL field.
-            boolean isExpiring = cellLiveness.ttl() != LivenessInfo.NO_TTL;
+            // Cell.Serializer treats deleted/expiring as mutually exclusive (else-if below), so a
+            // tombstone must never carry IS_EXPIRING or a TTL field.
+            boolean isExpiring = cellLiveness.isExpiring();
             boolean useRowTimestamp = !rowLiveness.isEmpty() && cellLiveness.timestamp() == rowLiveness.timestamp();
             boolean useRowTTL = isExpiring && rowLiveness.isExpiring() &&
                                 cellLiveness.ttl() == rowLiveness.ttl() &&
@@ -886,15 +926,10 @@ public class CursorCompactor extends CompactionInfo.Holder
             // (i.e. before expiry, the pure tombstone; after expiry, whichever is more recent)
             // this inconsistency has no user-visible distinction, as at this point they are both logically tombstones
             // (the only possible difference is the time at which the cells become purgeable)
-            // NOTE: ReusableLivenessInfo.isExpiring() means "has an expiration time", which is
-            // also true for tombstones — !isExpiring() would be false for BOTH sides here (both
-            // have an expiration time once we are past the presence check above), making this
-            // tie-break dead and letting the localDeletionTime comparison below pick an expiring
-            // cell over a tombstone. Tombstone semantics need AbstractCell.isTombstone():
-            // within this block both sides have localExpirationTime set, so ttl == NO_TTL is
-            // exactly "is a tombstone" (mirrors Cells.resolveRegular's !left.isExpiring()).
-            boolean leftIsTombstone = left.ttl() == LivenessInfo.NO_TTL;
-            boolean rightIsTombstone = right.ttl() == LivenessInfo.NO_TTL;
+            // Mirrors Cells.resolveRegular's !left.isExpiring(): within this block both sides have
+            // a localExpirationTime, so "no TTL" is exactly "is a tombstone".
+            boolean leftIsTombstone = !left.isExpiring();
+            boolean rightIsTombstone = !right.isExpiring();
             if (leftIsTombstone != rightIsTombstone)
                 return leftIsTombstone ? LEFT : RIGHT;
 

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -265,7 +265,14 @@ public class CursorCompactor extends CompactionInfo.Holder
     {
         this.controller = controller;
         this.type = type;
-        this.nowInSec = nowInSec;
+        // mirror CompactionIterator.purger(): accord-enabled (and accord-migrating) tables
+        // purge and expire relative to gcBefore — derived from accord's durability bounds by
+        // CompactionTask.getCompactionController — retaining data accord may still read at
+        // earlier timestamps; every nowInSec use below is a purge/expiry decision
+        TableMetadata tableMetadata = controller.cfs.metadata();
+        this.nowInSec = tableMetadata.isAccordEnabled() || tableMetadata.migratingFromAccord()
+                        ? controller.gcBefore
+                        : nowInSec;
         this.compactionId = compactionId;
 
         long inputBytes = 0;

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -690,9 +690,12 @@ public class CursorCompactor extends CompactionInfo.Holder
                     if (oCellSource.state() == CELL_VALUE_START)
                         oCellSource.copyCellValue(tempCellBuffer2, copyColumnValueBuffer);
 
+                    // Matches Cells.resolveRegular: left (the current winner) wins ties, the
+                    // challenger only wins with a strictly greater value
+                    // (compareValues(left, right) >= 0 ? left : right).
                     int compare = Arrays.compareUnsigned(tempCellBuffer1.getData(), 0, tempCellBuffer1.getLength(), tempCellBuffer2.getData(), 0, tempCellBuffer2.getLength());
-                    if (compare >= 0) {
-                        // swap the buffers
+                    if (compare < 0) {
+                        // challenger wins: swap buffers so tempCellBuffer1 holds the winner's value
                         tempCellBuffer = tempCellBuffer1;
                         tempCellBuffer1 = tempCellBuffer2;
                         tempCellBuffer2 = tempCellBuffer;
@@ -765,7 +768,11 @@ public class CursorCompactor extends CompactionInfo.Holder
             }
             /** {@link org.apache.cassandra.db.rows.Cell.Serializer#serialize(Cell, ColumnMetadata, DataOutputPlus, LivenessInfo, SerializationHeader)} */
             boolean isDeleted = cellLiveness.isTombstone();
-            boolean isExpiring = cellLiveness.isExpiring();
+            // NOTE: ReusableLivenessInfo.isExpiring() means "has an expiration time", which is
+            // also true for tombstones. Cell flag semantics need AbstractCell.isExpiring(),
+            // i.e. ttl set — and Cell.Serializer treats deleted/expiring as mutually exclusive
+            // (else-if), so a tombstone must never carry IS_EXPIRING or a TTL field.
+            boolean isExpiring = cellLiveness.ttl() != LivenessInfo.NO_TTL;
             boolean useRowTimestamp = !rowLiveness.isEmpty() && cellLiveness.timestamp() == rowLiveness.timestamp();
             boolean useRowTTL = isExpiring && rowLiveness.isExpiring() &&
                                 cellLiveness.ttl() == rowLiveness.ttl() &&
@@ -773,7 +780,7 @@ public class CursorCompactor extends CompactionInfo.Holder
             // Re-write cell flags to reflect resulting contents
             cellFlags &= Cell.Serializer.HAS_EMPTY_VALUE_MASK;
             if (isDeleted) cellFlags |= Cell.Serializer.IS_DELETED_MASK;
-            if (isExpiring) cellFlags |= Cell.Serializer.IS_EXPIRING_MASK;
+            else if (isExpiring) cellFlags |= Cell.Serializer.IS_EXPIRING_MASK;
             if (useRowTimestamp) cellFlags |= Cell.Serializer.USE_ROW_TIMESTAMP_MASK;
             if (useRowTTL) cellFlags |= Cell.Serializer.USE_ROW_TTL_MASK;
             ssTableCursorWriter.writeCellHeader(cellFlags, cellLiveness, cellSource.cellCursor().cellColumn);
@@ -839,6 +846,13 @@ public class CursorCompactor extends CompactionInfo.Holder
             // would otherwise always win (unless it had an empty value), until it expired and was translated to a tombstone
             if (leftLocalDeletionTime != rightLocalDeletionTime)
                 return leftLocalDeletionTime > rightLocalDeletionTime ? LEFT : RIGHT;
+
+            // Matches Cells.resolveRegular: both expiring at the same timestamp with the same
+            // expiration time but different TTLs — the lower TTL is probably from a more recent
+            // UPDATE USING TTL AND TIMESTAMP, so prefer it to be deterministic and closest to
+            // client intent.
+            if (!leftIsTombstone && left.ttl() != right.ttl())
+                return left.ttl() < right.ttl() ? LEFT : RIGHT;
         }
         return COMPARE;
     }

--- a/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CursorCompactor.java
@@ -315,7 +315,7 @@ public class CursorCompactor extends CompactionInfo.Holder
         this.sstableCursorsEqualsNext = new boolean[sstables.size()];
         this.enforceStrictLiveness = controller.cfs.metadata.get().enforceStrictLiveness();
 
-        purger = new Purger(type, controller, nowInSec);
+        purger = new Purger(type, controller);
 
         detachedLastWrittenKey = metadata.partitioner.createReusableKey(128);
     }
@@ -1423,8 +1423,6 @@ public class CursorCompactor extends CompactionInfo.Holder
      */
     static class Purger implements DeletionPurger
     {
-        private final long nowInSec;
-
         private final long oldestUnrepairedTombstone;
         private final boolean onlyPurgeRepairedTombstones;
         private final boolean shouldIgnoreGcGraceForAnyKey;
@@ -1438,12 +1436,11 @@ public class CursorCompactor extends CompactionInfo.Holder
 
         private long compactedUnfiltered;
 
-        Purger(OperationType type, AbstractCompactionController controller, long nowInSec)
+        Purger(OperationType type, AbstractCompactionController controller)
         {
             oldestUnrepairedTombstone = controller.compactingRepaired() ? Long.MAX_VALUE : Integer.MIN_VALUE;
             onlyPurgeRepairedTombstones = controller.cfs.getCompactionStrategyManager().onlyPurgeRepairedTombstones();
             shouldIgnoreGcGraceForAnyKey = controller.cfs.shouldIgnoreGcGraceForAnyKey();
-            this.nowInSec = nowInSec;
             this.controller = controller;
             this.type = type;
         }

--- a/src/java/org/apache/cassandra/db/compaction/PreSortedBubbleInsert.java
+++ b/src/java/org/apache/cassandra/db/compaction/PreSortedBubbleInsert.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.compaction;
+
+import java.util.Comparator;
+
+/**
+ * Use bubble sort to insert the <code>sortedFrom - 1</code> element into a pre-sorted array, and
+ * track element equality to next element to help in finding merge ranges.
+ * <p>
+ * The comparator is held as an instance field rather than passed per call so that this class can
+ * be duplicated under a new name via the {@code gen-java-copy} build step (see {@code build.xml}):
+ * each generated copy is a separately compiled class whose {@code comparator.compare(...)} call
+ * site is only ever exercised with the one comparator it was constructed with, keeping that call
+ * site monomorphic/inlinable instead of megamorphic across every comparator sharing this class.
+ */
+public class PreSortedBubbleInsert<T>
+{
+    private final Comparator<T> comparator;
+
+    public PreSortedBubbleInsert(Comparator<T> comparator)
+    {
+        this.comparator = comparator;
+    }
+
+    public void sortPerturbed(T[] preSortedArray, boolean[] equalsNext, int perturbedLimit, int sortedTo)
+    {
+        for (; perturbedLimit > 0; perturbedLimit--)
+            bubbleInsertToPreSorted(preSortedArray, equalsNext, perturbedLimit, sortedTo);
+    }
+
+    /**
+     * @param preSortedArray partially pre-sorted array of elements to be sorted in place
+     * @param equalsNext tracking the equality between each element and the next in the sorted array
+     * @param sortedFrom elements from <code>sortedFrom</code> are assumed sorted
+     * @param sortedTo the limit of our sort effort
+     */
+    private void bubbleInsertToPreSorted(T[] preSortedArray, boolean[] equalsNext, int sortedFrom, int sortedTo)
+    {
+        int insertInto = sortedFrom - 1;
+        T newElement = preSortedArray[insertInto];
+        for (; insertInto < sortedTo - 1; insertInto++)
+        {
+            int cmp = comparator.compare(newElement, preSortedArray[insertInto + 1]);
+            if (cmp < 0)
+            {
+                equalsNext[insertInto] = false;
+                break;
+            }
+            else if (cmp == 0) {
+                equalsNext[insertInto] = true;
+                break;
+            }
+            else
+            {
+                // skip the section of equal elements who are smaller than the new element
+                for (; insertInto < sortedTo - 1; insertInto++)
+                {
+                    if (!equalsNext[insertInto + 1])
+                    {
+                        break;
+                    }
+                    preSortedArray[insertInto] = preSortedArray[insertInto + 1];
+                    equalsNext[insertInto] = true;
+                }
+                preSortedArray[insertInto] = preSortedArray[insertInto + 1];
+                equalsNext[insertInto] = false;
+            }
+        }
+        preSortedArray[insertInto] = newElement;
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/StatefulCursor.java
+++ b/src/java/org/apache/cassandra/db/compaction/StatefulCursor.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.db.compaction;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -25,6 +27,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.UnfilteredValidation;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.rows.ReusableCellLivenessInfo;
 import org.apache.cassandra.io.sstable.PartitionDescriptor;
 import org.apache.cassandra.io.sstable.SSTableCursorReader;
 import org.apache.cassandra.io.sstable.UnfilteredDescriptor;
@@ -32,9 +35,11 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 import static org.apache.cassandra.db.rows.Cell.INVALID_DELETION_TIME;
 import static org.apache.cassandra.db.rows.Cell.NO_DELETION_TIME;
+import static org.apache.cassandra.db.rows.Cell.NO_TTL;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_END;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_HEADER_START;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_VALUE_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.UNFILTERED_END;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.isState;
 
 // Cursor state
@@ -49,7 +54,11 @@ class StatefulCursor extends SSTableCursorReader
      */
     private PartitionDescriptor prevPartition;
 
-    private final UnfilteredDescriptor unfiltered;
+    /** @see #partitionSwaps() */
+    private long partitionSwaps = 0;
+
+    /** Non-final: it is exchanged by {@link #detachUnfiltered}. */
+    private UnfilteredDescriptor unfiltered;
 
     private boolean resetAfterDone = false;
     private long bytesReadPositionSnapshot = 0;
@@ -76,6 +85,77 @@ class StatefulCursor extends SSTableCursorReader
         return state;
     }
 
+    /**
+     * Hands the write side the instance holding the PREVIOUS partition's header and takes {@code floater} in
+     * its place, so the caller owns a stable "last written partition" without copying the key.
+     *
+     * It is {@code prev} rather than {@code curr} because {@code curr} is the next read's out-of-order
+     * validation source: stealing that would make the comparison run against a foreign key, which for valid
+     * data still passes — the last written key is at or below this cursor's next key — so nothing would fail
+     * and one class of corrupt input would silently stop being detected.
+     *
+     * Taking {@code prev} is safe because it has already been consumed: {@link #readPartitionHeader} compares
+     * it against the freshly read {@code curr} before returning, and the swap means the floater only ever
+     * becomes a load target, never a comparison source. Its stale contents are therefore unobservable,
+     * including in the out-of-order message, which is built after the swap.
+     */
+    PartitionDescriptor detachPrevPartition(PartitionDescriptor floater)
+    {
+        assert floater != prevPartition && floater != currPartition
+             : "the floater is already one of this cursor's slots; a steal was not handed back";
+        PartitionDescriptor detached = prevPartition;
+        prevPartition = floater;
+        return detached;
+    }
+
+    /**
+     * Times the curr/prev partition slots have been exchanged, so the write side can assert the deferral rule
+     * its steal depends on: that the prev slot has advanced exactly once since the partition it recorded was
+     * written, and therefore holds that partition. The executable form of "the prepare loop reads at most once
+     * per cursor per round".
+     *
+     * Counts swaps rather than reads because {@link #resetAfterDone} also advances the slots — it swaps and
+     * then resets only {@code curr} — and that is the path by which the last written partition reaches the prev
+     * slot when the compaction finishes. A read counter would leave the steal on the finish path unaccounted
+     * for.
+     */
+    long partitionSwaps()
+    {
+        return partitionSwaps;
+    }
+
+    /**
+     * Hands the write side the instance holding the unfiltered this cursor has just had written out, and
+     * takes {@code floater} in its place, so the caller owns a stable "last written unfiltered" without
+     * copying the clustering.
+     *
+     * Unlike {@link #detachPrevPartition} this cannot be deferred by a round: there is one slot, so a value
+     * left to wait would be overwritten by the next read. It does not need to be. Once the unfiltered has
+     * been written, everything that reads the descriptor has run — the merge, the write, and the open
+     * range-tombstone bookkeeping, which copies deletion times rather than retaining them — and the cursor
+     * is at {@code UNFILTERED_END}, which the caller advances out of immediately after; the next load into
+     * the floater comes later, in the following round's prepare-and-sort. From every state that advance can
+     * reach, the next touch of the slot is another load into it: a {@link #readRowHeader} or
+     * {@link #readTombstoneMarker} from {@code ROW_START}/{@code TOMBSTONE_START}, or
+     * {@link #resetAfterDone}'s reset. At {@code PARTITION_END} nothing reads it
+     * at all, because the clustering comparison short-circuits on that state. So the floater's stale contents
+     * are unobservable.
+     *
+     * The {@code UNFILTERED_END} premise is asserted rather than argued, because it is what makes the steal
+     * safe undeferred: a cursor stolen from in any other state would keep the floater across a clustering
+     * comparison that reads it, and mis-order the merge silently.
+     */
+    UnfilteredDescriptor detachUnfiltered(UnfilteredDescriptor floater)
+    {
+        assert floater != unfiltered
+             : "the floater is already this cursor's slot; a steal was not handed back";
+        assert state() == UNFILTERED_END
+             : "an unfiltered was stolen from a cursor that has not finished it: " + this;
+        UnfilteredDescriptor detached = unfiltered;
+        unfiltered = floater;
+        return detached;
+    }
+
     private int corruptSSTableKeysOOO()
     {
         return corruptSSTable("Keys out of order. Current key: " + keyToString(currentKey()) + " <= "  + keyToString(prevKey()));
@@ -83,6 +163,7 @@ class StatefulCursor extends SSTableCursorReader
 
     private void swapCurrAndPrevPartition()
     {
+        partitionSwaps++;
         PartitionDescriptor temp = currPartition;
         currPartition = prevPartition;
         prevPartition = temp;
@@ -102,6 +183,12 @@ class StatefulCursor extends SSTableCursorReader
             return super.skipRowCells(unfiltered().dataStart(), unfiltered().size(), false);
 
         return super.skipStaticRow(false);
+    }
+
+    /** @see SSTableCursorReader#rewindRowCells(UnfilteredDescriptor, boolean) */
+    public int rewindRowCells(boolean isStatic)
+    {
+        return super.rewindRowCells(unfiltered, isStatic);
     }
 
     @Override
@@ -205,7 +292,11 @@ class StatefulCursor extends SSTableCursorReader
     public int readCellHeader()
     {
         int state = super.readCellHeader();
-        if (corruptedTombstoneValidationEnabled)
+        // Validate only where a cell was actually surfaced. Every path that surfaces one returns
+        // CELL_VALUE_START or CELL_END, including a valueless final cell; UNFILTERED_END means the
+        // dropped-column filter discarded every remaining column, and cellLiveness then still
+        // describes the last DISCARDED cell rather than the current position.
+        if (corruptedTombstoneValidationEnabled && isState(state, CELL_VALUE_START | CELL_END))
             validateInvalidCellDeletion();
         return state;
     }
@@ -230,15 +321,34 @@ class StatefulCursor extends SSTableCursorReader
 
     private void validateInvalidCellDeletion()
     {
-        ReusableLivenessInfo cellLiveness = cellCursor().cellLiveness;
-        long ldt = cellLiveness.localExpirationTime();
-        if (cellLiveness.ttl() < 0 || ldt == INVALID_DELETION_TIME || ldt < 0 || (cellLiveness.isExpiring() && ldt == NO_DELETION_TIME)) {
+        ReusableCellLivenessInfo cellLiveness = cellCursor().cellLiveness;
+        if (hasInvalidCellDeletion(cellLiveness.ttl(), cellLiveness.localDeletionTime())) {
             UnfilteredValidation.handleInvalid(
             ssTableReader().metadata(),
             currPartition.key(),
             ssTableReader(),
             "cellLiveness="+cellLiveness);
         }
+    }
+
+    /**
+     * Mirrors {@link org.apache.cassandra.db.rows.AbstractCell#hasInvalidDeletions()}, where
+     * {@code ttl != NO_TTL} is the reference's {@code isExpiring()}.
+     */
+    @VisibleForTesting
+    static boolean hasInvalidCellDeletion(int ttl, long localExpirationTime)
+    {
+        return ttl < 0
+               || localExpirationTime == INVALID_DELETION_TIME
+               || localExpirationTime < 0
+               || (ttl != NO_TTL && localExpirationTime == NO_DELETION_TIME);
+    }
+
+    /** Mirrors the primary-key liveness clause of {@link org.apache.cassandra.db.rows.AbstractRow#hasInvalidDeletions()}. */
+    @VisibleForTesting
+    static boolean hasInvalidRowLiveness(int ttl, long localExpirationTime)
+    {
+        return ttl != NO_TTL && (ttl < 0 || localExpirationTime < 0);
     }
 
     private void validateInvalidRowDeletion()
@@ -251,7 +361,7 @@ class StatefulCursor extends SSTableCursorReader
                 "rowDeletion="+currPartition.deletionTime().toString());
         }
         ReusableLivenessInfo livenessInfo = unfiltered.livenessInfo();
-        if (livenessInfo.isExpiring() && (livenessInfo.ttl() < 0 || livenessInfo.localExpirationTime() < 0)) {
+        if (hasInvalidRowLiveness(livenessInfo.ttl(), livenessInfo.localExpirationTime())) {
             UnfilteredValidation.handleInvalid(
                 ssTableReader().metadata(),
                 currPartition.key(),

--- a/src/java/org/apache/cassandra/db/compaction/StatefulCursor.java
+++ b/src/java/org/apache/cassandra/db/compaction/StatefulCursor.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.db.compaction;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -32,6 +34,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 import static org.apache.cassandra.db.rows.Cell.INVALID_DELETION_TIME;
 import static org.apache.cassandra.db.rows.Cell.NO_DELETION_TIME;
+import static org.apache.cassandra.db.rows.Cell.NO_TTL;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_END;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_HEADER_START;
 import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_VALUE_START;
@@ -205,7 +208,11 @@ class StatefulCursor extends SSTableCursorReader
     public int readCellHeader()
     {
         int state = super.readCellHeader();
-        if (corruptedTombstoneValidationEnabled)
+        // Validate only where a cell was actually surfaced. Every path that surfaces one returns
+        // CELL_VALUE_START or CELL_END, including a valueless final cell; UNFILTERED_END means the
+        // dropped-column filter discarded every remaining column, and cellLiveness then still
+        // describes the last DISCARDED cell rather than the current position.
+        if (corruptedTombstoneValidationEnabled && isState(state, CELL_VALUE_START | CELL_END))
             validateInvalidCellDeletion();
         return state;
     }
@@ -231,14 +238,33 @@ class StatefulCursor extends SSTableCursorReader
     private void validateInvalidCellDeletion()
     {
         ReusableLivenessInfo cellLiveness = cellCursor().cellLiveness;
-        long ldt = cellLiveness.localExpirationTime();
-        if (cellLiveness.ttl() < 0 || ldt == INVALID_DELETION_TIME || ldt < 0 || (cellLiveness.isExpiring() && ldt == NO_DELETION_TIME)) {
+        if (hasInvalidCellDeletion(cellLiveness.ttl(), cellLiveness.localExpirationTime())) {
             UnfilteredValidation.handleInvalid(
             ssTableReader().metadata(),
             currPartition.key(),
             ssTableReader(),
             "cellLiveness="+cellLiveness);
         }
+    }
+
+    /**
+     * Mirrors {@link org.apache.cassandra.db.rows.AbstractCell#hasInvalidDeletions()}, where
+     * {@code ttl != NO_TTL} is the reference's {@code isExpiring()}.
+     */
+    @VisibleForTesting
+    static boolean hasInvalidCellDeletion(int ttl, long localExpirationTime)
+    {
+        return ttl < 0
+               || localExpirationTime == INVALID_DELETION_TIME
+               || localExpirationTime < 0
+               || (ttl != NO_TTL && localExpirationTime == NO_DELETION_TIME);
+    }
+
+    /** Mirrors the primary-key liveness clause of {@link org.apache.cassandra.db.rows.AbstractRow#hasInvalidDeletions()}. */
+    @VisibleForTesting
+    static boolean hasInvalidRowLiveness(int ttl, long localExpirationTime)
+    {
+        return ttl != NO_TTL && (ttl < 0 || localExpirationTime < 0);
     }
 
     private void validateInvalidRowDeletion()
@@ -251,7 +277,7 @@ class StatefulCursor extends SSTableCursorReader
                 "rowDeletion="+currPartition.deletionTime().toString());
         }
         ReusableLivenessInfo livenessInfo = unfiltered.livenessInfo();
-        if (livenessInfo.isExpiring() && (livenessInfo.ttl() < 0 || livenessInfo.localExpirationTime() < 0)) {
+        if (hasInvalidRowLiveness(livenessInfo.ttl(), livenessInfo.localExpirationTime())) {
             UnfilteredValidation.handleInvalid(
                 ssTableReader().metadata(),
                 currPartition.key(),

--- a/src/java/org/apache/cassandra/db/rows/Cell.java
+++ b/src/java/org/apache/cassandra/db/rows/Cell.java
@@ -43,7 +43,7 @@ import org.apache.cassandra.utils.memory.Cloner;
  *   2) expiring cells: on top of regular cells, those have a ttl and a local deletion time (when they are expired).
  *   3) tombstone cells: those won't have value, but they have a local deletion time (when the tombstone was created).
  */
-public abstract class Cell<V> extends ColumnData
+public abstract class Cell<V> extends ColumnData implements CellLivenessInfo
 {
     public static final int NO_TTL = 0;
     public static final long NO_DELETION_TIME = Long.MAX_VALUE;
@@ -181,7 +181,7 @@ public abstract class Cell<V> extends ColumnData
 
     public final boolean isLive(long nowInSec, long localDeletionTime, int ttl)
     {
-        return localDeletionTime == NO_DELETION_TIME || ttl != NO_TTL && nowInSec < localDeletionTime;
+        return CellLivenessInfo.isLive(nowInSec, localDeletionTime, ttl);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/rows/CellLivenessInfo.java
+++ b/src/java/org/apache/cassandra/db/rows/CellLivenessInfo.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.rows;
+
+/**
+ * The liveness contract of a single cell, as defined by {@link Cell} and {@link Cells} — distinct from
+ * {@link org.apache.cassandra.db.LivenessInfo}, which is a row's primary-key liveness. The two disagree on
+ * enough of their shared vocabulary that holding both in one type leaves half of it valid in only one role:
+ * a cell's expiration field is a local deletion time, which a tombstone carries with no TTL, and a cell has
+ * no notion of being empty.
+ *
+ * It also houses the same-timestamp reconciliation tie-break, which two independent decision tables
+ * previously carried by hand.
+ */
+public interface CellLivenessInfo
+{
+    /** @see Cell#timestamp() */
+    long timestamp();
+
+    /** {@code Cell.NO_TTL} unless this is an expiring cell. @see Cell#ttl() */
+    int ttl();
+
+    /**
+     * {@code Cell.NO_DELETION_TIME} unless this is a tombstone or an expiring cell. This is the member the
+     * two contracts differ on most sharply: the row contract's equivalent field is a TTL expiration time and
+     * exists only alongside a TTL, whereas a cell tombstone carries a deletion time with no TTL.
+     *
+     * @see Cell#localDeletionTime()
+     */
+    long localDeletionTime();
+
+    /** "Has a TTL", not "has an expiration time" — a tombstone has the latter. @see Cell#isExpiring() */
+    boolean isExpiring();
+
+    /** @see Cell#isTombstone() */
+    boolean isTombstone();
+
+    /** @see Cell#isLive(long) */
+    boolean isLive(long nowInSec);
+
+    /**
+     * The cell liveness rule over primitives: a cell with no deletion time is live, otherwise it must carry a
+     * TTL that has not lapsed. Held here so {@link Cell} and {@link ReusableCellLivenessInfo} cannot drift,
+     * and reachable without an instance for callers that already hold the three fields.
+     */
+    static boolean isLive(long nowInSec, long localDeletionTime, int ttl)
+    {
+        return localDeletionTime == Cell.NO_DELETION_TIME || ttl != Cell.NO_TTL && nowInSec < localDeletionTime;
+    }
+
+    /**
+     * Which side of a same-timestamp reconciliation wins, or that the decision falls through to the
+     * callers' own value comparison. Callers differ in how they compare values — the reference consults
+     * the deserialized cell values, the cursor compares raw wire bytes — so only the decision is shared.
+     */
+    enum Resolution
+    {
+        LEFT, RIGHT, COMPARE
+    }
+
+    /**
+     * The whole non-counter cell reconciliation decision: the newer timestamp outright, else the
+     * same-timestamp tie-break below. Reached by {@code Cells.resolveRegular} on the read path and by
+     * {@code CursorCompactor.mergeCells} on the cursor compaction path.
+     *
+     * {@code ttl()} is read only inside the tie-break, so the ordinary live-versus-live tie costs the two
+     * {@code localDeletionTime()} reads it always cost and no more.
+     *
+     * <b>Callers holding a cell must narrow their arguments before calling.</b> The two callers hold
+     * unrelated types calling through this one interface method, which shares one receiver-type profile
+     * across both — see {@code Cells.resolveRegular} for why that pollutes without narrowing.
+     */
+    static Resolution resolve(CellLivenessInfo left, CellLivenessInfo right)
+    {
+        long leftTimestamp = left.timestamp();
+        long rightTimestamp = right.timestamp();
+        if (leftTimestamp != rightTimestamp)
+            return leftTimestamp > rightTimestamp ? Resolution.LEFT : Resolution.RIGHT;
+
+        long leftLocalDeletionTime = left.localDeletionTime();
+        long rightLocalDeletionTime = right.localDeletionTime();
+        if (leftLocalDeletionTime == Cell.NO_DELETION_TIME && rightLocalDeletionTime == Cell.NO_DELETION_TIME)
+            return Resolution.COMPARE;
+
+        return resolveSameTimestampTie(left.ttl(), leftLocalDeletionTime, right.ttl(), rightLocalDeletionTime);
+    }
+
+    /**
+     * The same-timestamp tie-break, reached from {@link #resolve} once at least one side carries a deletion
+     * time. Primitive and timestamp-free, so it stays callable by anything already holding the four fields.
+     *
+     * The precondition is asserted rather than assumed, so a future caller that reaches it directly without
+     * establishing the guard fails loudly instead of receiving a plausible COMPARE.
+     *
+     * @param leftTtl                {@code Cell.NO_TTL} for a tombstone or a live cell
+     * @param leftLocalDeletionTime  {@code Cell.NO_DELETION_TIME} for a live cell
+     */
+    static Resolution resolveSameTimestampTie(int leftTtl, long leftLocalDeletionTime,
+                                               int rightTtl, long rightLocalDeletionTime)
+    {
+        boolean leftIsExpiringOrTombstone = leftLocalDeletionTime != Cell.NO_DELETION_TIME;
+        boolean rightIsExpiringOrTombstone = rightLocalDeletionTime != Cell.NO_DELETION_TIME;
+        assert leftIsExpiringOrTombstone || rightIsExpiringOrTombstone
+             : "neither side carries a deletion time; the deletion-time guard was skipped";
+
+        // Tombstones always win reconciliation with live cells of the same timstamp
+        // CASSANDRA-14592: for consistency of reconciliation, regardless of system clock at time of reconciliation
+        // this requires us to treat expiring cells (which will become tombstones at some future date) the same wrt regular cells
+        if (leftIsExpiringOrTombstone != rightIsExpiringOrTombstone)
+            return leftIsExpiringOrTombstone ? Resolution.LEFT : Resolution.RIGHT;
+
+        // for most historical consistency, we still prefer tombstones over expiring cells.
+        // While this leads to an inconsistency over which is chosen
+        // (i.e. before expiry, the pure tombstone; after expiry, whichever is more recent)
+        // this inconsistency has no user-visible distinction, as at this point they are both logically tombstones
+        // (the only possible difference is the time at which the cells become purgeable)
+        //
+        // Both sides carry a deletion time here, so "no TTL" is exactly "is a tombstone" — the primitive form
+        // of the reference's !isExpiring(), which does not need to consider the deletion time either.
+        boolean leftIsTombstone = leftTtl == Cell.NO_TTL;
+        boolean rightIsTombstone = rightTtl == Cell.NO_TTL;
+        if (leftIsTombstone != rightIsTombstone)
+            return leftIsTombstone ? Resolution.LEFT : Resolution.RIGHT;
+
+        // ==> (leftIsExpiring && rightIsExpiring) or (leftIsTombstone && rightIsTombstone)
+        // if both are expiring, we do not want to consult the value bytes if we can avoid it, as like with C-14592
+        // the value bytes implicitly depend on the system time at reconciliation, as a
+        // would otherwise always win (unless it had an empty value), until it expired and was translated to a tombstone
+        if (leftLocalDeletionTime != rightLocalDeletionTime)
+            return leftLocalDeletionTime > rightLocalDeletionTime ? Resolution.LEFT : Resolution.RIGHT;
+
+        // Both cells are either tombstones or expiring at the same timestamp. If expiring and the
+        // TTLs differ, write the lower one -- the write is probably from a more recent
+        // UPDATE USING TTL AND TIMESTAMP, so select the most recent one to be deterministic and be
+        // closest to client intent.
+        if (!leftIsTombstone && leftTtl != rightTtl)
+        {
+            assert !rightIsTombstone;
+            return leftTtl < rightTtl ? Resolution.LEFT : Resolution.RIGHT;
+        }
+
+        return Resolution.COMPARE;
+    }
+}

--- a/src/java/org/apache/cassandra/db/rows/Cells.java
+++ b/src/java/org/apache/cassandra/db/rows/Cells.java
@@ -78,52 +78,31 @@ public abstract class Cells
 
     private static Cell<?> resolveRegular(Cell<?> left, Cell<?> right)
     {
-        long leftTimestamp = left.timestamp();
-        long rightTimestamp = right.timestamp();
-        if (leftTimestamp != rightTimestamp)
-            return leftTimestamp > rightTimestamp ? left : right;
-
-        long leftLocalDeletionTime = left.localDeletionTime();
-        long rightLocalDeletionTime = right.localDeletionTime();
-
-        boolean leftIsExpiringOrTombstone = leftLocalDeletionTime != Cell.NO_DELETION_TIME;
-        boolean rightIsExpiringOrTombstone = rightLocalDeletionTime != Cell.NO_DELETION_TIME;
-
-        if (leftIsExpiringOrTombstone | rightIsExpiringOrTombstone)
+        CellLivenessInfo.Resolution resolution;
+        if (left instanceof HeapAbstractCell && right instanceof HeapAbstractCell)
         {
-            // Tombstones always win reconciliation with live cells of the same timstamp
-            // CASSANDRA-14592: for consistency of reconciliation, regardless of system clock at time of reconciliation
-            // this requires us to treat expiring cells (which will become tombstones at some future date) the same wrt regular cells
-            if (leftIsExpiringOrTombstone != rightIsExpiringOrTombstone)
-                return leftIsExpiringOrTombstone ? left : right;
-
-            // for most historical consistency, we still prefer tombstones over expiring cells.
-            // While this leads to the an inconsistency over which is chosen
-            // (i.e. before expiry, the pure tombstone; after expiry, whichever is more recent)
-            // this inconsistency has no user-visible distinction, as at this point they are both logically tombstones
-            // (the only possible difference is the time at which the cells become purgeable)
-            boolean leftIsTombstone = !left.isExpiring(); // !isExpiring() == isTombstone(), but does not need to consider localDeletionTime()
-            boolean rightIsTombstone = !right.isExpiring();
-            if (leftIsTombstone != rightIsTombstone)
-                return leftIsTombstone ? left : right;
-
-            // ==> (leftIsExpiring && rightIsExpiring) or (leftIsTombstone && rightIsTombstone)
-            // if both are expiring, we do not want to consult the value bytes if we can avoid it, as like with C-14592
-            // the value bytes implicitly depend on the system time at reconciliation, as a
-            // would otherwise always win (unless it had an empty value), until it expired and was translated to a tombstone
-            if (leftLocalDeletionTime != rightLocalDeletionTime)
-                return leftLocalDeletionTime > rightLocalDeletionTime ? left : right;
-
-            // Both cells are either tombstones or expiring at the same timestamp. If expiring and the
-            // TTLs differ, write the lower one -- the write is probably from a more recent
-            // UPDATE USING TTL AND TIMESTAMP, so select the most recent one to be deterministic and be
-            // closest to client intent.
-            if (!leftIsTombstone && left.ttl() != right.ttl())
-            {
-                assert !rightIsTombstone;
-                return left.ttl() < right.ttl() ? left : right;
-            }
+            // Narrowed before the call to keep the liveness accessors bound from the static type here, rather
+            // than from resolve()'s receiver-type profile -- which is per-bytecode and shared with the cursor
+            // compaction path, so cells and the cursor's liveness holder pollute each other's. HeapAbstractCell
+            // declares those accessors and nothing below it overrides them; keep it that way, because an
+            // override anywhere under it silently returns this branch to the profile.
+            HeapAbstractCell<?> narrowLeft = (HeapAbstractCell<?>) left;
+            HeapAbstractCell<?> narrowRight = (HeapAbstractCell<?>) right;
+            resolution = CellLivenessInfo.resolve(narrowLeft, narrowRight);
         }
+        else
+        {
+            // Correct for any cell, and the branch that pays the pollution: NativeCell, SAI's CellWithSource,
+            // and anything else extending AbstractCell directly. Under memtable_allocation_type:
+            // offheap_objects the memtable's existing cells are NativeCells, so on that configuration this is
+            // the hot branch rather than the rare one.
+            resolution = CellLivenessInfo.resolve(left, right);
+        }
+
+        if (resolution == CellLivenessInfo.Resolution.LEFT)
+            return left;
+        if (resolution == CellLivenessInfo.Resolution.RIGHT)
+            return right;
 
         return compareValues(left, right) >= 0 ? left : right;
     }

--- a/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
+++ b/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
@@ -147,11 +147,84 @@ public class DeserializationHelper
 
     public boolean isDropped(Cell<?> cell, boolean isComplex)
     {
+        return isDropped(cell.column(), cell.timestamp(), isComplex);
+    }
+
+    /**
+     * Drop rule over the decoded cell header rather than a {@link Cell}: the body of
+     * {@link #isDropped(Cell, boolean)}, and the reference form of the rule. Its simple-column branch looks
+     * the column up by name on a table that has dropped columns, so a reader that decodes cell headers in
+     * bulk builds a {@link #droppedTimeOrMin} array once per column set and tests that with
+     * {@link #isDroppedAtHorizon} instead.
+     *
+     * @param column    the cell's column; ignored when {@code isComplex}
+     * @param timestamp the cell's timestamp
+     * @param isComplex reads the {@link #currentDroppedComplex} cache instead of looking the column
+     *                  up by name. Only correct after {@link #startOfComplexColumn} has primed that
+     *                  cache for this column; a caller that has not filters nothing.
+     */
+    public boolean isDropped(ColumnMetadata column, long timestamp, boolean isComplex)
+    {
         if (!hasDroppedColumns)
             return false;
 
-        DroppedColumn dropped = isComplex ? currentDroppedComplex : droppedColumns.get(cell.column().name.bytes);
-        return dropped != null && cell.timestamp() <= dropped.droppedTime;
+        DroppedColumn dropped = isComplex ? currentDroppedComplex : droppedColumns.get(column.name.bytes);
+        return dropped != null && timestamp <= dropped.droppedTime;
+    }
+
+    public boolean hasDroppedColumns()
+    {
+        return hasDroppedColumns;
+    }
+
+    /**
+     * The sentinel {@link #droppedTimeOrMin} returns for a column with no drop horizon. It is the
+     * least possible {@code long}, so {@code timestamp <= NO_DROP_HORIZON} is NOT unconditionally
+     * false — see {@link #isDroppedAtHorizon}, which is why that predicate exists rather than a
+     * bare comparison at each call site.
+     */
+    public static final long NO_DROP_HORIZON = Long.MIN_VALUE;
+
+    /**
+     * The column's drop horizon, or {@link #NO_DROP_HORIZON} if it has none. For callers that build
+     * a per-superset array of these once (e.g. {@code SSTableCursorReader.CellCursor}), so a per-cell
+     * drop check becomes a plain array read plus {@link #isDroppedAtHorizon} instead of a map lookup.
+     */
+    public long droppedTimeOrMin(ColumnMetadata column)
+    {
+        if (!hasDroppedColumns)
+            return NO_DROP_HORIZON;
+        DroppedColumn dropped = droppedColumns.get(column.name.bytes);
+        return dropped != null ? dropped.droppedTime : NO_DROP_HORIZON;
+    }
+
+    /**
+     * The drop rule against a horizon read from a {@link #droppedTimeOrMin} array, equivalent to
+     * {@code isDropped(column, timestamp, false)} for the column that horizon came from — for every
+     * input except a column whose recorded {@code droppedTime} is itself {@code Long.MIN_VALUE}, which
+     * {@link #droppedTimeOrMin} cannot distinguish from "no drop record". No schema path produces such a
+     * horizon ({@code AlterTableStatement} uses the schema mutation timestamp, {@code TableMetadata
+     * .Builder.recordColumnDrop} from a CQL DROP uses {@code Long.MAX_VALUE}), so the lossy encoding is
+     * sound in practice — but it IS lossy, which is worth knowing before treating the array as
+     * interchangeable with the map.
+     *
+     * The {@code NO_DROP_HORIZON} test is load-bearing, not defensive. That sentinel is
+     * {@code Long.MIN_VALUE}, which is also {@link LivenessInfo#NO_TIMESTAMP}, so
+     * {@code timestamp <= dropHorizon} alone discards a cell whose timestamp is exactly
+     * {@code Long.MIN_VALUE} on a column that was NEVER dropped — while
+     * {@code UnfilteredSerializer.readSimpleColumn}, which tests {@code dropped != null} first, keeps
+     * it. No sentinel value can avoid this: {@code Long.MIN_VALUE} is the minimum, so there is no
+     * long that makes {@code <=} false for every timestamp.
+     */
+    public static boolean isDroppedAtHorizon(long timestamp, long dropHorizon)
+    {
+        return dropHorizon != NO_DROP_HORIZON && timestamp <= dropHorizon;
+    }
+
+    /** True if {@code column} has a drop horizon at all, whatever the timestamp. */
+    public boolean isDroppedColumn(ColumnMetadata column)
+    {
+        return hasDroppedColumns && droppedColumns.containsKey(column.name.bytes);
     }
 
     public boolean isDroppedComplexDeletion(DeletionTime complexDeletion)

--- a/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
+++ b/src/java/org/apache/cassandra/db/rows/DeserializationHelper.java
@@ -147,11 +147,36 @@ public class DeserializationHelper
 
     public boolean isDropped(Cell<?> cell, boolean isComplex)
     {
+        return isDropped(cell.column(), cell.timestamp(), isComplex);
+    }
+
+    /**
+     * Drop rule over the decoded cell header, for readers that never materialize a {@link Cell}.
+     *
+     * @param column    the cell's column; ignored when {@code isComplex}
+     * @param timestamp the cell's timestamp
+     * @param isComplex reads the {@link #currentDroppedComplex} cache instead of looking the column
+     *                  up by name. Only correct after {@link #startOfComplexColumn} has primed that
+     *                  cache for this column; a caller that has not filters nothing.
+     */
+    public boolean isDropped(ColumnMetadata column, long timestamp, boolean isComplex)
+    {
         if (!hasDroppedColumns)
             return false;
 
-        DroppedColumn dropped = isComplex ? currentDroppedComplex : droppedColumns.get(cell.column().name.bytes);
-        return dropped != null && cell.timestamp() <= dropped.droppedTime;
+        DroppedColumn dropped = isComplex ? currentDroppedComplex : droppedColumns.get(column.name.bytes);
+        return dropped != null && timestamp <= dropped.droppedTime;
+    }
+
+    public boolean hasDroppedColumns()
+    {
+        return hasDroppedColumns;
+    }
+
+    /** True if {@code column} has a drop horizon at all, whatever the timestamp. */
+    public boolean isDroppedColumn(ColumnMetadata column)
+    {
+        return hasDroppedColumns && droppedColumns.containsKey(column.name.bytes);
     }
 
     public boolean isDroppedComplexDeletion(DeletionTime complexDeletion)

--- a/src/java/org/apache/cassandra/db/rows/ReusableCellLivenessInfo.java
+++ b/src/java/org/apache/cassandra/db/rows/ReusableCellLivenessInfo.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.rows;
+
+import org.apache.cassandra.db.LivenessInfo;
+
+/**
+ * A mutable {@link CellLivenessInfo}, for readers that walk cells without materializing a {@link Cell}.
+ *
+ * Deliberately does NOT implement {@link org.apache.cassandra.db.LivenessInfo}. That is the whole point of
+ * the type: it makes {@code supersedes}, {@code isEmpty}, {@code digest}, {@code validate},
+ * {@code withUpdatedTimestamp} and {@code unsharedHeapSize} unreachable on cell liveness rather than merely
+ * unused. All six are row-liveness operations, and {@code supersedes} in particular inverts the cell
+ * reconciliation rule that prefers a tombstone to a live cell at the same timestamp.
+ */
+public class ReusableCellLivenessInfo implements CellLivenessInfo
+{
+    private long timestamp = LivenessInfo.NO_TIMESTAMP;
+    private int ttl = Cell.NO_TTL;
+    private long localDeletionTime = Cell.NO_DELETION_TIME;
+
+    @Override
+    public long timestamp()
+    {
+        return timestamp;
+    }
+
+    @Override
+    public int ttl()
+    {
+        return ttl;
+    }
+
+    @Override
+    public long localDeletionTime()
+    {
+        return localDeletionTime;
+    }
+
+    @Override
+    public boolean isExpiring()
+    {
+        return ttl != Cell.NO_TTL;
+    }
+
+    @Override
+    public boolean isTombstone()
+    {
+        return localDeletionTime != Cell.NO_DELETION_TIME && ttl == Cell.NO_TTL;
+    }
+
+    @Override
+    public boolean isLive(long nowInSec)
+    {
+        return CellLivenessInfo.isLive(nowInSec, localDeletionTime, ttl);
+    }
+
+    /**
+     * Whether the TTL has lapsed at {@code nowInSec}. Cell-only, and unrelated to the row contract's no-arg
+     * {@code isExpired()}, which asks whether the liveness carries the view-maintenance
+     * {@code EXPIRED_LIVENESS_TTL} marker. The two shared a name and an arity-only distinction before the
+     * contracts were split.
+     */
+    public boolean isExpired(long nowInSec)
+    {
+        return nowInSec >= localDeletionTime;
+    }
+
+    /** Converts an expired expiring cell into the tombstone it becomes: the deletion time moves back to the
+     * second the TTL started from, and the TTL is dropped. Mirrors {@code AbstractCell.purge}'s
+     * {@code BufferCell.tombstone(column, timestamp(), localDeletionTime() - ttl(), path())}. */
+    public void ttlToTombstone()
+    {
+        localDeletionTime = localDeletionTime - ttl;
+        ttl = Cell.NO_TTL;
+    }
+
+    public void reset(long timestamp, int ttl, long localDeletionTime)
+    {
+        this.timestamp = timestamp;
+        this.ttl = ttl;
+        this.localDeletionTime = localDeletionTime;
+    }
+
+    /**
+     * Rendered into corrupt-sstable reports by {@code UnfilteredValidation.handleInvalid}, so this is a
+     * diagnostic and not cosmetic: without it such a report carries an identity hash.
+     */
+    @Override
+    public String toString()
+    {
+        return "ReusableCellLivenessInfo{"
+               + ((timestamp == LivenessInfo.NO_TIMESTAMP && ttl == Cell.NO_TTL && localDeletionTime == Cell.NO_DELETION_TIME)
+                  ? "NONE }"
+                  : "timestamp=" + (timestamp == LivenessInfo.NO_TIMESTAMP ? "NO_TIMESTAMP" : timestamp) +
+                    ", ttl=" + (ttl == Cell.NO_TTL ? "NO_TTL" : ttl) +
+                    ", localDeletionTime=" + (localDeletionTime == Cell.NO_DELETION_TIME ? "NO_DELETION_TIME" : localDeletionTime) +
+                    '}');
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.io.IOException;
+
+import com.google.common.primitives.Ints;
+
+import org.agrona.collections.IntArrayList;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter;
+import org.apache.cassandra.io.sstable.format.big.BigTableWriter;
+import org.apache.cassandra.io.sstable.format.big.RowIndexEntry;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.utils.BloomFilter;
+import org.apache.cassandra.utils.ByteArrayUtil;
+
+/**
+ * BIG-format index production for the cursor writer: promoted index blocks serialized
+ * incrementally (IndexInfo wire format) and Index.db entries with the tail-counted
+ * promotion decision, byte-identical to the iterator path
+ * (BigFormatPartitionWriter + RowIndexEntry.create + BigTableWriter.IndexWriter.append).
+ */
+public class BigCursorIndexWriter extends CursorIndexWriter
+{
+    private final BigTableWriter.IndexWriter indexWriter;
+    private final DeletionTime.Serializer deletionTimeSerializer;
+    // The garbage-free add() overload exists only on the concrete BloomFilter. With
+    // bloom_filter_fp_chance = 1.0 FilterFactory hands out the AlwaysPresentFilter instead,
+    // whose interface add() is a no-op (the iterator path calls it through IFilter) — null
+    // here means "nothing to add to".
+    private final BloomFilter bloomFilter;
+    /**
+     * See: {@link BloomFilter#reusableIndexes}
+     */
+    private final long[] reusableIndexes = new long[21];
+
+    private final DataOutputBuffer rowIndexEntries = new DataOutputBuffer();
+    private final IntArrayList rowIndexEntriesOffsets = new IntArrayList();
+    /** Whether the current index block holds more than one unfiltered, so its first name is not also its last. */
+    private boolean hasDistinctLastClustering = false;
+    private int rowIndexEntryOffset;
+    private final int indexBlockThreshold;
+
+    public BigCursorIndexWriter(BigTableWriter.IndexWriter indexWriter,
+                                DeletionTime.Serializer deletionTimeSerializer)
+    {
+        this.indexWriter = indexWriter;
+        this.deletionTimeSerializer = deletionTimeSerializer;
+        this.indexBlockThreshold = DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY);
+        this.bloomFilter = indexWriter.bf instanceof BloomFilter ? (BloomFilter) indexWriter.bf : null;
+    }
+
+    @Override
+    protected void reset()
+    {
+        rowIndexEntries.clear();
+        rowIndexEntriesOffsets.clear();
+        rowIndexEntryOffset = 0;
+        hasDistinctLastClustering = false;
+    }
+
+    @Override
+    public void rowWritten(UnfilteredDescriptor unfilteredDescriptor, long unfilteredStartPosition,
+                           long unfilteredEndPosition, DeletionTime openMarker) throws IOException
+    {
+        // write the first clustering into rowIndexEntries buffer (we will need it unless we never write the first entry)
+        if (currentOffsetInPartition(unfilteredStartPosition) == indexBlockStartOffset || (rowIndexEntryOffset == rowIndexEntries.position()))
+        {
+            writeClusteringToRowIndexEntries(unfilteredDescriptor);
+        }
+        else
+        {
+            hasDistinctLastClustering = true;
+        }
+
+        /** {@link BigFormatPartitionWriter#addUnfiltered(org.apache.cassandra.db.rows.Unfiltered)} */
+        // if we hit the index block size that we have to index after, go ahead and index it.
+        long indexBlockSize = currentOffsetInPartition(unfilteredEndPosition) - indexBlockStartOffset;
+        if (indexBlockSize >= this.indexBlockThreshold)
+            addIndexBlock(unfilteredEndPosition, indexBlockSize, openMarker, unfilteredDescriptor);
+    }
+
+    /**
+     *  See:
+     *  {@link BigFormatPartitionWriter#addIndexBlock()}
+     *  - {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}
+     *
+     * @param lastName the clustering of the block's last unfiltered. A mid-partition cut happens inside
+     *                 {@link #rowWritten}, where that is the live descriptor; the trailing cut happens at
+     *                 partition end, where it is the descriptor the write side detached from the cursor.
+     */
+    private void addIndexBlock(long endOfRowPosition, long indexBlockSize, DeletionTime openMarker,
+                               ClusteringDescriptor lastName) throws IOException
+    {
+        if (rowIndexEntriesOffsets.isEmpty() && rowIndexEntryOffset != 0) {
+            throw new IllegalStateException();
+        }
+
+        // serialize the index info
+        /** {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}*/
+        rowIndexEntriesOffsets.addInt(rowIndexEntryOffset);
+
+        // The block's FIRST clustering was serialized into this buffer eagerly when the
+        // block's first row was written (descriptors are transient — by block-cut time that
+        // row's clustering no longer exists anywhere else). The IndexInfo wire format wants
+        // [firstName][lastName][offset][width][openMarker]; the first name is already in
+        // place, so only the last name is appended here.
+        if (!hasDistinctLastClustering)
+        {
+            // single-unfiltered block: first IS last, so duplicate the already-serialized
+            // first entry bytes by self-copy from this same buffer (no re-serialization)
+            byte[] entriesData = rowIndexEntries.getData();
+            long endOfFirstEntry = rowIndexEntries.position();
+            rowIndexEntries.write(entriesData, rowIndexEntryOffset, (int) (endOfFirstEntry - rowIndexEntryOffset));
+        }
+        else
+        {
+            // hasDistinctLastClustering means two or more unfiltereds have been written to this block, so
+            // the write side's last written unfiltered is this block's last and belongs to this partition.
+            assert lastName != null : "an index block with a distinct last name has no last name";
+            writeClusteringToRowIndexEntries(lastName);
+        }
+        hasDistinctLastClustering = false;
+
+        rowIndexEntries.writeUnsignedVInt((long)indexBlockStartOffset);
+        rowIndexEntries.writeVInt(indexBlockSize - IndexInfo.Serializer.WIDTH_BASE);
+
+        boolean isDeleteTimePresent = !openMarker.isLive();
+        rowIndexEntries.writeBoolean(isDeleteTimePresent);
+        if (isDeleteTimePresent)
+            deletionTimeSerializer.serialize(openMarker, rowIndexEntries);
+        // next block starts
+        rowIndexEntryOffset = Ints.checkedCast(rowIndexEntries.position());
+        notePosition(endOfRowPosition);
+    }
+
+    private void writeClusteringToRowIndexEntries(ClusteringDescriptor clustering) throws IOException
+    {
+        ClusteringPrefix.Kind kind = clustering.clusteringKind();
+        rowIndexEntries.writeByte(kind.ordinal());
+        if (kind != ClusteringPrefix.Kind.CLUSTERING)
+            rowIndexEntries.writeShort(clustering.clusteringColumnsBound());
+        rowIndexEntries.write(clustering.clusteringBytes(), 0, clustering.clusteringLength());
+    }
+
+    @Override
+    public void endPartition(byte[] key, int keyLength, int headerLength,
+                             DeletionTime partitionDeletionTime, long partitionEnd,
+                             ClusteringDescriptor lastName) throws IOException
+    {
+        /**
+         * {@link BigTableWriter#createRowIndexEntry(org.apache.cassandra.db.DecoratedKey, DeletionTime, long)}
+         * {@link BigTableWriter.IndexWriter#append(org.apache.cassandra.db.DecoratedKey, RowIndexEntry, long, java.nio.ByteBuffer)}
+         *
+         */
+        SequentialWriter indexFileWriter = indexWriter.writer;
+        if (bloomFilter != null)
+            bloomFilter.add(key, 0, keyLength, reusableIndexes);
+        long indexStart = indexFileWriter.position();
+        try
+        {
+            ByteArrayUtil.writeWithShortLength(key, 0, keyLength, indexFileWriter);
+
+            indexFileWriter.writeUnsignedVInt(partitionStart);
+
+            // The trailing block must be counted BEFORE deciding whether to promote the index:
+            // the iterator (BigFormatPartitionWriter.finish + RowIndexEntry.create) promotes when
+            // the total block count INCLUDING the tail is > 1. A tail size of exactly 1 means only
+            // the end-of-partition marker remains since the last cut (the iterator's
+            // firstClustering == null case) and no tail block exists.
+            // The tail width itself includes the end-of-partition marker byte, matching the
+            // iterator, which indexes the final block AFTER SortedTablePartitionWriter.finish()
+            // has written the marker.
+            long tailBlockSize = (partitionEnd - partitionStart) - indexBlockStartOffset;
+            boolean hasTailBlock = tailBlockSize > 1;
+            int totalBlocks = rowIndexEntriesOffsets.size() + (hasTailBlock ? 1 : 0);
+
+            /** See: {@link org.apache.cassandra.io.sstable.format.big.RowIndexEntry#create} */
+            if (totalBlocks <= 1)
+            {
+                /**
+                 * {@link RowIndexEntry#serialize(org.apache.cassandra.io.util.DataOutputPlus, java.nio.ByteBuffer)}
+                 */
+                indexFileWriter.writeUnsignedVInt32(0); // size
+            }
+            else {
+                // add last block
+                if (hasTailBlock) {
+                    addIndexBlock(partitionEnd, tailBlockSize, DeletionTime.LIVE, lastName);
+                }
+                // if we have intermeddiate index info elements we also need to serialize the partitionDeletionTime
+                /** {@link RowIndexEntry.IndexedEntry#serialize(org.apache.cassandra.io.util.DataOutputPlus, java.nio.ByteBuffer) */
+                // size up to the offsets?
+                int endOfEntries = rowIndexEntries.getLength();
+                // Write the headerLength, partitionDeletionTime and rowIndexEntriesOffsets.size() after the entries,
+                // just to calculate size.
+                rowIndexEntries.writeUnsignedVInt((long)headerLength);
+                deletionTimeSerializer.serialize(partitionDeletionTime, rowIndexEntries);
+
+                rowIndexEntries.writeUnsignedVInt32(rowIndexEntriesOffsets.size()); // number of entries
+
+                // bytes until offsets
+                int entriesAndOffsetsSize = rowIndexEntries.getLength() + rowIndexEntriesOffsets.size() * 4;
+                assert entriesAndOffsetsSize > 0;
+                indexFileWriter.writeUnsignedVInt32(entriesAndOffsetsSize); // size != 0
+                // copy the header elements
+                indexFileWriter.write(rowIndexEntries.getData(), endOfEntries, rowIndexEntries.getLength() - endOfEntries);
+                indexFileWriter.write(rowIndexEntries.getData(), 0, endOfEntries);
+                for (int i = 0; i < rowIndexEntriesOffsets.size(); i++)
+                {
+                    int offset = rowIndexEntriesOffsets.getInt(i);
+                    indexFileWriter.writeInt(offset);
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, indexFileWriter.getPath());
+        }
+        indexWriter.summary.maybeAddEntry(key, 0, keyLength, indexStart);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
@@ -45,6 +45,11 @@ public class BigCursorIndexWriter extends CursorIndexWriter
 {
     private final BigTableWriter.IndexWriter indexWriter;
     private final DeletionTime.Serializer deletionTimeSerializer;
+    // The garbage-free add() overload exists only on the concrete BloomFilter. With
+    // bloom_filter_fp_chance = 1.0 FilterFactory hands out the AlwaysPresentFilter instead,
+    // whose interface add() is a no-op (the iterator path calls it through IFilter) — null
+    // here means "nothing to add to".
+    private final BloomFilter bloomFilter;
     /**
      * See: {@link BloomFilter#reusableIndexes}
      */
@@ -65,6 +70,7 @@ public class BigCursorIndexWriter extends CursorIndexWriter
         this.deletionTimeSerializer = deletionTimeSerializer;
         this.rowIndexEntryLastClustering = rowIndexEntryLastClustering;
         this.indexBlockThreshold = DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY);
+        this.bloomFilter = indexWriter.bf instanceof BloomFilter ? (BloomFilter) indexWriter.bf : null;
     }
 
     @Override
@@ -164,7 +170,8 @@ public class BigCursorIndexWriter extends CursorIndexWriter
          *
          */
         SequentialWriter indexFileWriter = indexWriter.writer;
-        ((BloomFilter)indexWriter.bf).add(key, 0, keyLength, reusableIndexes);
+        if (bloomFilter != null)
+            bloomFilter.add(key, 0, keyLength, reusableIndexes);
         long indexStart = indexFileWriter.position();
         try
         {

--- a/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.io.IOException;
+
+import com.google.common.primitives.Ints;
+import org.agrona.collections.IntArrayList;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter;
+import org.apache.cassandra.io.sstable.format.big.BigTableWriter;
+import org.apache.cassandra.io.sstable.format.big.RowIndexEntry;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.utils.ByteArrayUtil;
+import org.apache.cassandra.utils.BloomFilter;
+
+/**
+ * BIG-format index production for the cursor writer: promoted index blocks serialized
+ * incrementally (IndexInfo wire format) and Index.db entries with the tail-counted
+ * promotion decision, byte-identical to the iterator path
+ * (BigFormatPartitionWriter + RowIndexEntry.create + BigTableWriter.IndexWriter.append).
+ */
+public class BigCursorIndexWriter extends CursorIndexWriter
+{
+    private final BigTableWriter.IndexWriter indexWriter;
+    private final DeletionTime.Serializer deletionTimeSerializer;
+    /**
+     * See: {@link BloomFilter#reusableIndexes}
+     */
+    private final long[] reusableIndexes = new long[21];
+
+    private final DataOutputBuffer rowIndexEntries = new DataOutputBuffer();
+    private final IntArrayList rowIndexEntriesOffsets = new IntArrayList();
+    private final ClusteringDescriptor rowIndexEntryLastClustering;
+    private boolean hasDistinctLastClustering = false;
+    private int rowIndexEntryOffset;
+    private final int indexBlockThreshold;
+
+    public BigCursorIndexWriter(BigTableWriter.IndexWriter indexWriter,
+                                DeletionTime.Serializer deletionTimeSerializer,
+                                ClusteringDescriptor rowIndexEntryLastClustering)
+    {
+        this.indexWriter = indexWriter;
+        this.deletionTimeSerializer = deletionTimeSerializer;
+        this.rowIndexEntryLastClustering = rowIndexEntryLastClustering;
+        this.indexBlockThreshold = DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY);
+    }
+
+    @Override
+    protected void reset()
+    {
+        rowIndexEntries.clear();
+        rowIndexEntriesOffsets.clear();
+        rowIndexEntryOffset = 0;
+        hasDistinctLastClustering = false;
+    }
+
+    @Override
+    public void rowWritten(UnfilteredDescriptor unfilteredDescriptor, long unfilteredStartPosition,
+                           long unfilteredEndPosition, DeletionTime openMarker) throws IOException
+    {
+        // write the first clustering into rowIndexEntries buffer (we will need it unless we never write the first entry)
+        if (currentOffsetInPartition(unfilteredStartPosition) == indexBlockStartOffset || (rowIndexEntryOffset == rowIndexEntries.position()))
+        {
+            writeClusteringToRowIndexEntries(unfilteredDescriptor);
+        }
+        else
+        {
+            rowIndexEntryLastClustering.copy(unfilteredDescriptor);
+            hasDistinctLastClustering = true;
+        }
+
+        /** {@link BigFormatPartitionWriter#addUnfiltered(org.apache.cassandra.db.rows.Unfiltered)} */
+        // if we hit the index block size that we have to index after, go ahead and index it.
+        long indexBlockSize = currentOffsetInPartition(unfilteredEndPosition) - indexBlockStartOffset;
+        if (indexBlockSize >= this.indexBlockThreshold)
+            addIndexBlock(unfilteredEndPosition, indexBlockSize, openMarker);
+    }
+
+    /**
+     *  See:
+     *  {@link BigFormatPartitionWriter#addIndexBlock()}
+     *  - {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}
+     */
+    private void addIndexBlock(long endOfRowPosition, long indexBlockSize, DeletionTime openMarker) throws IOException
+    {
+        if (rowIndexEntriesOffsets.isEmpty() && rowIndexEntryOffset != 0) {
+            throw new IllegalStateException();
+        }
+
+        // serialize the index info
+        /** {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}*/
+        rowIndexEntriesOffsets.addInt(rowIndexEntryOffset);
+
+        // first clustering is already in, write last entry
+        if (!hasDistinctLastClustering)
+        {
+            // first entry is the last entry, copy it
+            byte[] entriesData = rowIndexEntries.getData();
+            long endOfFirstEntry = rowIndexEntries.position();
+            rowIndexEntries.write(entriesData, rowIndexEntryOffset, (int) (endOfFirstEntry - rowIndexEntryOffset));
+        }
+        else
+        {
+            writeClusteringToRowIndexEntries(rowIndexEntryLastClustering);
+            rowIndexEntryLastClustering.resetClustering();
+        }
+        hasDistinctLastClustering = false;
+
+        rowIndexEntries.writeUnsignedVInt((long)indexBlockStartOffset);
+        rowIndexEntries.writeVInt(indexBlockSize - IndexInfo.Serializer.WIDTH_BASE);
+
+        boolean isDeleteTimePresent = !openMarker.isLive();
+        rowIndexEntries.writeBoolean(isDeleteTimePresent);
+        if (isDeleteTimePresent)
+            deletionTimeSerializer.serialize(openMarker, rowIndexEntries);
+        // next block starts
+        rowIndexEntryOffset = Ints.checkedCast(rowIndexEntries.position());
+        notePosition(endOfRowPosition);
+    }
+
+    private void writeClusteringToRowIndexEntries(ClusteringDescriptor clustering) throws IOException
+    {
+        ClusteringPrefix.Kind kind = clustering.clusteringKind();
+        rowIndexEntries.writeByte(kind.ordinal());
+        if (kind != ClusteringPrefix.Kind.CLUSTERING)
+            rowIndexEntries.writeShort(clustering.clusteringColumnsBound());
+        rowIndexEntries.write(clustering.clusteringBytes(), 0, clustering.clusteringLength());
+    }
+
+    @Override
+    public void endPartition(byte[] key, int keyLength, int headerLength,
+                             DeletionTime partitionDeletionTime, long partitionEnd) throws IOException
+    {
+        /**
+         * {@link BigTableWriter#createRowIndexEntry(org.apache.cassandra.db.DecoratedKey, DeletionTime, long)}
+         * {@link BigTableWriter.IndexWriter#append(org.apache.cassandra.db.DecoratedKey, RowIndexEntry, long, java.nio.ByteBuffer)}
+         *
+         */
+        SequentialWriter indexFileWriter = indexWriter.writer;
+        ((BloomFilter)indexWriter.bf).add(key, 0, keyLength, reusableIndexes);
+        long indexStart = indexFileWriter.position();
+        try
+        {
+            ByteArrayUtil.writeWithShortLength(key, 0, keyLength, indexFileWriter);
+
+            indexFileWriter.writeUnsignedVInt(partitionStart);
+
+            // The trailing block must be counted BEFORE deciding whether to promote the index:
+            // the iterator (BigFormatPartitionWriter.finish + RowIndexEntry.create) promotes when
+            // the total block count INCLUDING the tail is > 1. A tail size of exactly 1 means only
+            // the end-of-partition marker remains since the last cut (the iterator's
+            // firstClustering == null case) and no tail block exists.
+            // The tail width itself includes the end-of-partition marker byte, matching the
+            // iterator, which indexes the final block AFTER SortedTablePartitionWriter.finish()
+            // has written the marker.
+            long tailBlockSize = (partitionEnd - partitionStart) - indexBlockStartOffset;
+            boolean hasTailBlock = tailBlockSize > 1;
+            int totalBlocks = rowIndexEntriesOffsets.size() + (hasTailBlock ? 1 : 0);
+
+            /** See: {@link org.apache.cassandra.io.sstable.format.big.RowIndexEntry#create} */
+            if (totalBlocks <= 1)
+            {
+                /**
+                 * {@link RowIndexEntry#serialize(org.apache.cassandra.io.util.DataOutputPlus, java.nio.ByteBuffer)}
+                 */
+                indexFileWriter.writeUnsignedVInt32(0); // size
+            }
+            else {
+                // add last block
+                if (hasTailBlock) {
+                    addIndexBlock(partitionEnd, tailBlockSize, DeletionTime.LIVE);
+                }
+                // if we have intermeddiate index info elements we also need to serialize the partitionDeletionTime
+                /** {@link RowIndexEntry.IndexedEntry#serialize(org.apache.cassandra.io.util.DataOutputPlus, java.nio.ByteBuffer) */
+                // size up to the offsets?
+                int endOfEntries = rowIndexEntries.getLength();
+                // Write the headerLength, partitionDeletionTime and rowIndexEntriesOffsets.size() after the entries,
+                // just to calculate size.
+                rowIndexEntries.writeUnsignedVInt((long)headerLength);
+                deletionTimeSerializer.serialize(partitionDeletionTime, rowIndexEntries);
+
+                rowIndexEntries.writeUnsignedVInt32(rowIndexEntriesOffsets.size()); // number of entries
+
+                // bytes until offsets
+                int entriesAndOffsetsSize = rowIndexEntries.getLength() + rowIndexEntriesOffsets.size() * 4;
+                assert entriesAndOffsetsSize > 0;
+                indexFileWriter.writeUnsignedVInt32(entriesAndOffsetsSize); // size != 0
+                // copy the header elements
+                indexFileWriter.write(rowIndexEntries.getData(), endOfEntries, rowIndexEntries.getLength() - endOfEntries);
+                indexFileWriter.write(rowIndexEntries.getData(), 0, endOfEntries);
+                for (int i = 0; i < rowIndexEntriesOffsets.size(); i++)
+                {
+                    int offset = rowIndexEntriesOffsets.get(i);
+                    indexFileWriter.writeInt(offset);
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, indexFileWriter.getPath());
+        }
+        indexWriter.summary.maybeAddEntry(key, 0, keyLength, indexStart);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/BigCursorIndexWriter.java
@@ -113,10 +113,15 @@ public class BigCursorIndexWriter extends CursorIndexWriter
         /** {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}*/
         rowIndexEntriesOffsets.addInt(rowIndexEntryOffset);
 
-        // first clustering is already in, write last entry
+        // The block's FIRST clustering was serialized into this buffer eagerly when the
+        // block's first row was written (descriptors are transient — by block-cut time that
+        // row's clustering no longer exists anywhere else). The IndexInfo wire format wants
+        // [firstName][lastName][offset][width][openMarker]; the first name is already in
+        // place, so only the last name is appended here.
         if (!hasDistinctLastClustering)
         {
-            // first entry is the last entry, copy it
+            // single-unfiltered block: first IS last, so duplicate the already-serialized
+            // first entry bytes by self-copy from this same buffer (no re-serialization)
             byte[] entriesData = rowIndexEntries.getData();
             long endOfFirstEntry = rowIndexEntries.position();
             rowIndexEntries.write(entriesData, rowIndexEntryOffset, (int) (endOfFirstEntry - rowIndexEntryOffset));

--- a/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.io.IOException;
+
+import org.apache.cassandra.db.DeletionTime;
+
+/**
+ * Format-specific partition/row index production for {@link SSTableCursorWriter}.
+ *
+ * The seam is EVENT-shaped because {@link UnfilteredDescriptor}s are transient (reused per
+ * row): implementations that need block-boundary clusterings must capture them at
+ * {@link #rowWritten} time, or take them from a descriptor the write side owns, rather than
+ * expecting one to still exist at a block boundary. The cursor writer owns all data-file
+ * serialization and the open range-tombstone marker; implementations own everything about
+ * their index format (BIG: promoted index blocks + Index.db entries + bloom filter/summary;
+ * other formats own their own index structures accordingly).
+ */
+public abstract class CursorIndexWriter
+{
+    protected long partitionStart;
+    // Offset within the current partition where the current index block begins. MUST be a
+    // long, like the reference SortedTablePartitionWriter.indexBlockStartOffset: partitions
+    // can exceed 2GiB, and an int here wraps negative past Integer.MAX_VALUE — the block-cut
+    // arithmetic then cuts every row and the serialized offsets corrupt the promoted index
+    // (pinned by CursorIndexWriterOffsetWidthTest, and exercised at scale by the giant-partition
+    // boundary run, ck_stride = rows_per_sstable).
+    protected long indexBlockStartOffset;
+
+    public final void startPartition(long partitionStartPosition, long positionAfterHeader)
+    {
+        this.partitionStart = partitionStartPosition;
+        reset();
+        notePosition(positionAfterHeader);
+    }
+
+    /** Static rows reset the block clock without participating in row index blocks. */
+    public final void staticRowWritten(long position)
+    {
+        notePosition(position);
+    }
+
+    public final long indexBlockStartOffset()
+    {
+        return indexBlockStartOffset;
+    }
+
+    protected final void notePosition(long endOfRowPosition)
+    {
+        indexBlockStartOffset = endOfRowPosition - partitionStart;
+    }
+
+    protected final long currentOffsetInPartition(long position)
+    {
+        return position - partitionStart;
+    }
+
+    /** Clear per-partition state. Called by {@link #startPartition}. */
+    protected abstract void reset();
+
+    /**
+     * A non-static row or range tombstone marker was written to [rowStart, rowEnd).
+     * The descriptor's clustering describes it; openMarker is the range deletion open at
+     * the END of this unfiltered (LIVE if none).
+     */
+    public abstract void rowWritten(UnfilteredDescriptor descriptor, long rowStart, long rowEnd,
+                                    DeletionTime openMarker) throws IOException;
+
+    /**
+     * The partition (including its end-of-partition marker) ends at partitionEnd.
+     *
+     * @param lastName the clustering of the last non-static unfiltered written to this partition, which a
+     *                 trailing index block needs as its last name; null if the partition wrote none, in which
+     *                 case there is no trailing block to cut.
+     */
+    public abstract void endPartition(byte[] key, int keyLength, int headerLength,
+                                      DeletionTime partitionDeletionTime, long partitionEnd,
+                                      ClusteringDescriptor lastName) throws IOException;
+}

--- a/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.io.IOException;
+
+import org.apache.cassandra.db.DeletionTime;
+
+/**
+ * Format-specific partition/row index production for {@link SSTableCursorWriter}.
+ *
+ * The seam is EVENT-shaped because {@link UnfilteredDescriptor}s are transient (reused per
+ * row): implementations that need block-boundary clusterings must capture them at
+ * {@link #rowWritten} time, not at block boundaries. The cursor writer owns all data-file
+ * serialization and the open range-tombstone marker; implementations own everything about
+ * their index format (BIG: promoted index blocks + Index.db entries + bloom filter/summary;
+ * other formats own their own index structures accordingly).
+ */
+public abstract class CursorIndexWriter
+{
+    protected long partitionStart;
+    // Offset within the current partition where the current index block begins.
+    protected int indexBlockStartOffset;
+
+    public final void startPartition(long partitionStartPosition, long positionAfterHeader)
+    {
+        this.partitionStart = partitionStartPosition;
+        reset();
+        notePosition(positionAfterHeader);
+    }
+
+    /** Static rows reset the block clock without participating in row index blocks. */
+    public final void staticRowWritten(long position)
+    {
+        notePosition(position);
+    }
+
+    public final int indexBlockStartOffset()
+    {
+        return indexBlockStartOffset;
+    }
+
+    protected final void notePosition(long endOfRowPosition)
+    {
+        indexBlockStartOffset = (int) (endOfRowPosition - partitionStart);
+    }
+
+    protected final long currentOffsetInPartition(long position)
+    {
+        return position - partitionStart;
+    }
+
+    /** Clear per-partition state. Called by {@link #startPartition}. */
+    protected abstract void reset();
+
+    /**
+     * A non-static row or range tombstone marker was written to [rowStart, rowEnd).
+     * The descriptor's clustering describes it; openMarker is the range deletion open at
+     * the END of this unfiltered (LIVE if none).
+     */
+    public abstract void rowWritten(UnfilteredDescriptor descriptor, long rowStart, long rowEnd,
+                                    DeletionTime openMarker) throws IOException;
+
+    /** The partition (including its end-of-partition marker) ends at partitionEnd. */
+    public abstract void endPartition(byte[] key, int keyLength, int headerLength,
+                                      DeletionTime partitionDeletionTime, long partitionEnd) throws IOException;
+}

--- a/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CursorIndexWriter.java
@@ -35,8 +35,12 @@ import org.apache.cassandra.db.DeletionTime;
 public abstract class CursorIndexWriter
 {
     protected long partitionStart;
-    // Offset within the current partition where the current index block begins.
-    protected int indexBlockStartOffset;
+    // Offset within the current partition where the current index block begins. MUST be a
+    // long, like the reference SortedTablePartitionWriter.indexBlockStartOffset: partitions
+    // can exceed 2GiB, and an int here wraps negative past Integer.MAX_VALUE — the block-cut
+    // arithmetic then cuts every row and the serialized offsets corrupt the promoted index
+    // (pinned by the giant-partition boundary run, ck_stride = rows_per_sstable).
+    protected long indexBlockStartOffset;
 
     public final void startPartition(long partitionStartPosition, long positionAfterHeader)
     {
@@ -51,14 +55,14 @@ public abstract class CursorIndexWriter
         notePosition(position);
     }
 
-    public final int indexBlockStartOffset()
+    public final long indexBlockStartOffset()
     {
         return indexBlockStartOffset;
     }
 
     protected final void notePosition(long endOfRowPosition)
     {
-        indexBlockStartOffset = (int) (endOfRowPosition - partitionStart);
+        indexBlockStartOffset = endOfRowPosition - partitionStart;
     }
 
     protected final long currentOffsetInPartition(long position)

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import com.google.common.collect.ImmutableList;
 
 import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.Columns;
 import org.apache.cassandra.db.DeletionTime;
@@ -34,6 +35,7 @@ import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.db.rows.DeserializationHelper;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
+import org.apache.cassandra.db.rows.ReusableCellLivenessInfo;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.SerializationHelper;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
@@ -93,37 +95,101 @@ public class SSTableCursorReader implements AutoCloseable
         }
     }
 
+    /** {@link CellCursor#readCellHeader()} result: no cell surfaced — every remaining
+     *  column in this row was dropped-column filtered */
+    static final int CELL_NONE_REMAINING = -1;
+    /** {@link CellCursor#readCellHeader()} result: cell surfaced with no value (tombstone) */
+    static final int CELL_NO_VALUE = 0;
+    /** {@link CellCursor#readCellHeader()} result: cell surfaced with a value */
+    static final int CELL_HAS_VALUE = 1;
+
     public class CellCursor {
         public ReusableLivenessInfo rowLiveness;
         public Columns columns;
 
         public int columnsSize;
-        public int columnsIndex;
         public int cellFlags;
-        public final ReusableLivenessInfo cellLiveness = new ReusableLivenessInfo();
+        public final ReusableCellLivenessInfo cellLiveness = new ReusableCellLivenessInfo();
         public CellPath cellPath;
         public AbstractType<?> cellType;
         public ColumnMetadata cellColumn;
         private ColumnMetadata[] columnsArray;
         private AbstractType<?>[] cellTypeArray;
+        // Parallel to columnsArray: each column's drop horizon, or DeserializationHelper.NO_DROP_HORIZON
+        // if none. That sentinel is Long.MIN_VALUE and so is NOT out of band for a timestamp — the drop
+        // test must go through DeserializationHelper.isDroppedAtHorizon, which checks the sentinel first;
+        // a bare "timestamp <= droppedTimeArray[i]" filters a cell timestamped LivenessInfo.NO_TIMESTAMP
+        // on a column that was never dropped, which the iterator path keeps. Built once per superset
+        // change (see init) so the per-cell drop check is a plain array read instead of a
+        // ByteBuffer-keyed map lookup on sstableHasDroppedColumns tables.
+        private long[] droppedTimeArray;
 
-        void init (Columns columns, ReusableLivenessInfo rowLiveness)
+        // Remaining PRESENT columns of this row as a bitmask over columnsArray indices.
+        // Garbage-free sparse-row iteration: rows that do not contain every header column
+        // pass the missing-columns mask (or, for >= 64-column supersets, present-mask
+        // words) instead of a freshly allocated Columns subset, so the identity cache
+        // below only rebuilds on a genuine superset change (stable per reader).
+        private long presentMask;
+        // >= 64-column supersets: present-mask words (bit i of word i/64 = superset column
+        // i present), walked word by word. Grow-once scratch, consumed destructively.
+        private long[] presentWords;
+        private int presentWordsCount;
+        private int presentWordIndex;
+
+        void init (Columns columns, long missingColumnsMask, long[] presentColumnsWords, ReusableLivenessInfo rowLiveness)
         {
+            // the sstable-scoped dropped-column flag is only sound while the superset comes from
+            // this sstable's header; a schema-derived Columns here would under-filter silently
+            assert columns == serializationHeader.columns(false) || columns == serializationHeader.columns(true)
+                 : "cell superset must be one of this sstable's header column sets";
             if (this.columns != columns)
             {
                 // This will be a problem with changing columns
                 this.columns = columns;
                 columnsArray = columns.toArray(COLUMN_METADATA_TYPE);
                 cellTypeArray = new AbstractType<?>[columnsArray.length];
+                droppedTimeArray = sstableHasDroppedColumns ? new long[columnsArray.length] : null;
                 for (int i = 0; i < columnsArray.length; i++)
                 {
-                    ColumnMetadata cellColumn = columnsArray[i];
-                    cellTypeArray[i]  = serializationHeader.getType(cellColumn);
+                    cellTypeArray[i] = serializationHeader.getType(columnsArray[i]);
+                    if (sstableHasDroppedColumns)
+                        droppedTimeArray[i] = deserializationHelper.droppedTimeOrMin(columnsArray[i]);
                 }
                 columnsSize = columns.size();
             }
+            if (columnsSize >= 64)
+            {
+                // word-mask walk over the superset; the descriptor decoded the large-subset
+                // wire format into presentColumnsWords (null = all columns present)
+                int nWords = (columnsSize + 63) >>> 6;
+                if (presentWords == null || presentWords.length < nWords)
+                    presentWords = new long[nWords]; // grow-once, amortized zero
+                presentWordsCount = nWords;
+                presentWordIndex = 0;
+                if (presentColumnsWords != null)
+                {
+                    System.arraycopy(presentColumnsWords, 0, presentWords, 0, nWords);
+                }
+                else
+                {
+                    java.util.Arrays.fill(presentWords, 0, nWords, -1L);
+                    if ((columnsSize & 63) != 0)
+                        presentWords[nWords - 1] = -1L >>> (64 - (columnsSize & 63));
+                }
+                presentMask = 0;
+            }
+            else
+            {
+                // Build the present-columns bitmask from the wire's MISSING-columns mask:
+                //   -1L >>> (64 - n)   is the "n low ones" template (e.g. n=3 -> 0b111): all 64
+                //                      bits set, then shifted so exactly the n column bits remain.
+                //                      n == 0 must be special-cased because Java shifts are mod 64
+                //                      (>>> 64 is a no-op, NOT zero).
+                //   ~missingColumnsMask flips missing->present but also sets every bit ABOVE the
+                //                      column range, so it is ANDed with the template to trim them.
+                presentMask = ~missingColumnsMask & (columnsSize == 0 ? 0 : (-1L >>> (64 - columnsSize)));
+            }
             this.rowLiveness = rowLiveness;
-            columnsIndex = 0;
             cellFlags = 0;
             cellPath = null;
             cellType = null;
@@ -131,44 +197,113 @@ public class SSTableCursorReader implements AutoCloseable
 
         public boolean hasNext()
         {
-            return columnsIndex < columnsSize;
+            return columnsSize >= 64 ? columnsRemain() : presentMask != 0;
+        }
+
+        private boolean columnsRemain()
+        {
+            // advance to the next non-empty word; position is retained across calls
+            while (presentWordIndex < presentWordsCount)
+            {
+                if (presentWords[presentWordIndex] != 0)
+                    return true;
+                presentWordIndex++;
+            }
+            return false;
         }
 
         /**
          * For Cell deserialization see {@link Cell.Serializer#deserialize}
          *
-         * @return true if the cell has a value, false otherwise
+         * Dropped-column filtering happens here, mirroring the iterator's deserialization:
+         * cells of a dropped column written at or before the drop are consumed and never
+         * surfaced; the loop advances to the next column in that case. A dropped column
+         * that turns out to be the row's last remaining column leaves NO cell at all for
+         * this position (distinct from a genuine valueless cell/tombstone), which is why
+         * this returns a tri-state rather than a plain hasValue boolean: the caller must
+         * skip straight past the row/unfiltered end rather than stopping at a cell that
+         * doesn't exist.
+         *
+         * @return 1 if the next cell has a value, 0 if it has none (tombstone), -1 if no
+         *         cell remains in this row (all trailing columns were dropped-filtered)
          */
-        boolean readCellHeader() throws IOException
+        int readCellHeader() throws IOException
         {
-            if (!(columnsIndex < columnsSize)) throw new IllegalStateException();
+            if (!hasNext()) throw new IllegalStateException();
 
-            // HOTSPOT: suprisingly expensive
-            int currIndex = columnsIndex++;
-            cellColumn = columnsArray[currIndex];
-            cellType = cellTypeArray[currIndex];
-            cellFlags = dataReader.readUnsignedByte();
-            // TODO: specialize common case where flags == HAS_VALUE | USE_ROW_TS?
-            boolean hasValue = Cell.Serializer.hasValue(cellFlags);
-            boolean isDeleted = Cell.Serializer.isDeleted(cellFlags);
-            boolean isExpiring = Cell.Serializer.isExpiring(cellFlags);
-            boolean useRowTimestamp = Cell.Serializer.useRowTimestamp(cellFlags);
-            boolean useRowTTL = Cell.Serializer.useRowTTL(cellFlags);
+            for (;;)
+            {
+                // HOTSPOT: suprisingly expensive
+                int currIndex;
+                if (columnsSize >= 64)
+                {
+                    // columnsRemain() (via hasNext() above, or the loop-continue path below)
+                    // parked presentWordIndex on a non-empty word; same low-to-high bit walk
+                    // as the single-mask path below
+                    long word = presentWords[presentWordIndex];
+                    currIndex = (presentWordIndex << 6) + Long.numberOfTrailingZeros(word);
+                    presentWords[presentWordIndex] = word & (word - 1);
+                }
+                else
+                {
+                    // Bit i of presentMask corresponds to the i-th column of the superset in
+                    // its iteration order — the SAME order the serializer assigned bits and
+                    // the same order cells appear on disk. Walking bits low-to-high therefore
+                    // visits cells in exactly their on-disk order:
+                    //   numberOfTrailingZeros = index of the lowest set bit (next present column)
+                    //   x & (x - 1)           = clears that lowest set bit (subtracting 1 borrows
+                    //                           through the trailing zeros; the AND kills both)
+                    currIndex = Long.numberOfTrailingZeros(presentMask);
+                    presentMask &= presentMask - 1;
+                }
+                cellColumn = columnsArray[currIndex];
+                cellType = cellTypeArray[currIndex];
+                cellFlags = dataReader.readUnsignedByte();
+                // TODO: specialize common case where flags == HAS_VALUE | USE_ROW_TS?
+                boolean hasValue = Cell.Serializer.hasValue(cellFlags);
+                boolean isDeleted = Cell.Serializer.isDeleted(cellFlags);
+                boolean isExpiring = Cell.Serializer.isExpiring(cellFlags);
+                boolean useRowTimestamp = Cell.Serializer.useRowTimestamp(cellFlags);
+                boolean useRowTTL = Cell.Serializer.useRowTTL(cellFlags);
 
-            long timestamp = useRowTimestamp ? rowLiveness.timestamp() : serializationHeader.readTimestamp(dataReader);
+                long timestamp = useRowTimestamp ? rowLiveness.timestamp() : serializationHeader.readTimestamp(dataReader);
 
-            long localDeletionTime = useRowTTL
-                                     ? rowLiveness.localExpirationTime()
-                                     : (isDeleted || isExpiring ? serializationHeader.readLocalDeletionTime(dataReader) : Cell.NO_DELETION_TIME);
+                long localDeletionTime = useRowTTL
+                                         ? rowLiveness.localExpirationTime()
+                                         : (isDeleted || isExpiring ? serializationHeader.readLocalDeletionTime(dataReader) : Cell.NO_DELETION_TIME);
 
-            int ttl = useRowTTL ? rowLiveness.ttl() : (isExpiring ? serializationHeader.readTTL(dataReader) : Cell.NO_TTL);
-            localDeletionTime = Cell.decodeLocalDeletionTime(localDeletionTime, ttl, deserializationHelper);
+                int ttl = useRowTTL ? rowLiveness.ttl() : (isExpiring ? serializationHeader.readTTL(dataReader) : Cell.NO_TTL);
+                localDeletionTime = Cell.decodeLocalDeletionTime(localDeletionTime, ttl, deserializationHelper);
 
-            cellLiveness.reset(timestamp, ttl, localDeletionTime);
-            cellPath = cellColumn.isComplex()
-                            ? cellColumn.cellPathSerializer().deserialize(dataReader)
-                            : null;
-            return hasValue;
+                cellLiveness.reset(timestamp, ttl, localDeletionTime);
+                // Complex (multi-cell) columns never reach the cell cursor: CursorCompactor's
+                // unsupportedSchema and unsupportedHeaderColumns gates both reject them before
+                // compaction starts, including a dropped complex column still recorded in an
+                // older sstable's header — see unsupportedHeaderColumns's javadoc for why that
+                // needs its own check. cellPath is therefore always null on this path; assert
+                // the invariant instead of paying a per-cell isComplex() dispatch and a dead
+                // deserialize call.
+                assert !cellColumn.isComplex() : "complex column reached the cell cursor: " + cellColumn;
+                cellPath = null;
+
+                // Equivalent to deserializationHelper.isDropped(cellColumn, timestamp, false), but
+                // via the precomputed per-superset array instead of a ByteBuffer-keyed map lookup
+                // per cell (isDropped's isComplex=false path would look up droppedColumns.get(
+                // column.name.bytes) every time; this reader never primes startOfComplexColumn's
+                // cache, so isComplex=true was never an option here either). isDroppedAtHorizon
+                // carries the sentinel test that keeps the two forms equivalent — see its javadoc.
+                if (sstableHasDroppedColumns && DeserializationHelper.isDroppedAtHorizon(timestamp, droppedTimeArray[currIndex]))
+                {
+                    // mirror UnfilteredSerializer.readSimpleColumn: cells of a dropped column
+                    // written at or before the drop are discarded on read
+                    if (hasValue)
+                        cellType.skipValue(dataReader);
+                    if (!hasNext())
+                        return CELL_NONE_REMAINING; // caller must skip past the row/unfiltered end
+                    continue;
+                }
+                return hasValue ? CELL_HAS_VALUE : CELL_NO_VALUE;
+            }
         }
     }
 
@@ -176,6 +311,13 @@ public class SSTableCursorReader implements AutoCloseable
     private final AbstractType<?>[] clusteringColumnTypes;
     private final DeserializationHelper deserializationHelper;
     private final SerializationHeader serializationHeader;
+    // True when a column of THIS sstable's header carries a drop horizon; the helper's
+    // identically-purposed flag is table-scoped, hence the name. Sstable scope is sound because the
+    // cell cursor's superset comes from serializationHeader.columns() — asserted in CellCursor.init
+    // — so a column absent from this header can never reach readCellHeader. Held as a field so an
+    // sstable with no dropped column builds no droppedTimeArray at all (see CellCursor.init) and
+    // costs a boolean field test per cell rather than an array load and a sentinel compare.
+    private final boolean sstableHasDroppedColumns;
 
     // need to be closed
     private final SSTableReader ssTableReader;
@@ -191,6 +333,23 @@ public class SSTableCursorReader implements AutoCloseable
     // SHARED STATIC_ROW/ROW/TOMB
     private int basicUnfilteredFlags = 0;
     private int extendedFlags = 0;
+
+    // Where the unfiltered whose cells are being read must end: dataStart + unfilteredSize, captured
+    // from the descriptor when the header was read. Nothing else checks that the cell walk consumes
+    // exactly the body the header declared, so without this a cell-level desync runs on into the NEXT
+    // unfiltered and surfaces far from its cause.
+    // Only the cell-walk funnel below consumes it, and it is cleared there and on markers. Paths that
+    // end an unfiltered WITHOUT walking cells — a row with no present columns, skipRowCells, a seek —
+    // leave it holding the closed row's end, which is why the check is scoped to that one funnel
+    // rather than applied wherever an unfiltered ends.
+    private static final long NO_UNFILTERED_END = -1;
+    private long unfilteredEnd = NO_UNFILTERED_END;
+
+    // Where the cell walk of the unfiltered currently being read BEGAN, so it can be walked again;
+    // see rewindRowCells. Not derivable from the descriptor: its dataStart() is the start of the row
+    // BODY, which still has previousUnfilteredSize, the liveness, the deletion and the missing-columns
+    // subset ahead of the first cell.
+    private long unfilteredCellsStart = NO_UNFILTERED_END;
 
     private int state = PARTITION_START;
 
@@ -226,9 +385,13 @@ public class SSTableCursorReader implements AutoCloseable
         }
         deserializationHelper = new DeserializationHelper(metadata, version.correspondingMessagingVersion(), DeserializationHelper.Flag.LOCAL, null);
         serializationHeader = reader.header;
+        sstableHasDroppedColumns = anyDroppedColumn(deserializationHelper, serializationHeader);
 
         dataReader = reader.openDataReaderForScan(diskAccessMode);
-        hasStaticColumns = metadata.hasStaticColumns();
+        // the HEADER decides whether this sstable can contain static rows: after
+        // ALTER TABLE ... DROP of the last static column, current metadata has no static
+        // columns but older sstables legitimately still carry static rows
+        hasStaticColumns = serializationHeader.hasStatic();
     }
 
     @Override
@@ -237,6 +400,19 @@ public class SSTableCursorReader implements AutoCloseable
         dataReader.close();
         if (ssTableReaderRef != null)
             ssTableReaderRef.close();
+    }
+
+    private static boolean anyDroppedColumn(DeserializationHelper deserializationHelper, SerializationHeader header)
+    {
+        if (!deserializationHelper.hasDroppedColumns())
+            return false;
+        // RegularAndStaticColumns iterates statics then regulars, so this covers both
+        for (ColumnMetadata column : header.columns())
+        {
+            if (deserializationHelper.isDroppedColumn(column))
+                return true;
+        }
+        return false;
     }
 
     private void resetOnPartitionStart()
@@ -329,13 +505,16 @@ public class SSTableCursorReader implements AutoCloseable
         try
         {
             unfilteredDescriptor.loadStaticRow(dataReader, serializationHeader, deserializationHelper, basicUnfilteredFlags, extendedFlags);
+            unfilteredEnd = unfilteredDescriptor.dataStart() + unfilteredDescriptor.size();
+            unfilteredCellsStart = dataReader.getPosition();
         }
         catch (IOException e)
         {
             return corruptSSTable(e);
         }
 
-        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.livenessInfo());
+        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(),
+                                 unfilteredDescriptor.presentColumnsWords(), unfilteredDescriptor.livenessInfo());
         cellCursor = staticRowCellCursor;
         if (!staticRowCellCursor.hasNext())
         {
@@ -385,20 +564,9 @@ public class SSTableCursorReader implements AutoCloseable
     // TODO: move to cell cursor? maybe avoid copy through buffer?
     private void copyCellContents(DataOutputPlus writer, byte[] transferBuffer, int length) throws IOException
     {
-        if (length >= 0)
+        if (length < 0)
         {
-            try
-            {
-                dataReader.readFully(transferBuffer, 0, length);
-            }
-            catch (Exception e)
-            {
-                corruptSSTable(e);
-            }
-            writer.write(transferBuffer, 0, length);
-        }
-        else
-        {
+            // variable length: the wire carries a length vint, which is mirrored to the output
             try
             {
                 length = dataReader.readUnsignedVInt32();
@@ -407,24 +575,31 @@ public class SSTableCursorReader implements AutoCloseable
             {
                 corruptSSTable(e);
             }
+            // both checks mirror AbstractType.read, the reference for this wire format
             if (length < 0)
                 corruptSSTable("Corrupt (negative) value length encountered");
+            if (length > DatabaseDescriptor.getMaxValueSize())
+                corruptSSTable(String.format("Corrupt value length %d encountered, as it exceeds the maximum of %d, " +
+                                             "which is set via max_value_size in cassandra.yaml",
+                                             length, DatabaseDescriptor.getMaxValueSize()));
             writer.writeUnsignedVInt32(length);
-            int remaining = length;
-            while (remaining > 0)
+        }
+        // Fixed-length values carry no vint but are not bounded by the transfer buffer either:
+        // valueLengthIfFixed() is 6144 for a vector<float, 1536>. Both cases copy in chunks.
+        int remaining = length;
+        while (remaining > 0)
+        {
+            int chunk = Math.min(remaining, transferBuffer.length);
+            try
             {
-                int readLength = Math.min(remaining, transferBuffer.length);
-                try
-                {
-                    dataReader.readFully(transferBuffer, 0, readLength);
-                }
-                catch (Exception e)
-                {
-                    corruptSSTable(e);
-                }
-                writer.write(transferBuffer, 0, readLength);
-                remaining -= readLength;
+                dataReader.readFully(transferBuffer, 0, chunk);
             }
+            catch (Exception e)
+            {
+                corruptSSTable(e);
+            }
+            writer.write(transferBuffer, 0, chunk);
+            remaining -= chunk;
         }
     }
 
@@ -445,9 +620,12 @@ public class SSTableCursorReader implements AutoCloseable
         if (!UnfilteredSerializer.isRow(basicUnfilteredFlags)) throw new IllegalStateException();
         try
         {
-            unfilteredDescriptor.loadRow(dataReader, serializationHeader, deserializationHelper, basicUnfilteredFlags);
+            unfilteredDescriptor.loadRow(dataReader, serializationHeader, deserializationHelper, basicUnfilteredFlags, extendedFlags);
+            unfilteredEnd = unfilteredDescriptor.dataStart() + unfilteredDescriptor.size();
+            unfilteredCellsStart = dataReader.getPosition();
 
-            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.livenessInfo());
+            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(),
+                               unfilteredDescriptor.presentColumnsWords(), unfilteredDescriptor.livenessInfo());
             cellCursor = rowCellCursor;
             if (!rowCellCursor.hasNext())
             {
@@ -470,7 +648,16 @@ public class SSTableCursorReader implements AutoCloseable
         if (state != State.CELL_HEADER_START) throw new IllegalStateException();
         try
         {
-            if (cellCursor.readCellHeader())
+            int cell = cellCursor.readCellHeader();
+            if (cell == CELL_NONE_REMAINING)
+            {
+                // no cell surfaced at all (every remaining column was dropped-column
+                // filtered): nothing is current, so advance straight past the would-be
+                // CELL_END stop instead of surfacing a cell-less position
+                checkNextFlagsAfterCellValuesEnd();
+                return continueReading();
+            }
+            if (cell == CELL_HAS_VALUE)
             {
                 return state = State.CELL_VALUE_START;
             }
@@ -526,6 +713,9 @@ public class SSTableCursorReader implements AutoCloseable
             if (state != TOMBSTONE_START) throw new IllegalStateException();
             if (!UnfilteredSerializer.isTombstoneMarker(basicUnfilteredFlags)) throw new IllegalStateException();
             unfilteredDescriptor.loadTombstone(dataReader, serializationHeader, basicUnfilteredFlags);
+            // a marker has no cells, and loadTombstone does not set dataStart, so the descriptor still
+            // holds the previous row's — close the window rather than leave that reachable
+            unfilteredEnd = NO_UNFILTERED_END;
             return checkNextFlagsAfterStaticRowOrUnfilteredStart(false);
         }
         catch (Exception e)
@@ -746,6 +936,52 @@ public class SSTableCursorReader implements AutoCloseable
         }
     }
 
+    /**
+     * Re-positions the cell walk of the row (or static row) that {@code unfilteredDescriptor} describes
+     * back to its FIRST cell, so the same cells can be walked a second time.
+     *
+     * The descriptor is what makes this possible without re-reading the row header: everything
+     * {@link #readRowHeader} feeds into {@code CellCursor.init} — the column superset, the
+     * missing-columns mask or the present-column words, the row liveness — survives there untouched, so
+     * re-running init restores the walk state readRowHeader left. {@code presentColumnsWords()} is
+     * COPIED into the cursor's own scratch by init rather than walked in place, which is what makes a
+     * second init from the same descriptor sound. Two of {@code CellCursor}'s fields, {@code cellColumn}
+     * and {@code cellLiveness}, are NOT reset by init and so still describe the last cell of the first
+     * walk; nothing reads either before the next {@code readCellHeader} overwrites them
+     * ({@code compareByColumn} refuses any state but {@code CELL_VALUE_START}/{@code CELL_END}).
+     *
+     * The position comes from {@link #unfilteredCellsStart} rather than the descriptor, whose
+     * {@code dataStart()} is the start of the row BODY and so sits ahead of the first cell.
+     * {@code unfilteredEnd} is restored from the descriptor: {@link #checkNextFlagsAfterCellValuesEnd}
+     * clears it when a walk completes, and its cell-desync check needs it on the second walk as much as
+     * on the first.
+     *
+     * <b>{@link #basicUnfilteredFlags} and {@link #extendedFlags} are deliberately NOT restored.</b> A
+     * first walk that ran to the end of the row has overwritten them with the NEXT unfiltered's flags,
+     * and this leaves them there. That is sound only because every way out of the second walk re-reads
+     * those same bytes at the same offset before anything consults them — {@code
+     * checkNextFlagsAfterCellValuesEnd} if the cells are walked again, {@code
+     * checkNextFlagsAfterStaticRowOrUnfilteredStart} if {@link #skipRowCells} skips them — so a caller
+     * that ends the second walk any other way has to restore them itself.
+     *
+     * @param isStatic which of the two cell cursors this row's cells are walked with, as
+     *        {@link #readStaticRowHeader} and {@link #readRowHeader} choose it
+     */
+    protected int rewindRowCells(UnfilteredDescriptor unfilteredDescriptor, boolean isStatic)
+    {
+        dataReader.seek(unfilteredCellsStart);
+        unfilteredEnd = unfilteredDescriptor.dataStart() + unfilteredDescriptor.size();
+        CellCursor rewound = isStatic ? staticRowCellCursor : rowCellCursor;
+        rewound.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(),
+                     unfilteredDescriptor.presentColumnsWords(), unfilteredDescriptor.livenessInfo());
+        cellCursor = rewound;
+        // Callers only rewind a cursor that WAS in a cell state, which is exactly the state the row
+        // header loaders leave when the row has a present column. No cell surfacing here would mean the
+        // descriptor and the state the caller recorded disagree.
+        assert rewound.hasNext() : "rewound a row whose columns are all absent: " + unfilteredDescriptor;
+        return state = State.CELL_HEADER_START;
+    }
+
     public int continueReading() {
         // TODO: can be optimized by pre-calculating next state when the flags are read
         switch (state)
@@ -788,25 +1024,51 @@ public class SSTableCursorReader implements AutoCloseable
             state = !autoContinue ? PARTITION_END :
                                     dataReader.isEOF() ? DONE : PARTITION_START;
         }
-        else if (UnfilteredSerializer.isExtended(basicUnfilteredFlags))
-        {
-            state = STATIC_ROW_START;
-            extendedFlags = dataReader.readUnsignedByte();
-            validateStaticRowFlags(preFlagsPosition);
-        }
         else
         {
-            state = UnfilteredSerializer.isRow(basicUnfilteredFlags) ? ROW_START : TOMBSTONE_START;
+            readRowExtendedFlags(basicUnfilteredFlags, true, preFlagsPosition);
+            if (UnfilteredSerializer.isStatic(extendedFlags))
+            {
+                state = STATIC_ROW_START;
+                validateStaticRowFlags(preFlagsPosition);
+            }
+            else
+            {
+                state = UnfilteredSerializer.isRow(basicUnfilteredFlags) ? ROW_START : TOMBSTONE_START;
+            }
         }
         return state;
     }
 
+    /**
+     * Reads the extended-flags byte for {@code basicFlags} if present, storing it (0 if absent)
+     * in the {@link #extendedFlags} field for the row loader to pick up. Extended flags are only
+     * meaningful on a row (not a marker): {@code IS_STATIC}, and — deprecated since 4.0
+     * (CASSANDRA-11500), reachable only on old Materialized View data — {@code HAS_SHADOWABLE_DELETION}
+     * on either a static or a non-static row. A static row is only legal as the partition's first
+     * unfiltered, hence {@code allowStatic}.
+     */
+    private void readRowExtendedFlags(int basicFlags, boolean allowStatic, long preFlagsPosition) throws IOException
+    {
+        if (!UnfilteredSerializer.isExtended(basicFlags))
+        {
+            extendedFlags = 0;
+            return;
+        }
+        if (!UnfilteredSerializer.isRow(basicFlags))
+        {
+            corruptSSTable("Marker at: " + preFlagsPosition + " has extended flags, flags: " + basicFlags);
+            return;
+        }
+        extendedFlags = dataReader.readUnsignedByte();
+        if (!allowStatic && UnfilteredSerializer.isStatic(extendedFlags))
+        {
+            corruptSSTable("Unexpected static row (flags=" + basicFlags + ") mid-partition, at position: " + preFlagsPosition);
+        }
+    }
+
     private void validateStaticRowFlags(long preFlagsPosition)
     {
-        if (!UnfilteredSerializer.isStatic(extendedFlags))
-        {
-            corruptSSTable("Row at: " + preFlagsPosition + " has extended flags but is not static, extendedFlags: " + extendedFlags);
-        }
         if (!UnfilteredSerializer.isRow(basicUnfilteredFlags))
         {
             corruptSSTable("Static row at: " + preFlagsPosition + " is not a row, flags: " + basicUnfilteredFlags);
@@ -815,19 +1077,13 @@ public class SSTableCursorReader implements AutoCloseable
         {
             corruptSSTable("Row at: " + preFlagsPosition + " is static, but table has no static columns " + ssTableReader.metadata());
         }
-        if (UnfilteredSerializer.deletionIsShadowable(extendedFlags))
-        {
-            throw new UnsupportedOperationException("Static row at: " + preFlagsPosition + " has deletionIsShadowable, which is deprecated since 4.0");
-        }
     }
 
     private int checkNextFlagsAfterStaticRowOrUnfilteredStart(boolean autoContinue) throws IOException
     {
+        long preFlagsPosition = dataReader.getPosition();
         int flags = this.basicUnfilteredFlags = dataReader.readUnsignedByte();
-        if (UnfilteredSerializer.isExtended(flags))
-        {
-            corruptSSTable("Unexpected static row (flags=" + flags + ") mid-partition, at position: " + (dataReader.getPosition() - 1));
-        }
+        readRowExtendedFlags(flags, false, preFlagsPosition);
 
         if (!autoContinue) {
             return this.state = UNFILTERED_END;
@@ -840,11 +1096,22 @@ public class SSTableCursorReader implements AutoCloseable
 
     private int checkNextFlagsAfterCellValuesEnd() throws IOException
     {
+        // The cell walk must have consumed exactly the body the row header declared. Checked here, the
+        // single point at which a cell-value walk COMPLETES, and BEFORE the next unfiltered's flag byte
+        // is read below, so the position is directly comparable. Aborting the compaction is the intended
+        // outcome: a desync means the cells written from here would not match the iterator path's.
+        //
+        // A decoder defect is as likely as on-disk damage here, but that's the same ambiguity
+        // UnfilteredSerializer.readRow's own catch (RuntimeException | AssertionError) already accepts;
+        // route through the same corruption handling rather than surface a raw AssertionError.
+        if (dataReader.getPosition() != unfilteredEnd)
+            corruptSSTable("cell desync: cells consumed to " + dataReader.getPosition()
+                            + ", unfiltered body declared end " + unfilteredEnd);
+        unfilteredEnd = NO_UNFILTERED_END;
+
+        long preFlagsPosition = dataReader.getPosition();
         int flags = this.basicUnfilteredFlags = dataReader.readUnsignedByte();
-        if (UnfilteredSerializer.isExtended(flags))
-        {
-            corruptSSTable("Unexpected static row (flags=" + flags + ") mid-partition, at position: " + (dataReader.getPosition() - 1));
-        }
+        readRowExtendedFlags(flags, false, preFlagsPosition);
         return this.state = CELL_END;
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -129,8 +129,17 @@ public class SSTableCursorReader implements AutoCloseable
                 }
                 columnsSize = columns.size();
             }
+            // Build the present-columns bitmask from the wire's MISSING-columns mask:
+            //   -1L >>> (64 - n)   is the "n low ones" template (e.g. n=3 -> 0b111): all 64
+            //                      bits set, then shifted so exactly the n column bits remain.
+            //                      n == 0 must be special-cased because Java shifts are mod 64
+            //                      (>>> 64 is a no-op, NOT zero).
+            //   ~missingColumnsMask flips missing->present but also sets every bit ABOVE the
+            //                      column range, so it is ANDed with the template to trim them.
+            // For >= 64 columns the wire uses a structurally different "large subset" format
+            // and `columns` was already replaced with the exact subset: walk it fully.
             presentMask = columnsSize >= 64
-                          ? -1L // fallback: columns is already the exact subset, walk it fully
+                          ? -1L
                           : ~missingColumnsMask & (columnsSize == 0 ? 0 : (-1L >>> (64 - columnsSize)));
             this.rowLiveness = rowLiveness;
             columnsIndex = 0;
@@ -161,8 +170,15 @@ public class SSTableCursorReader implements AutoCloseable
             }
             else
             {
+                // Bit i of presentMask corresponds to the i-th column of the superset in
+                // its iteration order — the SAME order the serializer assigned bits and
+                // the same order cells appear on disk. Walking bits low-to-high therefore
+                // visits cells in exactly their on-disk order:
+                //   numberOfTrailingZeros = index of the lowest set bit (next present column)
+                //   x & (x - 1)           = clears that lowest set bit (subtracting 1 borrows
+                //                           through the trailing zeros; the AND kills both)
                 currIndex = Long.numberOfTrailingZeros(presentMask);
-                presentMask &= presentMask - 1; // clear lowest set bit
+                presentMask &= presentMask - 1;
                 columnsIndex++;
             }
             cellColumn = columnsArray[currIndex];

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -107,7 +107,14 @@ public class SSTableCursorReader implements AutoCloseable
         private ColumnMetadata[] columnsArray;
         private AbstractType<?>[] cellTypeArray;
 
-        void init (Columns columns, ReusableLivenessInfo rowLiveness)
+        // Remaining PRESENT columns of this row as a bitmask over columnsArray indices.
+        // Garbage-free sparse-row iteration: rows that do not contain every header column
+        // pass the missing-columns mask instead of a freshly allocated Columns subset, so
+        // the identity cache below only rebuilds on a genuine superset change (stable per
+        // reader) or in the >= 64 column fallback.
+        private long presentMask;
+
+        void init (Columns columns, long missingColumnsMask, ReusableLivenessInfo rowLiveness)
         {
             if (this.columns != columns)
             {
@@ -122,6 +129,9 @@ public class SSTableCursorReader implements AutoCloseable
                 }
                 columnsSize = columns.size();
             }
+            presentMask = columnsSize >= 64
+                          ? -1L // fallback: columns is already the exact subset, walk it fully
+                          : ~missingColumnsMask & (columnsSize == 0 ? 0 : (-1L >>> (64 - columnsSize)));
             this.rowLiveness = rowLiveness;
             columnsIndex = 0;
             cellFlags = 0;
@@ -131,7 +141,7 @@ public class SSTableCursorReader implements AutoCloseable
 
         public boolean hasNext()
         {
-            return columnsIndex < columnsSize;
+            return columnsSize >= 64 ? columnsIndex < columnsSize : presentMask != 0;
         }
 
         /**
@@ -141,10 +151,20 @@ public class SSTableCursorReader implements AutoCloseable
          */
         boolean readCellHeader() throws IOException
         {
-            if (!(columnsIndex < columnsSize)) throw new IllegalStateException();
+            if (!hasNext()) throw new IllegalStateException();
 
             // HOTSPOT: suprisingly expensive
-            int currIndex = columnsIndex++;
+            int currIndex;
+            if (columnsSize >= 64)
+            {
+                currIndex = columnsIndex++;
+            }
+            else
+            {
+                currIndex = Long.numberOfTrailingZeros(presentMask);
+                presentMask &= presentMask - 1; // clear lowest set bit
+                columnsIndex++;
+            }
             cellColumn = columnsArray[currIndex];
             cellType = cellTypeArray[currIndex];
             cellFlags = dataReader.readUnsignedByte();
@@ -335,7 +355,7 @@ public class SSTableCursorReader implements AutoCloseable
             return corruptSSTable(e);
         }
 
-        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.livenessInfo());
+        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(), unfilteredDescriptor.livenessInfo());
         cellCursor = staticRowCellCursor;
         if (!staticRowCellCursor.hasNext())
         {
@@ -447,7 +467,7 @@ public class SSTableCursorReader implements AutoCloseable
         {
             unfilteredDescriptor.loadRow(dataReader, serializationHeader, deserializationHelper, basicUnfilteredFlags);
 
-            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.livenessInfo());
+            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(), unfilteredDescriptor.livenessInfo());
             cellCursor = rowCellCursor;
             if (!rowCellCursor.hasNext())
             {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -19,6 +19,8 @@
 package org.apache.cassandra.io.sstable;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 
@@ -44,6 +46,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.ResizableByteBuffer;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.DroppedColumn;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.tools.Util;
@@ -105,6 +108,10 @@ public class SSTableCursorReader implements AutoCloseable
         public ColumnMetadata cellColumn;
         private ColumnMetadata[] columnsArray;
         private AbstractType<?>[] cellTypeArray;
+        // Per-column drop horizon (microseconds), Long.MIN_VALUE when the column was never
+        // dropped; cells with timestamp <= the horizon are discarded, mirroring
+        // DeserializationHelper.isDropped. Built once per superset, like cellTypeArray.
+        private long[] droppedTimesArray;
 
         // Remaining PRESENT columns of this row as a bitmask over columnsArray indices.
         // Garbage-free sparse-row iteration: rows that do not contain every header column
@@ -126,10 +133,13 @@ public class SSTableCursorReader implements AutoCloseable
                 this.columns = columns;
                 columnsArray = columns.toArray(COLUMN_METADATA_TYPE);
                 cellTypeArray = new AbstractType<?>[columnsArray.length];
+                droppedTimesArray = new long[columnsArray.length];
                 for (int i = 0; i < columnsArray.length; i++)
                 {
                     ColumnMetadata cellColumn = columnsArray[i];
                     cellTypeArray[i]  = serializationHeader.getType(cellColumn);
+                    DroppedColumn dropped = droppedColumns.get(cellColumn.name.bytes);
+                    droppedTimesArray[i] = dropped == null ? Long.MIN_VALUE : dropped.droppedTime;
                 }
                 columnsSize = columns.size();
             }
@@ -191,58 +201,84 @@ public class SSTableCursorReader implements AutoCloseable
         /**
          * For Cell deserialization see {@link Cell.Serializer#deserialize}
          *
-         * @return true if the cell has a value, false otherwise
+         * Dropped-column filtering happens here, mirroring the iterator's deserialization:
+         * cells of a dropped column written at or before the drop are consumed and never
+         * surfaced; the loop advances to the next column in that case. A dropped column
+         * that turns out to be the row's last remaining column leaves NO cell at all for
+         * this position (distinct from a genuine valueless cell/tombstone), which is why
+         * this returns a tri-state rather than a plain hasValue boolean: the caller must
+         * skip straight past the row/unfiltered end rather than stopping at a cell that
+         * doesn't exist.
+         *
+         * @return 1 if the next cell has a value, 0 if it has none (tombstone), -1 if no
+         *         cell remains in this row (all trailing columns were dropped-filtered)
          */
-        boolean readCellHeader() throws IOException
+        int readCellHeader() throws IOException
         {
             if (!hasNext()) throw new IllegalStateException();
 
-            // HOTSPOT: suprisingly expensive
-            int currIndex;
-            if (columnsSize >= 64)
+            for (;;)
             {
-                // columnsRemain() (via hasNext() above) parked presentWordIndex on a
-                // non-empty word; same low-to-high bit walk as the single-mask path below
-                long word = presentWords[presentWordIndex];
-                currIndex = (presentWordIndex << 6) + Long.numberOfTrailingZeros(word);
-                presentWords[presentWordIndex] = word & (word - 1);
+                // HOTSPOT: suprisingly expensive
+                int currIndex;
+                if (columnsSize >= 64)
+                {
+                    // columnsRemain() (via hasNext() above, or the loop-continue path below)
+                    // parked presentWordIndex on a non-empty word; same low-to-high bit walk
+                    // as the single-mask path below
+                    long word = presentWords[presentWordIndex];
+                    currIndex = (presentWordIndex << 6) + Long.numberOfTrailingZeros(word);
+                    presentWords[presentWordIndex] = word & (word - 1);
+                }
+                else
+                {
+                    // Bit i of presentMask corresponds to the i-th column of the superset in
+                    // its iteration order — the SAME order the serializer assigned bits and
+                    // the same order cells appear on disk. Walking bits low-to-high therefore
+                    // visits cells in exactly their on-disk order:
+                    //   numberOfTrailingZeros = index of the lowest set bit (next present column)
+                    //   x & (x - 1)           = clears that lowest set bit (subtracting 1 borrows
+                    //                           through the trailing zeros; the AND kills both)
+                    currIndex = Long.numberOfTrailingZeros(presentMask);
+                    presentMask &= presentMask - 1;
+                }
+                cellColumn = columnsArray[currIndex];
+                cellType = cellTypeArray[currIndex];
+                long cellDroppedTime = droppedTimesArray[currIndex];
+                cellFlags = dataReader.readUnsignedByte();
+                // TODO: specialize common case where flags == HAS_VALUE | USE_ROW_TS?
+                boolean hasValue = Cell.Serializer.hasValue(cellFlags);
+                boolean isDeleted = Cell.Serializer.isDeleted(cellFlags);
+                boolean isExpiring = Cell.Serializer.isExpiring(cellFlags);
+                boolean useRowTimestamp = Cell.Serializer.useRowTimestamp(cellFlags);
+                boolean useRowTTL = Cell.Serializer.useRowTTL(cellFlags);
+
+                long timestamp = useRowTimestamp ? rowLiveness.timestamp() : serializationHeader.readTimestamp(dataReader);
+
+                long localDeletionTime = useRowTTL
+                                         ? rowLiveness.localExpirationTime()
+                                         : (isDeleted || isExpiring ? serializationHeader.readLocalDeletionTime(dataReader) : Cell.NO_DELETION_TIME);
+
+                int ttl = useRowTTL ? rowLiveness.ttl() : (isExpiring ? serializationHeader.readTTL(dataReader) : Cell.NO_TTL);
+                localDeletionTime = Cell.decodeLocalDeletionTime(localDeletionTime, ttl, deserializationHelper);
+
+                cellLiveness.reset(timestamp, ttl, localDeletionTime);
+                cellPath = cellColumn.isComplex()
+                                ? cellColumn.cellPathSerializer().deserialize(dataReader)
+                                : null;
+
+                if (hasDroppedColumns && timestamp <= cellDroppedTime)
+                {
+                    // mirror UnfilteredSerializer.readSimpleColumn: cells of a dropped column
+                    // written at or before the drop are discarded on read
+                    if (hasValue)
+                        cellType.skipValue(dataReader);
+                    if (!hasNext())
+                        return -1; // no cell remains; caller must skip past the row/unfiltered end
+                    continue;
+                }
+                return hasValue ? 1 : 0;
             }
-            else
-            {
-                // Bit i of presentMask corresponds to the i-th column of the superset in
-                // its iteration order — the SAME order the serializer assigned bits and
-                // the same order cells appear on disk. Walking bits low-to-high therefore
-                // visits cells in exactly their on-disk order:
-                //   numberOfTrailingZeros = index of the lowest set bit (next present column)
-                //   x & (x - 1)           = clears that lowest set bit (subtracting 1 borrows
-                //                           through the trailing zeros; the AND kills both)
-                currIndex = Long.numberOfTrailingZeros(presentMask);
-                presentMask &= presentMask - 1;
-            }
-            cellColumn = columnsArray[currIndex];
-            cellType = cellTypeArray[currIndex];
-            cellFlags = dataReader.readUnsignedByte();
-            // TODO: specialize common case where flags == HAS_VALUE | USE_ROW_TS?
-            boolean hasValue = Cell.Serializer.hasValue(cellFlags);
-            boolean isDeleted = Cell.Serializer.isDeleted(cellFlags);
-            boolean isExpiring = Cell.Serializer.isExpiring(cellFlags);
-            boolean useRowTimestamp = Cell.Serializer.useRowTimestamp(cellFlags);
-            boolean useRowTTL = Cell.Serializer.useRowTTL(cellFlags);
-
-            long timestamp = useRowTimestamp ? rowLiveness.timestamp() : serializationHeader.readTimestamp(dataReader);
-
-            long localDeletionTime = useRowTTL
-                                     ? rowLiveness.localExpirationTime()
-                                     : (isDeleted || isExpiring ? serializationHeader.readLocalDeletionTime(dataReader) : Cell.NO_DELETION_TIME);
-
-            int ttl = useRowTTL ? rowLiveness.ttl() : (isExpiring ? serializationHeader.readTTL(dataReader) : Cell.NO_TTL);
-            localDeletionTime = Cell.decodeLocalDeletionTime(localDeletionTime, ttl, deserializationHelper);
-
-            cellLiveness.reset(timestamp, ttl, localDeletionTime);
-            cellPath = cellColumn.isComplex()
-                            ? cellColumn.cellPathSerializer().deserialize(dataReader)
-                            : null;
-            return hasValue;
         }
     }
 
@@ -250,6 +286,13 @@ public class SSTableCursorReader implements AutoCloseable
     private final AbstractType<?>[] clusteringColumnTypes;
     private final DeserializationHelper deserializationHelper;
     private final SerializationHeader serializationHeader;
+    // Dropped-column filtering, mirroring DeserializationHelper.isDropped /
+    // isDroppedComplexDeletion: cells (and complex deletions) of a dropped column written at or
+    // before the drop are discarded at deserialization on the iterator path
+    // (UnfilteredSerializer.readSimpleColumn/readComplexColumn), so the cursor must never
+    // surface them either.
+    private final Map<ByteBuffer, DroppedColumn> droppedColumns;
+    private final boolean hasDroppedColumns;
 
     // need to be closed
     private final SSTableReader ssTableReader;
@@ -300,9 +343,14 @@ public class SSTableCursorReader implements AutoCloseable
         }
         deserializationHelper = new DeserializationHelper(metadata, version.correspondingMessagingVersion(), DeserializationHelper.Flag.LOCAL, null);
         serializationHeader = reader.header;
+        droppedColumns = metadata.droppedColumns;
+        hasDroppedColumns = !droppedColumns.isEmpty();
 
         dataReader = reader.openDataReaderForScan(diskAccessMode);
-        hasStaticColumns = metadata.hasStaticColumns();
+        // the HEADER decides whether this sstable can contain static rows: after
+        // ALTER TABLE ... DROP of the last static column, current metadata has no static
+        // columns but older sstables legitimately still carry static rows
+        hasStaticColumns = serializationHeader.hasStatic();
     }
 
     @Override
@@ -546,7 +594,16 @@ public class SSTableCursorReader implements AutoCloseable
         if (state != State.CELL_HEADER_START) throw new IllegalStateException();
         try
         {
-            if (cellCursor.readCellHeader())
+            int cell = cellCursor.readCellHeader();
+            if (cell < 0)
+            {
+                // no cell surfaced at all (every remaining column was dropped-column
+                // filtered): nothing is current, so advance straight past the would-be
+                // CELL_END stop instead of surfacing a cell-less position
+                checkNextFlagsAfterCellValuesEnd();
+                return continueReading();
+            }
+            if (cell > 0)
             {
                 return state = State.CELL_VALUE_START;
             }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -19,12 +19,11 @@
 package org.apache.cassandra.io.sstable;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 
 import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.Columns;
 import org.apache.cassandra.db.DeletionTime;
@@ -46,7 +45,6 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.ResizableByteBuffer;
 import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.schema.DroppedColumn;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.tools.Util;
@@ -108,10 +106,6 @@ public class SSTableCursorReader implements AutoCloseable
         public ColumnMetadata cellColumn;
         private ColumnMetadata[] columnsArray;
         private AbstractType<?>[] cellTypeArray;
-        // Per-column drop horizon (microseconds), Long.MIN_VALUE when the column was never
-        // dropped; cells with timestamp <= the horizon are discarded, mirroring
-        // DeserializationHelper.isDropped. Built once per superset, like cellTypeArray.
-        private long[] droppedTimesArray;
 
         // Remaining PRESENT columns of this row as a bitmask over columnsArray indices.
         // Garbage-free sparse-row iteration: rows that do not contain every header column
@@ -127,19 +121,19 @@ public class SSTableCursorReader implements AutoCloseable
 
         void init (Columns columns, long missingColumnsMask, long[] presentColumnsWords, ReusableLivenessInfo rowLiveness)
         {
+            // the sstable-scoped dropped-column flag is only sound while the superset comes from
+            // this sstable's header; a schema-derived Columns here would under-filter silently
+            assert columns == serializationHeader.columns(false) || columns == serializationHeader.columns(true)
+                 : "cell superset must be one of this sstable's header column sets";
             if (this.columns != columns)
             {
                 // This will be a problem with changing columns
                 this.columns = columns;
                 columnsArray = columns.toArray(COLUMN_METADATA_TYPE);
                 cellTypeArray = new AbstractType<?>[columnsArray.length];
-                droppedTimesArray = new long[columnsArray.length];
                 for (int i = 0; i < columnsArray.length; i++)
                 {
-                    ColumnMetadata cellColumn = columnsArray[i];
-                    cellTypeArray[i]  = serializationHeader.getType(cellColumn);
-                    DroppedColumn dropped = droppedColumns.get(cellColumn.name.bytes);
-                    droppedTimesArray[i] = dropped == null ? Long.MIN_VALUE : dropped.droppedTime;
+                    cellTypeArray[i] = serializationHeader.getType(columnsArray[i]);
                 }
                 columnsSize = columns.size();
             }
@@ -244,7 +238,6 @@ public class SSTableCursorReader implements AutoCloseable
                 }
                 cellColumn = columnsArray[currIndex];
                 cellType = cellTypeArray[currIndex];
-                long cellDroppedTime = droppedTimesArray[currIndex];
                 cellFlags = dataReader.readUnsignedByte();
                 // TODO: specialize common case where flags == HAS_VALUE | USE_ROW_TS?
                 boolean hasValue = Cell.Serializer.hasValue(cellFlags);
@@ -267,7 +260,10 @@ public class SSTableCursorReader implements AutoCloseable
                                 ? cellColumn.cellPathSerializer().deserialize(dataReader)
                                 : null;
 
-                if (hasDroppedColumns && timestamp <= cellDroppedTime)
+                // pass isComplex=false unconditionally: the complex branch reads the helper's
+                // startOfComplexColumn cache, which this reader never primes, so it would always
+                // read null and filter nothing
+                if (sstableHasDroppedColumns && deserializationHelper.isDropped(cellColumn, timestamp, false))
                 {
                     // mirror UnfilteredSerializer.readSimpleColumn: cells of a dropped column
                     // written at or before the drop are discarded on read
@@ -286,13 +282,12 @@ public class SSTableCursorReader implements AutoCloseable
     private final AbstractType<?>[] clusteringColumnTypes;
     private final DeserializationHelper deserializationHelper;
     private final SerializationHeader serializationHeader;
-    // Dropped-column filtering, mirroring DeserializationHelper.isDropped /
-    // isDroppedComplexDeletion: cells (and complex deletions) of a dropped column written at or
-    // before the drop are discarded at deserialization on the iterator path
-    // (UnfilteredSerializer.readSimpleColumn/readComplexColumn), so the cursor must never
-    // surface them either.
-    private final Map<ByteBuffer, DroppedColumn> droppedColumns;
-    private final boolean hasDroppedColumns;
+    // True when a column of THIS sstable's header carries a drop horizon; the helper's
+    // identically-purposed flag is table-scoped, hence the name. Sstable scope is sound because the
+    // cell cursor's superset comes from serializationHeader.columns() — asserted in CellCursor.init
+    // — so a column absent from this header can never reach readCellHeader. Held as a field so the
+    // common case, no dropped column in this sstable, costs one boolean per cell not a map lookup.
+    private final boolean sstableHasDroppedColumns;
 
     // need to be closed
     private final SSTableReader ssTableReader;
@@ -343,8 +338,7 @@ public class SSTableCursorReader implements AutoCloseable
         }
         deserializationHelper = new DeserializationHelper(metadata, version.correspondingMessagingVersion(), DeserializationHelper.Flag.LOCAL, null);
         serializationHeader = reader.header;
-        droppedColumns = metadata.droppedColumns;
-        hasDroppedColumns = !droppedColumns.isEmpty();
+        sstableHasDroppedColumns = anyDroppedColumn(deserializationHelper, serializationHeader);
 
         dataReader = reader.openDataReaderForScan(diskAccessMode);
         // the HEADER decides whether this sstable can contain static rows: after
@@ -359,6 +353,19 @@ public class SSTableCursorReader implements AutoCloseable
         dataReader.close();
         if (ssTableReaderRef != null)
             ssTableReaderRef.close();
+    }
+
+    private static boolean anyDroppedColumn(DeserializationHelper deserializationHelper, SerializationHeader header)
+    {
+        if (!deserializationHelper.hasDroppedColumns())
+            return false;
+        // RegularAndStaticColumns iterates statics then regulars, so this covers both
+        for (ColumnMetadata column : header.columns())
+        {
+            if (deserializationHelper.isDroppedColumn(column))
+                return true;
+        }
+        return false;
     }
 
     private void resetOnPartitionStart()
@@ -508,20 +515,9 @@ public class SSTableCursorReader implements AutoCloseable
     // TODO: move to cell cursor? maybe avoid copy through buffer?
     private void copyCellContents(DataOutputPlus writer, byte[] transferBuffer, int length) throws IOException
     {
-        if (length >= 0)
+        if (length < 0)
         {
-            try
-            {
-                dataReader.readFully(transferBuffer, 0, length);
-            }
-            catch (Exception e)
-            {
-                corruptSSTable(e);
-            }
-            writer.write(transferBuffer, 0, length);
-        }
-        else
-        {
+            // variable length: the wire carries a length vint, which is mirrored to the output
             try
             {
                 length = dataReader.readUnsignedVInt32();
@@ -530,24 +526,31 @@ public class SSTableCursorReader implements AutoCloseable
             {
                 corruptSSTable(e);
             }
+            // both checks mirror AbstractType.read, the reference for this wire format
             if (length < 0)
                 corruptSSTable("Corrupt (negative) value length encountered");
+            if (length > DatabaseDescriptor.getMaxValueSize())
+                corruptSSTable(String.format("Corrupt value length %d encountered, as it exceeds the maximum of %d, " +
+                                             "which is set via max_value_size in cassandra.yaml",
+                                             length, DatabaseDescriptor.getMaxValueSize()));
             writer.writeUnsignedVInt32(length);
-            int remaining = length;
-            while (remaining > 0)
+        }
+        // Fixed-length values carry no vint but are not bounded by the transfer buffer either:
+        // valueLengthIfFixed() is 6144 for a vector<float, 1536>. Both cases copy in chunks.
+        int remaining = length;
+        while (remaining > 0)
+        {
+            int chunk = Math.min(remaining, transferBuffer.length);
+            try
             {
-                int readLength = Math.min(remaining, transferBuffer.length);
-                try
-                {
-                    dataReader.readFully(transferBuffer, 0, readLength);
-                }
-                catch (Exception e)
-                {
-                    corruptSSTable(e);
-                }
-                writer.write(transferBuffer, 0, readLength);
-                remaining -= readLength;
+                dataReader.readFully(transferBuffer, 0, chunk);
             }
+            catch (Exception e)
+            {
+                corruptSSTable(e);
+            }
+            writer.write(transferBuffer, 0, chunk);
+            remaining -= chunk;
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -98,7 +98,6 @@ public class SSTableCursorReader implements AutoCloseable
         public Columns columns;
 
         public int columnsSize;
-        public int columnsIndex;
         public int cellFlags;
         public final ReusableLivenessInfo cellLiveness = new ReusableLivenessInfo();
         public CellPath cellPath;
@@ -109,12 +108,17 @@ public class SSTableCursorReader implements AutoCloseable
 
         // Remaining PRESENT columns of this row as a bitmask over columnsArray indices.
         // Garbage-free sparse-row iteration: rows that do not contain every header column
-        // pass the missing-columns mask instead of a freshly allocated Columns subset, so
-        // the identity cache below only rebuilds on a genuine superset change (stable per
-        // reader) or in the >= 64 column fallback.
+        // pass the missing-columns mask (or, for >= 64-column supersets, present-mask
+        // words) instead of a freshly allocated Columns subset, so the identity cache
+        // below only rebuilds on a genuine superset change (stable per reader).
         private long presentMask;
+        // >= 64-column supersets: present-mask words (bit i of word i/64 = superset column
+        // i present), walked word by word. Grow-once scratch, consumed destructively.
+        private long[] presentWords;
+        private int presentWordsCount;
+        private int presentWordIndex;
 
-        void init (Columns columns, long missingColumnsMask, ReusableLivenessInfo rowLiveness)
+        void init (Columns columns, long missingColumnsMask, long[] presentColumnsWords, ReusableLivenessInfo rowLiveness)
         {
             if (this.columns != columns)
             {
@@ -129,20 +133,39 @@ public class SSTableCursorReader implements AutoCloseable
                 }
                 columnsSize = columns.size();
             }
-            // Build the present-columns bitmask from the wire's MISSING-columns mask:
-            //   -1L >>> (64 - n)   is the "n low ones" template (e.g. n=3 -> 0b111): all 64
-            //                      bits set, then shifted so exactly the n column bits remain.
-            //                      n == 0 must be special-cased because Java shifts are mod 64
-            //                      (>>> 64 is a no-op, NOT zero).
-            //   ~missingColumnsMask flips missing->present but also sets every bit ABOVE the
-            //                      column range, so it is ANDed with the template to trim them.
-            // For >= 64 columns the wire uses a structurally different "large subset" format
-            // and `columns` was already replaced with the exact subset: walk it fully.
-            presentMask = columnsSize >= 64
-                          ? -1L
-                          : ~missingColumnsMask & (columnsSize == 0 ? 0 : (-1L >>> (64 - columnsSize)));
+            if (columnsSize >= 64)
+            {
+                // word-mask walk over the superset; the descriptor decoded the large-subset
+                // wire format into presentColumnsWords (null = all columns present)
+                int nWords = (columnsSize + 63) >>> 6;
+                if (presentWords == null || presentWords.length < nWords)
+                    presentWords = new long[nWords]; // grow-once, amortized zero
+                presentWordsCount = nWords;
+                presentWordIndex = 0;
+                if (presentColumnsWords != null)
+                {
+                    System.arraycopy(presentColumnsWords, 0, presentWords, 0, nWords);
+                }
+                else
+                {
+                    java.util.Arrays.fill(presentWords, 0, nWords, -1L);
+                    if ((columnsSize & 63) != 0)
+                        presentWords[nWords - 1] = -1L >>> (64 - (columnsSize & 63));
+                }
+                presentMask = 0;
+            }
+            else
+            {
+                // Build the present-columns bitmask from the wire's MISSING-columns mask:
+                //   -1L >>> (64 - n)   is the "n low ones" template (e.g. n=3 -> 0b111): all 64
+                //                      bits set, then shifted so exactly the n column bits remain.
+                //                      n == 0 must be special-cased because Java shifts are mod 64
+                //                      (>>> 64 is a no-op, NOT zero).
+                //   ~missingColumnsMask flips missing->present but also sets every bit ABOVE the
+                //                      column range, so it is ANDed with the template to trim them.
+                presentMask = ~missingColumnsMask & (columnsSize == 0 ? 0 : (-1L >>> (64 - columnsSize)));
+            }
             this.rowLiveness = rowLiveness;
-            columnsIndex = 0;
             cellFlags = 0;
             cellPath = null;
             cellType = null;
@@ -150,7 +173,19 @@ public class SSTableCursorReader implements AutoCloseable
 
         public boolean hasNext()
         {
-            return columnsSize >= 64 ? columnsIndex < columnsSize : presentMask != 0;
+            return columnsSize >= 64 ? columnsRemain() : presentMask != 0;
+        }
+
+        private boolean columnsRemain()
+        {
+            // advance to the next non-empty word; position is retained across calls
+            while (presentWordIndex < presentWordsCount)
+            {
+                if (presentWords[presentWordIndex] != 0)
+                    return true;
+                presentWordIndex++;
+            }
+            return false;
         }
 
         /**
@@ -166,7 +201,11 @@ public class SSTableCursorReader implements AutoCloseable
             int currIndex;
             if (columnsSize >= 64)
             {
-                currIndex = columnsIndex++;
+                // columnsRemain() (via hasNext() above) parked presentWordIndex on a
+                // non-empty word; same low-to-high bit walk as the single-mask path below
+                long word = presentWords[presentWordIndex];
+                currIndex = (presentWordIndex << 6) + Long.numberOfTrailingZeros(word);
+                presentWords[presentWordIndex] = word & (word - 1);
             }
             else
             {
@@ -179,7 +218,6 @@ public class SSTableCursorReader implements AutoCloseable
                 //                           through the trailing zeros; the AND kills both)
                 currIndex = Long.numberOfTrailingZeros(presentMask);
                 presentMask &= presentMask - 1;
-                columnsIndex++;
             }
             cellColumn = columnsArray[currIndex];
             cellType = cellTypeArray[currIndex];
@@ -371,7 +409,8 @@ public class SSTableCursorReader implements AutoCloseable
             return corruptSSTable(e);
         }
 
-        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(), unfilteredDescriptor.livenessInfo());
+        staticRowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(),
+                                 unfilteredDescriptor.presentColumnsWords(), unfilteredDescriptor.livenessInfo());
         cellCursor = staticRowCellCursor;
         if (!staticRowCellCursor.hasNext())
         {
@@ -483,7 +522,8 @@ public class SSTableCursorReader implements AutoCloseable
         {
             unfilteredDescriptor.loadRow(dataReader, serializationHeader, deserializationHelper, basicUnfilteredFlags);
 
-            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(), unfilteredDescriptor.livenessInfo());
+            rowCellCursor.init(unfilteredDescriptor.rowColumns(), unfilteredDescriptor.missingColumnsMask(),
+                               unfilteredDescriptor.presentColumnsWords(), unfilteredDescriptor.livenessInfo());
             cellCursor = rowCellCursor;
             if (!rowCellCursor.hasNext())
             {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -21,40 +21,32 @@ package org.apache.cassandra.io.sstable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import com.google.common.primitives.Ints;
+import com.google.common.annotations.VisibleForTesting;
 
 import org.agrona.collections.IntArrayList;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.DeletionTime.ReusableDeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
-import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.Threshold;
-import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellLivenessInfo;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.SerializationHelper;
-import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
 import org.apache.cassandra.dht.IPartitioner;
-import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
-import org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter;
 import org.apache.cassandra.io.sstable.format.big.BigTableWriter;
-import org.apache.cassandra.io.sstable.format.big.RowIndexEntry;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.utils.BloomFilter;
-import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.concurrent.Ref;
 
@@ -75,13 +67,18 @@ public class SSTableCursorWriter implements AutoCloseable
     private final DeletionTime.Serializer deletionTimeSerializer;
     private final MetadataCollector metadataCollector;
     private final SerializationHeader serializationHeader;
-    /**
-     * See: {@link BloomFilter#reusableIndexes}
-     */
-    private final long[] reusableIndexes = new long[21];
     private final boolean hasStaticColumns;
 
     private long partitionStart;
+    // File position of the previous non-static unfiltered's first byte, or the partition start while the
+    // partition has none. previousUnfilteredSize is the distance from it, exactly as the iterator path
+    // computes it (see SortedTablePartitionWriter.addUnfiltered): rows/markers write the distance from
+    // the previous unfiltered's start; static rows write 0 and do not advance it.
+    private long previousUnfilteredStart;
+    // The dataWriter position writeRowStart encoded previousUnfilteredSize against. Nothing may write to
+    // dataWriter between writeRowStart and writeRowEnd or that distance is stale, so writeRowEnd asserts
+    // the position has not moved.
+    private long rowStartPosition;
     // ROW contents, needed because of the order of writing and the var int fields
     private int rowFlags; // discovered as we go along
     private int rowExtendedFlags;
@@ -95,14 +92,9 @@ public class SSTableCursorWriter implements AutoCloseable
     private ColumnMetadata[] columns; // points to static/regular
     private int columnsWrittenCount = 0;
     private int nextCellIndex = 0;
-    // Index info
-    private final DataOutputBuffer rowIndexEntries = new DataOutputBuffer();
-    private final IntArrayList rowIndexEntriesOffsets = new IntArrayList();
-    private final ClusteringDescriptor rowIndexEntryLastClustering;
-    private boolean hasDistinctLastClustering = false;
-    private int indexBlockStartOffset;
-    private int rowIndexEntryOffset;
-    private final int indexBlockThreshold;
+    // Format-specific index production (BIG: promoted blocks + Index.db + bloom filter/summary;
+    // other formats own their own index structures accordingly)
+    private final CursorIndexWriter cursorIndexWriter;
 
     private SSTableCursorWriter(
         Descriptor desc,
@@ -121,8 +113,8 @@ public class SSTableCursorWriter implements AutoCloseable
         hasStaticColumns = serializationHeader.hasStatic();
         staticColumns = hasStaticColumns ? serializationHeader.columns(true).toArray(EMPTY_COL_META) : EMPTY_COL_META;
         regularColumns = serializationHeader.columns(false).toArray(EMPTY_COL_META);
-        this.indexBlockThreshold = DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY);
-        rowIndexEntryLastClustering = new ClusteringDescriptor(serializationHeader.clusteringTypes().toArray(AbstractType[]::new));
+        this.cursorIndexWriter = new BigCursorIndexWriter((BigTableWriter.IndexWriter) indexWriter,
+                                                           this.deletionTimeSerializer);
     }
 
     public SSTableCursorWriter(SortedTableWriter<?,?> ssTableWriter)
@@ -158,19 +150,22 @@ public class SSTableCursorWriter implements AutoCloseable
 
     public int writePartitionStart(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime) throws IOException
     {
-        rowIndexEntries.clear();
-        rowIndexEntriesOffsets.clear();
-        rowIndexEntryOffset = 0;
         openMarker.resetLive();
-        hasDistinctLastClustering = false;
 
         partitionStart = dataWriter.position();
+        previousUnfilteredStart = partitionStart;
         writePartitionHeader(partitionKey, partitionKeyLength, partitionDeletionTime);
-        updateIndexBlockStartOffset(dataWriter.position());
-        return indexBlockStartOffset;
+        cursorIndexWriter.startPartition(partitionStart, dataWriter.position());
+        // immediately after startPartition this is the partition header length — always small
+        return Math.toIntExact(cursorIndexWriter.indexBlockStartOffset());
     }
 
-    public void writePartitionEnd(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime, int headerLength) throws IOException
+    /**
+     * @param lastName the clustering of the last non-static unfiltered written to this partition, needed as
+     *                 the last name of a trailing index block; null if the partition wrote none.
+     */
+    public void writePartitionEnd(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime,
+                                  int headerLength, ClusteringDescriptor lastName) throws IOException
     {
         SERIALIZER.writeEndOfPartition(dataWriter);
         long partitionEnd = dataWriter.position();
@@ -187,72 +182,9 @@ public class SSTableCursorWriter implements AutoCloseable
          // this is implemented differently for BIG/BTI
          createRowIndexEntry(key, partitionLevelDeletion, partitionEnd - 1);
          */
-        appendBIGIndex(partitionKey, partitionKeyLength, partitionStart, headerLength, partitionDeletionTime, partitionEnd);
+        cursorIndexWriter.endPartition(partitionKey, partitionKeyLength, headerLength, partitionDeletionTime, partitionEnd, lastName);
     }
 
-    private void appendBIGIndex(byte[] key, int keyLength, long partitionStart, int headerLength, DeletionTime partitionDeletionTime, long partitionEnd) throws IOException
-    {
-        /**
-         * {@link BigTableWriter#createRowIndexEntry(DecoratedKey, DeletionTime, long)}
-         * {@link BigTableWriter.IndexWriter#append(DecoratedKey, RowIndexEntry, long, ByteBuffer)}
-         *
-         */
-        BigTableWriter.IndexWriter indexWriter = (BigTableWriter.IndexWriter) this.indexWriter;
-        SequentialWriter indexFileWriter = indexWriter.writer;
-        ((BloomFilter)indexWriter.bf).add(key, 0, keyLength, reusableIndexes);
-        long indexStart = indexFileWriter.position();
-        try
-        {
-            ByteArrayUtil.writeWithShortLength(key, 0, keyLength, indexFileWriter);
-
-            indexFileWriter.writeUnsignedVInt(partitionStart);
-
-            // if the list of entries has one or fewer entries, no point in index entries.
-            /** See: {@link org.apache.cassandra.io.sstable.format.big.RowIndexEntry#create} */
-            if (rowIndexEntriesOffsets.size() <= 1)
-            {
-                /**
-                 * {@link RowIndexEntry#serialize(DataOutputPlus, ByteBuffer)}
-                 */
-                indexFileWriter.writeUnsignedVInt32(0); // size
-            }
-            else {
-                // add last block
-                long indexBlockSize = (partitionEnd - partitionStart - 1) - indexBlockStartOffset;
-                if (indexBlockSize != 0) {
-                    addIndexBlock(partitionEnd - 1, indexBlockSize);
-                }
-                // if we have intermeddiate index info elements we also need to serialize the partitionDeletionTime
-                /** {@link RowIndexEntry.IndexedEntry#serialize(DataOutputPlus, ByteBuffer) */
-                // size up to the offsets?
-                int endOfEntries = rowIndexEntries.getLength();
-                // Write the headerLength, partitionDeletionTime and rowIndexEntriesOffsets.size() after the entries,
-                // just to calculate size.
-                rowIndexEntries.writeUnsignedVInt((long)headerLength);
-                deletionTimeSerializer.serialize(partitionDeletionTime, rowIndexEntries);
-
-                rowIndexEntries.writeUnsignedVInt32(rowIndexEntriesOffsets.size()); // number of entries
-
-                // bytes until offsets
-                int entriesAndOffsetsSize = rowIndexEntries.getLength() + rowIndexEntriesOffsets.size() * 4;
-                assert entriesAndOffsetsSize > 0;
-                indexFileWriter.writeUnsignedVInt32(entriesAndOffsetsSize); // size != 0
-                // copy the header elements
-                indexFileWriter.write(rowIndexEntries.getData(), endOfEntries, rowIndexEntries.getLength() - endOfEntries);
-                indexFileWriter.write(rowIndexEntries.getData(), 0, endOfEntries);
-                for (int i = 0; i < rowIndexEntriesOffsets.size(); i++)
-                {
-                    int offset = rowIndexEntriesOffsets.get(i);
-                    indexFileWriter.writeInt(offset);
-                }
-            }
-        }
-        catch (IOException e)
-        {
-            throw new FSWriteError(e, indexFileWriter.getPath());
-        }
-        indexWriter.summary.maybeAddEntry(key, 0, keyLength, indexStart);
-    }
 
     final long guardrailsPartitionSizeWarning = Guardrails.partitionSize.warnValue(null);
     final long guardrailsPartitionTombstonesWarning = Guardrails.partitionTombstones.warnValue(null);
@@ -303,41 +235,42 @@ public class SSTableCursorWriter implements AutoCloseable
         columns = staticColumns;
         // TOD: we should be able to skip the use of the row buffers in this special case, maybe it doesn't matter
         rowHeaderBuffer.clear();
-        // NOTE: if we are to write this value (which is not used), this is where we should compute it.
-        rowHeaderBuffer.writeUnsignedVInt32(0);
+        rowHeaderBuffer.writeUnsignedVInt(0L); // previousUnfilteredSize, always 0 for a static row
         rowBuffer.clear();
         columnsWrittenCount = 0;
         missingColumns.clear();
         writeRowEnd(null, false);
 
-        updateIndexBlockStartOffset(dataWriter.position());
+        cursorIndexWriter.staticRowWritten(dataWriter.position());
         return true;
     }
 
-    public void writeRowStart(LivenessInfo livenessInfo, DeletionTime deletionTime, boolean isStatic) throws IOException
+    public void writeRowStart(LivenessInfo livenessInfo, DeletionTime deletionTime, boolean isShadowable, boolean isStatic) throws IOException
     {
-        if (isStatic) {
-            rowFlags = UnfilteredSerializer.EXTENSION_FLAG;
-            rowExtendedFlags = UnfilteredSerializer.IS_STATIC;
-            columns = staticColumns;
-        }
-        else {
-            rowFlags = 0;
-            rowExtendedFlags = 0;
-            columns = regularColumns;
-        }
+        // Row.Deletion's own constructor enforces this: a live deletion is never shadowable. Callers
+        // (CursorCompactor.mergeRows) must reset isShadowable alongside every reset of deletionTime to
+        // LIVE; this catches a future caller that adds a reset path and misses that pairing.
+        assert !deletionTime.isLive() || !isShadowable : "shadowable deletion must not be live";
+        rowExtendedFlags = 0;
+        if (isStatic)
+            rowExtendedFlags |= UnfilteredSerializer.IS_STATIC;
+        if (isShadowable)
+            rowExtendedFlags |= UnfilteredSerializer.HAS_SHADOWABLE_DELETION;
+        rowFlags = rowExtendedFlags != 0 ? UnfilteredSerializer.EXTENSION_FLAG : 0;
+        columns = isStatic ? staticColumns : regularColumns;
         // NOTE: Data after this point needs a computed ahead of write size. This, combined with the cost of rewriting
         // the size after the writing completes, means we have to buffer the row timestamps (most likely to differ in length)
         // and the row columns data (will differ if they use their own timestamps, probably). Unfortunate.
         // rest of header
         rowHeaderBuffer.clear();
+        // previousUnfilteredSize leads the row body, ahead of the liveness data. dataWriter has not been
+        // written since the previous unfiltered finished, so its position is this unfiltered's first byte.
+        rowStartPosition = dataWriter.position();
+        rowHeaderBuffer.writeUnsignedVInt(isStatic ? 0 : rowStartPosition - previousUnfilteredStart);
         missingColumns.clear();
         rowBuffer.clear();
         columnsWrittenCount = 0;
         nextCellIndex = 0;
-
-        // NOTE: if we are to write this value (which is not used), this is where we should compute it.
-        rowHeaderBuffer.writeUnsignedVInt32(0);
 
         // copy TS/TTL/deletion data
         rowFlags |= writeRowTimeData(livenessInfo, deletionTime, rowHeaderBuffer);
@@ -384,7 +317,7 @@ public class SSTableCursorWriter implements AutoCloseable
         metadataCollector.update(deletionTime);
     }
 
-    public void writeCellHeader(int cellFlags, ReusableLivenessInfo cellLiveness, ColumnMetadata cellColumn) throws IOException
+    public void writeCellHeader(int cellFlags, CellLivenessInfo cellLiveness, ColumnMetadata cellColumn) throws IOException
     {
         for (; nextCellIndex < columns.length; nextCellIndex++) {
             if (columns[nextCellIndex].compareTo(cellColumn) == 0)
@@ -397,7 +330,7 @@ public class SSTableCursorWriter implements AutoCloseable
         writeCellHeader(cellFlags, cellLiveness, rowBuffer);
     }
 
-    private void writeCellHeader(int cellFlags, ReusableLivenessInfo cellLiveness, DataOutputPlus writer) throws IOException
+    private void writeCellHeader(int cellFlags, CellLivenessInfo cellLiveness, DataOutputPlus writer) throws IOException
     {
         columnsWrittenCount++;
         writer.writeByte(cellFlags);
@@ -409,8 +342,7 @@ public class SSTableCursorWriter implements AutoCloseable
             boolean isDeleted = Cell.Serializer.isDeleted(cellFlags);
             boolean isExpiring = Cell.Serializer.isExpiring(cellFlags);
             if (isDeleted || isExpiring) {
-                // TODO: is this conversion from LET to LDT correct?
-                serializationHeader.writeLocalDeletionTime(cellLiveness.localExpirationTime(), writer);
+                serializationHeader.writeLocalDeletionTime(cellLiveness.localDeletionTime(), writer);
             }
             if (isExpiring) {
                 serializationHeader.writeTTL(cellLiveness.ttl(), writer);
@@ -457,19 +389,16 @@ public class SSTableCursorWriter implements AutoCloseable
             for (; nextCellIndex < columnsLength; nextCellIndex++)
                 missingColumns.addInt(nextCellIndex);
 
-            if (columnsLength < 64) {
-                // set a bit for every missing column
-                long mask = 0;
-                for (int missingIndex : missingColumns) {
-                    mask |= (1L << missingIndex);
-                }
-                rowHeaderBuffer.writeUnsignedVInt(mask);
-            }
-            else {
-                encodeLargeColumnsSubset();
-            }
+            encodeColumnsSubset(missingColumns, columnsLength, rowHeaderBuffer);
         }
-        long unfilteredStartPosition = dataWriter.position();
+        // rowStartPosition was already captured in writeRowStart, and the invariant this class
+        // documents (nothing writes to dataWriter between writeRowStart and writeRowEnd) means
+        // a fresh read here would always equal it; reuse it instead of re-reading. The verifying
+        // read moves into the assert itself (evaluated before any of this method's own writes),
+        // so it costs nothing with assertions disabled.
+        assert isStatic || dataWriter.position() == rowStartPosition
+               : "dataWriter moved between writeRowStart and writeRowEnd: " + rowStartPosition + " != " + dataWriter.position();
+        long unfilteredStartPosition = rowStartPosition;
         /** See: {@link UnfilteredSerializer#serialize} */
         dataWriter.writeByte(rowFlags);
         if (isExtended)
@@ -482,9 +411,11 @@ public class SSTableCursorWriter implements AutoCloseable
             byte[] clustering = rHeader.clusteringBytes();
             int clusteringLength = rHeader.clusteringLength();
             dataWriter.write(clustering, 0, clusteringLength);
+            previousUnfilteredStart = unfilteredStartPosition;
         }
-
-        // Now that we know the size, write it + the rest of the data
+        // The size spans the whole row body, previousUnfilteredSize included: it is the leading vint of
+        // rowHeaderBuffer. UnfilteredSerializer.serialize reaches the same bytes by adding that field's
+        // vint width to the size of a body buffer that excludes it.
         dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength() + rowBuffer.getLength());
 
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
@@ -493,13 +424,22 @@ public class SSTableCursorWriter implements AutoCloseable
         long unfilteredEndPosition = getPosition();
 
         /**
-         * Matching the: {@link org.apache.cassandra.db.rows.Rows#collectStats} along with above cell level metadata updates
+         * Matching the: {@link org.apache.cassandra.db.rows.Rows#collectStats} along with above cell level metadata updates.
+         * The iterator path only collects row stats for non-empty rows
+         * ({@link org.apache.cassandra.io.sstable.format.SortedTableWriter#addStaticRow} guards with
+         * !row.isEmpty()): an empty static row is still WRITTEN for static-column tables whose
+         * partition has no static values, but it must not count towards totalRows/totalColumnsSet.
+         * Empty == no cells, no liveness timestamp/TTL, no row deletion.
          */
-        metadataCollector.updateColumnSetPerRow(columnsWrittenCount);
+        boolean rowIsEmpty = columnsWrittenCount == 0
+                             && (rowFlags & (HAS_TIMESTAMP | HAS_TTL | HAS_DELETION)) == 0;
+        if (!rowIsEmpty)
+            metadataCollector.updateColumnSetPerRow(columnsWrittenCount);
 
         if (isStatic)
         {
-            updateIndexBlockStartOffset(dataWriter.position());
+            // Nothing writes to dataWriter between the unfilteredEndPosition read above and here.
+            cursorIndexWriter.staticRowWritten(unfilteredEndPosition);
         }
         else
         {
@@ -528,8 +468,9 @@ public class SSTableCursorWriter implements AutoCloseable
             dataWriter.write(clustering, 0, clusteringLength);
         }
         rowHeaderBuffer.clear();
-        // TODO: previousUnfilteredSize
-        rowHeaderBuffer.writeUnsignedVInt32(0);
+        // previousUnfilteredSize leads the marker body, ahead of the deletion times
+        rowHeaderBuffer.writeUnsignedVInt(unfilteredStartPosition - previousUnfilteredStart);
+        previousUnfilteredStart = unfilteredStartPosition;
 
         if (kind.isBoundary())
         {
@@ -546,12 +487,15 @@ public class SSTableCursorWriter implements AutoCloseable
                 openMarker.resetLive();
         }
 
+        // The size spans the whole marker body, previousUnfilteredSize included; see
+        // UnfilteredSerializer.serialize(RangeTombstoneMarker...), which reaches the same bytes by
+        // adding that field's vint width to a body size that excludes it.
         dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength());
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
 
         long unfilteredEndPosition = getPosition();
 
-        /** {@link org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter#addUnfiltered(Unfiltered)} */
+        /** {@link org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter#addUnfiltered(org.apache.cassandra.db.rows.Unfiltered)} */
         // if we hit the index block size that we have to index after, go ahead and index it.
         updateMetadataAndIndexBlock(rangeTombstone, unfilteredStartPosition, unfilteredEndPosition, updateClusteringMetadata);
     }
@@ -562,117 +506,69 @@ public class SSTableCursorWriter implements AutoCloseable
                                              boolean updateClusteringMetadata) throws IOException
     {
         if (updateClusteringMetadata) updateClusteringMetadata(unfilteredDescriptor);
-        // write the first clustering into rowIndexEntries buffer (we will need it unless we never write the first entry)
-        if (currentOffsetInPartition(unfilteredStartPosition) == indexBlockStartOffset || (rowIndexEntryOffset == rowIndexEntries.position()))
-        {
-            writeClusteringToRowIndexEntries(unfilteredDescriptor);
-        }
-        else
-        {
-            rowIndexEntryLastClustering.copy(unfilteredDescriptor);
-            hasDistinctLastClustering = true;
-        }
-
-        /** {@link BigFormatPartitionWriter#addUnfiltered(Unfiltered)} */
-        // if we hit the index block size that we have to index after, go ahead and index it.
-        long indexBlockSize = currentOffsetInPartition(unfilteredEndPosition) - indexBlockStartOffset;
-        if (indexBlockSize >= this.indexBlockThreshold)
-            addIndexBlock(unfilteredEndPosition, indexBlockSize);
+        cursorIndexWriter.rowWritten(unfilteredDescriptor, unfilteredStartPosition, unfilteredEndPosition, openMarker);
     }
 
-    public void updateClusteringMetadata(UnfilteredDescriptor unfilteredDescriptor)
+    public void updateClusteringMetadata(ClusteringDescriptor clusteringDescriptor)
     {
-        metadataCollector.updateClusteringValues(unfilteredDescriptor);
+        metadataCollector.updateClusteringValues(clusteringDescriptor);
     }
 
     /**
-     *  See:
-     *  {@link BigFormatPartitionWriter#addIndexBlock()}
-     *  - {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}
+     * Garbage-free equivalent of {@link org.apache.cassandra.db.Columns.Serializer}'s
+     * serializeSubset for a PARTIAL subset (not all-present, not all-missing — callers
+     * handle those fast paths): the < 64 missing-bitmap form, or the large-subset form
+     * (delta vint + present- or missing-index vints). Hand-mirrored because the upstream
+     * serializer requires a materialized Columns + iterator per call — a per-row allocation
+     * this path must not make. The mirror has already drifted from the upstream serializer
+     * once, producing corrupt output; {@code CursorColumnsSubsetEncodingTest} pins it byte-for-byte
+     * against the upstream serializer across sizes, shapes, and both mode boundaries.
+     *
+     * @param missingColumns ascending superset positions of the columns ABSENT from the row
      */
-    private void addIndexBlock(long endOfRowPosition, long indexBlockSize) throws IOException
+    @VisibleForTesting
+    static void encodeColumnsSubset(IntArrayList missingColumns, int supersetCount, DataOutputBuffer out) throws IOException
     {
-        if (rowIndexEntriesOffsets.isEmpty() && rowIndexEntryOffset != 0) {
-            throw new IllegalStateException();
+        if (supersetCount < 64)
+        {
+            // set a bit for every missing column (Columns.Serializer.encodeBitmap)
+            long mask = 0;
+            for (int i = 0; i < missingColumns.size(); i++)
+                mask |= 1L << missingColumns.getInt(i);
+            out.writeUnsignedVInt(mask);
+            return;
         }
 
-        // serialize the index info
-        /** {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}*/
-        rowIndexEntriesOffsets.addInt(rowIndexEntryOffset);
-
-        // first clustering is already in, write last entry
-        if (!hasDistinctLastClustering)
+        out.writeUnsignedVInt32(missingColumns.size());
+        // Mode selection must mirror Columns.Serializer.serializeLargeSubset AND its
+        // deserializer exactly: present-index mode iff presentCount < supersetCount / 2.
+        // The previous condition (missing > supersetCount / 2) agreed for even superset
+        // sizes but flipped the mode for odd sizes at missing == supersetCount/2 + 1,
+        // which the deserializer then read in the WRONG mode — corrupted output.
+        int presentCount = supersetCount - missingColumns.size();
+        if (presentCount < supersetCount / 2)
         {
-            // first entry is the last entry, copy it
-            byte[] entriesData = rowIndexEntries.getData();
-            long endOfFirstEntry = rowIndexEntries.position();
-            rowIndexEntries.write(entriesData, rowIndexEntryOffset, (int) (endOfFirstEntry - rowIndexEntryOffset));
-        }
-        else
-        {
-            writeClusteringToRowIndexEntries(rowIndexEntryLastClustering);
-            rowIndexEntryLastClustering.resetClustering();
-        }
-        hasDistinctLastClustering = false;
-
-        rowIndexEntries.writeUnsignedVInt((long)indexBlockStartOffset);
-        rowIndexEntries.writeVInt(indexBlockSize - IndexInfo.Serializer.WIDTH_BASE);
-
-        boolean isDeleteTimePresent = !openMarker.isLive();
-        rowIndexEntries.writeBoolean(isDeleteTimePresent);
-        if (isDeleteTimePresent)
-            deletionTimeSerializer.serialize(openMarker, rowIndexEntries);
-        // next block starts
-        rowIndexEntryOffset = Ints.checkedCast(rowIndexEntries.position());
-        updateIndexBlockStartOffset(endOfRowPosition);
-    }
-
-    private void updateIndexBlockStartOffset(long endOfRowPosition)
-    {
-        indexBlockStartOffset = (int) (endOfRowPosition - partitionStart);
-    }
-
-    private void writeClusteringToRowIndexEntries(ClusteringDescriptor clustering) throws IOException
-    {
-        ClusteringPrefix.Kind kind = clustering.clusteringKind();
-        rowIndexEntries.writeByte(kind.ordinal());
-        if (kind != ClusteringPrefix.Kind.CLUSTERING)
-            rowIndexEntries.writeShort(clustering.clusteringColumnsBound());
-        rowIndexEntries.write(clustering.clusteringBytes(), 0, clustering.clusteringLength());
-    }
-
-    private long currentOffsetInPartition(long position)
-    {
-        return position - partitionStart;
-    }
-
-    private void encodeLargeColumnsSubset() throws IOException
-    {
-        // no columns are present, nothing to write
-        rowHeaderBuffer.writeUnsignedVInt32(missingColumns.size());
-        if (missingColumns.size() > columns.length / 2)
-        {
-            // write present columns
+            // write present column indices: the gaps between missing indices, INCLUDING the
+            // tail after the last missing index — the previous tail loop's bound was the
+            // last missing index itself (vacuously empty), so present columns sorting after
+            // the last missing one were silently dropped from the encoding and the
+            // deserializer consumed row-body bytes as column indices — corrupted output
             int presentIndex = 0;
-            int missingIndex = 0;
             for (int i = 0; i < missingColumns.size(); i++)
             {
-                missingIndex = missingColumns.get(i);
+                int missingIndex = missingColumns.getInt(i);
                 for (; presentIndex < missingIndex; presentIndex++)
-                    rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
+                    out.writeUnsignedVInt32(presentIndex);
                 presentIndex = missingIndex + 1;
             }
-            if (missingIndex < columns.length-1) {
-                for (; presentIndex < missingIndex; presentIndex++)
-                    rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
-            }
+            for (; presentIndex < supersetCount; presentIndex++)
+                out.writeUnsignedVInt32(presentIndex);
         }
         else
         {
-            // write missing columns
-            for (int missingIndex : missingColumns) {
-                rowHeaderBuffer.writeUnsignedVInt32(missingIndex);
-            }
+            // write missing columns (indexed loop: agrona's for-each would box per element)
+            for (int i = 0; i < missingColumns.size(); i++)
+                out.writeUnsignedVInt32(missingColumns.getInt(i));
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.agrona.collections.IntArrayList;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
@@ -33,19 +32,16 @@ import org.apache.cassandra.db.DeletionTime.ReusableDeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
 import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.SerializationHeader;
-import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.Threshold;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.SerializationHelper;
-import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
-import org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter;
 import org.apache.cassandra.io.sstable.format.big.BigTableWriter;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -75,11 +71,15 @@ public class SSTableCursorWriter implements AutoCloseable
     private final boolean hasStaticColumns;
 
     private long partitionStart;
-    // Offset within the current partition of the previous non-static unfiltered's first byte.
-    // Used to write the previousUnfilteredSize field exactly as the iterator path does
-    // (see SortedTablePartitionWriter.addUnfiltered): rows/markers write the distance from the
-    // previous unfiltered's start; static rows write 0 and do not advance this offset.
-    private long previousRowStartOffset;
+    // File position of the previous non-static unfiltered's first byte, or the partition start while the
+    // partition has none. previousUnfilteredSize is the distance from it, exactly as the iterator path
+    // computes it (see SortedTablePartitionWriter.addUnfiltered): rows/markers write the distance from
+    // the previous unfiltered's start; static rows write 0 and do not advance it.
+    private long previousUnfilteredStart;
+    // The dataWriter position writeRowStart encoded previousUnfilteredSize against. Nothing may write to
+    // dataWriter between writeRowStart and writeRowEnd or that distance is stale, so writeRowEnd asserts
+    // the position has not moved.
+    private long rowStartPosition;
     // ROW contents, needed because of the order of writing and the var int fields
     private int rowFlags; // discovered as we go along
     private int rowExtendedFlags;
@@ -155,7 +155,7 @@ public class SSTableCursorWriter implements AutoCloseable
         openMarker.resetLive();
 
         partitionStart = dataWriter.position();
-        previousRowStartOffset = 0;
+        previousUnfilteredStart = partitionStart;
         writePartitionHeader(partitionKey, partitionKeyLength, partitionDeletionTime);
         cursorIndexWriter.startPartition(partitionStart, dataWriter.position());
         // immediately after startPartition this is the partition header length — always small
@@ -232,6 +232,7 @@ public class SSTableCursorWriter implements AutoCloseable
         columns = staticColumns;
         // TOD: we should be able to skip the use of the row buffers in this special case, maybe it doesn't matter
         rowHeaderBuffer.clear();
+        rowHeaderBuffer.writeUnsignedVInt(0L); // previousUnfilteredSize, always 0 for a static row
         rowBuffer.clear();
         columnsWrittenCount = 0;
         missingColumns.clear();
@@ -258,6 +259,10 @@ public class SSTableCursorWriter implements AutoCloseable
         // and the row columns data (will differ if they use their own timestamps, probably). Unfortunate.
         // rest of header
         rowHeaderBuffer.clear();
+        // previousUnfilteredSize leads the row body, ahead of the liveness data. dataWriter has not been
+        // written since the previous unfiltered finished, so its position is this unfiltered's first byte.
+        rowStartPosition = dataWriter.position();
+        rowHeaderBuffer.writeUnsignedVInt(isStatic ? 0 : rowStartPosition - previousUnfilteredStart);
         missingColumns.clear();
         rowBuffer.clear();
         columnsWrittenCount = 0;
@@ -398,19 +403,16 @@ public class SSTableCursorWriter implements AutoCloseable
             dataWriter.write(clustering, 0, clusteringLength);
         }
 
-        // Matches UnfilteredSerializer.serialize: the row size includes the vint length of the
-        // previousUnfilteredSize field, which is written between the size and the row body.
-        // Static rows write 0 and do not advance the chain (UnfilteredSerializer.serializeStaticRow).
-        long previousUnfilteredSize = 0;
         if (!isStatic)
         {
-            long offsetInPartition = unfilteredStartPosition - partitionStart;
-            previousUnfilteredSize = offsetInPartition - previousRowStartOffset;
-            previousRowStartOffset = offsetInPartition;
+            assert rowStartPosition == unfilteredStartPosition
+                   : "dataWriter moved between writeRowStart and writeRowEnd: " + rowStartPosition + " != " + unfilteredStartPosition;
+            previousUnfilteredStart = unfilteredStartPosition;
         }
-        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength() + rowBuffer.getLength()
-                                       + TypeSizes.sizeofUnsignedVInt(previousUnfilteredSize));
-        dataWriter.writeUnsignedVInt(previousUnfilteredSize);
+        // The size spans the whole row body, previousUnfilteredSize included: it is the leading vint of
+        // rowHeaderBuffer. UnfilteredSerializer.serialize reaches the same bytes by adding that field's
+        // vint width to the size of a body buffer that excludes it.
+        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength() + rowBuffer.getLength());
 
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
         dataWriter.write(rowBuffer.getData(), 0, rowBuffer.getLength());
@@ -461,6 +463,9 @@ public class SSTableCursorWriter implements AutoCloseable
             dataWriter.write(clustering, 0, clusteringLength);
         }
         rowHeaderBuffer.clear();
+        // previousUnfilteredSize leads the marker body, ahead of the deletion times
+        rowHeaderBuffer.writeUnsignedVInt(unfilteredStartPosition - previousUnfilteredStart);
+        previousUnfilteredStart = unfilteredStartPosition;
 
         if (kind.isBoundary())
         {
@@ -477,19 +482,15 @@ public class SSTableCursorWriter implements AutoCloseable
                 openMarker.resetLive();
         }
 
-        // Matches UnfilteredSerializer.serialize(RangeTombstoneMarker...): marker size includes the
-        // vint length of previousUnfilteredSize, written between the size and the marker body.
-        long offsetInPartition = unfilteredStartPosition - partitionStart;
-        long previousUnfilteredSize = offsetInPartition - previousRowStartOffset;
-        previousRowStartOffset = offsetInPartition;
-        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength()
-                                       + TypeSizes.sizeofUnsignedVInt(previousUnfilteredSize));
-        dataWriter.writeUnsignedVInt(previousUnfilteredSize);
+        // The size spans the whole marker body, previousUnfilteredSize included; see
+        // UnfilteredSerializer.serialize(RangeTombstoneMarker...), which reaches the same bytes by
+        // adding that field's vint width to a body size that excludes it.
+        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength());
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
 
         long unfilteredEndPosition = getPosition();
 
-        /** {@link org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter#addUnfiltered(Unfiltered)} */
+        /** {@link org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter#addUnfiltered(org.apache.cassandra.db.rows.Unfiltered)} */
         // if we hit the index block size that we have to index after, go ahead and index it.
         updateMetadataAndIndexBlock(rangeTombstone, unfilteredStartPosition, unfilteredEndPosition, updateClusteringMetadata);
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.db.DeletionTime.ReusableDeletionTime;
 import org.apache.cassandra.db.LivenessInfo;
 import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.SerializationHeader;
+import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.Threshold;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -82,6 +83,11 @@ public class SSTableCursorWriter implements AutoCloseable
     private final boolean hasStaticColumns;
 
     private long partitionStart;
+    // Offset within the current partition of the previous non-static unfiltered's first byte.
+    // Used to write the previousUnfilteredSize field exactly as the iterator path does
+    // (see SortedTablePartitionWriter.addUnfiltered): rows/markers write the distance from the
+    // previous unfiltered's start; static rows write 0 and do not advance this offset.
+    private long previousRowStartOffset;
     // ROW contents, needed because of the order of writing and the var int fields
     private int rowFlags; // discovered as we go along
     private int rowExtendedFlags;
@@ -165,6 +171,7 @@ public class SSTableCursorWriter implements AutoCloseable
         hasDistinctLastClustering = false;
 
         partitionStart = dataWriter.position();
+        previousRowStartOffset = 0;
         writePartitionHeader(partitionKey, partitionKeyLength, partitionDeletionTime);
         updateIndexBlockStartOffset(dataWriter.position());
         return indexBlockStartOffset;
@@ -207,9 +214,20 @@ public class SSTableCursorWriter implements AutoCloseable
 
             indexFileWriter.writeUnsignedVInt(partitionStart);
 
-            // if the list of entries has one or fewer entries, no point in index entries.
+            // The trailing block must be counted BEFORE deciding whether to promote the index:
+            // the iterator (BigFormatPartitionWriter.finish + RowIndexEntry.create) promotes when
+            // the total block count INCLUDING the tail is > 1. A tail size of exactly 1 means only
+            // the end-of-partition marker remains since the last cut (the iterator's
+            // firstClustering == null case) and no tail block exists.
+            // The tail width itself includes the end-of-partition marker byte, matching the
+            // iterator, which indexes the final block AFTER SortedTablePartitionWriter.finish()
+            // has written the marker.
+            long tailBlockSize = (partitionEnd - partitionStart) - indexBlockStartOffset;
+            boolean hasTailBlock = tailBlockSize > 1;
+            int totalBlocks = rowIndexEntriesOffsets.size() + (hasTailBlock ? 1 : 0);
+
             /** See: {@link org.apache.cassandra.io.sstable.format.big.RowIndexEntry#create} */
-            if (rowIndexEntriesOffsets.size() <= 1)
+            if (totalBlocks <= 1)
             {
                 /**
                  * {@link RowIndexEntry#serialize(DataOutputPlus, ByteBuffer)}
@@ -218,9 +236,8 @@ public class SSTableCursorWriter implements AutoCloseable
             }
             else {
                 // add last block
-                long indexBlockSize = (partitionEnd - partitionStart - 1) - indexBlockStartOffset;
-                if (indexBlockSize != 0) {
-                    addIndexBlock(partitionEnd - 1, indexBlockSize);
+                if (hasTailBlock) {
+                    addIndexBlock(partitionEnd, tailBlockSize);
                 }
                 // if we have intermeddiate index info elements we also need to serialize the partitionDeletionTime
                 /** {@link RowIndexEntry.IndexedEntry#serialize(DataOutputPlus, ByteBuffer) */
@@ -303,8 +320,6 @@ public class SSTableCursorWriter implements AutoCloseable
         columns = staticColumns;
         // TOD: we should be able to skip the use of the row buffers in this special case, maybe it doesn't matter
         rowHeaderBuffer.clear();
-        // NOTE: if we are to write this value (which is not used), this is where we should compute it.
-        rowHeaderBuffer.writeUnsignedVInt32(0);
         rowBuffer.clear();
         columnsWrittenCount = 0;
         missingColumns.clear();
@@ -335,9 +350,6 @@ public class SSTableCursorWriter implements AutoCloseable
         rowBuffer.clear();
         columnsWrittenCount = 0;
         nextCellIndex = 0;
-
-        // NOTE: if we are to write this value (which is not used), this is where we should compute it.
-        rowHeaderBuffer.writeUnsignedVInt32(0);
 
         // copy TS/TTL/deletion data
         rowFlags |= writeRowTimeData(livenessInfo, deletionTime, rowHeaderBuffer);
@@ -484,8 +496,19 @@ public class SSTableCursorWriter implements AutoCloseable
             dataWriter.write(clustering, 0, clusteringLength);
         }
 
-        // Now that we know the size, write it + the rest of the data
-        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength() + rowBuffer.getLength());
+        // Matches UnfilteredSerializer.serialize: the row size includes the vint length of the
+        // previousUnfilteredSize field, which is written between the size and the row body.
+        // Static rows write 0 and do not advance the chain (UnfilteredSerializer.serializeStaticRow).
+        long previousUnfilteredSize = 0;
+        if (!isStatic)
+        {
+            long offsetInPartition = unfilteredStartPosition - partitionStart;
+            previousUnfilteredSize = offsetInPartition - previousRowStartOffset;
+            previousRowStartOffset = offsetInPartition;
+        }
+        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength() + rowBuffer.getLength()
+                                       + TypeSizes.sizeofUnsignedVInt(previousUnfilteredSize));
+        dataWriter.writeUnsignedVInt(previousUnfilteredSize);
 
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
         dataWriter.write(rowBuffer.getData(), 0, rowBuffer.getLength());
@@ -528,8 +551,6 @@ public class SSTableCursorWriter implements AutoCloseable
             dataWriter.write(clustering, 0, clusteringLength);
         }
         rowHeaderBuffer.clear();
-        // TODO: previousUnfilteredSize
-        rowHeaderBuffer.writeUnsignedVInt32(0);
 
         if (kind.isBoundary())
         {
@@ -546,7 +567,14 @@ public class SSTableCursorWriter implements AutoCloseable
                 openMarker.resetLive();
         }
 
-        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength());
+        // Matches UnfilteredSerializer.serialize(RangeTombstoneMarker...): marker size includes the
+        // vint length of previousUnfilteredSize, written between the size and the marker body.
+        long offsetInPartition = unfilteredStartPosition - partitionStart;
+        long previousUnfilteredSize = offsetInPartition - previousRowStartOffset;
+        previousRowStartOffset = offsetInPartition;
+        dataWriter.writeUnsignedVInt32(rowHeaderBuffer.getLength()
+                                       + TypeSizes.sizeofUnsignedVInt(previousUnfilteredSize));
+        dataWriter.writeUnsignedVInt(previousUnfilteredSize);
         dataWriter.write(rowHeaderBuffer.getData(), 0, rowHeaderBuffer.getLength());
 
         long unfilteredEndPosition = getPosition();

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -162,7 +162,8 @@ public class SSTableCursorWriter implements AutoCloseable
         previousRowStartOffset = 0;
         writePartitionHeader(partitionKey, partitionKeyLength, partitionDeletionTime);
         cursorIndexWriter.startPartition(partitionStart, dataWriter.position());
-        return cursorIndexWriter.indexBlockStartOffset();
+        // immediately after startPartition this is the partition header length — always small
+        return Math.toIntExact(cursorIndexWriter.indexBlockStartOffset());
     }
 
     public void writePartitionEnd(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime, int headerLength) throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -529,24 +529,30 @@ public class SSTableCursorWriter implements AutoCloseable
 
     private void encodeLargeColumnsSubset() throws IOException
     {
-        // no columns are present, nothing to write
         rowHeaderBuffer.writeUnsignedVInt32(missingColumns.size());
-        if (missingColumns.size() > columns.length / 2)
+        // Mode selection must mirror Columns.Serializer.serializeLargeSubset AND its
+        // deserializer exactly: present-index mode iff presentCount < supersetCount / 2.
+        // The previous condition (missing > supersetCount / 2) agreed for even superset
+        // sizes but flipped the mode for odd sizes at missing == supersetCount/2 + 1,
+        // which the deserializer then read in the WRONG mode — corrupted output.
+        int presentCount = columns.length - missingColumns.size();
+        if (presentCount < columns.length / 2)
         {
-            // write present columns
+            // write present column indices: the gaps between missing indices, INCLUDING the
+            // tail after the last missing index — the previous tail loop's bound was the
+            // last missing index itself (vacuously empty), so present columns sorting after
+            // the last missing one were silently dropped from the encoding and the
+            // deserializer consumed row-body bytes as column indices — corrupted output
             int presentIndex = 0;
-            int missingIndex = 0;
             for (int i = 0; i < missingColumns.size(); i++)
             {
-                missingIndex = missingColumns.get(i);
+                int missingIndex = missingColumns.get(i);
                 for (; presentIndex < missingIndex; presentIndex++)
                     rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
                 presentIndex = missingIndex + 1;
             }
-            if (missingIndex < columns.length-1) {
-                for (; presentIndex < missingIndex; presentIndex++)
-                    rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
-            }
+            for (; presentIndex < columns.length; presentIndex++)
+                rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
         }
         else
         {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -76,10 +76,6 @@ public class SSTableCursorWriter implements AutoCloseable
     private final DeletionTime.Serializer deletionTimeSerializer;
     private final MetadataCollector metadataCollector;
     private final SerializationHeader serializationHeader;
-    /**
-     * See: {@link BloomFilter#reusableIndexes}
-     */
-    private final long[] reusableIndexes = new long[21];
     private final boolean hasStaticColumns;
 
     private long partitionStart;
@@ -101,14 +97,9 @@ public class SSTableCursorWriter implements AutoCloseable
     private ColumnMetadata[] columns; // points to static/regular
     private int columnsWrittenCount = 0;
     private int nextCellIndex = 0;
-    // Index info
-    private final DataOutputBuffer rowIndexEntries = new DataOutputBuffer();
-    private final IntArrayList rowIndexEntriesOffsets = new IntArrayList();
-    private final ClusteringDescriptor rowIndexEntryLastClustering;
-    private boolean hasDistinctLastClustering = false;
-    private int indexBlockStartOffset;
-    private int rowIndexEntryOffset;
-    private final int indexBlockThreshold;
+    // Format-specific index production (BIG: promoted blocks + Index.db + bloom filter/summary;
+    // other formats own their own index structures accordingly)
+    private final CursorIndexWriter cursorIndexWriter;
 
     private SSTableCursorWriter(
         Descriptor desc,
@@ -127,8 +118,9 @@ public class SSTableCursorWriter implements AutoCloseable
         hasStaticColumns = serializationHeader.hasStatic();
         staticColumns = hasStaticColumns ? serializationHeader.columns(true).toArray(EMPTY_COL_META) : EMPTY_COL_META;
         regularColumns = serializationHeader.columns(false).toArray(EMPTY_COL_META);
-        this.indexBlockThreshold = DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY);
-        rowIndexEntryLastClustering = new ClusteringDescriptor(serializationHeader.clusteringTypes().toArray(AbstractType[]::new));
+        this.cursorIndexWriter = new BigCursorIndexWriter((BigTableWriter.IndexWriter) indexWriter,
+                                                           this.deletionTimeSerializer,
+                                                           new ClusteringDescriptor(serializationHeader.clusteringTypes().toArray(AbstractType[]::new)));
     }
 
     public SSTableCursorWriter(SortedTableWriter<?,?> ssTableWriter)
@@ -164,17 +156,13 @@ public class SSTableCursorWriter implements AutoCloseable
 
     public int writePartitionStart(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime) throws IOException
     {
-        rowIndexEntries.clear();
-        rowIndexEntriesOffsets.clear();
-        rowIndexEntryOffset = 0;
         openMarker.resetLive();
-        hasDistinctLastClustering = false;
 
         partitionStart = dataWriter.position();
         previousRowStartOffset = 0;
         writePartitionHeader(partitionKey, partitionKeyLength, partitionDeletionTime);
-        updateIndexBlockStartOffset(dataWriter.position());
-        return indexBlockStartOffset;
+        cursorIndexWriter.startPartition(partitionStart, dataWriter.position());
+        return cursorIndexWriter.indexBlockStartOffset();
     }
 
     public void writePartitionEnd(byte[] partitionKey, int partitionKeyLength, DeletionTime partitionDeletionTime, int headerLength) throws IOException
@@ -194,82 +182,9 @@ public class SSTableCursorWriter implements AutoCloseable
          // this is implemented differently for BIG/BTI
          createRowIndexEntry(key, partitionLevelDeletion, partitionEnd - 1);
          */
-        appendBIGIndex(partitionKey, partitionKeyLength, partitionStart, headerLength, partitionDeletionTime, partitionEnd);
+        cursorIndexWriter.endPartition(partitionKey, partitionKeyLength, headerLength, partitionDeletionTime, partitionEnd);
     }
 
-    private void appendBIGIndex(byte[] key, int keyLength, long partitionStart, int headerLength, DeletionTime partitionDeletionTime, long partitionEnd) throws IOException
-    {
-        /**
-         * {@link BigTableWriter#createRowIndexEntry(DecoratedKey, DeletionTime, long)}
-         * {@link BigTableWriter.IndexWriter#append(DecoratedKey, RowIndexEntry, long, ByteBuffer)}
-         *
-         */
-        BigTableWriter.IndexWriter indexWriter = (BigTableWriter.IndexWriter) this.indexWriter;
-        SequentialWriter indexFileWriter = indexWriter.writer;
-        ((BloomFilter)indexWriter.bf).add(key, 0, keyLength, reusableIndexes);
-        long indexStart = indexFileWriter.position();
-        try
-        {
-            ByteArrayUtil.writeWithShortLength(key, 0, keyLength, indexFileWriter);
-
-            indexFileWriter.writeUnsignedVInt(partitionStart);
-
-            // The trailing block must be counted BEFORE deciding whether to promote the index:
-            // the iterator (BigFormatPartitionWriter.finish + RowIndexEntry.create) promotes when
-            // the total block count INCLUDING the tail is > 1. A tail size of exactly 1 means only
-            // the end-of-partition marker remains since the last cut (the iterator's
-            // firstClustering == null case) and no tail block exists.
-            // The tail width itself includes the end-of-partition marker byte, matching the
-            // iterator, which indexes the final block AFTER SortedTablePartitionWriter.finish()
-            // has written the marker.
-            long tailBlockSize = (partitionEnd - partitionStart) - indexBlockStartOffset;
-            boolean hasTailBlock = tailBlockSize > 1;
-            int totalBlocks = rowIndexEntriesOffsets.size() + (hasTailBlock ? 1 : 0);
-
-            /** See: {@link org.apache.cassandra.io.sstable.format.big.RowIndexEntry#create} */
-            if (totalBlocks <= 1)
-            {
-                /**
-                 * {@link RowIndexEntry#serialize(DataOutputPlus, ByteBuffer)}
-                 */
-                indexFileWriter.writeUnsignedVInt32(0); // size
-            }
-            else {
-                // add last block
-                if (hasTailBlock) {
-                    addIndexBlock(partitionEnd, tailBlockSize);
-                }
-                // if we have intermeddiate index info elements we also need to serialize the partitionDeletionTime
-                /** {@link RowIndexEntry.IndexedEntry#serialize(DataOutputPlus, ByteBuffer) */
-                // size up to the offsets?
-                int endOfEntries = rowIndexEntries.getLength();
-                // Write the headerLength, partitionDeletionTime and rowIndexEntriesOffsets.size() after the entries,
-                // just to calculate size.
-                rowIndexEntries.writeUnsignedVInt((long)headerLength);
-                deletionTimeSerializer.serialize(partitionDeletionTime, rowIndexEntries);
-
-                rowIndexEntries.writeUnsignedVInt32(rowIndexEntriesOffsets.size()); // number of entries
-
-                // bytes until offsets
-                int entriesAndOffsetsSize = rowIndexEntries.getLength() + rowIndexEntriesOffsets.size() * 4;
-                assert entriesAndOffsetsSize > 0;
-                indexFileWriter.writeUnsignedVInt32(entriesAndOffsetsSize); // size != 0
-                // copy the header elements
-                indexFileWriter.write(rowIndexEntries.getData(), endOfEntries, rowIndexEntries.getLength() - endOfEntries);
-                indexFileWriter.write(rowIndexEntries.getData(), 0, endOfEntries);
-                for (int i = 0; i < rowIndexEntriesOffsets.size(); i++)
-                {
-                    int offset = rowIndexEntriesOffsets.get(i);
-                    indexFileWriter.writeInt(offset);
-                }
-            }
-        }
-        catch (IOException e)
-        {
-            throw new FSWriteError(e, indexFileWriter.getPath());
-        }
-        indexWriter.summary.maybeAddEntry(key, 0, keyLength, indexStart);
-    }
 
     final long guardrailsPartitionSizeWarning = Guardrails.partitionSize.warnValue(null);
     final long guardrailsPartitionTombstonesWarning = Guardrails.partitionTombstones.warnValue(null);
@@ -325,7 +240,7 @@ public class SSTableCursorWriter implements AutoCloseable
         missingColumns.clear();
         writeRowEnd(null, false);
 
-        updateIndexBlockStartOffset(dataWriter.position());
+        cursorIndexWriter.staticRowWritten(dataWriter.position());
         return true;
     }
 
@@ -530,7 +445,7 @@ public class SSTableCursorWriter implements AutoCloseable
 
         if (isStatic)
         {
-            updateIndexBlockStartOffset(dataWriter.position());
+            cursorIndexWriter.staticRowWritten(dataWriter.position());
         }
         else
         {
@@ -598,22 +513,7 @@ public class SSTableCursorWriter implements AutoCloseable
                                              boolean updateClusteringMetadata) throws IOException
     {
         if (updateClusteringMetadata) updateClusteringMetadata(unfilteredDescriptor);
-        // write the first clustering into rowIndexEntries buffer (we will need it unless we never write the first entry)
-        if (currentOffsetInPartition(unfilteredStartPosition) == indexBlockStartOffset || (rowIndexEntryOffset == rowIndexEntries.position()))
-        {
-            writeClusteringToRowIndexEntries(unfilteredDescriptor);
-        }
-        else
-        {
-            rowIndexEntryLastClustering.copy(unfilteredDescriptor);
-            hasDistinctLastClustering = true;
-        }
-
-        /** {@link BigFormatPartitionWriter#addUnfiltered(Unfiltered)} */
-        // if we hit the index block size that we have to index after, go ahead and index it.
-        long indexBlockSize = currentOffsetInPartition(unfilteredEndPosition) - indexBlockStartOffset;
-        if (indexBlockSize >= this.indexBlockThreshold)
-            addIndexBlock(unfilteredEndPosition, indexBlockSize);
+        cursorIndexWriter.rowWritten(unfilteredDescriptor, unfilteredStartPosition, unfilteredEndPosition, openMarker);
     }
 
     public void updateClusteringMetadata(UnfilteredDescriptor unfilteredDescriptor)
@@ -621,61 +521,6 @@ public class SSTableCursorWriter implements AutoCloseable
         metadataCollector.updateClusteringValues(unfilteredDescriptor);
     }
 
-    /**
-     *  See:
-     *  {@link BigFormatPartitionWriter#addIndexBlock()}
-     *  - {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}
-     */
-    private void addIndexBlock(long endOfRowPosition, long indexBlockSize) throws IOException
-    {
-        if (rowIndexEntriesOffsets.isEmpty() && rowIndexEntryOffset != 0) {
-            throw new IllegalStateException();
-        }
-
-        // serialize the index info
-        /** {@link org.apache.cassandra.io.sstable.IndexInfo.Serializer#serialize(org.apache.cassandra.io.sstable.IndexInfo, org.apache.cassandra.io.util.DataOutputPlus)}*/
-        rowIndexEntriesOffsets.addInt(rowIndexEntryOffset);
-
-        // first clustering is already in, write last entry
-        if (!hasDistinctLastClustering)
-        {
-            // first entry is the last entry, copy it
-            byte[] entriesData = rowIndexEntries.getData();
-            long endOfFirstEntry = rowIndexEntries.position();
-            rowIndexEntries.write(entriesData, rowIndexEntryOffset, (int) (endOfFirstEntry - rowIndexEntryOffset));
-        }
-        else
-        {
-            writeClusteringToRowIndexEntries(rowIndexEntryLastClustering);
-            rowIndexEntryLastClustering.resetClustering();
-        }
-        hasDistinctLastClustering = false;
-
-        rowIndexEntries.writeUnsignedVInt((long)indexBlockStartOffset);
-        rowIndexEntries.writeVInt(indexBlockSize - IndexInfo.Serializer.WIDTH_BASE);
-
-        boolean isDeleteTimePresent = !openMarker.isLive();
-        rowIndexEntries.writeBoolean(isDeleteTimePresent);
-        if (isDeleteTimePresent)
-            deletionTimeSerializer.serialize(openMarker, rowIndexEntries);
-        // next block starts
-        rowIndexEntryOffset = Ints.checkedCast(rowIndexEntries.position());
-        updateIndexBlockStartOffset(endOfRowPosition);
-    }
-
-    private void updateIndexBlockStartOffset(long endOfRowPosition)
-    {
-        indexBlockStartOffset = (int) (endOfRowPosition - partitionStart);
-    }
-
-    private void writeClusteringToRowIndexEntries(ClusteringDescriptor clustering) throws IOException
-    {
-        ClusteringPrefix.Kind kind = clustering.clusteringKind();
-        rowIndexEntries.writeByte(kind.ordinal());
-        if (kind != ClusteringPrefix.Kind.CLUSTERING)
-            rowIndexEntries.writeShort(clustering.clusteringColumnsBound());
-        rowIndexEntries.write(clustering.clusteringBytes(), 0, clustering.clusteringLength());
-    }
 
     private long currentOffsetInPartition(long position)
     {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.io.sstable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 
 import org.agrona.collections.IntArrayList;
@@ -385,17 +386,7 @@ public class SSTableCursorWriter implements AutoCloseable
             for (; nextCellIndex < columnsLength; nextCellIndex++)
                 missingColumns.addInt(nextCellIndex);
 
-            if (columnsLength < 64) {
-                // set a bit for every missing column
-                long mask = 0;
-                for (int missingIndex : missingColumns) {
-                    mask |= (1L << missingIndex);
-                }
-                rowHeaderBuffer.writeUnsignedVInt(mask);
-            }
-            else {
-                encodeLargeColumnsSubset();
-            }
+            encodeColumnsSubset(missingColumns, columnsLength, rowHeaderBuffer);
         }
         long unfilteredStartPosition = dataWriter.position();
         /** See: {@link UnfilteredSerializer#serialize} */
@@ -528,16 +519,39 @@ public class SSTableCursorWriter implements AutoCloseable
         return position - partitionStart;
     }
 
-    private void encodeLargeColumnsSubset() throws IOException
+    /**
+     * Garbage-free equivalent of {@link org.apache.cassandra.db.Columns.Serializer}'s
+     * serializeSubset for a PARTIAL subset (not all-present, not all-missing — callers
+     * handle those fast paths): the < 64 missing-bitmap form, or the large-subset form
+     * (delta vint + present- or missing-index vints). Hand-mirrored because the upstream
+     * serializer requires a materialized Columns + iterator per call — a per-row allocation
+     * this path must not make. The mirror has already drifted from the upstream serializer
+     * once, producing corrupt output; {@code CursorColumnsSubsetEncodingTest} pins it byte-for-byte
+     * against the upstream serializer across sizes, shapes, and both mode boundaries.
+     *
+     * @param missingColumns ascending superset positions of the columns ABSENT from the row
+     */
+    @VisibleForTesting
+    static void encodeColumnsSubset(IntArrayList missingColumns, int supersetCount, DataOutputBuffer out) throws IOException
     {
-        rowHeaderBuffer.writeUnsignedVInt32(missingColumns.size());
+        if (supersetCount < 64)
+        {
+            // set a bit for every missing column (Columns.Serializer.encodeBitmap)
+            long mask = 0;
+            for (int i = 0; i < missingColumns.size(); i++)
+                mask |= 1L << missingColumns.getInt(i);
+            out.writeUnsignedVInt(mask);
+            return;
+        }
+
+        out.writeUnsignedVInt32(missingColumns.size());
         // Mode selection must mirror Columns.Serializer.serializeLargeSubset AND its
         // deserializer exactly: present-index mode iff presentCount < supersetCount / 2.
         // The previous condition (missing > supersetCount / 2) agreed for even superset
         // sizes but flipped the mode for odd sizes at missing == supersetCount/2 + 1,
         // which the deserializer then read in the WRONG mode — corrupted output.
-        int presentCount = columns.length - missingColumns.size();
-        if (presentCount < columns.length / 2)
+        int presentCount = supersetCount - missingColumns.size();
+        if (presentCount < supersetCount / 2)
         {
             // write present column indices: the gaps between missing indices, INCLUDING the
             // tail after the last missing index — the previous tail loop's bound was the
@@ -547,20 +561,19 @@ public class SSTableCursorWriter implements AutoCloseable
             int presentIndex = 0;
             for (int i = 0; i < missingColumns.size(); i++)
             {
-                int missingIndex = missingColumns.get(i);
+                int missingIndex = missingColumns.getInt(i);
                 for (; presentIndex < missingIndex; presentIndex++)
-                    rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
+                    out.writeUnsignedVInt32(presentIndex);
                 presentIndex = missingIndex + 1;
             }
-            for (; presentIndex < columns.length; presentIndex++)
-                rowHeaderBuffer.writeUnsignedVInt32(presentIndex);
+            for (; presentIndex < supersetCount; presentIndex++)
+                out.writeUnsignedVInt32(presentIndex);
         }
         else
         {
-            // write missing columns
-            for (int missingIndex : missingColumns) {
-                rowHeaderBuffer.writeUnsignedVInt32(missingIndex);
-            }
+            // write missing columns (indexed loop: agrona's for-each would box per element)
+            for (int i = 0; i < missingColumns.size(); i++)
+                out.writeUnsignedVInt32(missingColumns.getInt(i));
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.primitives.Ints;
 
 import org.agrona.collections.IntArrayList;
 
@@ -44,19 +43,15 @@ import org.apache.cassandra.db.rows.SerializationHelper;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredSerializer;
 import org.apache.cassandra.dht.IPartitioner;
-import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
 import org.apache.cassandra.io.sstable.format.big.BigFormatPartitionWriter;
 import org.apache.cassandra.io.sstable.format.big.BigTableWriter;
-import org.apache.cassandra.io.sstable.format.big.RowIndexEntry;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.utils.BloomFilter;
-import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.concurrent.Ref;
 
@@ -511,12 +506,6 @@ public class SSTableCursorWriter implements AutoCloseable
     public void updateClusteringMetadata(UnfilteredDescriptor unfilteredDescriptor)
     {
         metadataCollector.updateClusteringValues(unfilteredDescriptor);
-    }
-
-
-    private long currentOffsetInPartition(long position)
-    {
-        return position - partitionStart;
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -503,9 +503,9 @@ public class SSTableCursorWriter implements AutoCloseable
         cursorIndexWriter.rowWritten(unfilteredDescriptor, unfilteredStartPosition, unfilteredEndPosition, openMarker);
     }
 
-    public void updateClusteringMetadata(UnfilteredDescriptor unfilteredDescriptor)
+    public void updateClusteringMetadata(ClusteringDescriptor clusteringDescriptor)
     {
-        metadataCollector.updateClusteringValues(unfilteredDescriptor);
+        metadataCollector.updateClusteringValues(clusteringDescriptor);
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorWriter.java
@@ -516,9 +516,17 @@ public class SSTableCursorWriter implements AutoCloseable
         long unfilteredEndPosition = getPosition();
 
         /**
-         * Matching the: {@link org.apache.cassandra.db.rows.Rows#collectStats} along with above cell level metadata updates
+         * Matching the: {@link org.apache.cassandra.db.rows.Rows#collectStats} along with above cell level metadata updates.
+         * The iterator path only collects row stats for non-empty rows
+         * ({@link org.apache.cassandra.io.sstable.format.SortedTableWriter#addStaticRow} guards with
+         * !row.isEmpty()): an empty static row is still WRITTEN for static-column tables whose
+         * partition has no static values, but it must not count towards totalRows/totalColumnsSet.
+         * Empty == no cells, no liveness timestamp/TTL, no row deletion.
          */
-        metadataCollector.updateColumnSetPerRow(columnsWrittenCount);
+        boolean rowIsEmpty = columnsWrittenCount == 0
+                             && (rowFlags & (HAS_TIMESTAMP | HAS_TTL | HAS_DELETION)) == 0;
+        if (!rowIsEmpty)
+            metadataCollector.updateColumnSetPerRow(columnsWrittenCount);
 
         if (isStatic)
         {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -228,7 +228,9 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
 
             if (lowerbound.compareTo(latest.getLast()) >= 0)
             {
-                if (!transaction.isObsolete(latest))
+                // a fully-covered original must still be retained when the caller asked to
+                // keep the originals; obsoleting here deleted them despite keepOriginals=true
+                if (!keepOriginals && !transaction.isObsolete(latest))
                     transaction.obsolete(latest);
                 continue;
             }

--- a/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
@@ -44,6 +44,16 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     private long unfilteredDataStart;
     private long prevUnfilteredSize;
     Columns rowColumns;
+    // For supersets of < 64 columns: bit i set means the i-th column of rowColumns (in
+    // iteration order) is ABSENT from this row; 0 means all present. Always 0 for markers,
+    // all-columns rows, and >= 64-column supersets (which use the words below).
+    private long missingColumnsMask;
+    // For supersets of >= 64 columns: PRESENT-column mask words over superset iteration
+    // order (bit i of word i/64 set means superset column i is present in this row).
+    // Reusable grow-once scratch; valid only when useColumnsWords is set (a row that took
+    // the large-subset decode), consumed by CellCursor within the same row.
+    private long[] presentColumnsWords;
+    private boolean useColumnsWords;
 
     public UnfilteredDescriptor(AbstractType<?>[] clusteringTypes)
     {
@@ -57,6 +67,8 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         this.flags = flags;
         this.extendedFlags = 0;
         rowColumns = null;
+        missingColumnsMask = 0;
+        useColumnsWords = false;
         byte clusteringKind = dataReader.readByte();
         if (clusteringKind == STATIC_CLUSTERING_KIND || clusteringKind == ROW_CLUSTERING_KIND) {
             // STATIC_CLUSTERING or CLUSTERING -> no deletion info, should not happen
@@ -87,11 +99,13 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     void loadRow(RandomAccessReader dataReader,
                  SerializationHeader serializationHeader,
                  DeserializationHelper deserializationHelper,
-                 int flags) throws IOException {
+                 int flags,
+                 int extendedFlags) throws IOException {
         // body = whatever is covered by size, so inclusive of the prev_row_size inclusive of flags
-        position = dataReader.getPosition() - 1;
+        // (and the extended-flags byte too, when a non-static row carries one for a shadowable deletion)
+        position = dataReader.getPosition() - (UnfilteredSerializer.isExtended(flags) ? 2 : 1);
         this.flags = flags;
-        this.extendedFlags = 0;
+        this.extendedFlags = extendedFlags;
 
         loadClustering(dataReader, ROW_CLUSTERING_KIND, this.clusteringTypes.length);
 
@@ -143,10 +157,76 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         {
             deletionTime.resetLive();
         }
+        useColumnsWords = false;
         if (!UnfilteredSerializer.hasAllColumns(flags))
         {
-            // TODO: re-implement GC free
-            rowColumns = Columns.serializer.deserializeSubset(rowColumns, dataReader);
+            if (rowColumns.size() < 64)
+            {
+                // Garbage-free subset decode. Wire format per Columns.Serializer.deserializeSubset
+                // (Columns.java): an unsigned vint bitmask of MISSING columns, bit i corresponding
+                // to the i-th column of the superset in iteration order; 0 means all present.
+                // rowColumns stays the superset; consumers filter via missingColumnsMask().
+                long encoded = dataReader.readUnsignedVInt();
+                // sanity: shifting out the valid column bits must leave nothing — any higher
+                // bit set means the vint encodes more columns than the header knows about
+                // (mirrors Columns.Serializer.deserializeSubset's corruption check)
+                if ((encoded >>> rowColumns.size()) != 0)
+                    throw new IOException("Invalid Columns subset bytes; too many bits set: " + Long.toBinaryString(encoded));
+                missingColumnsMask = encoded;
+            }
+            else
+            {
+                // >= 64-column superset: LARGE-subset wire format (Columns.Serializer
+                // .serializeLargeSubset) — vint delta = supersetCount - presentCount, then
+                // either the present indices (presentCount < supersetCount/2) or the missing
+                // indices, each an unsigned vint superset position. Decoded garbage-free
+                // into reusable present-mask words; rowColumns stays the superset so
+                // CellCursor's identity cache never rebuilds per row (the < 64 mask path's
+                // design, extended to words).
+                long encoded = dataReader.readUnsignedVInt();
+                int supersetCount = rowColumns.size();
+                if (encoded > supersetCount)
+                    throw new IOException("Invalid large Columns subset: missing count " + encoded + " of " + supersetCount);
+                int delta = (int) encoded;
+                int columnCount = supersetCount - delta;
+                int nWords = (supersetCount + 63) >>> 6;
+                if (presentColumnsWords == null || presentColumnsWords.length < nWords)
+                    presentColumnsWords = new long[nWords]; // grow-once, amortized zero
+                if (columnCount < supersetCount / 2)
+                {
+                    // present-mode: start all-absent, set each present index
+                    java.util.Arrays.fill(presentColumnsWords, 0, nWords, 0L);
+                    for (int i = 0; i < columnCount; i++)
+                    {
+                        int idx = dataReader.readUnsignedVInt32();
+                        if (idx < 0 || idx >= supersetCount)
+                            throw new IOException("Invalid large Columns subset: present index " + idx + " of " + supersetCount);
+                        presentColumnsWords[idx >>> 6] |= 1L << (idx & 63);
+                    }
+                }
+                else
+                {
+                    // missing-mode: start all-present (last word trimmed to the column
+                    // range), clear each missing index. delta == 0 degenerates to
+                    // all-present, matching deserializeSubset's encoded == 0 case.
+                    java.util.Arrays.fill(presentColumnsWords, 0, nWords, -1L);
+                    if ((supersetCount & 63) != 0)
+                        presentColumnsWords[nWords - 1] = -1L >>> (64 - (supersetCount & 63));
+                    for (int i = 0; i < delta; i++)
+                    {
+                        int idx = dataReader.readUnsignedVInt32();
+                        if (idx < 0 || idx >= supersetCount)
+                            throw new IOException("Invalid large Columns subset: missing index " + idx + " of " + supersetCount);
+                        presentColumnsWords[idx >>> 6] &= ~(1L << (idx & 63));
+                    }
+                }
+                useColumnsWords = true;
+                missingColumnsMask = 0;
+            }
+        }
+        else
+        {
+            missingColumnsMask = 0;
         }
     }
 
@@ -160,6 +240,8 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         unfilteredDataStart = 0;
         prevUnfilteredSize = 0;
         rowColumns = null;
+        missingColumnsMask = 0;
+        useColumnsWords = false;
     }
 
     public long position()
@@ -187,6 +269,15 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         return deletionTime2;
     }
 
+    // Row.Deletion.isShadowable(): deprecated since 4.0 (CASSANDRA-11500), reachable only on
+    // old Materialized View data nothing still produces. A live deletion is never shadowable
+    // (Row.Deletion's own constructor asserts this), so this is meaningful only alongside a
+    // non-live deletionTime().
+    public boolean isShadowableDeletion()
+    {
+        return UnfilteredSerializer.deletionIsShadowable(extendedFlags);
+    }
+
     public int flags()
     {
         return flags;
@@ -205,6 +296,23 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     public Columns rowColumns()
     {
         return rowColumns;
+    }
+
+    /** See {@link #missingColumnsMask} */
+    public long missingColumnsMask()
+    {
+        return missingColumnsMask;
+    }
+
+    /**
+     * See {@link #presentColumnsWords}: present-column mask words for this row when the
+     * superset has >= 64 columns and the row carried a subset encoding; null otherwise
+     * (all columns present, or the < 64 mask path applies). The array is per-row scratch —
+     * the consumer may mutate it but must finish before the next unfiltered is loaded.
+     */
+    public long[] presentColumnsWords()
+    {
+        return useColumnsWords ? presentColumnsWords : null;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
@@ -67,6 +67,7 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         this.flags = flags;
         this.extendedFlags = 0;
         rowColumns = null;
+        missingColumnsMask = 0;
         useColumnsWords = false;
         byte clusteringKind = dataReader.readByte();
         if (clusteringKind == STATIC_CLUSTERING_KIND || clusteringKind == ROW_CLUSTERING_KIND) {

--- a/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
@@ -156,6 +156,9 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
                 // to the i-th column of the superset in iteration order; 0 means all present.
                 // rowColumns stays the superset; consumers filter via missingColumnsMask().
                 long encoded = dataReader.readUnsignedVInt();
+                // sanity: shifting out the valid column bits must leave nothing — any higher
+                // bit set means the vint encodes more columns than the header knows about
+                // (mirrors Columns.Serializer.deserializeSubset's corruption check)
                 if ((encoded >>> rowColumns.size()) != 0)
                     throw new IOException("Invalid Columns subset bytes; too many bits set: " + Long.toBinaryString(encoded));
                 missingColumnsMask = encoded;

--- a/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
@@ -44,6 +44,10 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     private long unfilteredDataStart;
     private long prevUnfilteredSize;
     Columns rowColumns;
+    // For supersets of < 64 columns: bit i set means the i-th column of rowColumns (in
+    // iteration order) is ABSENT from this row; 0 means all present. Always 0 when
+    // rowColumns is already an exact subset (>= 64 column fallback) or for markers.
+    private long missingColumnsMask;
 
     public UnfilteredDescriptor(AbstractType<?>[] clusteringTypes)
     {
@@ -145,8 +149,29 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         }
         if (!UnfilteredSerializer.hasAllColumns(flags))
         {
-            // TODO: re-implement GC free
-            rowColumns = Columns.serializer.deserializeSubset(rowColumns, dataReader);
+            if (rowColumns.size() < 64)
+            {
+                // Garbage-free subset decode. Wire format per Columns.Serializer.deserializeSubset
+                // (Columns.java): an unsigned vint bitmask of MISSING columns, bit i corresponding
+                // to the i-th column of the superset in iteration order; 0 means all present.
+                // rowColumns stays the superset; consumers filter via missingColumnsMask().
+                long encoded = dataReader.readUnsignedVInt();
+                if ((encoded >>> rowColumns.size()) != 0)
+                    throw new IOException("Invalid Columns subset bytes; too many bits set: " + Long.toBinaryString(encoded));
+                missingColumnsMask = encoded;
+            }
+            else
+            {
+                // Rare shape (>= 64 columns in the header superset): keep the allocating path.
+                // The large-subset wire format is structural, not a single mask; accepted
+                // allocation, documented trade-off.
+                rowColumns = Columns.serializer.deserializeSubset(rowColumns, dataReader);
+                missingColumnsMask = 0;
+            }
+        }
+        else
+        {
+            missingColumnsMask = 0;
         }
     }
 
@@ -160,6 +185,7 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         unfilteredDataStart = 0;
         prevUnfilteredSize = 0;
         rowColumns = null;
+        missingColumnsMask = 0;
     }
 
     public long position()
@@ -205,6 +231,12 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     public Columns rowColumns()
     {
         return rowColumns;
+    }
+
+    /** See {@link #missingColumnsMask} */
+    public long missingColumnsMask()
+    {
+        return missingColumnsMask;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/UnfilteredDescriptor.java
@@ -45,9 +45,15 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     private long prevUnfilteredSize;
     Columns rowColumns;
     // For supersets of < 64 columns: bit i set means the i-th column of rowColumns (in
-    // iteration order) is ABSENT from this row; 0 means all present. Always 0 when
-    // rowColumns is already an exact subset (>= 64 column fallback) or for markers.
+    // iteration order) is ABSENT from this row; 0 means all present. Always 0 for markers,
+    // all-columns rows, and >= 64-column supersets (which use the words below).
     private long missingColumnsMask;
+    // For supersets of >= 64 columns: PRESENT-column mask words over superset iteration
+    // order (bit i of word i/64 set means superset column i is present in this row).
+    // Reusable grow-once scratch; valid only when useColumnsWords is set (a row that took
+    // the large-subset decode), consumed by CellCursor within the same row.
+    private long[] presentColumnsWords;
+    private boolean useColumnsWords;
 
     public UnfilteredDescriptor(AbstractType<?>[] clusteringTypes)
     {
@@ -61,6 +67,7 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         this.flags = flags;
         this.extendedFlags = 0;
         rowColumns = null;
+        useColumnsWords = false;
         byte clusteringKind = dataReader.readByte();
         if (clusteringKind == STATIC_CLUSTERING_KIND || clusteringKind == ROW_CLUSTERING_KIND) {
             // STATIC_CLUSTERING or CLUSTERING -> no deletion info, should not happen
@@ -147,6 +154,7 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         {
             deletionTime.resetLive();
         }
+        useColumnsWords = false;
         if (!UnfilteredSerializer.hasAllColumns(flags))
         {
             if (rowColumns.size() < 64)
@@ -165,10 +173,51 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
             }
             else
             {
-                // Rare shape (>= 64 columns in the header superset): keep the allocating path.
-                // The large-subset wire format is structural, not a single mask; accepted
-                // allocation, documented trade-off.
-                rowColumns = Columns.serializer.deserializeSubset(rowColumns, dataReader);
+                // >= 64-column superset: LARGE-subset wire format (Columns.Serializer
+                // .serializeLargeSubset) — vint delta = supersetCount - presentCount, then
+                // either the present indices (presentCount < supersetCount/2) or the missing
+                // indices, each an unsigned vint superset position. Decoded garbage-free
+                // into reusable present-mask words; rowColumns stays the superset so
+                // CellCursor's identity cache never rebuilds per row (the < 64 mask path's
+                // design, extended to words).
+                long encoded = dataReader.readUnsignedVInt();
+                int supersetCount = rowColumns.size();
+                if (encoded > supersetCount)
+                    throw new IOException("Invalid large Columns subset: missing count " + encoded + " of " + supersetCount);
+                int delta = (int) encoded;
+                int columnCount = supersetCount - delta;
+                int nWords = (supersetCount + 63) >>> 6;
+                if (presentColumnsWords == null || presentColumnsWords.length < nWords)
+                    presentColumnsWords = new long[nWords]; // grow-once, amortized zero
+                if (columnCount < supersetCount / 2)
+                {
+                    // present-mode: start all-absent, set each present index
+                    java.util.Arrays.fill(presentColumnsWords, 0, nWords, 0L);
+                    for (int i = 0; i < columnCount; i++)
+                    {
+                        int idx = dataReader.readUnsignedVInt32();
+                        if (idx < 0 || idx >= supersetCount)
+                            throw new IOException("Invalid large Columns subset: present index " + idx + " of " + supersetCount);
+                        presentColumnsWords[idx >>> 6] |= 1L << (idx & 63);
+                    }
+                }
+                else
+                {
+                    // missing-mode: start all-present (last word trimmed to the column
+                    // range), clear each missing index. delta == 0 degenerates to
+                    // all-present, matching deserializeSubset's encoded == 0 case.
+                    java.util.Arrays.fill(presentColumnsWords, 0, nWords, -1L);
+                    if ((supersetCount & 63) != 0)
+                        presentColumnsWords[nWords - 1] = -1L >>> (64 - (supersetCount & 63));
+                    for (int i = 0; i < delta; i++)
+                    {
+                        int idx = dataReader.readUnsignedVInt32();
+                        if (idx < 0 || idx >= supersetCount)
+                            throw new IOException("Invalid large Columns subset: missing index " + idx + " of " + supersetCount);
+                        presentColumnsWords[idx >>> 6] &= ~(1L << (idx & 63));
+                    }
+                }
+                useColumnsWords = true;
                 missingColumnsMask = 0;
             }
         }
@@ -189,6 +238,7 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
         prevUnfilteredSize = 0;
         rowColumns = null;
         missingColumnsMask = 0;
+        useColumnsWords = false;
     }
 
     public long position()
@@ -240,6 +290,17 @@ public class UnfilteredDescriptor extends ClusteringDescriptor
     public long missingColumnsMask()
     {
         return missingColumnsMask;
+    }
+
+    /**
+     * See {@link #presentColumnsWords}: present-column mask words for this row when the
+     * superset has >= 64 columns and the row carried a subset encoding; null otherwise
+     * (all columns present, or the < 64 mask path applies). The array is per-row scratch —
+     * the consumer may mutate it but must finish before the next unfiltered is loaded.
+     */
+    public long[] presentColumnsWords()
+    {
+        return useColumnsWords ? presentColumnsWords : null;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.partitions.PartitionStatisticsCollector;
 import org.apache.cassandra.db.rows.ArrayCell;
 import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellLivenessInfo;
 import org.apache.cassandra.db.rows.NativeCell;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.sstable.ClusteringDescriptor;
@@ -288,11 +289,25 @@ public class MetadataCollector implements PartitionStatisticsCollector
 
     /**
      * Cell level stats, if we accept that LDT and LET are the same...
+     *
+     * Mirrors {@link #update(Cell)} rather than delegating to {@link #update(LivenessInfo)}. That overload
+     * early-returns on {@link LivenessInfo#isEmpty()}, which is a ROW concept — an empty primary-key
+     * liveness contributes nothing — and applying it to a cell silently drops the timestamp, TTL and
+     * deletion-time contributions of a cell timestamped {@link LivenessInfo#NO_TIMESTAMP}.
+     * {@link #update(Cell)}, which the iterator path uses, has no such branch, so the unconditional form is
+     * the reference.
+     *
+     * It does not delegate to {@link #update(Cell)} either: that method opens with its own
+     * {@code ++currentPartitionCells}, so delegating would count every cell twice.
      */
-    public void updateCellLiveness(LivenessInfo newInfo)
+    public void updateCellLiveness(CellLivenessInfo newInfo)
     {
         ++currentPartitionCells;
-        update(newInfo);
+        updateTimestamp(newInfo.timestamp());
+        updateTTL(newInfo.ttl());
+        updateLocalDeletionTime(newInfo.localDeletionTime());
+        if (!newInfo.isLive(nowInSec))
+            updateTombstoneCount();
     }
 
     public void updatePartitionDeletion(DeletionTime dt)

--- a/src/java/org/apache/cassandra/utils/ThreadStats.java
+++ b/src/java/org/apache/cassandra/utils/ThreadStats.java
@@ -46,6 +46,11 @@ public class ThreadStats
         threadMxBean = threadMxBeanToInit;
     }
 
+    public static boolean isThreadAllocatedMemorySupported()
+    {
+        return threadMxBean != null && threadMxBean.isThreadAllocatedMemorySupported();
+    }
+
     public static long getCurrentThreadCpuTimeNano()
     {
         return threadMxBean == null || !threadMxBean.isCurrentThreadCpuTimeSupported()

--- a/test/burn/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
+++ b/test/burn/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Volume scenario: FORTY MILLION written rows across TWENTY input sstables — 20,000 partitions
+ * x 100 rows per round x 20 flush rounds, with each round's clustering window overlapping the
+ * previous round's by half so most output rows genuinely merge from 2-3 inputs, plus one
+ * reserved single-row tie partition (see TIE_PK). The mutation mix runs at scale; at the
+ * defaults: ~14% TTL'd rows, 6.7% of writes at the explicit tie timestamp — which the
+ * overlapping windows turn into a cross-sstable same-timestamp tie at 50 of every bulk
+ * partition's 1,012 distinct clusterings, 49 of them decided by the tie-break (the other one
+ * also takes a wall-clock TTL write in a third covering round, which wins on timestamp), so
+ * 980K rows table-wide whose tie the tie-break decides out of 1M carrying one — ~3%
+ * null-overwrite cell tombstones, plus per-round row deletes, bounded and single-sided range
+ * deletes, and cycling partition deletes with resurrection.
+ *
+ * Runs in scale-capture mode (see DifferentialCompactionTester.scaleCapture): the logical
+ * dump streams into a SHA-256 digest and byte comparison streams, so harness memory stays
+ * flat. Two generations as everywhere.
+ *
+ * Lives in test/burn, not test/unit — this is a multi-minute, multi-GB compaction, not a unit
+ * test. All scale parameters are still property-configurable (defaults reproduce the standard
+ * 40M-row / 20-sstable run). Properties must reach the forked test JVM via -Dtest.jvm.args:
+ *
+ *   ant test-burn -Dtest.name=...BigVolumeDifferentialCompactionTest \
+ *       -Dtest.timeout=14400000 \
+ *       -Dtest.jvm.args="-Dcassandra.test.differential.bigvolume.rounds=40
+ *                        -Dcassandra.test.differential.bigvolume.partitions=10000
+ *                        -Dcassandra.test.differential.bigvolume.rows_per_round=100
+ *                        -Dcassandra.test.differential.bigvolume.value_padding=200"
+ *
+ *  - rounds          = number of input sstables (one flush per round)
+ *  - partitions      = partitions per round
+ *  - rows_per_round  = rows per partition per round (total rows = rounds x partitions x this, plus
+ *                      one reserved tie row per round in partition PARTITIONS; see TIE_PK)
+ *  - value_padding   = extra bytes appended to every text value (row size knob)
+ *
+ * Delete counts scale with the partition count; the clustering stride is derived so
+ * consecutive rounds always overlap by roughly half a window.
+ */
+public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    private static final int ROUNDS = CassandraRelevantProperties.TEST_DIFFERENTIAL_BIGVOLUME_ROUNDS.getInt();
+    private static final int PARTITIONS = CassandraRelevantProperties.TEST_DIFFERENTIAL_BIGVOLUME_PARTITIONS.getInt();
+    private static final int ROWS_PER_ROUND = CassandraRelevantProperties.TEST_DIFFERENTIAL_BIGVOLUME_ROWS_PER_ROUND.getInt();
+    private static final String VALUE_PADDING =
+        "p".repeat(CassandraRelevantProperties.TEST_DIFFERENTIAL_BIGVOLUME_VALUE_PADDING.getInt());
+    /** < ROWS_PER_ROUND so consecutive rounds overlap by roughly half a window (100 -> 48). */
+    private static final int CK_STRIDE = Math.max(1, ROWS_PER_ROUND / 2 - 2);
+
+    /**
+     * Reserved tie partition, outside {@code [0, PARTITIONS)} — which is the whole space every delete
+     * in the workload can reach: the row, bounded-range and open-ended-range deletes all take their
+     * partition key modulo PARTITIONS, and the cycling partition delete stays inside
+     * {@code [max(0, PARTITIONS - 5), max(0, PARTITIONS - 5) + min(5, PARTITIONS))}. Its one row is
+     * written once per round at the explicit tie timestamp, so it is a ROUNDS-way same-timestamp tie
+     * across ROUNDS sstables whose winner is guaranteed to reach the output.
+     */
+    private static final long TIE_PK = PARTITIONS;
+    private static final long TIE_CK = 0;
+
+    /**
+     * v2 of the reserved tie row for {@code round}, zero-padded to a fixed width so that unsigned byte
+     * order is DESCENDING in the round: the greatest value bytes belong to the FIRST round written. v1
+     * ascends with the round instead, so a merge that resolved the tie by write order in either
+     * direction — rather than per cell on the value bytes — cannot produce both.
+     */
+    private static String tieValue(int round)
+    {
+        return String.format("tie%010d", ROUNDS - 1 - round);
+    }
+
+    @Override
+    protected boolean scaleCapture()
+    {
+        return true;
+    }
+
+    @Test
+    public void fortyMillionRowsTwentySSTables() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, " +
+                    "PRIMARY KEY (pk, ck)) WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        assertTrue("the reserved tie needs at least two input sstables to be a cross-sstable tie: rounds=" +
+                   ROUNDS, ROUNDS >= 2);
+        logger.info("big-volume parameters: rounds={} partitions={} rowsPerRound={} valuePadding={}B " +
+                    "ckStride={} -> {} total rows across {} input sstables, plus one reserved tie row " +
+                    "per round in partition {}",
+                    ROUNDS, PARTITIONS, ROWS_PER_ROUND, VALUE_PADDING.length(), CK_STRIDE,
+                    (long) ROUNDS * PARTITIONS * ROWS_PER_ROUND, ROUNDS, TIE_PK);
+
+        String insert = "INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)";
+        String insertTtl = insert + " USING TTL 86400";
+        String insertTs = insert + " USING TIMESTAMP 5000";
+
+        // A clustering written at the explicit tie timestamp in two ADJACENT rounds is a genuine
+        // cross-sstable same-timestamp tie (rounds are sstables here, one flush each). Counted from the
+        // same boolean the write branch uses, so a predicate that stops producing ties fails the
+        // assertion below instead of passing silently. Two adjacent-round sets are enough for existence
+        // — CK_STRIDE < ROWS_PER_ROUND makes consecutive windows overlap — and bound the memory by one
+        // round's tie writes rather than by the whole run. One partition is enough: the predicate does
+        // not read pk, and within a round a clustering is written at most once. Not tracked at all
+        // where the windows are disjoint: no BULK row is overwritten then, so the reserved tie is the
+        // only cross-sstable tie there. It has no tally of its own — a round-count precondition and an
+        // absolute assertion on its resolved winner cover it instead.
+        boolean overlappingWindows = CK_STRIDE < ROWS_PER_ROUND;
+        Set<Long> tieCksThisRound = new HashSet<>();
+        Set<Long> tieCksPrevRound = new HashSet<>();
+        long adjacentRoundTieWrites = 0;
+
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            long ckBase = (long) round * CK_STRIDE;
+            for (long pk = 0; pk < PARTITIONS; pk++)
+            {
+                for (int j = 0; j < ROWS_PER_ROUND; j++)
+                {
+                    long ck = ckBase + j;
+                    long v1 = ck * 31 + round;
+                    String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck + VALUE_PADDING;
+                    boolean ttlWrite = j % 7 == 3;
+                    // ck, not j: the clustering window shifts by CK_STRIDE every round, so a predicate
+                    // on the in-round offset j can never select the same clustering in two rounds and
+                    // produces ZERO cross-sstable ties. A predicate on ck holds in every round whose
+                    // window covers it.
+                    boolean tieWrite = !ttlWrite && ck % 13 == 7;
+                    if (ttlWrite)
+                        execute(insertTtl, pk, ck, v1, v2);
+                    else if (tieWrite)
+                    {
+                        execute(insertTs, pk, ck, v1, "tie" + round + "_" + ck + VALUE_PADDING);
+                        if (pk == 0 && overlappingWindows)
+                        {
+                            tieCksThisRound.add(ck);
+                            if (tieCksPrevRound.contains(ck))
+                                adjacentRoundTieWrites++;
+                        }
+                    }
+                    else
+                        execute(insert, pk, ck, v1, v2);
+                }
+            }
+
+            // the reserved tie: same clustering, same timestamp, every round
+            execute(insertTs, TIE_PK, TIE_CK, (long) round, tieValue(round));
+
+            // delete counts scale with the partition count (defaults: 1000 / 303 / 200)
+            for (int i = 0; i < Math.max(1, PARTITIONS / 20); i++)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?",
+                        (long) ((round * 97 + i * 13) % PARTITIONS), ckBase + (i % ROWS_PER_ROUND));
+            for (int i = 0; i < Math.max(1, PARTITIONS / 66); i++)
+            {
+                long start = ckBase + (i % 40);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                        (long) ((round * 53 + i * 29) % PARTITIONS), start, start + 4);
+            }
+            for (int i = 0; i < Math.max(1, PARTITIONS / 100); i++)
+            {
+                long pk = (round * 41 + i * 17) % PARTITIONS;
+                if (i % 2 == 0)
+                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", pk, ckBase + ROWS_PER_ROUND / 2);
+                else
+                    execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", pk, ckBase + 5);
+            }
+            // cycling partition deletes over the same 5 partitions: tombstone + resurrection
+            execute("DELETE FROM %s WHERE pk = ?", (long) (Math.max(0, PARTITIONS - 5) + round % Math.min(5, PARTITIONS)));
+
+            flush();
+            tieCksPrevRound = tieCksThisRound;
+            tieCksThisRound = new HashSet<>();
+            logger.info("big-volume round {}/{} flushed", round + 1, ROUNDS);
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        if (overlappingWindows)
+        {
+            logger.info("cross-sstable same-timestamp tie writes (clusterings written at the tie timestamp " +
+                        "in two adjacent rounds): {} per partition, in each of {} partitions",
+                        adjacentRoundTieWrites, PARTITIONS);
+            assertTrue("no cross-sstable same-timestamp tie was written despite overlapping clustering " +
+                       "windows: the tie predicate's clustering selection must key on ck rather than on " +
+                       "the in-round offset j, or the shifting window never selects a clustering twice " +
+                       "(adjacentRoundTieWrites=" +
+                       adjacentRoundTieWrites + ')', adjacentRoundTieWrites > 0);
+        }
+        else
+        {
+            logger.info("disjoint clustering windows (ckStride={} >= rowsPerRound={}): the bulk rows are " +
+                        "never overwritten, so the only cross-sstable tie is the reserved one",
+                        CK_STRIDE, ROWS_PER_ROUND);
+        }
+
+        // ABSOLUTE: at equal timestamps the greater raw value bytes win, decided PER CELL — so the
+        // reserved tie must keep v1 from the LAST round and v2 from the FIRST. Byte equality between the
+        // two paths cannot see a tie-break they both get wrong, and the tally above only proves ties were
+        // written, not that one was decided. The read lands on a compaction output rather than on a
+        // read-time merge of the inputs: the cross-generation rung commits a real cursor compaction and
+        // the live set is its output (scale mode makes the logical dump a digest, so the JSON-based
+        // absolute assertions the unit scenarios use are not available here).
+        assertRows(execute("SELECT v1, v2 FROM %s WHERE pk = ? AND ck = ?", TIE_PK, TIE_CK),
+                   row((long) (ROUNDS - 1), tieValue(0)));
+    }
+}

--- a/test/burn/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
+++ b/test/burn/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * ONE giant partition, merged from many inputs — sized for the POSITIONAL boundaries that
+ * row count alone never touches:
+ *
+ *  - intra-partition offsets crossing Integer.MAX_VALUE (2GiB) — int casts and vint widths
+ *    on the partition-relative position arithmetic (previousUnfilteredSize chains, header
+ *    lengths, index block offsets);
+ *  - the promoted index at hundreds of thousands of index blocks in a single partition,
+ *    orders of magnitude past the scale the index-promotion logic is normally exercised at;
+ *  - small partitions on BOTH sides of the giant one in KEY order — but partitions are stored in
+ *    TOKEN order, and under Murmur3 the tokens run pk 2 &lt; pk 3 &lt; pk 0 &lt; pk 1, so both
+ *    small partitions precede the giant one and it is always LAST. What this exercises is
+ *    per-partition state ENTERING the monster; demonstrating the reset AFTER it would need a key
+ *    whose token exceeds pk 1's.
+ *
+ * Lives in test/burn, not test/unit — this genuinely crosses the 2GiB boundary by default now,
+ * not just on an opt-in scaled run. Defaults use DISJOINT windows (ck_stride = rows_per_sstable)
+ * to maximize merged partition size for a given row count: distinct rows = (sstables-1) *
+ * ck_stride + rows_per_sstable — NOT sstables * rows_per_sstable (an earlier "2.6GiB" boundary
+ * run conflated pre-merge input rows with merged output rows and only reached ~1.4GiB). At the
+ * defaults below that's ~8.8M distinct rows at ~280B/row: a ~2.3GiB single MERGED partition
+ * SERIALIZED, which is the size the intra-partition offset arithmetic sees and the only one this
+ * class is about. On DISK it is far smaller — the padding is a repeated character and Data.db is
+ * compressed, so a measured run wrote a 156MiB output sstable and peaked under 1GiB across the
+ * whole test directory. Judge the workload from the "Compacted (…) N total partitions merged" line
+ * and the parameter log below, never from megabytes on disk. The
+ * memtable may auto-flush large rounds, so the sstables parameter is a minimum input count,
+ * which the differential does not care about. All scale parameters remain property-configurable
+ * via -Dtest.jvm.args, e.g. to shrink back down for a quick local check:
+ *
+ *   ant test-burn -Dtest.name=...LargePartitionDifferentialCompactionTest \
+ *       -Dtest.timeout=14400000 \
+ *       -Dtest.jvm.args="-Dcassandra.test.differential.largepartition.sstables=4
+ *                        -Dcassandra.test.differential.largepartition.rows_per_sstable=250000
+ *                        -Dcassandra.test.differential.largepartition.value_padding=120"
+ */
+public class LargePartitionDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    private static final int SSTABLES =
+        CassandraRelevantProperties.TEST_DIFFERENTIAL_LARGEPARTITION_SSTABLES.getInt();
+    private static final int ROWS_PER_SSTABLE =
+        CassandraRelevantProperties.TEST_DIFFERENTIAL_LARGEPARTITION_ROWS_PER_SSTABLE.getInt();
+    private static final String VALUE_PADDING =
+        "p".repeat(CassandraRelevantProperties.TEST_DIFFERENTIAL_LARGEPARTITION_VALUE_PADDING.getInt());
+    /**
+     * Window stride between rounds. Default: DISJOINT windows (equal to rows_per_sstable),
+     * which maximizes the merged partition size — this class's whole point is crossing the
+     * 2GiB boundary. Override down to rows_per_sstable / 2 for half-window overlap instead,
+     * where every output row in the overlap merges from two inputs.
+     */
+    private static final long CK_STRIDE = Math.max(1,
+        CassandraRelevantProperties.TEST_DIFFERENTIAL_LARGEPARTITION_CK_STRIDE.getInt(ROWS_PER_SSTABLE));
+
+    /**
+     * Reserved tie partition. The small side partitions are pk 0 and pk 2, the giant one is pk 1, and
+     * every delete in the scenario targets pk 1 — so pk 3 is untouched and its one row is guaranteed to
+     * reach the output. Written once per round at the explicit tie timestamp, it is an SSTABLES-way
+     * same-timestamp tie across SSTABLES sstables, and unlike the bulk ties it exists at every
+     * parameter setting, disjoint clustering windows included.
+     */
+    private static final long TIE_PK = 3;
+    private static final long TIE_CK = 0;
+
+    /**
+     * v2 of the reserved tie row for {@code round}, zero-padded to a fixed width so that unsigned byte
+     * order is DESCENDING in the round: the greatest value bytes belong to the FIRST round written. v1
+     * ascends with the round instead, so a merge that resolved the tie by write order in either
+     * direction — rather than per cell on the value bytes — cannot produce both.
+     */
+    private static String tieValue(int round)
+    {
+        return String.format("tie%010d", SSTABLES - 1 - round);
+    }
+
+    @Override
+    protected boolean scaleCapture()
+    {
+        return true;
+    }
+
+    @Test
+    public void giantPartition() throws Throwable
+    {
+        long distinctRows = (long) (SSTABLES - 1) * CK_STRIDE + ROWS_PER_SSTABLE;
+        logger.info("large-partition parameters: sstables={} rowsPerSSTable={} ckStride={} valuePadding={}B " +
+                    "-> ~{} distinct rows in one merged partition, ~{}MiB serialized",
+                    SSTABLES, ROWS_PER_SSTABLE, CK_STRIDE, VALUE_PADDING.length(),
+                    distinctRows,
+                    distinctRows * (40 + VALUE_PADDING.length()) / (1 << 20));
+
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, " +
+                    "PRIMARY KEY (pk, ck)) WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        assertTrue("the reserved tie needs at least two input sstables to be a cross-sstable tie: sstables=" +
+                   SSTABLES, SSTABLES >= 2);
+
+        String insert = "INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)";
+        String insertTtl = insert + " USING TTL 86400";
+        String insertTs = insert + " USING TIMESTAMP 5000";
+
+        // A clustering of the giant partition written at the explicit tie timestamp in two ADJACENT
+        // rounds is a genuine cross-sstable same-timestamp tie (rounds are sstables here, one flush
+        // each). Counted from the same boolean the write branch uses, so a predicate that stops producing
+        // ties fails the assertion below instead of passing silently. Two adjacent-round sets are enough
+        // for existence — CK_STRIDE < ROWS_PER_SSTABLE makes consecutive windows overlap — and bound
+        // the memory by one round's tie writes rather than by the whole run. Not tracked at all where
+        // the windows are disjoint: no BULK row is overwritten then, so the reserved tie is the only
+        // cross-sstable tie there. It has no tally of its own — an sstable-count precondition and an
+        // absolute assertion on its resolved winner cover it instead.
+        boolean overlappingWindows = CK_STRIDE < ROWS_PER_SSTABLE;
+        Set<Long> tieCksThisRound = new HashSet<>();
+        Set<Long> tieCksPrevRound = new HashSet<>();
+        long adjacentRoundTieWrites = 0;
+
+        for (int round = 0; round < SSTABLES; round++)
+        {
+            long ckBase = round * CK_STRIDE;
+
+            // small partitions on both sides of the giant one in KEY order — both precede it by TOKEN,
+            // which is the order they are stored in; see the class javadoc — every round
+            execute(insert, 0L, (long) round, (long) round, "side" + round);
+            execute(insert, 2L, (long) round, (long) round, "side" + round);
+            // the reserved tie: same clustering, same timestamp, every round
+            execute(insertTs, TIE_PK, TIE_CK, (long) round, tieValue(round));
+
+            for (int j = 0; j < ROWS_PER_SSTABLE; j++)
+            {
+                long ck = ckBase + j;
+                long v1 = ck * 31 + round;
+                String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck + VALUE_PADDING;
+                boolean ttlWrite = j % 7 == 3;
+                // ck, not j: the clustering window shifts by CK_STRIDE every round, so a predicate on the
+                // in-round offset j can never select the same clustering in two rounds and produces ZERO
+                // cross-sstable ties. A predicate on ck holds in every round whose window covers it.
+                boolean tieWrite = !ttlWrite && ck % 13 == 7;
+                if (ttlWrite)
+                    execute(insertTtl, 1L, ck, v1, v2);
+                else if (tieWrite)
+                {
+                    execute(insertTs, 1L, ck, v1, "tie" + round + "_" + ck + VALUE_PADDING);
+                    if (overlappingWindows)
+                    {
+                        tieCksThisRound.add(ck);
+                        if (tieCksPrevRound.contains(ck))
+                            adjacentRoundTieWrites++;
+                    }
+                }
+                else
+                    execute(insert, 1L, ck, v1, v2);
+            }
+
+            // tombstones at various depths of the giant partition: bounded ranges inside
+            // this round's window, an open-ended slice off its tail, scattered row deletes
+            for (int i = 0; i < 10; i++)
+            {
+                long start = ckBase + (long) i * (ROWS_PER_SSTABLE / 12);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, start, start + 7);
+            }
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, ckBase + ROWS_PER_SSTABLE - 11);
+            for (int i = 0; i < 20; i++)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?", 1L, ckBase + (long) i * (ROWS_PER_SSTABLE / 21));
+
+            flush();
+            tieCksPrevRound = tieCksThisRound;
+            tieCksThisRound = new HashSet<>();
+            logger.info("large-partition round {}/{} flushed", round + 1, SSTABLES);
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // Disjoint windows (ck_stride == rows_per_sstable — the 2GiB boundary run) overwrite no bulk
+        // row, so the reserved tie is the only cross-sstable tie; assert the bulk count only where the
+        // windows overlap.
+        if (overlappingWindows)
+        {
+            logger.info("cross-sstable same-timestamp tie writes in the giant partition (clusterings " +
+                        "written at the tie timestamp in two adjacent rounds): {}", adjacentRoundTieWrites);
+            assertTrue("no cross-sstable same-timestamp tie was written despite overlapping clustering " +
+                       "windows: the tie predicate must be a function of ck, not of the in-round offset j, " +
+                       "or the shifting window never selects a clustering twice (adjacentRoundTieWrites=" +
+                       adjacentRoundTieWrites + ')', adjacentRoundTieWrites > 0);
+        }
+        else
+        {
+            logger.info("disjoint clustering windows (ckStride={} >= rowsPerSSTable={}): the bulk rows " +
+                        "are never overwritten, so the only cross-sstable tie is the reserved one",
+                        CK_STRIDE, ROWS_PER_SSTABLE);
+        }
+
+        // ABSOLUTE: at equal timestamps the greater raw value bytes win, decided PER CELL — so the
+        // reserved tie must keep v1 from the LAST round and v2 from the FIRST. Byte equality between the
+        // two paths cannot see a tie-break they both get wrong, and the count above only proves ties were
+        // written, not that one was decided. The read lands on a compaction output rather than on a
+        // read-time merge of the inputs: the cross-generation rung commits a real cursor compaction and
+        // the live set is its output (scale mode makes the logical dump a digest, so the JSON-based
+        // absolute assertions the unit scenarios use are not available here).
+        assertRows(execute("SELECT v1, v2 FROM %s WHERE pk = ? AND ck = ?", TIE_PK, TIE_CK),
+                   row((long) (SSTABLES - 1), tieValue(0)));
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/sstable/CompactionDroppedColumnBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sstable/CompactionDroppedColumnBench.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sstable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.test.microbench.CompactionBench;
+
+/**
+ * Isolates the cost of SSTableCursorReader.CellCursor's dropped-column check
+ * (sstableHasDroppedColumns) on an otherwise identical row/cell shape to the base
+ * CompactionBench: same schema, same row count, same value columns, differing only in whether
+ * a column was dropped from the table AFTER these sstables were flushed (so their on-disk
+ * header still carries it, and every cell merged from them pays the per-cell drop check).
+ *
+ * dropColumn=false is the CompactionBench baseline shape with 5 extra value columns instead of
+ * 1, so the two dropColumn values are apples-to-apples on data volume/shape; only the drop
+ * horizon differs.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 25, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class CompactionDroppedColumnBench extends CompactionBench
+{
+    private static final int VALUE_COLUMN_COUNT = 5;
+
+    @Param({"false", "true"})
+    boolean dropColumn = false;
+
+    protected void createSStables()
+    {
+        keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        StringBuilder tableCreate = new StringBuilder("CREATE TABLE %s ( userid bigint, picid bigint");
+        for (int i = 0; i < VALUE_COLUMN_COUNT; i++)
+            tableCreate.append(", c").append(i).append(" bigint");
+        tableCreate.append(", PRIMARY KEY(userid, picid))");
+        table = createTable(keyspace, tableCreate.toString());
+        execute("use " + keyspace + ";");
+
+        StringBuilder insert = new StringBuilder("INSERT INTO " + table + "(userid,picid");
+        for (int i = 0; i < VALUE_COLUMN_COUNT; i++)
+            insert.append(",c").append(i);
+        insert.append(")VALUES(?,?");
+        for (int i = 0; i < VALUE_COLUMN_COUNT; i++)
+            insert.append(",?");
+        insert.append(")");
+        writeStatement = insert.toString();
+
+        Object[] values = new Object[2 + VALUE_COLUMN_COUNT];
+
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(c -> c.disableAutoCompaction()));
+
+        cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        for (int j = 0; j < sstableCount; j++)
+        {
+            int pPrefix = overlap.startsWith("PK") ? 0 : j * rowCount;
+            int rPrefix = overlap.startsWith("PK.ROW") ? 0 : j * rowCount;
+            for (long i = 0; i < rowCount; i++)
+            {
+                values[0] = pPrefix + i;
+                values[1] = rPrefix + i;
+                for (int c = 0; c < VALUE_COLUMN_COUNT; c++)
+                    values[2 + c] = j * rowCount + i;
+                execute(writeStatement, values);
+            }
+
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        }
+
+        // Dropped AFTER the sstables above are flushed: their on-disk header still carries c0,
+        // so DeserializationHelper.hasDroppedColumns()/sstableHasDroppedColumns is true for
+        // every one of them and every cell read back from them pays the per-cell drop check —
+        // the exact condition SSTableCursorReader.CellCursor's droppedTimeArray targets.
+        if (dropColumn)
+            execute("ALTER TABLE " + table + " DROP c0");
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/sstable/SSTableCursorPipeUtil.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sstable/SSTableCursorPipeUtil.java
@@ -21,9 +21,9 @@ package org.apache.cassandra.test.microbench.sstable;
 import java.io.IOException;
 
 import org.apache.cassandra.db.DeletionTime;
-import org.apache.cassandra.db.ReusableLivenessInfo;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.ReusableCellLivenessInfo;
 import org.apache.cassandra.io.sstable.PartitionDescriptor;
 import org.apache.cassandra.io.sstable.SSTableCursorReader;
 import org.apache.cassandra.io.sstable.SSTableCursorWriter;
@@ -92,7 +92,8 @@ public class SSTableCursorPipeUtil
                     readerState = copyRangeTombstone(reader, writer, unfilteredDescriptor, unfilteredCounter++);
             }
         }
-        writer.writePartitionEnd(keyBytes, keyLength, pDeletionTime, headerLength);
+        writer.writePartitionEnd(keyBytes, keyLength, pDeletionTime, headerLength,
+                                 unfilteredCounter > 0 ? unfilteredDescriptor : null);
         if (unfilteredCounter > 1) {
             writer.updateClusteringMetadata(unfilteredDescriptor);
         }
@@ -122,7 +123,8 @@ public class SSTableCursorPipeUtil
 
     public static int copyRowAfterDescriptor(SSTableCursorReader reader, SSTableCursorWriter writer, UnfilteredDescriptor unfilteredDescriptor, int readerState, boolean isStatic, boolean updateClusteringMetadata) throws IOException
     {
-        writer.writeRowStart(unfilteredDescriptor.livenessInfo(), unfilteredDescriptor.deletionTime(), isStatic);
+        writer.writeRowStart(unfilteredDescriptor.livenessInfo(), unfilteredDescriptor.deletionTime(),
+                             unfilteredDescriptor.isShadowableDeletion(), isStatic);
 
         // Copy cells
         while (readerState != UNFILTERED_END)
@@ -136,7 +138,7 @@ public class SSTableCursorPipeUtil
              * {@link Cell.Serializer#serialize}
              */
             int cellFlags = cellCursor.cellFlags;
-            ReusableLivenessInfo cellLiveness = cellCursor.cellLiveness;
+            ReusableCellLivenessInfo cellLiveness = cellCursor.cellLiveness;
             writer.writeCellHeader(cellFlags, cellLiveness, cellCursor.cellColumn);
             if (readerState == CELL_VALUE_START)
             {

--- a/test/unit/org/apache/cassandra/db/DeletionTimeTest.java
+++ b/test/unit/org/apache/cassandra/db/DeletionTimeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.rows.Cell;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DeletionTimeTest
+{
+    /**
+     * NO_DELETION_TIME (Long.MAX_VALUE) is the canonical "no deletion" long value and must
+     * round-trip through the long-based reset to a LIVE deletion time, mirroring
+     * {@link Cell#deletionTimeLongToUnsignedInteger}. It used to be classified as invalid,
+     * so {@code reset(LIVE.markedForDeleteAt(), LIVE.localDeletionTime())} produced a
+     * NON-live deletion. Latent hardening rather than an observed bug: the only production
+     * caller of this overload is {@code SerializationHeader.readDeletionTime}, which passes a
+     * vint delta read from the data file rebased on the header's minLocalDeletionTime — a value
+     * that cannot reach Long.MAX_VALUE. This pins the sentinel so a future caller resetting from
+     * LIVE — the obvious use of the overload — cannot silently produce a non-live marker.
+     */
+    @Test
+    public void resetWithLiveLongsStaysLive()
+    {
+        DeletionTime.ReusableDeletionTime reusable = DeletionTime.ReusableDeletionTime.live();
+        assertTrue(reusable.isLive());
+
+        reusable.reset(DeletionTime.LIVE.markedForDeleteAt(), DeletionTime.LIVE.localDeletionTime());
+        assertTrue("reset with LIVE's long values must stay live, got mfda=" + reusable.markedForDeleteAt() +
+                   " ldt=" + reusable.localDeletionTime(), reusable.isLive());
+        assertEquals(DeletionTime.LIVE.localDeletionTime(), reusable.localDeletionTime());
+    }
+
+    @Test
+    public void resetWithRealAndInvalidValues()
+    {
+        DeletionTime.ReusableDeletionTime reusable = DeletionTime.ReusableDeletionTime.live();
+
+        reusable.reset(123456789L, 1_700_000_000L);
+        assertFalse(reusable.isLive());
+        assertEquals(123456789L, reusable.markedForDeleteAt());
+        assertEquals(1_700_000_000L, reusable.localDeletionTime());
+
+        // negative and beyond-max (but not NO_DELETION_TIME) stay classified as invalid
+        reusable.reset(1L, -5L);
+        assertFalse(reusable.isLive());
+        assertFalse(reusable.validate());
+
+        reusable.reset(1L, Cell.MAX_DELETION_TIME + 1);
+        assertFalse(reusable.isLive());
+        assertFalse(reusable.validate());
+    }
+
+    /**
+     * A LIVE deletion shadows nothing, at any timestamp. {@link DeletionTime#deletes(long)} cannot say so
+     * on its own: LIVE's {@code markedForDeleteAt} is Long.MIN_VALUE, which is also
+     * {@link LivenessInfo#NO_TIMESTAMP}, so {@code timestamp <= markedForDeleteAt} is TRUE for a cell
+     * carrying that timestamp. {@code deletesCellAt} tests the LIVE case first, as
+     * {@link DeletionTime#deletes(Cell)} already did.
+     *
+     * The row-liveness overload {@link DeletionTime#deletes(LivenessInfo)} deliberately keeps the
+     * unguarded answer, so it is pinned here too. The reason is parity, not a caller's dependency: the
+     * iterator path applies that same unguarded form to row liveness ({@code Row.Merger.merge},
+     * {@code BTreeRow}), so guarding it would move the reference as well as the cursor. It is also
+     * behaviour-neutral where the cursor reads it — an empty row liveness has nothing to shadow — which is
+     * why the guard belongs to the cell contract alone.
+     */
+    @Test
+    public void liveDeletionShadowsNoCellAtAnyTimestamp()
+    {
+        assertFalse("LIVE must not shadow a NO_TIMESTAMP cell",
+                    DeletionTime.LIVE.deletesCellAt(LivenessInfo.NO_TIMESTAMP));
+        assertFalse(DeletionTime.LIVE.deletesCellAt(Long.MIN_VALUE + 1));
+        assertFalse(DeletionTime.LIVE.deletesCellAt(0L));
+        assertFalse(DeletionTime.LIVE.deletesCellAt(Long.MAX_VALUE));
+
+        // both unguarded forms answer the other way on that one input, which is why the cell path cannot
+        // use either. NO_TIMESTAMP is a long, so the second line binds deletes(long), not the
+        // LivenessInfo overload — the two are pinned separately on purpose.
+        assertTrue(DeletionTime.LIVE.deletes(LivenessInfo.EMPTY));
+        assertTrue(DeletionTime.LIVE.deletes(LivenessInfo.NO_TIMESTAMP));
+
+        // a real deletion is unaffected: at, below and above its markedForDeleteAt
+        DeletionTime at100 = DeletionTime.build(100L, 1_700_000_000L);
+        assertTrue(at100.deletesCellAt(99L));
+        assertTrue(at100.deletesCellAt(100L));
+        assertFalse(at100.deletesCellAt(101L));
+        assertTrue("a real deletion shadows a NO_TIMESTAMP cell, as the unguarded form does",
+                   at100.deletesCellAt(LivenessInfo.NO_TIMESTAMP));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/DeletionTimeTest.java
+++ b/test/unit/org/apache/cassandra/db/DeletionTimeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.rows.Cell;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DeletionTimeTest
+{
+    /**
+     * NO_DELETION_TIME (Long.MAX_VALUE) is the canonical "no deletion" long value and must
+     * round-trip through the long-based reset to a LIVE deletion time, mirroring
+     * {@link Cell#deletionTimeLongToUnsignedInteger}. It used to be classified as invalid,
+     * so {@code reset(LIVE.markedForDeleteAt(), LIVE.localDeletionTime())} produced a
+     * NON-live deletion — which let a live marker slip past MetadataCollector's isLive
+     * guard during cursor compaction and poison minTimestamp/tombstone stats.
+     */
+    @Test
+    public void resetWithLiveLongsStaysLive()
+    {
+        DeletionTime.ReusableDeletionTime reusable = DeletionTime.ReusableDeletionTime.live();
+        assertTrue(reusable.isLive());
+
+        reusable.reset(DeletionTime.LIVE.markedForDeleteAt(), DeletionTime.LIVE.localDeletionTime());
+        assertTrue("reset with LIVE's long values must stay live, got mfda=" + reusable.markedForDeleteAt() +
+                   " ldt=" + reusable.localDeletionTime(), reusable.isLive());
+        assertEquals(DeletionTime.LIVE.localDeletionTime(), reusable.localDeletionTime());
+    }
+
+    @Test
+    public void resetWithRealAndInvalidValues()
+    {
+        DeletionTime.ReusableDeletionTime reusable = DeletionTime.ReusableDeletionTime.live();
+
+        reusable.reset(123456789L, 1_700_000_000L);
+        assertFalse(reusable.isLive());
+        assertEquals(123456789L, reusable.markedForDeleteAt());
+        assertEquals(1_700_000_000L, reusable.localDeletionTime());
+
+        // negative and beyond-max (but not NO_DELETION_TIME) stay classified as invalid
+        reusable.reset(1L, -5L);
+        assertFalse(reusable.isLive());
+        assertFalse(reusable.validate());
+
+        reusable.reset(1L, Cell.MAX_DELETION_TIME + 1);
+        assertFalse(reusable.isLive());
+        assertFalse(reusable.validate());
+    }
+}

--- a/test/unit/org/apache/cassandra/db/ReusableLivenessInfoTest.java
+++ b/test/unit/org/apache/cassandra/db/ReusableLivenessInfoTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ReusableLivenessInfo} carries row primary-key liveness only; the cell role has its own type and its
+ * own test. Every assertion here is against {@link LivenessInfo#withExpirationTime}, the reference that
+ * decides which of the three row implementations a given (ttl, expiration time) is, so the mutable holder
+ * cannot drift from any of them.
+ *
+ * {@code isLive} in particular follows the row contract, which disagrees with the cell one on three inputs;
+ * {@code ReusableCellLivenessInfoTest} covers that side.
+ */
+public class ReusableLivenessInfoTest
+{
+    private static final long TIMESTAMP = 1000L;
+    private static final long NOW_IN_SEC = 1_700_000_000L;
+
+    /** Every (ttl, expiration time) shape the row references distinguish, including the view-maintenance
+     * {@code EXPIRED_LIVENESS_TTL} marker, and an expiration time before, at and after now. */
+    private static int[] ttls()
+    {
+        return new int[]{ LivenessInfo.NO_TTL, 1, 100, LivenessInfo.EXPIRED_LIVENESS_TTL };
+    }
+
+    private static long[] expirationTimes()
+    {
+        return new long[]{ LivenessInfo.NO_EXPIRATION_TIME, NOW_IN_SEC - 10, NOW_IN_SEC, NOW_IN_SEC + 10 };
+    }
+
+    /**
+     * A liveness carrying an expiration time with no TTL is not a well-formed ROW liveness — the reader only
+     * reads an expiration time inside {@code hasTTL(flags)} — and it is the one shape where this holder cannot
+     * mirror the reference, because {@link LivenessInfo#withExpirationTime} DISCARDS the expiration time when
+     * {@code ttl == NO_TTL} while a raw mutable holder keeps what it was given.
+     */
+    private static boolean referenceNormalisesAway(int ttl, long expirationTime)
+    {
+        return ttl == LivenessInfo.NO_TTL && expirationTime != LivenessInfo.NO_EXPIRATION_TIME;
+    }
+
+    /**
+     * The mirror shape: a TTL with no expiration time. The reference cannot hold it —
+     * {@code ExpiringLivenessInfo}'s constructor asserts {@code ttl != NO_TTL && localExpirationTime !=
+     * NO_EXPIRATION_TIME} — so these shapes are skipped rather than asserted, with nothing to compare against.
+     */
+    private static boolean referenceRejects(int ttl, long expirationTime)
+    {
+        return ttl != LivenessInfo.NO_TTL && expirationTime == LivenessInfo.NO_EXPIRATION_TIME;
+    }
+
+    private static ReusableLivenessInfo reusable(long timestamp, int ttl, long expirationTime)
+    {
+        ReusableLivenessInfo liveness = new ReusableLivenessInfo();
+        liveness.reset(timestamp, ttl, expirationTime);
+        return liveness;
+    }
+
+    /**
+     * For row liveness the reference is {@link LivenessInfo#withExpirationTime}, which is expiring precisely
+     * when it has a TTL and discards the expiration time otherwise.
+     */
+    @Test
+    public void predicatesAgreeWithRowReference()
+    {
+        int asserted = 0;
+        int skipped = 0;
+        for (int ttl : ttls())
+        {
+            for (long ldt : expirationTimes())
+            {
+                if (referenceRejects(ttl, ldt))
+                {
+                    skipped++;
+                    continue;
+                }
+                ReusableLivenessInfo liveness = reusable(TIMESTAMP, ttl, ldt);
+                LivenessInfo reference = LivenessInfo.withExpirationTime(TIMESTAMP, ttl, ldt);
+                String at = " at ttl=" + ttl + " localExpirationTime=" + ldt;
+
+                assertEquals("isExpiring must match LivenessInfo.isExpiring()" + at,
+                             reference.isExpiring(), liveness.isExpiring());
+                assertEquals("isExpired must match LivenessInfo.isExpired()" + at,
+                             reference.isExpired(), liveness.isExpired());
+                assertEquals("isEmpty must match LivenessInfo.isEmpty()" + at,
+                             reference.isEmpty(), liveness.isEmpty());
+                assertEquals("isLive must match LivenessInfo.isLive()" + at,
+                             reference.isLive(NOW_IN_SEC), liveness.isLive(NOW_IN_SEC));
+                asserted++;
+            }
+        }
+        assertEquals("the asserted set changed size", 13, asserted);
+        assertEquals("the reference-rejected set changed size", 3, skipped);
+    }
+
+    /**
+     * Empty liveness is the input the cell reading got wrong, so it is pinned on its own: the row references
+     * treat it as not live ({@code ImmutableLivenessInfo.isLive} is {@code !isEmpty()}), where the cell rule
+     * reports live because there is no deletion time.
+     */
+    @Test
+    public void emptyLivenessIsNotLive()
+    {
+        ReusableLivenessInfo fresh = new ReusableLivenessInfo();
+        assertTrue(fresh.isEmpty());
+        assertFalse(fresh.isExpiring());
+        assertFalse(fresh.isExpired());
+        assertEquals(LivenessInfo.EMPTY.isLive(NOW_IN_SEC), fresh.isLive(NOW_IN_SEC));
+        assertFalse("empty row liveness is not live", fresh.isLive(NOW_IN_SEC));
+
+        // and resetting to the empty sentinel gets there too, not just a fresh instance
+        assertFalse(reusable(LivenessInfo.NO_TIMESTAMP, LivenessInfo.NO_TTL, LivenessInfo.NO_EXPIRATION_TIME)
+                    .isLive(NOW_IN_SEC));
+    }
+
+    /**
+     * {@code supersedes} is the row-side analogue of cell reconciliation, is load-bearing in the cursor's row
+     * merge, and is inherited default behaviour on a mutable holder — so it is asserted against the reference
+     * over the whole shape cross product rather than left to the default's own tests.
+     *
+     * Pairs where either side is a shape the reference {@link #referenceRejects} or
+     * {@link #referenceNormalisesAway} are counted, not asserted, since the reference can't hold the same
+     * input; both counts are themselves asserted so neither set can change size unnoticed.
+     */
+    @Test
+    public void supersedesAgreesWithRowReference()
+    {
+        long[] timestamps = { TIMESTAMP, TIMESTAMP + 1 };
+        int asserted = 0;
+        int normalised = 0;
+        for (long leftTs : timestamps)
+            for (int leftTtl : ttls())
+                for (long leftLdt : expirationTimes())
+                    for (long rightTs : timestamps)
+                        for (int rightTtl : ttls())
+                            for (long rightLdt : expirationTimes())
+                            {
+                                if (referenceRejects(leftTtl, leftLdt) || referenceRejects(rightTtl, rightLdt)
+                                    || referenceNormalisesAway(leftTtl, leftLdt) || referenceNormalisesAway(rightTtl, rightLdt))
+                                {
+                                    normalised++;
+                                    continue;
+                                }
+                                LivenessInfo leftRef = LivenessInfo.withExpirationTime(leftTs, leftTtl, leftLdt);
+                                LivenessInfo rightRef = LivenessInfo.withExpirationTime(rightTs, rightTtl, rightLdt);
+                                ReusableLivenessInfo left = reusable(leftTs, leftTtl, leftLdt);
+                                ReusableLivenessInfo right = reusable(rightTs, rightTtl, rightLdt);
+
+                                assertEquals("supersedes must match the reference for left(ts=" + leftTs
+                                             + " ttl=" + leftTtl + " let=" + leftLdt + ") right(ts=" + rightTs
+                                             + " ttl=" + rightTtl + " let=" + rightLdt + ')',
+                                             leftRef.supersedes(rightRef), left.supersedes(right));
+                                asserted++;
+                            }
+        assertEquals("the asserted set changed size; a shape was added or dropped silently", 400, asserted);
+        assertEquals("the skipped set changed size", 624, normalised);
+    }
+
+    /**
+     * The one shape where this holder cannot mirror the reference, pinned rather than excluded.
+     * {@code withExpirationTime} drops an expiration time that arrives without a TTL, so the reference ends up
+     * comparing {@code NO_EXPIRATION_TIME} against {@code NO_EXPIRATION_TIME} and reports no supersession; the
+     * holder keeps both values and reports that the later one wins.
+     *
+     * Only reachable from a corrupt or degenerate sstable whose TTL delta decodes to zero: the reader reads an
+     * expiration time only inside {@code hasTTL(flags)}. {@code StatefulCursor.hasInvalidRowLiveness} does not
+     * flag it either, because its whole body is guarded by {@code ttl != NO_TTL}.
+     */
+    @Test
+    public void supersedesDivergesOnLivenessThatTheReferenceNormalises()
+    {
+        assertTrue(referenceNormalisesAway(LivenessInfo.NO_TTL, NOW_IN_SEC));
+
+        ReusableLivenessInfo later = reusable(TIMESTAMP, LivenessInfo.NO_TTL, NOW_IN_SEC);
+        ReusableLivenessInfo earlier = reusable(TIMESTAMP, LivenessInfo.NO_TTL, NOW_IN_SEC - 10);
+        assertTrue("the holder compares the expiration times it was given", later.supersedes(earlier));
+
+        LivenessInfo laterRef = LivenessInfo.withExpirationTime(TIMESTAMP, LivenessInfo.NO_TTL, NOW_IN_SEC);
+        LivenessInfo earlierRef = LivenessInfo.withExpirationTime(TIMESTAMP, LivenessInfo.NO_TTL, NOW_IN_SEC - 10);
+        assertEquals("the reference discards both expiration times",
+                     LivenessInfo.NO_EXPIRATION_TIME, laterRef.localExpirationTime());
+        assertFalse("so the reference sees two identical livenesses", laterRef.supersedes(earlierRef));
+
+        // isLive is unaffected: both answer live for this shape, which is why only supersedes diverges
+        assertEquals(laterRef.isLive(NOW_IN_SEC), later.isLive(NOW_IN_SEC));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/ReusableLivenessInfoTest.java
+++ b/test/unit/org/apache/cassandra/db/ReusableLivenessInfoTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.nio.ByteBuffer;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ReusableLivenessInfo} backs both row primary-key liveness and cell liveness on the cursor
+ * path, and only {@code isExpiring} answers the same way for both references. {@code isExpired}
+ * mirrors {@link LivenessInfo} alone, {@code isTombstone} and {@code isLive} mirror
+ * {@link org.apache.cassandra.db.rows.AbstractCell} alone.
+ */
+public class ReusableLivenessInfoTest
+{
+    private static final long TIMESTAMP = 1000L;
+    private static final long NOW_IN_SEC = 1_700_000_000L;
+
+    private static ColumnMetadata column;
+    private static ByteBuffer value;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        column = ColumnMetadata.regularColumn("ks", "tbl", "v", Int32Type.instance, 0);
+        value = Int32Type.instance.decompose(1);
+    }
+
+    /**
+     * {@code isExpiring()} is "has a TTL" and {@code isTombstone()} is "has an expiration time and
+     * no TTL", exactly as the cell reference defines them — a tombstone carries an expiration time
+     * without a TTL, which is why the two cannot share a predicate.
+     */
+    @Test
+    public void predicatesAgreeWithCellReference()
+    {
+        // (ttl, localExpirationTime): live, tombstone, expiring, and the corrupt TTL with no
+        // expiration time. All four are representable by a Cell.
+        int[] ttls = { Cell.NO_TTL, Cell.NO_TTL, 100, 100 };
+        long[] ldts = { Cell.NO_DELETION_TIME, NOW_IN_SEC - 10, NOW_IN_SEC + 10, Cell.NO_DELETION_TIME };
+
+        for (int i = 0; i < ttls.length; i++)
+        {
+            ReusableLivenessInfo liveness = new ReusableLivenessInfo();
+            liveness.reset(TIMESTAMP, ttls[i], ldts[i]);
+            Cell<?> reference = new BufferCell(column, TIMESTAMP, ttls[i], ldts[i], value, null);
+            String at = " at ttl=" + ttls[i] + " localExpirationTime=" + ldts[i];
+
+            assertEquals("isExpiring must match AbstractCell.isExpiring()" + at,
+                         reference.isExpiring(), liveness.isExpiring());
+            assertEquals("isTombstone must match AbstractCell.isTombstone()" + at,
+                         reference.isTombstone(), liveness.isTombstone());
+            assertEquals("isLive must match AbstractCell.isLive()" + at,
+                         reference.isLive(NOW_IN_SEC), liveness.isLive(NOW_IN_SEC));
+        }
+    }
+
+    /**
+     * For row liveness the reference is {@link LivenessInfo#withExpirationTime}, which is expiring
+     * precisely when it has a TTL and discards the expiration time otherwise.
+     */
+    @Test
+    public void isExpiringAgreesWithRowReference()
+    {
+        for (int ttl : new int[]{ LivenessInfo.NO_TTL, 1, 100, LivenessInfo.EXPIRED_LIVENESS_TTL })
+        {
+            for (long ldt : new long[]{ NOW_IN_SEC - 10, NOW_IN_SEC, NOW_IN_SEC + 10 })
+            {
+                ReusableLivenessInfo liveness = new ReusableLivenessInfo();
+                liveness.reset(TIMESTAMP, ttl, ldt);
+                LivenessInfo reference = LivenessInfo.withExpirationTime(TIMESTAMP, ttl, ldt);
+
+                assertEquals("isExpiring must match LivenessInfo.isExpiring() at ttl=" + ttl +
+                             " localExpirationTime=" + ldt,
+                             reference.isExpiring(), liveness.isExpiring());
+                assertEquals("isExpired must match LivenessInfo.isExpired() at ttl=" + ttl +
+                             " localExpirationTime=" + ldt,
+                             reference.isExpired(), liveness.isExpired());
+            }
+        }
+    }
+
+    /**
+     * Converting a lapsed TTL to a tombstone rewinds the expiration time by the TTL, to the second
+     * the data was written, matching {@link org.apache.cassandra.db.rows.AbstractCell#purge}'s
+     * {@code localDeletionTime() - ttl()}, and leaves liveness that is a tombstone rather than
+     * expiring.
+     */
+    @Test
+    public void ttlToTombstoneProducesATombstone()
+    {
+        ReusableLivenessInfo liveness = new ReusableLivenessInfo();
+        liveness.reset(TIMESTAMP, 100, NOW_IN_SEC);
+        assertTrue(liveness.isExpiring());
+        assertFalse(liveness.isTombstone());
+
+        liveness.ttlToTombstone();
+
+        assertFalse("a converted TTL no longer has one", liveness.isExpiring());
+        assertTrue("a converted TTL is a tombstone", liveness.isTombstone());
+        assertEquals("the expiration time is rewound by the TTL",
+                     NOW_IN_SEC - 100, liveness.localExpirationTime());
+        assertEquals(LivenessInfo.NO_TTL, liveness.ttl());
+    }
+
+    @Test
+    public void freshInstanceIsEmptyAndNeitherExpiringNorTombstone()
+    {
+        ReusableLivenessInfo liveness = new ReusableLivenessInfo();
+        assertTrue(liveness.isEmpty());
+        assertFalse(liveness.isExpiring());
+        assertFalse(liveness.isTombstone());
+        assertFalse(liveness.isExpired());
+        // isLive() implements the cell contract, under which no expiration time means live. Row
+        // callers gate on isEmpty() instead, so this differs from LivenessInfo.EMPTY by design.
+        assertTrue(liveness.isLive(NOW_IN_SEC));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/CellResolutionAgreementTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CellResolutionAgreementTest.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellLivenessInfo;
+import org.apache.cassandra.db.rows.CellLivenessInfo.Resolution;
+import org.apache.cassandra.db.rows.Cells;
+import org.apache.cassandra.db.rows.ReusableCellLivenessInfo;
+import org.apache.cassandra.index.sai.utils.CellWithSource;
+import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.apache.cassandra.db.rows.CellLivenessInfo.Resolution.COMPARE;
+import static org.apache.cassandra.db.rows.CellLivenessInfo.Resolution.LEFT;
+import static org.apache.cassandra.db.rows.CellLivenessInfo.Resolution.RIGHT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * The cursor compaction path and the reference path reach one decision, {@link CellLivenessInfo#resolve}.
+ * They did not always: the cursor carried a hand-mirrored copy of {@code Cells.resolveRegular}'s
+ * same-timestamp table, and the copies drifted — the cursor's used {@code !isExpiring()} to mean "is a
+ * tombstone" while {@code isExpiring()} still meant "has an expiration time", which is true of tombstones
+ * too. Both arms of the tombstone-vs-expiring tie-break were therefore dead, and the
+ * {@code localDeletionTime} comparison below it picked an expiring cell over a genuine tombstone at the same
+ * timestamp — resurrecting deleted data, with its value. That was found by reading, not by a test.
+ *
+ * With one decision, agreement between the two entry points can no longer distinguish "both right" from "both
+ * wrong the same way", so what this class pins is threefold: the shared decision's verdict per rule against
+ * literals; that the reference path's mapping of that verdict onto a cell is faithful to it; and that neither
+ * depends on which cell class carries the liveness, since the reference path narrows its arguments to one
+ * subtree for the JIT's sake and has a second branch for everything else.
+ *
+ * The reference is reached through the public {@link Cells#reconcile}, which dispatches to its private
+ * {@code resolveRegular} for non-counter cells, so no upstream visibility is widened.
+ */
+public class CellResolutionAgreementTest
+{
+    private static final long NOW = 1_700_000_000L;
+    private static final long TIMESTAMP = 42L;
+
+    /** The cursor's holder is built by reset(...), never by LivenessInfo.withExpirationTime — see the
+     * javadoc on {@link #shapes()}. */
+    private static final TableMetadata METADATA =
+    TableMetadata.builder("CellResolutionAgreementTest", "Test")
+                 .addPartitionKeyColumn("key", AsciiType.instance)
+                 .addClusteringColumn("clustering", Int32Type.instance)
+                 .addRegularColumn("v", Int32Type.instance)
+                 .build();
+
+    private static final ColumnMetadata COLUMN = METADATA.getColumn(ByteBufferUtil.bytes("v"));
+
+    /** A same-timestamp cell shape: everything {@code resolveRegular} reads apart from the value. */
+    private static final class Shape
+    {
+        final int ttl;
+        final long localDeletionTime;
+
+        Shape(int ttl, long localDeletionTime)
+        {
+            this.ttl = ttl;
+            this.localDeletionTime = localDeletionTime;
+        }
+
+        public String toString()
+        {
+            return "(ttl=" + (ttl == Cell.NO_TTL ? "NO_TTL" : ttl)
+                   + ", ldt=" + (localDeletionTime == Cell.NO_DELETION_TIME ? "NO_DELETION_TIME"
+                                                                           : (localDeletionTime - NOW) + "+NOW") + ')';
+        }
+    }
+
+    /**
+     * The full cross product, deliberately including two shapes that are not well-formed cells:
+     *
+     *  - {@code ttl != NO_TTL} with {@code ldt == NO_DELETION_TIME} is corrupt (an expiring cell must carry
+     *    an expiration time), but it is constructible as a {@link BufferCell} and both tables read it, so
+     *    excluding it would leave a live disagreement uncovered.
+     *  - {@code ldt} in the past, at, and after {@code NOW} separates the tie-break's expiration comparison
+     *    from any clock-dependent notion of "already expired"; neither table consults a clock.
+     *
+     * {@code LivenessInfo.EXPIRED_LIVENESS_TTL} is excluded: it is a ROW liveness marker produced only by
+     * view maintenance, never a cell TTL, so no cell of that shape can reach either table.
+     */
+    private static List<Shape> shapes()
+    {
+        List<Shape> shapes = new ArrayList<>();
+        for (int ttl : new int[]{ Cell.NO_TTL, 1, 100 })
+            for (long ldt : new long[]{ Cell.NO_DELETION_TIME, NOW - 10, NOW, NOW + 10 })
+                shapes.add(new Shape(ttl, ldt));
+        return shapes;
+    }
+
+    /**
+     * The cursor returns a verdict; the reference returns a cell. One run cannot separate LEFT from COMPARE,
+     * because {@code compareValues(left, right) >= 0 ? left : right} hands back the left cell on equal
+     * values. So each pair is run twice, with equal values and with a strictly smaller left value, and the
+     * verdict is read off the pair of outcomes:
+     *
+     * <pre>
+     *   reference picks   equal values   left &lt; right      verdict
+     *   ---------------------------------------------------------
+     *   LEFT              left           left              LEFT
+     *   RIGHT             right          right              RIGHT
+     *   COMPARE           left           right              COMPARE
+     * </pre>
+     *
+     * ("reference picks right on equal values, left when left is smaller" is not producible by either table
+     * and is asserted against as a fourth case.)
+     */
+    @Test
+    public void theTwoTablesAgreeOnEveryOrderedPair()
+    {
+        List<Shape> shapes = shapes();
+        int pairs = 0;
+        for (Shape left : shapes)
+        {
+            for (Shape right : shapes)
+            {
+                Resolution cursor = cursorVerdict(left, right);
+                Resolution reference = referenceVerdict(left, right);
+                assertEquals("tables disagree for left=" + left + " right=" + right,
+                             reference, cursor);
+                pairs++;
+            }
+        }
+        assertEquals("the enumeration shrank; a shape was dropped silently", 144, pairs);
+    }
+
+    /**
+     * Both tables are folded left-to-right across N sources, so a non-commutative tie-break would make the
+     * output depend on sstable order. Asserted on the VERDICT, not on the returned cell: the cell-level
+     * property does not hold, because the value tail returns the left argument both ways on equal values.
+     *
+     * Associativity is relied on by both folds and is NOT asserted here.
+     */
+    @Test
+    public void theVerdictIsCommutative()
+    {
+        for (Shape left : shapes())
+        {
+            for (Shape right : shapes())
+            {
+                Resolution forward = cursorVerdict(left, right);
+                Resolution mirrored = mirror(cursorVerdict(right, left));
+                assertEquals("verdict is not commutative for left=" + left + " right=" + right,
+                             forward, mirrored);
+            }
+        }
+    }
+
+    private static Resolution mirror(Resolution resolution)    {
+        switch (resolution)
+        {
+            case LEFT: return RIGHT;
+            case RIGHT: return LEFT;
+            default: return COMPARE;
+        }
+    }
+
+    private static Resolution cursorVerdict(Shape left, Shape right)
+    {
+        return cursorVerdict(TIMESTAMP, left, TIMESTAMP, right);
+    }
+
+    private static Resolution cursorVerdict(long leftTimestamp, Shape left, long rightTimestamp, Shape right)
+    {
+        ReusableCellLivenessInfo leftLiveness = new ReusableCellLivenessInfo();
+        ReusableCellLivenessInfo rightLiveness = new ReusableCellLivenessInfo();
+        leftLiveness.reset(leftTimestamp, left.ttl, left.localDeletionTime);
+        rightLiveness.reset(rightTimestamp, right.ttl, right.localDeletionTime);
+        return CellLivenessInfo.resolve(leftLiveness, rightLiveness);
+    }
+
+    private static Resolution referenceVerdict(Shape left, Shape right)
+    {
+        return referenceVerdict(TIMESTAMP, left, TIMESTAMP, right);
+    }
+
+    private static Resolution referenceVerdict(long leftTimestamp, Shape left, long rightTimestamp, Shape right)
+    {
+        boolean equalPicksLeft = reconcilePicksLeft(leftTimestamp, left, rightTimestamp, right, 1, 1);
+        boolean smallerLeftPicksLeft = reconcilePicksLeft(leftTimestamp, left, rightTimestamp, right, 1, 2);
+
+        if (equalPicksLeft && smallerLeftPicksLeft)
+            return LEFT;
+        if (!equalPicksLeft && !smallerLeftPicksLeft)
+            return RIGHT;
+        if (equalPicksLeft)
+            return COMPARE;
+        throw new AssertionError("reference picked right on equal values and left on a smaller left value, "
+                                 + "which neither table can produce: left=" + left + " right=" + right);
+    }
+
+    private static boolean reconcilePicksLeft(long leftTimestamp, Shape left, long rightTimestamp, Shape right,
+                                              int leftValue, int rightValue)
+    {
+        Cell<?> leftCell = cell(leftTimestamp, left, leftValue);
+        Cell<?> rightCell = cell(rightTimestamp, right, rightValue);
+        return Cells.reconcile(leftCell, rightCell) == leftCell;
+    }
+
+    private static Cell<?> cell(long timestamp, Shape shape, int value)
+    {
+        ByteBuffer bytes = Int32Type.instance.decompose(value);
+        return new BufferCell(COLUMN, timestamp, shape.ttl, shape.localDeletionTime, bytes, null);
+    }
+
+    /**
+     * The same cell reached through a class outside the {@link org.apache.cassandra.db.rows.HeapAbstractCell}
+     * subtree. {@link CellWithSource} is a real one — SAI wraps cells in it to carry the source table — and it
+     * delegates every liveness accessor, so the verdict must not depend on which of the two arrives.
+     */
+    private static Cell<?> cellOutsideTheHeapSubtree(long timestamp, Shape shape, int value)
+    {
+        return new CellWithSource<>(cast(cell(timestamp, shape, value)), new SequenceBasedSSTableId(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Cell<T> cast(Cell<?> cell)
+    {
+        return (Cell<T>) cell;
+    }
+
+    /**
+     * The verdict must be a function of the liveness fields alone, not of the concrete cell class carrying
+     * them. Nothing else here varies that: every other assertion builds {@link BufferCell}s, so a reference
+     * path that dispatched on the cell's class — or narrowed to one subtree and mishandled the rest — would
+     * leave the whole rest of this class green.
+     *
+     * Each pair is run twice, with equal values and with a strictly smaller left value, because on equal
+     * values the value tail returns the left cell for both LEFT and COMPARE. One run cannot tell those apart,
+     * so a branch that collapsed COMPARE to LEFT would agree with itself across cell classes and pass.
+     */
+    @Test
+    public void theVerdictDoesNotDependOnTheCellClass()
+    {
+        List<Shape> shapes = shapes();
+        int pairs = 0;
+        for (Shape left : shapes)
+        {
+            for (Shape right : shapes)
+            {
+                for (long rightTimestamp : new long[]{ TIMESTAMP, TIMESTAMP + 1 })
+                {
+                    for (int leftValue : new int[]{ 1, 2 })
+                    {
+                        assertSameAcrossCellClasses(left, right, rightTimestamp, leftValue);
+                        pairs++;
+                    }
+                }
+            }
+        }
+        assertEquals("the enumeration shrank; a shape was dropped silently", 576, pairs);
+    }
+
+    private static void assertSameAcrossCellClasses(Shape left, Shape right, long rightTimestamp, int leftValue)
+    {
+        String where = " for left=" + left + " right=" + right + " rightTimestamp=" + rightTimestamp
+                       + " leftValue=" + leftValue;
+
+        Cell<?> heapLeft = cell(TIMESTAMP, left, leftValue);
+        Cell<?> heapRight = cell(rightTimestamp, right, 2);
+        boolean heapPicksLeft = Cells.reconcile(heapLeft, heapRight) == heapLeft;
+
+        Cell<?> wrappedLeft = cellOutsideTheHeapSubtree(TIMESTAMP, left, leftValue);
+        Cell<?> wrappedRight = cellOutsideTheHeapSubtree(rightTimestamp, right, 2);
+        boolean wrappedPicksLeft = Cells.reconcile(wrappedLeft, wrappedRight) == wrappedLeft;
+        assertEquals("the reference path disagrees with itself across cell classes" + where,
+                     heapPicksLeft, wrappedPicksLeft);
+
+        // and mixing the two classes across one pair resolves the same way, in both arrangements
+        boolean mixedRightPicksLeft = Cells.reconcile(heapLeft, wrappedRight) == heapLeft;
+        assertEquals("the reference path disagrees on a heap/wrapped pair" + where,
+                     heapPicksLeft, mixedRightPicksLeft);
+
+        boolean mixedLeftPicksLeft = Cells.reconcile(wrappedLeft, heapRight) == wrappedLeft;
+        assertEquals("the reference path disagrees on a wrapped/heap pair" + where,
+                     heapPicksLeft, mixedLeftPicksLeft);
+    }
+
+    /**
+     * The answer, not merely agreement. Both callers now delegate to one table, so agreement alone can no
+     * longer distinguish "both right" from "both wrong the same way", and the shared entry point interleaves
+     * two types across two sides — {@code (int ttl, long localDeletionTime)} per side — so transposing a
+     * side's pair, or swapping the sides at one call site, is the easiest available error and would leave
+     * both callers agreeing on a wrong verdict.
+     *
+     * One case per rule, plus the two rules above the table.
+     */
+    @Test
+    public void theSharedTableGivesTheExpectedVerdict()
+    {
+        Shape live = new Shape(Cell.NO_TTL, Cell.NO_DELETION_TIME);
+        Shape tombstoneAtNow = new Shape(Cell.NO_TTL, NOW);
+        Shape tombstoneLater = new Shape(Cell.NO_TTL, NOW + 10);
+        Shape expiringAtNow = new Shape(100, NOW);
+        Shape expiringLater = new Shape(100, NOW + 10);
+        Shape expiringShortTtl = new Shape(1, NOW);
+
+        // the deletion-time guard: live-vs-live never enters the table and falls through to the value
+        // comparison. The rule above it, differing timestamps, is pinned by theNewerTimestampWinsOutright.
+        assertEquals(COMPARE, cursorVerdict(live, live));
+
+        // (a) anything with a deletion time beats a live cell, in either position
+        assertEquals(LEFT, cursorVerdict(tombstoneAtNow, live));
+        assertEquals(RIGHT, cursorVerdict(live, tombstoneAtNow));
+        assertEquals(LEFT, cursorVerdict(expiringAtNow, live));
+        assertEquals(RIGHT, cursorVerdict(live, expiringAtNow));
+
+        // (b) a tombstone beats an expiring cell, even one expiring later — this is the arm that was dead
+        assertEquals(LEFT, cursorVerdict(tombstoneAtNow, expiringLater));
+        assertEquals(RIGHT, cursorVerdict(expiringLater, tombstoneAtNow));
+
+        // (c) same kind, later expiration wins
+        assertEquals(RIGHT, cursorVerdict(tombstoneAtNow, tombstoneLater));
+        assertEquals(LEFT, cursorVerdict(tombstoneLater, tombstoneAtNow));
+        assertEquals(RIGHT, cursorVerdict(expiringAtNow, expiringLater));
+
+        // (d) both expiring, same expiration, lower TTL wins
+        assertEquals(LEFT, cursorVerdict(expiringShortTtl, expiringAtNow));
+        assertEquals(RIGHT, cursorVerdict(expiringAtNow, expiringShortTtl));
+
+        // identical shapes fall through to the value comparison, for tombstones and expiring cells alike
+        assertEquals(COMPARE, cursorVerdict(tombstoneAtNow, tombstoneAtNow));
+        assertEquals(COMPARE, cursorVerdict(expiringAtNow, expiringAtNow));
+    }
+
+    /**
+     * The differing-timestamp rule outranks everything below it, and nothing else here varies the timestamp
+     * — every other assertion resets both sides to the same one. So inverting it would leave the rest of this
+     * class green while compaction silently reverted an UPDATE: at differing timestamps the older cell would
+     * win.
+     */
+    @Test
+    public void theNewerTimestampWinsOutright()
+    {
+        Shape live = new Shape(Cell.NO_TTL, Cell.NO_DELETION_TIME);
+        Shape tombstone = new Shape(Cell.NO_TTL, NOW);
+
+        // asserted through both entry points, since the reference path maps the verdict onto a cell itself
+        assertEquals(LEFT, cursorVerdict(TIMESTAMP + 1, live, TIMESTAMP, live));
+        assertEquals(RIGHT, cursorVerdict(TIMESTAMP, live, TIMESTAMP + 1, live));
+        assertEquals(LEFT, referenceVerdict(TIMESTAMP + 1, live, TIMESTAMP, live));
+        assertEquals(RIGHT, referenceVerdict(TIMESTAMP, live, TIMESTAMP + 1, live));
+
+        // and it outranks the tie-break entirely: a newer LIVE cell beats an older tombstone, where at equal
+        // timestamps the tombstone would win
+        assertEquals(LEFT, cursorVerdict(TIMESTAMP + 1, live, TIMESTAMP, tombstone));
+        assertEquals(RIGHT, cursorVerdict(TIMESTAMP, tombstone, TIMESTAMP + 1, live));
+        assertEquals(LEFT, referenceVerdict(TIMESTAMP + 1, live, TIMESTAMP, tombstone));
+        assertEquals(RIGHT, referenceVerdict(TIMESTAMP, tombstone, TIMESTAMP + 1, live));
+        assertEquals("at equal timestamps the tombstone wins, which is what makes the pair above meaningful",
+                     LEFT, cursorVerdict(tombstone, live));
+    }
+
+    /**
+     * The tie-break asserts its own precondition — at least one side carries a deletion time — because
+     * {@link CellLivenessInfo#resolve} establishes it above the call, and a future caller reaching the
+     * tie-break directly would otherwise get a plausible {@code COMPARE} instead of a failure. {@code -ea} is
+     * live in production here, so this pins that the assert is present and reachable rather than optimised
+     * into nothing.
+     */
+    @Test
+    public void theSharedTableRejectsALiveVersusLivePair()
+    {
+        try
+        {
+            CellLivenessInfo.resolveSameTimestampTie(Cell.NO_TTL, Cell.NO_DELETION_TIME,
+                                                     Cell.NO_TTL, Cell.NO_DELETION_TIME);
+            fail("the precondition assert did not fire; is -ea enabled for this fork?");
+        }
+        catch (AssertionError expected)
+        {
+            // the callers' guard is what keeps this unreachable in production
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionPipelineCounts.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionPipelineCounts.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Snapshot of {@link AbstractCompactionPipeline}'s pipeline-selection counters, plus the assertion
+ * that a compaction really went through the pipeline the scenario asked for.
+ * <p>
+ * {@code CursorCompactor.isSupported} answers whether the cursor path COULD run;
+ * {@link AbstractCompactionPipeline#create} additionally gates on
+ * {@code DatabaseDescriptor.cursorCompactionEnabled()}, which isSupported never reads. So a
+ * scenario can satisfy a supportability precheck and still be served by the iterator pipeline,
+ * comparing that path against itself or asserting nothing about the cursor writer at all.
+ * <p>
+ * Lives in {@code org.apache.cassandra.db.compaction} so that it can read the package-private
+ * counters without widening any production declaration.
+ * <p>
+ * Always a DELTA across one compaction, never an absolute: {@code forkmode=perTest} gives each test
+ * class its own JVM, but the methods within a class share it, so the counters carry every earlier
+ * compaction in the same fork.
+ */
+public final class CompactionPipelineCounts
+{
+    private final long cursor;
+    private final long iterator;
+    private final boolean cursorCompactionEnabled;
+
+    private CompactionPipelineCounts(long cursor, long iterator, boolean cursorCompactionEnabled)
+    {
+        this.cursor = cursor;
+        this.iterator = iterator;
+        this.cursorCompactionEnabled = cursorCompactionEnabled;
+    }
+
+    /**
+     * Snapshots both counters and the current {@code cursorCompactionEnabled} setting. Take it
+     * immediately before the compaction under test, and after any flip of the flag that the exact
+     * check in {@link #assertPipelineRan} should apply to.
+     */
+    public static CompactionPipelineCounts mark()
+    {
+        return new CompactionPipelineCounts(AbstractCompactionPipeline.cursorPipelinesCreated(),
+                                            AbstractCompactionPipeline.iteratorPipelinesCreated(),
+                                            DatabaseDescriptor.cursorCompactionEnabled());
+    }
+
+    /**
+     * Asserts that at least one compaction selecting the expected pipeline happened since
+     * {@code before}, and that no cursor pipeline was created at all if cursor compaction was
+     * switched off for the whole bracket.
+     * <p>
+     * The first is a lower bound on one counter only. A compaction unrelated to the scenario — a
+     * system table's, or a background compaction the test did not disable — moves the same static
+     * counters, so requiring the other counter to be unmoved, or requiring an exact delta, would
+     * fail for reasons that are not defects. A lower bound cannot fail that way: an incidental
+     * compaction only ever adds to a delta.
+     * <p>
+     * That lower bound alone can be satisfied by an incidental compaction while the scenario's own
+     * compaction selected the other pipeline. The second assertion closes that: while
+     * {@code cursorCompactionEnabled} is off, a compaction reaching
+     * {@link AbstractCompactionPipeline#create} cannot select the cursor pipeline, so any cursor
+     * pipeline across the bracket is a real defect. It applies only when the flag reads off both
+     * before and after, so a caller that flips the flag inside its own bracket cannot trip it. It
+     * reads the same accessor {@code create} does, so it cannot detect a setter that never changed
+     * that accessor's value; what it does pin is that {@code create} still honours it.
+     * <p>
+     * The exact check assumes no compaction was already in flight when the flag was flipped, which
+     * is why callers disable autocompaction on tables they do not intend to compact.
+     */
+    public static void assertPipelineRan(boolean expectCursor, CompactionPipelineCounts before)
+    {
+        CompactionPipelineCounts after = mark();
+        String detail = " (cursor pipelines +" + (after.cursor - before.cursor) +
+                        ", iterator pipelines +" + (after.iterator - before.iterator) + ')';
+        if (expectCursor)
+            assertTrue("cursor compaction was requested, but no cursor pipeline was created for " +
+                       "this compaction: it ran the iterator path instead, so this scenario asserts " +
+                       "nothing about the cursor reader or writer" + detail,
+                       after.cursor - before.cursor >= 1);
+        else
+            assertTrue("the iterator path was requested, but no iterator pipeline was created for " +
+                       "this compaction" + detail,
+                       after.iterator - before.iterator >= 1);
+
+        if (!before.cursorCompactionEnabled && !after.cursorCompactionEnabled)
+            assertEquals("cursor compaction was switched off across this compaction, so nothing " +
+                         "could have selected the cursor pipeline, yet one was created" + detail,
+                         0, after.cursor - before.cursor);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/StatefulCursorTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/StatefulCursorTest.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.PartitionDescriptor;
+import org.apache.cassandra.io.sstable.SSTableCursorReader;
+import org.apache.cassandra.io.sstable.UnfilteredDescriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_HEADER_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_VALUE_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.DONE;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.PARTITION_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.ROW_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.STATIC_ROW_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.TOMBSTONE_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.UNFILTERED_END;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.isState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for cursor-read defects that the differential harness cannot isolate. */
+public class StatefulCursorTest extends CQLTester
+{
+    /** Hooks for {@link #drive}, so the cursor-driving tests share one state machine. */
+    private interface CursorVisitor
+    {
+        default void onRow(StatefulCursor cursor) {}
+        default void onTombstone(StatefulCursor cursor) {}
+        /** @param state what readCellHeader returned; UNFILTERED_END means no cell was surfaced */
+        default void onCellHeader(StatefulCursor cursor, int state) {}
+    }
+
+    /** Drives the cursor over the whole sstable, calling back at rows, markers and cell headers. */
+    private static void drive(StatefulCursor cursor, CursorVisitor visitor)
+    {
+        int state = cursor.readPartitionHeader();
+        while (!isState(state, DONE))
+        {
+            if (isState(state, PARTITION_START))
+            {
+                state = cursor.readPartitionHeader();
+            }
+            else if (isState(state, STATIC_ROW_START))
+            {
+                cursor.readStaticRowHeader();
+                state = cursor.state();
+            }
+            else if (isState(state, ROW_START))
+            {
+                cursor.readRowHeader();
+                visitor.onRow(cursor);
+                state = cursor.state();
+            }
+            else if (isState(state, TOMBSTONE_START))
+            {
+                cursor.readTombstoneMarker();
+                visitor.onTombstone(cursor);
+                state = cursor.state();
+            }
+            else if (isState(state, CELL_HEADER_START))
+            {
+                state = cursor.readCellHeader();
+                visitor.onCellHeader(cursor, state);
+            }
+            else if (isState(state, CELL_VALUE_START))
+            {
+                state = cursor.skipCellValue();
+            }
+            else
+            {
+                state = cursor.continueReading();
+            }
+        }
+    }
+
+    /**
+     * The cursor's cell-liveness check must agree with the iterator path's oracle,
+     * {@code AbstractCell.hasInvalidDeletions()}, on every combination — including a cell that
+     * declares a TTL with no expiration time, which the previous predicate could not report because
+     * it tested "has an expiration time" where the oracle tests "has a TTL".
+     */
+    @Test
+    public void cellDeletionPredicateAgreesWithCellOracle()
+    {
+        ColumnMetadata column = ColumnMetadata.regularColumn("ks", "tbl", "v", Int32Type.instance, 0);
+        ByteBuffer value = Int32Type.instance.decompose(1);
+
+        // A Cell cannot hold a negative localExpirationTime: the BufferCell constructor runs it
+        // through Cell.deletionTimeLongToUnsignedInteger, which rejects negatives. So the oracle is
+        // only defined over the values below, and the negative cases are asserted separately.
+        for (int ttl : new int[]{ Cell.NO_TTL, 1, 100, -1, Integer.MIN_VALUE })
+        {
+            for (long ldt : new long[]{ Cell.NO_DELETION_TIME, Cell.INVALID_DELETION_TIME, 0, 1,
+                                        1_700_000_000L, Cell.MAX_DELETION_TIME })
+            {
+                boolean oracle = new BufferCell(column, 1000L, ttl, ldt, value, null).hasInvalidDeletions();
+                assertEquals("cell validation must match AbstractCell.hasInvalidDeletions() at ttl=" +
+                             ttl + " localExpirationTime=" + ldt,
+                             oracle, StatefulCursor.hasInvalidCellDeletion(ttl, ldt));
+            }
+        }
+
+        // the combination the old predicate could never report: its last clause asked whether the
+        // cell had an EXPIRATION TIME, contradicting the ldt == NO_DELETION_TIME it was ANDed with
+        assertTrue("a cell with a TTL but no expiration time is invalid",
+                   StatefulCursor.hasInvalidCellDeletion(100, Cell.NO_DELETION_TIME));
+        assertFalse("a cell with no TTL and no expiration time is the normal live cell",
+                    StatefulCursor.hasInvalidCellDeletion(Cell.NO_TTL, Cell.NO_DELETION_TIME));
+        // a negative expiration time cannot occur in a Cell, and off disk it only decodes
+        // alongside a negative TTL, so neither reference can express this pair
+        assertTrue("a negative expiration time is invalid",
+                   StatefulCursor.hasInvalidCellDeletion(Cell.NO_TTL, -1));
+    }
+
+    /**
+     * The row-liveness check has the same oracle mismatch: {@code AbstractRow.hasInvalidDeletions()}
+     * guards with {@code LivenessInfo.isExpiring()}, which is "has a TTL".
+     */
+    @Test
+    public void rowLivenessPredicateAgreesWithRowOracle()
+    {
+        // ExpiringLivenessInfo asserts ttl != NO_TTL && localExpirationTime != NO_EXPIRATION_TIME,
+        // so — as with the cell oracle — the reference type cannot represent the corrupt states the
+        // cursor decodes off disk. Compare against the oracle over what it CAN represent, then
+        // assert the corrupt domain against the specification.
+        for (int ttl : new int[]{ LivenessInfo.NO_TTL, 1, 100, -1, Integer.MIN_VALUE })
+        {
+            for (long ldt : new long[]{ LivenessInfo.NO_EXPIRATION_TIME, 0, 1, 1_700_000_000L, -1,
+                                        Long.MIN_VALUE })
+            {
+                if (ttl != LivenessInfo.NO_TTL && ldt == LivenessInfo.NO_EXPIRATION_TIME)
+                    continue;
+                LivenessInfo liveness = LivenessInfo.withExpirationTime(1000L, ttl, ldt);
+                boolean oracle = liveness.isExpiring()
+                                 && (liveness.ttl() < 0 || liveness.localExpirationTime() < 0);
+                assertEquals("row validation must match AbstractRow.hasInvalidDeletions() at ttl=" +
+                             ttl + " localExpirationTime=" + ldt,
+                             oracle, StatefulCursor.hasInvalidRowLiveness(ttl, ldt));
+            }
+        }
+
+        // the combination the old predicate could never report, and which no LivenessInfo can hold:
+        // a corrupt negative TTL decoded alongside the no-expiration sentinel
+        assertTrue("row liveness with a negative TTL is invalid",
+                   StatefulCursor.hasInvalidRowLiveness(-1, LivenessInfo.NO_EXPIRATION_TIME));
+        assertFalse("row liveness with no TTL is not expiring, so there is nothing to validate",
+                    StatefulCursor.hasInvalidRowLiveness(LivenessInfo.NO_TTL, -1));
+    }
+
+    /**
+     * When the dropped-column filter discards every remaining column of a row, readCellHeader
+     * surfaces no cell and returns UNFILTERED_END, leaving the cell liveness describing the
+     * DISCARDED cell. Validation keys off exactly that state, so pin it: the drop-filtered row must
+     * report UNFILTERED_END and a surviving row must report a cell state.
+     */
+    @Test
+    public void readCellHeaderReturnsUnfilteredEndWhenEveryColumnIsDropFiltered() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, dropped int, kept int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // Both rows are written below the wall-clock droppedTime recorded by the ALTER, so the drop
+        // filter definitely covers the dropped cell.
+        // ck 0: only the to-be-dropped column is set, so after the drop the row has no cells left
+        execute("INSERT INTO %s (pk, ck, dropped) VALUES (0, 0, 1) USING TIMESTAMP 1000");
+        // ck 1: a surviving cell, the control for the same code path
+        execute("INSERT INTO %s (pk, ck, kept) VALUES (0, 1, 2) USING TIMESTAMP 1000");
+        flush();
+        alterTable("ALTER TABLE %s DROP dropped");
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        boolean[] seen = new boolean[2];   // [0] no cell surfaced, [1] cell surfaced
+        try (StatefulCursor cursor = new StatefulCursor(sstable, DiskAccessMode.standard))
+        {
+            drive(cursor, new CursorVisitor()
+            {
+                public void onCellHeader(StatefulCursor c, int state)
+                {
+                    seen[isState(state, UNFILTERED_END) ? 0 : 1] = true;
+                }
+            });
+        }
+
+        assertTrue("expected the row whose only cell was drop-filtered to return UNFILTERED_END",
+                   seen[0]);
+        assertTrue("expected the surviving row's cell to return a cell state, as a control", seen[1]);
+    }
+
+    /**
+     * The column-subset fields are row state. A range tombstone marker has no columns, so reading
+     * one must clear them; otherwise missingColumnsMask() keeps reporting the previous row's subset
+     * while rowColumns() is null.
+     */
+    @Test
+    public void rangeTombstoneClearsTheColumnSubsetState() throws Throwable
+    {
+        // two regular columns, so a row setting only one is subset-encoded and has a non-zero mask
+        createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // both columns must appear SOMEWHERE in the sstable, or the header superset is just {a} and
+        // the row below is an all-columns row rather than a subset-encoded one
+        execute("INSERT INTO %s (pk, ck, a) VALUES (0, 0, 1)");
+        execute("INSERT INTO %s (pk, ck, b) VALUES (0, 1, 2)");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck > 5");
+        flush();
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        boolean[] sawNonZeroMaskOnRow = { false };
+        int[] markers = { 0 };
+        long[] maskBitsAfterAnyMarker = { 0 };   // OR across markers, so no violation can be hidden
+        try (StatefulCursor cursor = new StatefulCursor(sstable, DiskAccessMode.standard))
+        {
+            drive(cursor, new CursorVisitor()
+            {
+                public void onRow(StatefulCursor c)
+                {
+                    sawNonZeroMaskOnRow[0] |= c.unfiltered().missingColumnsMask() != 0;
+                }
+
+                public void onTombstone(StatefulCursor c)
+                {
+                    markers[0]++;
+                    maskBitsAfterAnyMarker[0] |= c.unfiltered().missingColumnsMask();
+                    assertNull("a marker has no columns, so rowColumns must be null",
+                               c.unfiltered().rowColumns());
+                    assertNull("a marker has no columns, so presentColumnsWords must be null",
+                               c.unfiltered().presentColumnsWords());
+                }
+            });
+        }
+
+        assertTrue("expected the sparse row to carry a non-zero column-subset mask",
+                   sawNonZeroMaskOnRow[0]);
+        assertTrue("expected at least one range tombstone marker", markers[0] > 0);
+        assertEquals("a marker has no columns, so the subset mask must be cleared",
+                     0L, maskBitsAfterAnyMarker[0]);
+    }
+
+    /**
+     * The cell walk must consume exactly the body its row header declared. Nothing else checks that,
+     * so a cell-level desync would run on into the NEXT unfiltered and surface far from its cause —
+     * either as a corruption report naming an unrelated offset or as garbage written to the output.
+     * <p>
+     * Driven through the plain reader rather than {@link StatefulCursor} because the descriptor has
+     * to be supplied: over-declaring {@link UnfilteredDescriptor#size()} by one byte is a desync the
+     * check must catch, and the unmodified descriptor is the control that it does not fire normally.
+     * Off-by-one matters here — the check runs before the next unfiltered's flag byte is consumed —
+     * so a version comparing against the wrong position would fail the control.
+     * <p>
+     * The desync is reported as a {@link CorruptSSTableException} wrapping the diagnostic, not as a bare
+     * assertion, so it reaches callers through the same path as any other corrupted sstable and fires
+     * whether or not {@code -ea} is on. The cause carries the offsets and the wrapper carries the file
+     * name, so the cause is what this asserts against.
+     */
+    @Test
+    public void cellWalkMustConsumeExactlyTheDeclaredRowBody() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // several rows, including a subset-encoded one, so the walk covers more than a single shape
+        execute("INSERT INTO %s (pk, ck, a, b) VALUES (0, 0, 1, 2)");
+        execute("INSERT INTO %s (pk, ck, a) VALUES (0, 1, 3)");
+        execute("INSERT INTO %s (pk, ck, b) VALUES (1, 0, 4)");
+        flush();
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // control: the declared size is the real one, so the whole sstable reads without tripping. It
+        // has to run BEFORE the desync, which marks the reader suspect.
+        driveReader(sstable, false);
+        assertFalse("the control read must not have marked the sstable suspect", sstable.isMarkedSuspect());
+
+        // No assertion runs inside the try; every check that observes the desync runs after the block.
+        // The catch is narrow to CorruptSSTableException, so any other throwable propagates as itself
+        // instead of being recorded as the expected one.
+        CorruptSSTableException tripped = null;
+        try
+        {
+            driveReader(sstable, true);
+        }
+        catch (CorruptSSTableException e)
+        {
+            tripped = e;
+        }
+        assertNotNull("a row body declared one byte longer than it is must trip the "
+                      + "consumed-vs-declared check", tripped);
+        assertNotNull("the desync diagnostic must be carried as the cause", tripped.getCause());
+        assertTrue("expected the cell-desync diagnostic, got: " + tripped.getCause().getMessage(),
+                   tripped.getCause().getMessage() != null
+                   && tripped.getCause().getMessage().startsWith("cell desync:"));
+        assertTrue("a desync must mark the sstable suspect, as any other corruption report does",
+                   sstable.isMarkedSuspect());
+    }
+
+    /**
+     * Reads every unfiltered of the sstable through the plain cursor reader.
+     *
+     * @param overDeclareRowBody report each row body as one byte longer than it is. This moves the
+     *                           EXPECTED end where a real desync would move the ACTUAL position; the
+     *                           two meet at the same inequality, which is what makes the {@code ==}
+     *                           comparison observable without needing a corrupt sstable.
+     */
+    private static void driveReader(SSTableReader sstable, boolean overDeclareRowBody) throws Exception
+    {
+        AbstractType<?>[] clusteringTypes = sstable.header.clusteringTypes().toArray(AbstractType[]::new);
+        UnfilteredDescriptor unfiltered = overDeclareRowBody
+                                         ? new UnfilteredDescriptor(clusteringTypes)
+                                           {
+                                               @Override
+                                               public long size()
+                                               {
+                                                   return super.size() + 1;
+                                               }
+                                           }
+                                         : new UnfilteredDescriptor(clusteringTypes);
+        PartitionDescriptor partition =
+            new PartitionDescriptor(sstable.getPartitioner().createReusableKey(0));
+
+        try (SSTableCursorReader reader = new SSTableCursorReader(sstable, DiskAccessMode.standard))
+        {
+            int state = reader.readPartitionHeader(partition);
+            while (!isState(state, DONE))
+            {
+                if (isState(state, PARTITION_START))
+                    state = reader.readPartitionHeader(partition);
+                else if (isState(state, STATIC_ROW_START))
+                    state = reader.readStaticRowHeader(unfiltered);
+                else if (isState(state, ROW_START))
+                    state = reader.readRowHeader(unfiltered);
+                else if (isState(state, TOMBSTONE_START))
+                    state = reader.readTombstoneMarker(unfiltered);
+                else if (isState(state, CELL_HEADER_START))
+                    state = reader.readCellHeader();
+                else if (isState(state, CELL_VALUE_START))
+                    state = reader.skipCellValue();
+                else
+                    state = reader.continueReading();
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/StatefulCursorTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/StatefulCursorTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_HEADER_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.CELL_VALUE_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.DONE;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.PARTITION_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.ROW_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.STATIC_ROW_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.TOMBSTONE_START;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.UNFILTERED_END;
+import static org.apache.cassandra.io.sstable.SSTableCursorReader.State.isState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for cursor-read defects that the differential harness cannot isolate. */
+public class StatefulCursorTest extends CQLTester
+{
+    /** Hooks for {@link #drive}, so the cursor-driving tests share one state machine. */
+    private interface CursorVisitor
+    {
+        default void onRow(StatefulCursor cursor) {}
+        default void onTombstone(StatefulCursor cursor) {}
+        /** @param state what readCellHeader returned; UNFILTERED_END means no cell was surfaced */
+        default void onCellHeader(StatefulCursor cursor, int state) {}
+    }
+
+    /** Drives the cursor over the whole sstable, calling back at rows, markers and cell headers. */
+    private static void drive(StatefulCursor cursor, CursorVisitor visitor)
+    {
+        int state = cursor.readPartitionHeader();
+        while (!isState(state, DONE))
+        {
+            if (isState(state, PARTITION_START))
+            {
+                state = cursor.readPartitionHeader();
+            }
+            else if (isState(state, STATIC_ROW_START))
+            {
+                cursor.readStaticRowHeader();
+                state = cursor.state();
+            }
+            else if (isState(state, ROW_START))
+            {
+                cursor.readRowHeader();
+                visitor.onRow(cursor);
+                state = cursor.state();
+            }
+            else if (isState(state, TOMBSTONE_START))
+            {
+                cursor.readTombstoneMarker();
+                visitor.onTombstone(cursor);
+                state = cursor.state();
+            }
+            else if (isState(state, CELL_HEADER_START))
+            {
+                state = cursor.readCellHeader();
+                visitor.onCellHeader(cursor, state);
+            }
+            else if (isState(state, CELL_VALUE_START))
+            {
+                state = cursor.skipCellValue();
+            }
+            else
+            {
+                state = cursor.continueReading();
+            }
+        }
+    }
+
+    /**
+     * The cursor's cell-liveness check must agree with the iterator path's oracle,
+     * {@code AbstractCell.hasInvalidDeletions()}, on every combination — including a cell that
+     * declares a TTL with no expiration time, which the previous predicate could not report because
+     * it tested "has an expiration time" where the oracle tests "has a TTL".
+     */
+    @Test
+    public void cellDeletionPredicateAgreesWithCellOracle()
+    {
+        ColumnMetadata column = ColumnMetadata.regularColumn("ks", "tbl", "v", Int32Type.instance, 0);
+        ByteBuffer value = Int32Type.instance.decompose(1);
+
+        // A Cell cannot hold a negative localExpirationTime: the BufferCell constructor runs it
+        // through Cell.deletionTimeLongToUnsignedInteger, which rejects negatives. So the oracle is
+        // only defined over the values below, and the negative cases are asserted separately.
+        for (int ttl : new int[]{ Cell.NO_TTL, 1, 100, -1, Integer.MIN_VALUE })
+        {
+            for (long ldt : new long[]{ Cell.NO_DELETION_TIME, Cell.INVALID_DELETION_TIME, 0, 1,
+                                        1_700_000_000L, Cell.MAX_DELETION_TIME })
+            {
+                boolean oracle = new BufferCell(column, 1000L, ttl, ldt, value, null).hasInvalidDeletions();
+                assertEquals("cell validation must match AbstractCell.hasInvalidDeletions() at ttl=" +
+                             ttl + " localExpirationTime=" + ldt,
+                             oracle, StatefulCursor.hasInvalidCellDeletion(ttl, ldt));
+            }
+        }
+
+        // the combination the old predicate could never report: its last clause asked whether the
+        // cell had an EXPIRATION TIME, contradicting the ldt == NO_DELETION_TIME it was ANDed with
+        assertTrue("a cell with a TTL but no expiration time is invalid",
+                   StatefulCursor.hasInvalidCellDeletion(100, Cell.NO_DELETION_TIME));
+        assertFalse("a cell with no TTL and no expiration time is the normal live cell",
+                    StatefulCursor.hasInvalidCellDeletion(Cell.NO_TTL, Cell.NO_DELETION_TIME));
+        // a negative expiration time cannot occur in a Cell, and off disk it only decodes
+        // alongside a negative TTL, so neither reference can express this pair
+        assertTrue("a negative expiration time is invalid",
+                   StatefulCursor.hasInvalidCellDeletion(Cell.NO_TTL, -1));
+    }
+
+    /**
+     * The row-liveness check has the same oracle mismatch: {@code AbstractRow.hasInvalidDeletions()}
+     * guards with {@code LivenessInfo.isExpiring()}, which is "has a TTL".
+     */
+    @Test
+    public void rowLivenessPredicateAgreesWithRowOracle()
+    {
+        // ExpiringLivenessInfo asserts ttl != NO_TTL && localExpirationTime != NO_EXPIRATION_TIME,
+        // so — as with the cell oracle — the reference type cannot represent the corrupt states the
+        // cursor decodes off disk. Compare against the oracle over what it CAN represent, then
+        // assert the corrupt domain against the specification.
+        for (int ttl : new int[]{ LivenessInfo.NO_TTL, 1, 100, -1, Integer.MIN_VALUE })
+        {
+            for (long ldt : new long[]{ LivenessInfo.NO_EXPIRATION_TIME, 0, 1, 1_700_000_000L, -1,
+                                        Long.MIN_VALUE })
+            {
+                if (ttl != LivenessInfo.NO_TTL && ldt == LivenessInfo.NO_EXPIRATION_TIME)
+                    continue;
+                LivenessInfo liveness = LivenessInfo.withExpirationTime(1000L, ttl, ldt);
+                boolean oracle = liveness.isExpiring()
+                                 && (liveness.ttl() < 0 || liveness.localExpirationTime() < 0);
+                assertEquals("row validation must match AbstractRow.hasInvalidDeletions() at ttl=" +
+                             ttl + " localExpirationTime=" + ldt,
+                             oracle, StatefulCursor.hasInvalidRowLiveness(ttl, ldt));
+            }
+        }
+
+        // the combination the old predicate could never report, and which no LivenessInfo can hold:
+        // a corrupt negative TTL decoded alongside the no-expiration sentinel
+        assertTrue("row liveness with a negative TTL is invalid",
+                   StatefulCursor.hasInvalidRowLiveness(-1, LivenessInfo.NO_EXPIRATION_TIME));
+        assertFalse("row liveness with no TTL is not expiring, so there is nothing to validate",
+                    StatefulCursor.hasInvalidRowLiveness(LivenessInfo.NO_TTL, -1));
+    }
+
+    /**
+     * When the dropped-column filter discards every remaining column of a row, readCellHeader
+     * surfaces no cell and returns UNFILTERED_END, leaving the cell liveness describing the
+     * DISCARDED cell. Validation keys off exactly that state, so pin it: the drop-filtered row must
+     * report UNFILTERED_END and a surviving row must report a cell state.
+     */
+    @Test
+    public void readCellHeaderReturnsUnfilteredEndWhenEveryColumnIsDropFiltered() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, dropped int, kept int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // Both rows are written below the wall-clock droppedTime recorded by the ALTER, so the drop
+        // filter definitely covers the dropped cell.
+        // ck 0: only the to-be-dropped column is set, so after the drop the row has no cells left
+        execute("INSERT INTO %s (pk, ck, dropped) VALUES (0, 0, 1) USING TIMESTAMP 1000");
+        // ck 1: a surviving cell, the control for the same code path
+        execute("INSERT INTO %s (pk, ck, kept) VALUES (0, 1, 2) USING TIMESTAMP 1000");
+        flush();
+        alterTable("ALTER TABLE %s DROP dropped");
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        boolean[] seen = new boolean[2];   // [0] no cell surfaced, [1] cell surfaced
+        try (StatefulCursor cursor = new StatefulCursor(sstable, DiskAccessMode.standard))
+        {
+            drive(cursor, new CursorVisitor()
+            {
+                public void onCellHeader(StatefulCursor c, int state)
+                {
+                    seen[isState(state, UNFILTERED_END) ? 0 : 1] = true;
+                }
+            });
+        }
+
+        assertTrue("expected the row whose only cell was drop-filtered to return UNFILTERED_END",
+                   seen[0]);
+        assertTrue("expected the surviving row's cell to return a cell state, as a control", seen[1]);
+    }
+
+    /**
+     * The column-subset fields are row state. A range tombstone marker has no columns, so reading
+     * one must clear them; otherwise missingColumnsMask() keeps reporting the previous row's subset
+     * while rowColumns() is null.
+     */
+    @Test
+    public void rangeTombstoneClearsTheColumnSubsetState() throws Throwable
+    {
+        // two regular columns, so a row setting only one is subset-encoded and has a non-zero mask
+        createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // both columns must appear SOMEWHERE in the sstable, or the header superset is just {a} and
+        // the row below is an all-columns row rather than a subset-encoded one
+        execute("INSERT INTO %s (pk, ck, a) VALUES (0, 0, 1)");
+        execute("INSERT INTO %s (pk, ck, b) VALUES (0, 1, 2)");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck > 5");
+        flush();
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        boolean[] sawNonZeroMaskOnRow = { false };
+        int[] markers = { 0 };
+        long[] maskBitsAfterAnyMarker = { 0 };   // OR across markers, so no violation can be hidden
+        try (StatefulCursor cursor = new StatefulCursor(sstable, DiskAccessMode.standard))
+        {
+            drive(cursor, new CursorVisitor()
+            {
+                public void onRow(StatefulCursor c)
+                {
+                    sawNonZeroMaskOnRow[0] |= c.unfiltered().missingColumnsMask() != 0;
+                }
+
+                public void onTombstone(StatefulCursor c)
+                {
+                    markers[0]++;
+                    maskBitsAfterAnyMarker[0] |= c.unfiltered().missingColumnsMask();
+                    assertNull("a marker has no columns, so rowColumns must be null",
+                               c.unfiltered().rowColumns());
+                    assertNull("a marker has no columns, so presentColumnsWords must be null",
+                               c.unfiltered().presentColumnsWords());
+                }
+            });
+        }
+
+        assertTrue("expected the sparse row to carry a non-zero column-subset mask",
+                   sawNonZeroMaskOnRow[0]);
+        assertTrue("expected at least one range tombstone marker", markers[0] > 0);
+        assertEquals("a marker has no columns, so the subset mask must be cleared",
+                     0L, maskBitsAfterAnyMarker[0]);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/AccordTableDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/AccordTableDifferentialCompactionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Accord-enabled user tables purge and expire relative to gcBefore, not wall-clock now:
+ * CompactionIterator.purger() overrides nowInSec = controller.gcBefore when
+ * metadata.isAccordEnabled() or migratingFromAccord(), deliberately deferring TTL-expiry
+ * conversion and liveness purging so accord can still read the data at earlier timestamps and
+ * during migration. For accord tables gcBefore itself is derived from the accord node's
+ * durability bounds (CompactionTask.getCompactionController); with no transaction history that
+ * derivation yields NO_GC, i.e. "expire and purge nothing". The cursor path must apply the
+ * same nowInSec override.
+ *
+ * transactional_mode = 'test_unsafe' sets accordIsEnabled without routing plain CQL
+ * reads/writes through accord; a real local AccordService is started because the gcBefore
+ * derivation reads the node's durableBefore/redundantBefore state.
+ */
+public class AccordTableDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    @BeforeClass
+    public static void startAccord()
+    {
+        DatabaseDescriptor.setAccordTransactionsEnabled(true);
+        AccordService.localStartup(ClusterMetadata.current().myNodeId());
+        AccordService.distributedStartup();
+    }
+
+    @Test
+    public void expiredCellsDeferToGcBefore() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND transactional_mode = 'test_unsafe'");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // expiring rows (row liveness + cells carry the TTL) alongside plain ones
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?) USING TTL 1", ck, ck, "ttl-" + ck);
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (1, ?, ?)", ck, ck);
+        flush();
+
+        // overlapping second generation, plus cell-level TTLs over previously live rows
+        for (long ck = 5; ck < 10; ck++)
+            execute("UPDATE %s USING TTL 1 SET v2 = ? WHERE pk = 1 AND ck = ?", "cell-ttl-" + ck, ck);
+        for (long ck = 10; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (1, ?, ?)", ck, ck + 100);
+        flush();
+
+        // fixed "now" two seconds past the LAST write, so every TTL=1 cell above has expired
+        // relative to it however long the write phase took — not relative to the accord gcBefore,
+        // which is NO_GC with no transaction history
+        long fixedNow = FBUtilities.nowInSeconds() + 2;
+        assertSomethingExpiredAt(cfs, fixedNow);
+
+        // NO_GC mirrors what the compaction scheduler passes for accord tables
+        // (CompactionTask.getCompactionController asserts gcBefore <= 0 before deriving)
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(),
+                                                         taskWithFixedNow(fixedNow), CompactionManager.NO_GC);
+
+        // ABSOLUTE, and the scenario's non-vacuity guard in one. Every TTL above has lapsed
+        // relative to the fixed nowInSec pinned above, so a path using nowInSec would have
+        // converted these cells to tombstones and dropped their values. Under the accord gcBefore
+        // they must survive intact, still carrying their TTL. This cannot be a CQL read: CQL
+        // applies expiry at read time, so an expired-but-retained cell is invisible either way.
+        String json = allJson(out);
+        for (long ck = 0; ck < 10; ck++)
+            assertTrue("an expiring cell was converted to a tombstone despite the accord gcBefore " +
+                       "deferral, at pk 0 ck " + ck, json.contains(cellValue("ttl-" + ck)));
+        for (long ck = 5; ck < 10; ck++)
+            assertTrue("a cell-level TTL was converted to a tombstone despite the accord gcBefore " +
+                       "deferral, at pk 1 ck " + ck, json.contains(cellValue("cell-ttl-" + ck)));
+        assertFalse("no cell should have been converted to a tombstone under the accord gcBefore, " +
+                    "which is what the deferral exists to prevent",
+                    json.contains(CELL_TOMBSTONE));
+        // A survivor is still an EXPIRING cell rather than a plain one, i.e. the TTL travelled with it.
+        // Where the field lands depends on the write: JsonTransformer suppresses a cell's ttl when it
+        // equals the row liveness's, so the pk-0 INSERTs render it on liveness_info and the pk-1
+        // UPDATEs (which write no row liveness) render it on the cell. Either satisfies this; the
+        // trailing comma is what keeps it from also matching "ttl":10.
+        assertTrue("the retained cells lost their TTL", json.contains("\"ttl\":1,"));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/AccordTableDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/AccordTableDifferentialCompactionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.tcm.ClusterMetadata;
+
+/**
+ * Accord-enabled user tables purge and expire relative to gcBefore, not wall-clock now:
+ * CompactionIterator.purger() overrides nowInSec = controller.gcBefore when
+ * metadata.isAccordEnabled() or migratingFromAccord(), deliberately deferring TTL-expiry
+ * conversion and liveness purging so accord can still read the data at earlier timestamps and
+ * during migration. For accord tables gcBefore itself is derived from the accord node's
+ * durability bounds (CompactionTask.getCompactionController); with no transaction history that
+ * derivation yields NO_GC, i.e. "expire and purge nothing". The cursor path must apply the
+ * same nowInSec override.
+ *
+ * transactional_mode = 'test_unsafe' sets accordIsEnabled without routing plain CQL
+ * reads/writes through accord; a real local AccordService is started because the gcBefore
+ * derivation reads the node's durableBefore/redundantBefore state.
+ */
+public class AccordTableDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    @BeforeClass
+    public static void startAccord()
+    {
+        DatabaseDescriptor.setAccordTransactionsEnabled(true);
+        AccordService.localStartup(ClusterMetadata.current().myNodeId());
+        AccordService.distributedStartup();
+    }
+
+    @Test
+    public void expiredCellsDeferToGcBefore() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND transactional_mode = 'test_unsafe'");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // expiring rows (row liveness + cells carry the TTL) alongside plain ones
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?) USING TTL 1", ck, ck, "ttl-" + ck);
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (1, ?, ?)", ck, ck);
+        flush();
+
+        // overlapping second generation, plus cell-level TTLs over previously live rows
+        for (long ck = 5; ck < 10; ck++)
+            execute("UPDATE %s USING TTL 1 SET v2 = ? WHERE pk = 1 AND ck = ?", "cell-ttl-" + ck, ck);
+        for (long ck = 10; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (1, ?, ?)", ck, ck + 100);
+        flush();
+
+        // let every TTL lapse relative to wall-clock now (but not relative to the accord
+        // gcBefore, which is NO_GC with no transaction history)
+        Thread.sleep(1100);
+
+        // NO_GC mirrors what the compaction scheduler passes for accord tables
+        // (CompactionTask.getCompactionController asserts gcBefore <= 0 before deriving)
+        assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, CompactionManager.NO_GC);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Smoke scenarios for the differential cursor-vs-iterator compaction harness.
+ * The full edge-case corpus lives in EdgeCaseDifferentialCompactionTest; this class
+ * exists to prove the harness mechanics on the simplest supported shapes.
+ */
+public class BasicDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    /** Start empty: byte-identical output is the hypothesis increment 1 tests. */
+
+    @Test
+    public void overlappingOverwrites() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 10; pk++)
+                for (long ck = 0; ck < 20; ck++)
+                    execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)",
+                            pk, ck, round * 1000 + ck, "round-" + round + "-" + ck);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    @Test
+    public void tombstonesRetained() throws Exception
+    {
+        // large gc_grace: nothing purgeable, all tombstone kinds must survive the merge identically
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 20; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "v" + ck);
+        flush();
+
+        // row deletes, cell deletes, range deletes, partition delete — one sstable of tombstones
+        execute("DELETE FROM %s WHERE pk = 1 AND ck = 5");
+        execute("DELETE v1 FROM %s WHERE pk = 2 AND ck = 7");
+        execute("DELETE FROM %s WHERE pk = 3 AND ck >= 5 AND ck < 15");
+        execute("DELETE FROM %s WHERE pk = 4");
+        flush();
+
+        // and a third sstable with data written over some of the deletions
+        for (long ck = 0; ck < 20; ck += 2)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    @Test
+    public void tombstonesPurged() throws Exception
+    {
+        // gc_grace 0: tombstones written below are purgeable by the time we compact;
+        // partition 4 becomes fully empty and must be dropped by both paths
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 4");
+        execute("DELETE FROM %s WHERE pk = 5 AND ck >= 0 AND ck < 5");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck = 0");
+        flush();
+
+        // purge boundary: gcBefore strictly past the tombstones' recorded local deletion time,
+        // read from the sstable's own stats instead of sleeping past wall-clock now
+        long maxLdt = maxTombstoneLocalDeletionTime(cfs.getLiveSSTables());
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, maxLdt + 1);
+
+        // ABSOLUTE, and this scenario's non-vacuity guard: deriving gcBefore from the sstable stats makes
+        // everything above purgeable, so the merge must actually DROP it. Byte-equality cannot see a purge
+        // rule both paths get wrong, and maxTombstoneLocalDeletionTime only establishes that a tombstone
+        // existed to purge, not that it went. Surviving rows: pk 0 loses ck 0 (9), pk 1..3 keep all 10,
+        // pk 4 is dropped whole (0), pk 5 loses ck 0-4 (5).
+        assertEquals("expected a single compaction output", 1, out.sstables.size());
+        assertTrue("purgeable tombstones and the data they shadow were not dropped; expected totalRows=44, " +
+                   "got: " + out.sstables.get(0).statsSummary,
+                   out.sstables.get(0).statsSummary.contains("totalRows=44 "));
+    }
+
+    /** Same as tombstonesRetained but uncompressed, so Data.db bytes are directly comparable. */
+    @Test
+    public void tombstonesRetainedUncompressed() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 20; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "v" + ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 1 AND ck = 5");
+        execute("DELETE v1 FROM %s WHERE pk = 2 AND ck = 7");
+        execute("DELETE FROM %s WHERE pk = 3 AND ck >= 5 AND ck < 15");
+        execute("DELETE FROM %s WHERE pk = 4");
+        flush();
+
+        for (long ck = 0; ck < 20; ck += 2)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    @Test
+    public void staticRows() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s1 bigint static, s2 text static, ck bigint, v1 bigint, " +
+                    "PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 8; pk++)
+        {
+            execute("INSERT INTO %s (pk, s1, s2, ck, v1) VALUES (?, ?, ?, ?, ?)", pk, pk * 10, "static" + pk, 0L, 0L);
+            for (long ck = 1; ck < 5; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        }
+        flush();
+
+        // static-only partitions + static overwrite in second sstable
+        for (long pk = 0; pk < 4; pk++)
+            execute("INSERT INTO %s (pk, s1, s2) VALUES (?, ?, ?)", pk, pk * 100, "updated" + pk);
+        execute("INSERT INTO %s (pk, s1) VALUES (?, ?)", 100L, 1L);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /**
+     * A table with no clustering columns, which CursorSupportMatrixTest.noClusteringSupported
+     * declares supported without ever compacting one. Every row is the empty clustering, so each
+     * partition holds exactly one row and the merge decides on the partition key alone.
+     */
+    @Test
+    public void noClusteringColumns() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint PRIMARY KEY, v1 bigint, v2 text)");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 20; pk++)
+            execute("INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", pk, pk, "v" + pk);
+        flush();
+
+        // pk 10..19 are overwritten and pk 20..29 are new, so the output is a genuine merge
+        for (long pk = 10; pk < 30; pk++)
+            execute("INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", pk, pk + 100, "updated" + pk);
+        flush();
+
+        assertEquals("the scenario needs two overlapping sstables to merge", 2, cfs.getLiveSSTables().size());
+        assertCursorMatchesIterator(cfs);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -32,7 +31,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 public class BasicDifferentialCompactionTest extends DifferentialCompactionTester
 {
     /** Start empty: byte-identical output is the hypothesis increment 1 tests. */
-    private static final Set<String> ALLOWLIST = Set.of();
 
     @Test
     public void overlappingOverwrites() throws Exception
@@ -50,7 +48,7 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 
     @Test
@@ -79,7 +77,7 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
             execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 
     @Test
@@ -105,7 +103,7 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
         // ensure local deletion times are strictly in the past relative to both compaction runs
         Thread.sleep(1100);
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 
     /** Same as tombstonesRetained but uncompressed, so Data.db bytes are directly comparable. */
@@ -132,7 +130,7 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
             execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 
     @Test
@@ -157,6 +155,6 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
         execute("INSERT INTO %s (pk, s1) VALUES (?, ?)", 100L, 1L);
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+/**
+ * Smoke scenarios for the differential cursor-vs-iterator compaction harness.
+ * The full edge-case corpus lives in EdgeCaseDifferentialCompactionTest; this class
+ * exists to prove the harness mechanics on the simplest supported shapes.
+ */
+public class BasicDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    /** Start empty: byte-identical output is the hypothesis increment 1 tests. */
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    @Test
+    public void overlappingOverwrites() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 10; pk++)
+                for (long ck = 0; ck < 20; ck++)
+                    execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)",
+                            pk, ck, round * 1000 + ck, "round-" + round + "-" + ck);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    @Test
+    public void tombstonesRetained() throws Exception
+    {
+        // large gc_grace: nothing purgeable, all tombstone kinds must survive the merge identically
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 20; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "v" + ck);
+        flush();
+
+        // row deletes, cell deletes, range deletes, partition delete — one sstable of tombstones
+        execute("DELETE FROM %s WHERE pk = 1 AND ck = 5");
+        execute("DELETE v1 FROM %s WHERE pk = 2 AND ck = 7");
+        execute("DELETE FROM %s WHERE pk = 3 AND ck >= 5 AND ck < 15");
+        execute("DELETE FROM %s WHERE pk = 4");
+        flush();
+
+        // and a third sstable with data written over some of the deletions
+        for (long ck = 0; ck < 20; ck += 2)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    @Test
+    public void tombstonesPurged() throws Exception
+    {
+        // gc_grace 0: tombstones written below are purgeable by the time we compact;
+        // partition 4 becomes fully empty and must be dropped by both paths
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 4");
+        execute("DELETE FROM %s WHERE pk = 5 AND ck >= 0 AND ck < 5");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck = 0");
+        flush();
+
+        // ensure local deletion times are strictly in the past relative to both compaction runs
+        Thread.sleep(1100);
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Same as tombstonesRetained but uncompressed, so Data.db bytes are directly comparable. */
+    @Test
+    public void tombstonesRetainedUncompressed() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 20; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "v" + ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 1 AND ck = 5");
+        execute("DELETE v1 FROM %s WHERE pk = 2 AND ck = 7");
+        execute("DELETE FROM %s WHERE pk = 3 AND ck >= 5 AND ck < 15");
+        execute("DELETE FROM %s WHERE pk = 4");
+        flush();
+
+        for (long ck = 0; ck < 20; ck += 2)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 3L, ck, ck + 100, "resurrect" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    @Test
+    public void staticRows() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s1 bigint static, s2 text static, ck bigint, v1 bigint, " +
+                    "PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 8; pk++)
+        {
+            execute("INSERT INTO %s (pk, s1, s2, ck, v1) VALUES (?, ?, ?, ?, ?)", pk, pk * 10, "static" + pk, 0L, 0L);
+            for (long ck = 1; ck < 5; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        }
+        flush();
+
+        // static-only partitions + static overwrite in second sstable
+        for (long pk = 0; pk < 4; pk++)
+            execute("INSERT INTO %s (pk, s1, s2) VALUES (?, ?, ?)", pk, pk * 100, "updated" + pk);
+        execute("INSERT INTO %s (pk, s1) VALUES (?, ?)", 100L, 1L);
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BasicDifferentialCompactionTest.java
@@ -133,6 +133,33 @@ public class BasicDifferentialCompactionTest extends DifferentialCompactionTeste
         assertCursorMatchesIterator(cfs);
     }
 
+    /**
+     * bloom_filter_fp_chance = 1.0 is the documented way to disable bloom filters: FilterFactory
+     * returns the AlwaysPresentFilter singleton, which is an IFilter but NOT a BloomFilter. The
+     * BIG cursor index writer must not assume the concrete class (the iterator path goes through
+     * the IFilter interface, where add() is a no-op).
+     */
+    @Test
+    public void bloomFilterDisabled() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, PRIMARY KEY (pk, ck)) " +
+                    "WITH bloom_filter_fp_chance = 1.0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        flush();
+
+        for (long pk = 5; pk < 15; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck + 100);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
     @Test
     public void staticRows() throws Exception
     {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
@@ -36,17 +36,35 @@ import org.apache.cassandra.db.ColumnFamilyStore;
  * dump streams into a SHA-256 digest and byte comparison streams, so harness memory stays
  * flat. Two generations as everywhere.
  *
- * Runtime is minutes, dominated by the 2M inserts — run with a raised junit timeout:
- * ant testsome -Dtest.name=...BigVolumeDifferentialCompactionTest -Dtest.timeout=2400000
+ * All scale parameters are property-configurable (defaults reproduce the standard 2M-row /
+ * 20-sstable run). Properties must reach the forked test JVM via -Dtest.jvm.args:
+ *
+ *   ant testsome -Dtest.name=...BigVolumeDifferentialCompactionTest \
+ *       -Dtest.timeout=14400000 \
+ *       -Dtest.jvm.args="-Dcassandra.test.differential.bigvolume.rounds=40
+ *                        -Dcassandra.test.differential.bigvolume.partitions=10000
+ *                        -Dcassandra.test.differential.bigvolume.rows_per_round=100
+ *                        -Dcassandra.test.differential.bigvolume.value_padding=200"
+ *
+ *  - rounds          = number of input sstables (one flush per round)
+ *  - partitions      = partitions per round
+ *  - rows_per_round  = rows per partition per round (total rows = rounds x partitions x this)
+ *  - value_padding   = extra bytes appended to every text value (row size knob; default 0)
+ *
+ * Delete counts scale with the partition count; the clustering stride is derived so
+ * consecutive rounds always overlap by roughly half a window.
  */
 public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionTester
 {
     private static final Set<String> ALLOWLIST = Set.of();
 
-    private static final int ROUNDS = 20;
-    private static final int PARTITIONS = 2000;
-    private static final int ROWS_PER_ROUND = 50;
-    private static final int CK_STRIDE = 23; // < ROWS_PER_ROUND: consecutive rounds overlap by 27 cks
+    private static final int ROUNDS = Integer.getInteger("cassandra.test.differential.bigvolume.rounds", 20);
+    private static final int PARTITIONS = Integer.getInteger("cassandra.test.differential.bigvolume.partitions", 2000);
+    private static final int ROWS_PER_ROUND = Integer.getInteger("cassandra.test.differential.bigvolume.rows_per_round", 50);
+    private static final String VALUE_PADDING =
+        "p".repeat(Integer.getInteger("cassandra.test.differential.bigvolume.value_padding", 0));
+    /** < ROWS_PER_ROUND so consecutive rounds overlap by roughly half a window (50 -> 23, the original). */
+    private static final int CK_STRIDE = Math.max(1, ROWS_PER_ROUND / 2 - 2);
 
     @Override
     protected boolean scaleCapture()
@@ -62,6 +80,11 @@ public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionT
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         cfs.disableAutoCompaction();
 
+        logger.info("big-volume parameters: rounds={} partitions={} rowsPerRound={} valuePadding={}B " +
+                    "ckStride={} -> {} total rows across {} input sstables",
+                    ROUNDS, PARTITIONS, ROWS_PER_ROUND, VALUE_PADDING.length(), CK_STRIDE,
+                    (long) ROUNDS * PARTITIONS * ROWS_PER_ROUND, ROUNDS);
+
         String insert = "INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)";
         String insertTtl = insert + " USING TTL 86400";
         String insertTs = insert + " USING TIMESTAMP 5000";
@@ -75,35 +98,36 @@ public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionT
                 {
                     long ck = ckBase + j;
                     long v1 = ck * 31 + round;
-                    String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck;
+                    String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck + VALUE_PADDING;
                     if (j % 7 == 3)
                         execute(insertTtl, pk, ck, v1, v2);
                     else if (j % 13 == 7)
-                        execute(insertTs, pk, ck, v1, "tie" + round + "_" + ck);
+                        execute(insertTs, pk, ck, v1, "tie" + round + "_" + ck + VALUE_PADDING);
                     else
                         execute(insert, pk, ck, v1, v2);
                 }
             }
 
-            for (int i = 0; i < 100; i++)
+            // delete counts scale with the partition count (defaults: 100 / 30 / 20)
+            for (int i = 0; i < Math.max(1, PARTITIONS / 20); i++)
                 execute("DELETE FROM %s WHERE pk = ? AND ck = ?",
                         (long) ((round * 97 + i * 13) % PARTITIONS), ckBase + (i % ROWS_PER_ROUND));
-            for (int i = 0; i < 30; i++)
+            for (int i = 0; i < Math.max(1, PARTITIONS / 66); i++)
             {
                 long start = ckBase + (i % 40);
                 execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
                         (long) ((round * 53 + i * 29) % PARTITIONS), start, start + 4);
             }
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < Math.max(1, PARTITIONS / 100); i++)
             {
                 long pk = (round * 41 + i * 17) % PARTITIONS;
                 if (i % 2 == 0)
-                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", pk, ckBase + 25);
+                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", pk, ckBase + ROWS_PER_ROUND / 2);
                 else
                     execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", pk, ckBase + 5);
             }
             // cycling partition deletes over the same 5 partitions: tombstone + resurrection
-            execute("DELETE FROM %s WHERE pk = ?", (long) (1995 + round % 5));
+            execute("DELETE FROM %s WHERE pk = ?", (long) (Math.max(0, PARTITIONS - 5) + round % Math.min(5, PARTITIONS)));
 
             flush();
             logger.info("big-volume round {}/{} flushed", round + 1, ROUNDS);

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -56,7 +55,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
  */
 public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     private static final int ROUNDS = Integer.getInteger("cassandra.test.differential.bigvolume.rounds", 20);
     private static final int PARTITIONS = Integer.getInteger("cassandra.test.differential.bigvolume.partitions", 2000);
@@ -133,6 +131,6 @@ public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionT
             logger.info("big-volume round {}/{} flushed", round + 1, ROUNDS);
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/BigVolumeDifferentialCompactionTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+/**
+ * Volume scenario: TWO MILLION written rows across TWENTY input sstables — 2,000 partitions
+ * x 50 rows per round x 20 flush rounds, with each round's clustering window overlapping the
+ * previous round's by half so most output rows genuinely merge from 2-3 inputs. The mutation
+ * mix runs at scale: ~14% TTL'd rows, ~8% explicit-timestamp ties on overwritten keys, ~3%
+ * null-overwrite cell tombstones, plus per-round row deletes, bounded and single-sided range
+ * deletes, and cycling partition deletes with resurrection.
+ *
+ * Runs in scale-capture mode (see DifferentialCompactionTester.scaleCapture): the logical
+ * dump streams into a SHA-256 digest and byte comparison streams, so harness memory stays
+ * flat. Two generations as everywhere.
+ *
+ * Runtime is minutes, dominated by the 2M inserts — run with a raised junit timeout:
+ * ant testsome -Dtest.name=...BigVolumeDifferentialCompactionTest -Dtest.timeout=2400000
+ */
+public class BigVolumeDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    private static final int ROUNDS = 20;
+    private static final int PARTITIONS = 2000;
+    private static final int ROWS_PER_ROUND = 50;
+    private static final int CK_STRIDE = 23; // < ROWS_PER_ROUND: consecutive rounds overlap by 27 cks
+
+    @Override
+    protected boolean scaleCapture()
+    {
+        return true;
+    }
+
+    @Test
+    public void twoMillionRowsTwentySSTables() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, " +
+                    "PRIMARY KEY (pk, ck)) WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String insert = "INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)";
+        String insertTtl = insert + " USING TTL 86400";
+        String insertTs = insert + " USING TIMESTAMP 5000";
+
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            long ckBase = (long) round * CK_STRIDE;
+            for (long pk = 0; pk < PARTITIONS; pk++)
+            {
+                for (int j = 0; j < ROWS_PER_ROUND; j++)
+                {
+                    long ck = ckBase + j;
+                    long v1 = ck * 31 + round;
+                    String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck;
+                    if (j % 7 == 3)
+                        execute(insertTtl, pk, ck, v1, v2);
+                    else if (j % 13 == 7)
+                        execute(insertTs, pk, ck, v1, "tie" + round + "_" + ck);
+                    else
+                        execute(insert, pk, ck, v1, v2);
+                }
+            }
+
+            for (int i = 0; i < 100; i++)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?",
+                        (long) ((round * 97 + i * 13) % PARTITIONS), ckBase + (i % ROWS_PER_ROUND));
+            for (int i = 0; i < 30; i++)
+            {
+                long start = ckBase + (i % 40);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                        (long) ((round * 53 + i * 29) % PARTITIONS), start, start + 4);
+            }
+            for (int i = 0; i < 20; i++)
+            {
+                long pk = (round * 41 + i * 17) % PARTITIONS;
+                if (i % 2 == 0)
+                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", pk, ckBase + 25);
+                else
+                    execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", pk, ckBase + 5);
+            }
+            // cycling partition deletes over the same 5 partitions: tombstone + resurrection
+            execute("DELETE FROM %s WHERE pk = ?", (long) (1995 + round % 5));
+
+            flush();
+            logger.info("big-volume round {}/{} flushed", round + 1, ROUNDS);
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -1,0 +1,609 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.ThreadStats;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression gate for cursor compaction's GARBAGE-FREE property: steady-state heap
+ * allocation must not scale with the number of rows/cells compacted.
+ *
+ * Method: measure thread-allocated bytes (ThreadStats) around CompactionTask.execute for a
+ * SMALL table and a 10x BIG table (same row shape, warmed by prior iterations, min over
+ * several measured iterations to suppress transient noise), and assert the difference stays
+ * under a fixed ceiling.
+ *
+ * The ceiling is NOT zero. JFR decomposition of the measured baseline delta (~450KB at these
+ * sizes) shows it is entirely outside cursor-owned code:
+ * Ref$Debug stack captures (-Dcassandra.debugrefcount=true in the ant test JVM, build.xml —
+ * production default is false) scaling with buffer-chunk Ref churn, chunk-cache machinery
+ * scaling with data volume, and per-key metadata (bloom/summary). The cursor reader/writer/
+ * compactor hot loops contribute ZERO scaling allocation: ClusteringPrefix.Kind.values()'s
+ * per-call array allocation on the cursor's hot read/write paths is already eliminated
+ * upstream via Kind.fromOrdinal() (CASSANDRA-21528).
+ * Ceiling 512KB = measured 450KB + margin; run-to-run variance of the min-of-3 measurement
+ * is ~hundreds of bytes, so this trips at a regression of ~+60KB ≈ +6 bytes per row.
+ * JMH gc.alloc.rate.norm remains the precision instrument; this is the always-on tripwire.
+ *
+ * The differential harness cannot catch allocation regressions — output bytes are identical
+ * whether or not the path allocates — hence this separate gate.
+ */
+public class CursorCompactionAllocationGateTest extends DifferentialCompactionTester
+{
+    private static final int SMALL_ROWS_PER_PARTITION = 100;
+    private static final int SMALL_PARTITIONS = 6;
+    private static final int SCALE = 10;
+    private static final int WARMUP_ITERATIONS = 4;
+    private static final int MEASURED_ITERATIONS = 3;
+    private static final long CEILING_BYTES = 512 * 1024;
+
+    private interface ThrowingRunnable
+    {
+        void run() throws Exception;
+    }
+
+    /**
+     * Disables preemptive-open (so the gate sees a deterministic, stable sstable set) for the
+     * duration of {@code body}, restoring it and cursorCompactionEnabled to their original
+     * values afterward. Callers that need cursor compaction on set it themselves inside
+     * {@code body} (some measure both cursor and iterator paths within the same call).
+     */
+    private void withMeasurementEnv(ThrowingRunnable body) throws Exception
+    {
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        try
+        {
+            body.run();
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Runs warmup + measured compactions, returning the minimum allocated over the measured tail. */
+    private long measureBest(ColumnFamilyStore cfs, long gcBefore, int warmup, int measured) throws Exception
+    {
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < warmup + measured; i++)
+        {
+            long allocated = compactOnceMeasured(cfs, gcBefore);
+            if (i >= warmup)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /** Records lastInputBytes as the total on-disk length of cfs's current live sstables. */
+    private void captureLastInputBytes(ColumnFamilyStore cfs)
+    {
+        lastInputBytes = 0;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            lastInputBytes += sstable.onDiskLength();
+    }
+
+    private void dumpAllocationProfile(java.nio.file.Path dest, int iterations,
+                                       ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        dumpAllocationProfile(dest, WARMUP_ITERATIONS, iterations, cfs, gcBefore);
+    }
+
+    /** Warms up, then records a JFR allocation profile (with stacks) over `iterations` cursor
+     *  compactions of cfs, dumped to dest for offline attribution. */
+    private void dumpAllocationProfile(java.nio.file.Path dest, int warmup, int iterations,
+                                       ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        for (int i = 0; i < warmup; i++)
+            compactOnceMeasured(cfs, gcBefore);
+
+        try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
+        {
+            recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
+            recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
+            recording.start();
+            for (int i = 0; i < iterations; i++)
+                compactOnceMeasured(cfs, gcBefore);
+            recording.stop();
+            recording.dump(dest);
+        }
+    }
+
+    @Test
+    public void allocationDoesNotScaleWithRows() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            long smallAlloc = measureSteadyStateAllocation(SMALL_PARTITIONS, true);
+            long bigAlloc = measureSteadyStateAllocation(SMALL_PARTITIONS * SCALE, true);
+            long delta = bigAlloc - smallAlloc;
+
+            // iterator-path numbers measured purely for context in the log: the iterator
+            // allocates per row/cell BY DESIGN and is not gated
+            long smallIter = measureSteadyStateAllocation(SMALL_PARTITIONS, false);
+            long bigIter = measureSteadyStateAllocation(SMALL_PARTITIONS * SCALE, false);
+
+            logger.info("cursor compaction allocation: small={}B big={}B delta={}B ceiling={}B " +
+                        "(iterator path for context: small={}B big={}B delta={}B)",
+                        smallAlloc, bigAlloc, delta, CEILING_BYTES,
+                        smallIter, bigIter, bigIter - smallIter);
+            assertTrue(String.format("cursor compaction allocation scales with data: " +
+                                     "%,dB (small) -> %,dB (big), delta %,dB exceeds ceiling %,dB. " +
+                                     "A per-row/cell allocation has been introduced on the cursor hot path.",
+                                     smallAlloc, bigAlloc, delta, CEILING_BYTES),
+                       delta <= CEILING_BYTES);
+        });
+    }
+
+    private long measureSteadyStateAllocation(int partitions, boolean cursor) throws Exception
+    {
+        return measureSteadyStateAllocation(partitions, cursor, 2, "val", WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+    }
+
+    private long measureSteadyStateAllocation(int partitions, boolean cursor,
+                                              int rounds, String valuePadding, int warmup, int measured) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < rounds; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                    execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, valuePadding + ck);
+            flush();
+        }
+
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        // guard against vacuous measurement: the gate is meaningless if the cursor run
+        // silently fell back to the iterator pipeline
+        if (cursor)
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+        captureLastInputBytes(cfs);
+        return measureBest(cfs, gcBefore, warmup, measured);
+    }
+
+    /** Total on-disk input bytes of the most recent measureSteadyStateAllocation call. */
+    private long lastInputBytes;
+
+    /**
+     * Measurement at realistic file sizes (4 input sstables of ~10MB each, uncompressed):
+     * 192 partitions x 100 rows x ~520B rows per file vs a 10x-smaller small run. The scaling
+     * assertion is per input BYTE, not an absolute delta, because the residual here grows with the
+     * workload instead of staying constant, so the small-file gate's fixed ceiling does not transfer.
+     * Its ceiling and the measurement it was calibrated from are stated at the assertion itself.
+     */
+    @Test
+    public void allocationAtLargeFileSizes() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        String padding = "v".repeat(500);
+        withMeasurementEnv(() -> {
+            // 4 rounds = 4 input files; big: 192 partitions * 100 rows * ~520B = ~10MB/file
+            long smallAlloc = measureSteadyStateAllocation(19, true, 4, padding, 2, 2);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureSteadyStateAllocation(192, true, 4, padding, 2, 2);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            long smallIter = measureSteadyStateAllocation(19, false, 4, padding, 2, 2);
+            long bigIter = measureSteadyStateAllocation(192, false, 4, padding, 2, 2);
+
+            logger.info("LARGE-FILE cursor compaction allocation (4 files, ~10MB each big): " +
+                        "cursor small={}B big={}B delta={}B over {}B extra input = {}B/B; " +
+                        "iterator small={}B big={}B delta={}B",
+                        smallAlloc, bigAlloc, delta, extraBytes, String.format("%.3f", perInputByte),
+                        smallIter, bigIter, bigIter - smallIter);
+            // The residual scales with data VOLUME, not row count: JFR decomposition at this
+            // scale = 62% Ref$Debug stack captures (test-env only,
+            // -Dcassandra.debugrefcount=true), chunk-cache machinery, per-compaction
+            // constants — ZERO cursor-owned sites. Measured ~0.27 B allocated per extra
+            // input byte in the test env; ceiling 0.5 B/B trips on any real per-element
+            // regression while absorbing volume-proportional test-env noise.
+            assertTrue(String.format("cursor allocation per input byte too high: %.3f B/B (delta %,dB over %,dB)",
+                                     perInputByte, delta, extraBytes),
+                       perInputByte <= 0.5);
+        });
+    }
+
+    /** Compacts all live sstables on the cursor path, measuring ONLY execute(); restores inputs. */
+    private long compactOnceMeasured(ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        Set<SSTableReader> inputs = new HashSet<>(cfs.getLiveSSTables());
+        Set<Descriptor> liveBeforeDescs = new HashSet<>();
+        List<Descriptor> inputDescriptors = new ArrayList<>();
+        for (SSTableReader in : inputs)
+        {
+            liveBeforeDescs.add(in.descriptor);
+            inputDescriptors.add(in.descriptor);
+        }
+
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting", txn);
+        CompactionTask task = new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */);
+
+        long before = ThreadStats.getCurrentThreadAllocatedBytes();
+        task.execute(ActiveCompactionsTracker.NOOP);
+        long after = ThreadStats.getCurrentThreadAllocatedBytes();
+        // -1 is what the JVM returns while thread allocation measurement is DISABLED, which
+        // isThreadAllocatedMemorySupported() — the condition every Assume in this class checks — reports
+        // as supported anyway. Two -1 readings subtract to a delta of 0, and 0 satisfies every scaling
+        // assertion in this class, so the whole gate would report green having measured nothing at all.
+        assertTrue("thread allocation measurement returned no reading (before=" + before +
+                   " after=" + after + "); the allocation gate cannot measure and must not report a pass",
+                   before >= 0 && after >= 0);
+        long allocated = after - before;
+
+        List<SSTableReader> retainedInputClones = new ArrayList<>();
+        List<SSTableReader> outputs = identifyOutputs(cfs, liveBeforeDescs, liveBeforeDescs, retainedInputClones);
+        restoreAfterCompaction(cfs, outputs, retainedInputClones, inputDescriptors, inputs.size());
+        return allocated;
+    }
+
+    /**
+     * Sparse rows: every other row omits a column, so the row carries a column-subset
+     * encoding instead of the all-columns flag. Exercises the per-row subset path in
+     * SSTableCursorReader (UnfilteredDescriptor.loadRow -> Columns.deserializeSubset ->
+     * CellCursor.init identity-cache miss), which the full-row scenario cannot see.
+     */
+    @Test
+    public void allocationDoesNotScaleWithSparseRows() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            long smallAlloc = measureSparse(SMALL_PARTITIONS);
+            long bigAlloc = measureSparse(SMALL_PARTITIONS * SCALE);
+            long delta = bigAlloc - smallAlloc;
+            logger.info("sparse-row cursor compaction allocation: small={}B big={}B delta={}B ceiling={}B",
+                        smallAlloc, bigAlloc, delta, CEILING_BYTES);
+            assertTrue(String.format("sparse-row cursor compaction allocation scales with data: " +
+                                     "%,dB -> %,dB, delta %,dB exceeds ceiling %,dB",
+                                     smallAlloc, bigAlloc, delta, CEILING_BYTES),
+                       delta <= CEILING_BYTES);
+        });
+    }
+
+    private long measureSparse(int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                {
+                    if (ck % 2 == 0)
+                        execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+                    else
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "val" + ck);
+                }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        return measureBest(cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+    }
+
+    /**
+     * Sparse rows in a >= 64-column superset: the column subset uses the LARGE-subset wire
+     * format (index vints, present- or missing-mode), which the reader historically decoded
+     * by materializing a fresh Columns per row — cascading through CellCursor.init's
+     * identity cache into a per-row toArray + AbstractType[] rebuild + O(columns) getType
+     * lookups. The small-superset gate (allocationDoesNotScaleWithSparseRows) cannot see
+     * this: its mask fast path only covers < 64 columns. The schema declares 70 columns but
+     * only 69 ever carry a cell — the present-mode window's base is always even, so c69 is
+     * never written and the sstable header's superset (the union of the columns actually
+     * written) is 69, still comfortably over the 64-column boundary. Rows alternate
+     * present-mode (3 of 69 set) and missing-mode (67 of 69 set) so both wire modes are
+     * exercised.
+     */
+    @Test
+    public void allocationDoesNotScaleWithWideSchemaSparseRows() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            long smallAlloc = measureWideSparse(SMALL_PARTITIONS);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureWideSparse(SMALL_PARTITIONS * SCALE);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            logger.info("wide-schema sparse-row cursor compaction allocation: small={}B big={}B delta={}B " +
+                        "over {}B extra input = {} B/B",
+                        smallAlloc, bigAlloc, delta, extraBytes, String.format("%.3f", perInputByte));
+            // Per INPUT BYTE calibration: the mixed 3-of-69 and
+            // 67-of-69 rows make multi-MB inputs whose volume-proportional test-env residual
+            // (Ref$Debug, chunk cache) dwarfs any fixed ceiling. Measured post-fix: ~0.37 B/B
+            // (BIG). The pre-fix per-row cascade (fresh Columns + CellCursor rebuild per
+            // sparse row) measured ~3.8 B/B. A leak of one small object per row costs ~+0.2 B/B at
+            // this row size, landing at ~0.57 B/B, which still passes: this gate catches a
+            // whole-pipeline regression, not a single re-introduced per-row object.
+            assertTrue(String.format("wide-schema (>=64 col) sparse-row cursor allocation per input byte too high: " +
+                                     "%.3f B/B (delta %,dB over %,dB extra input)",
+                                     perInputByte, delta, extraBytes),
+                       perInputByte <= 0.6);
+        });
+    }
+
+    private long measureWideSparse(int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        int cols = 70;
+        StringBuilder schema = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int c = 0; c < cols; c++)
+            schema.append(", c").append(c).append(" bigint");
+        schema.append(", PRIMARY KEY (pk, ck)) WITH compression = {'enabled': 'false'}");
+        createTable(schema.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // missing-mode insert: 67 of the 69-column superset (2 missing -> missing-index encoding)
+        StringBuilder wide = new StringBuilder("INSERT INTO %s (pk, ck");
+        StringBuilder marks = new StringBuilder("?, ?");
+        for (int c = 0; c < cols - 3; c++)
+        {
+            wide.append(", c").append(c);
+            marks.append(", ?");
+        }
+        String wideInsert = wide.append(") VALUES (").append(marks).append(")").toString();
+        Object[] wideArgs = new Object[2 + cols - 3];
+        for (int c = 0; c < cols - 3; c++)
+            wideArgs[2 + c] = (long) c;
+
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                {
+                    if (ck % 2 == 0)
+                    {
+                        // present-mode: rotating 3-column window
+                        int base = (int) ((ck * 3) % (cols - 2));
+                        execute("INSERT INTO %s (pk, ck, c" + base + ", c" + (base + 1) + ", c" + (base + 2) +
+                                ") VALUES (?, ?, ?, ?, ?)", pk, ck, ck, ck + 1, ck + 2);
+                    }
+                    else
+                    {
+                        wideArgs[0] = pk;
+                        wideArgs[1] = ck;
+                        execute(wideInsert, wideArgs);
+                    }
+                }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        captureLastInputBytes(cfs);
+        return measureBest(cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+    }
+
+    /**
+     * Garbage-free property for RANGE-TOMBSTONE-dense workloads: the marker
+     * read/merge/write path runs on the ReusableDeletionTime pool and open-marker tracking,
+     * which the row-centric gates barely touch. Each partition carries 300 bounded range
+     * tombstones per round, the second round's bounds shifted by one so every marker pair
+     * overlaps across sstables and forces real deletion reconciliation.
+     *
+     * Asserted per INPUT BYTE, not as a fixed delta: at marker-dense (sub-MB) scales the
+     * test-env residual (Ref$Debug stack captures, chunk-cache machinery) exceeds any fixed
+     * ceiling. JFR attribution of the first run (recordRangeTombstoneAllocationProfile): ZERO
+     * cursor-owned sites; the profile is Ref$Debug + buffer-pool + per-compaction constants.
+     * Markers are ~25-35B on disk, so a leak of one small object per marker costs >1.5 B/B and
+     * trips the 1.0 B/B ceiling with wide margin.
+     */
+    @Test
+    public void allocationDoesNotScaleWithRangeTombstones() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            long smallAlloc = measureRangeTombstones(12);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureRangeTombstones(96);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            logger.info("RT-dense cursor compaction allocation: small={}B big={}B delta={}B " +
+                        "over {}B extra input = {} B/B (ceiling {} B/B)",
+                        smallAlloc, bigAlloc, delta, extraBytes,
+                        String.format("%.3f", perInputByte), rtPerInputByteCeiling());
+            assertTrue(String.format("RT-dense cursor compaction allocation scales with markers: " +
+                                     "%,dB -> %,dB, delta %,dB over %,dB extra input = %.3f B/B exceeds " +
+                                     "ceiling %.2f B/B. A per-marker allocation has been introduced on " +
+                                     "the cursor hot path.",
+                                     smallAlloc, bigAlloc, delta, extraBytes, perInputByte,
+                                     rtPerInputByteCeiling()),
+                       perInputByte <= rtPerInputByteCeiling());
+        });
+    }
+
+    /** Calibrated from measured 0.684 B/B — all test-env residual by JFR attribution
+     *  (Ref$Debug, buffer pool; zero cursor frames). */
+    protected double rtPerInputByteCeiling()
+    {
+        return 1.0;
+    }
+
+    private long measureRangeTombstones(int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'} AND gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+            {
+                // a few surviving rows well outside the tombstoned ck range
+                for (long r = 0; r < 5; r++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, 100_000L + r, "v" + r);
+                // 300 bounded RTs; round 1 shifts bounds by 1 so markers overlap across rounds
+                for (long t = 0; t < 300; t++)
+                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                            pk, t * 4 + round, t * 4 + round + 2);
+            }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        captureLastInputBytes(cfs);
+        return measureBest(cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+    }
+
+    /**
+     * Diagnostic, not a gate: records JFR allocation events (with stacks) over many warmed
+     * cursor compactions of the big table and dumps to /tmp/cursor-alloc.jfr for offline
+     * attribution of the scaling allocation (jfr print + aggregation). Always passes.
+     */
+    @Test
+    public void recordAllocationProfile() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            int partitions = SMALL_PARTITIONS * SCALE;
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < partitions; pk++)
+                    for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "val" + ck);
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc.jfr"), 30, cfs, gcBefore);
+            logger.info("allocation profile dumped to /tmp/cursor-alloc.jfr");
+        });
+    }
+
+    /** Diagnostic, not a gate: JFR allocation profile over warmed cursor compactions of the
+     *  big RANGE-TOMBSTONE-dense table; dumps /tmp/cursor-alloc-rt.jfr for attribution. */
+    @Test
+    public void recordRangeTombstoneAllocationProfile() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'} AND gc_grace_seconds = 864000");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            int partitions = SMALL_PARTITIONS * SCALE;
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < partitions; pk++)
+                {
+                    for (long r = 0; r < 5; r++)
+                        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, 100_000L + r, "v" + r);
+                    for (long t = 0; t < 150; t++)
+                        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                                pk, t * 4 + round, t * 4 + round + 2);
+                }
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc-rt.jfr"), 30, cfs, gcBefore);
+            logger.info("allocation profile dumped to /tmp/cursor-alloc-rt.jfr");
+        });
+    }
+
+    /** Diagnostic: JFR profile at large file sizes; dumps /tmp/cursor-alloc-large.jfr. */
+    @Test
+    public void recordLargeFileAllocationProfile() throws Exception
+    {
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          ThreadStats.isThreadAllocatedMemorySupported());
+        String padding = "v".repeat(500);
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            for (int round = 0; round < 4; round++)
+            {
+                for (long pk = 0; pk < 192; pk++)
+                    for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, padding + ck);
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc-large.jfr"), 2, 8, cfs, gcBefore);
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -302,6 +302,101 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
     }
 
     /**
+     * Garbage-free property for RANGE-TOMBSTONE-dense workloads: the marker
+     * read/merge/write path runs on the ReusableDeletionTime pool and open-marker tracking,
+     * which the row-centric gates barely touch. Each partition carries 300 bounded range
+     * tombstones per round, the second round's bounds shifted by one so every marker pair
+     * overlaps across sstables and forces real deletion reconciliation.
+     *
+     * Asserted per INPUT BYTE, not as a fixed delta: at marker-dense (sub-MB) scales the
+     * test-env residual (Ref$Debug stack captures, chunk-cache machinery) exceeds any fixed
+     * ceiling. JFR attribution of the first run (recordRangeTombstoneAllocationProfile): ZERO
+     * cursor-owned sites; the profile is Ref$Debug + buffer-pool + per-compaction constants.
+     * Markers are ~25-35B on disk, so a leak of one small object per marker costs >1.5 B/B and
+     * trips the 1.0 B/B ceiling with wide margin.
+     */
+    @Test
+    public void allocationDoesNotScaleWithRangeTombstones() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            long smallAlloc = measureRangeTombstones(threadMXBean, 12);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureRangeTombstones(threadMXBean, 96);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            logger.info("RT-dense cursor compaction allocation: small={}B big={}B delta={}B " +
+                        "over {}B extra input = {} B/B (ceiling {} B/B)",
+                        smallAlloc, bigAlloc, delta, extraBytes,
+                        String.format("%.3f", perInputByte), rtPerInputByteCeiling());
+            assertTrue(String.format("RT-dense cursor compaction allocation scales with markers: " +
+                                     "%,dB -> %,dB, delta %,dB over %,dB extra input = %.3f B/B exceeds " +
+                                     "ceiling %.2f B/B. A per-marker allocation has been introduced on " +
+                                     "the cursor hot path.",
+                                     smallAlloc, bigAlloc, delta, extraBytes, perInputByte,
+                                     rtPerInputByteCeiling()),
+                       perInputByte <= rtPerInputByteCeiling());
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Calibrated from measured 0.684 B/B — all test-env residual by JFR attribution
+     *  (Ref$Debug, buffer pool; zero cursor frames). */
+    protected double rtPerInputByteCeiling()
+    {
+        return 1.0;
+    }
+
+    private long measureRangeTombstones(com.sun.management.ThreadMXBean threadMXBean, int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'} AND gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+            {
+                // a few surviving rows well outside the tombstoned ck range
+                for (long r = 0; r < 5; r++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, 100_000L + r, "v" + r);
+                // 300 bounded RTs; round 1 shifts bounds by 1 so markers overlap across rounds
+                for (long t = 0; t < 300; t++)
+                    execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                            pk, t * 4 + round, t * 4 + round + 2);
+            }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        lastInputBytes = 0;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            lastInputBytes += sstable.onDiskLength();
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
+        {
+            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            if (i >= WARMUP_ITERATIONS)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /**
      * Diagnostic, not a gate: records JFR allocation events (with stacks) over many warmed
      * cursor compactions of the big table and dumps to /tmp/cursor-alloc.jfr for offline
      * attribution of the scaling allocation (jfr print + aggregation). Always passes.
@@ -347,6 +442,62 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
                 recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc.jfr"));
             }
             logger.info("allocation profile dumped to /tmp/cursor-alloc.jfr");
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Diagnostic, not a gate: JFR allocation profile over warmed cursor compactions of the
+     *  big RANGE-TOMBSTONE-dense table; dumps /tmp/cursor-alloc-rt.jfr for attribution. */
+    @Test
+    public void recordRangeTombstoneAllocationProfile() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'} AND gc_grace_seconds = 864000");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            int partitions = SMALL_PARTITIONS * SCALE;
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < partitions; pk++)
+                {
+                    for (long r = 0; r < 5; r++)
+                        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, 100_000L + r, "v" + r);
+                    for (long t = 0; t < 150; t++)
+                        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?",
+                                pk, t * 4 + round, t * 4 + round + 2);
+                }
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+            for (int i = 0; i < WARMUP_ITERATIONS; i++)
+                compactOnceMeasured(threadMXBean, cfs, gcBefore);
+
+            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
+            {
+                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
+                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
+                recording.start();
+                for (int i = 0; i < 30; i++)
+                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
+                recording.stop();
+                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc-rt.jfr"));
+            }
+            logger.info("allocation profile dumped to /tmp/cursor-alloc-rt.jfr");
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -73,6 +73,83 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
     private static final int MEASURED_ITERATIONS = 3;
     private static final long CEILING_BYTES = 512 * 1024;
 
+    private interface ThrowingRunnable
+    {
+        void run() throws Exception;
+    }
+
+    /**
+     * Disables preemptive-open (so the gate sees a deterministic, stable sstable set) for the
+     * duration of {@code body}, restoring it and cursorCompactionEnabled to their original
+     * values afterward. Callers that need cursor compaction on set it themselves inside
+     * {@code body} (some measure both cursor and iterator paths within the same call).
+     */
+    private void withMeasurementEnv(ThrowingRunnable body) throws Exception
+    {
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        try
+        {
+            body.run();
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Runs warmup + measured compactions, returning the minimum allocated over the measured tail. */
+    private long measureBest(com.sun.management.ThreadMXBean threadMXBean, ColumnFamilyStore cfs, long gcBefore,
+                             int warmup, int measured) throws Exception
+    {
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < warmup + measured; i++)
+        {
+            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            if (i >= warmup)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /** Records lastInputBytes as the total on-disk length of cfs's current live sstables. */
+    private void captureLastInputBytes(ColumnFamilyStore cfs)
+    {
+        lastInputBytes = 0;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            lastInputBytes += sstable.onDiskLength();
+    }
+
+    private void dumpAllocationProfile(java.nio.file.Path dest, int iterations,
+                                       com.sun.management.ThreadMXBean threadMXBean,
+                                       ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        dumpAllocationProfile(dest, WARMUP_ITERATIONS, iterations, threadMXBean, cfs, gcBefore);
+    }
+
+    /** Warms up, then records a JFR allocation profile (with stacks) over `iterations` cursor
+     *  compactions of cfs, dumped to dest for offline attribution. */
+    private void dumpAllocationProfile(java.nio.file.Path dest, int warmup, int iterations,
+                                       com.sun.management.ThreadMXBean threadMXBean,
+                                       ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        for (int i = 0; i < warmup; i++)
+            compactOnceMeasured(threadMXBean, cfs, gcBefore);
+
+        try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
+        {
+            recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
+            recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
+            recording.start();
+            for (int i = 0; i < iterations; i++)
+                compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            recording.stop();
+            recording.dump(dest);
+        }
+    }
+
     @Test
     public void allocationDoesNotScaleWithRows() throws Exception
     {
@@ -80,12 +157,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
                           threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             long smallAlloc = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS, true);
             long bigAlloc = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS * SCALE, true);
             long delta = bigAlloc - smallAlloc;
@@ -104,12 +177,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
                                      "A per-row/cell allocation has been introduced on the cursor hot path.",
                                      smallAlloc, bigAlloc, delta, CEILING_BYTES),
                        delta <= CEILING_BYTES);
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     private long measureSteadyStateAllocation(com.sun.management.ThreadMXBean threadMXBean, int partitions, boolean cursor) throws Exception
@@ -140,18 +208,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         if (cursor)
             assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
 
-        lastInputBytes = 0;
-        for (SSTableReader sstable : cfs.getLiveSSTables())
-            lastInputBytes += sstable.onDiskLength();
-
-        long best = Long.MAX_VALUE;
-        for (int i = 0; i < warmup + measured; i++)
-        {
-            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
-            if (i >= warmup)
-                best = Math.min(best, allocated);
-        }
-        return best;
+        captureLastInputBytes(cfs);
+        return measureBest(threadMXBean, cfs, gcBefore, warmup, measured);
     }
 
     /** Total on-disk input bytes of the most recent measureSteadyStateAllocation call. */
@@ -170,11 +228,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         Assume.assumeTrue(threadMXBean != null);
 
         String padding = "v".repeat(500);
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        try
-        {
+        withMeasurementEnv(() -> {
             // 4 rounds = 4 input files; big: 192 partitions * 100 rows * ~520B = ~10MB/file
             long smallAlloc = measureSteadyStateAllocation(threadMXBean, 19, true, 4, padding, 2, 2);
             long smallBytes = lastInputBytes;
@@ -200,12 +254,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
             assertTrue(String.format("cursor allocation per input byte too high: %.3f B/B (delta %,dB over %,dB)",
                                      perInputByte, delta, extraBytes),
                        perInputByte <= 0.5);
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     /** Compacts all live sstables on the cursor path, measuring ONLY execute(); restores inputs. */
@@ -247,12 +296,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             long smallAlloc = measureSparse(threadMXBean, SMALL_PARTITIONS);
             long bigAlloc = measureSparse(threadMXBean, SMALL_PARTITIONS * SCALE);
             long delta = bigAlloc - smallAlloc;
@@ -262,12 +307,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
                                      "%,dB -> %,dB, delta %,dB exceeds ceiling %,dB",
                                      smallAlloc, bigAlloc, delta, CEILING_BYTES),
                        delta <= CEILING_BYTES);
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     private long measureSparse(com.sun.management.ThreadMXBean threadMXBean, int partitions) throws Exception
@@ -291,14 +331,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         }
         long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
         assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
-        long best = Long.MAX_VALUE;
-        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
-        {
-            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
-            if (i >= WARMUP_ITERATIONS)
-                best = Math.min(best, allocated);
-        }
-        return best;
+        return measureBest(threadMXBean, cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
     }
 
     /**
@@ -316,12 +349,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             long smallAlloc = measureWideSparse(threadMXBean, SMALL_PARTITIONS);
             long smallBytes = lastInputBytes;
             long bigAlloc = measureWideSparse(threadMXBean, SMALL_PARTITIONS * SCALE);
@@ -342,12 +371,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
                                      "%.3f B/B (delta %,dB over %,dB extra input)",
                                      perInputByte, delta, extraBytes),
                        perInputByte <= 0.6);
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     private long measureWideSparse(com.sun.management.ThreadMXBean threadMXBean, int partitions) throws Exception
@@ -398,17 +422,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         }
         long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
         assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
-        lastInputBytes = 0;
-        for (SSTableReader sstable : cfs.getLiveSSTables())
-            lastInputBytes += sstable.onDiskLength();
-        long best = Long.MAX_VALUE;
-        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
-        {
-            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
-            if (i >= WARMUP_ITERATIONS)
-                best = Math.min(best, allocated);
-        }
-        return best;
+        captureLastInputBytes(cfs);
+        return measureBest(threadMXBean, cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
     }
 
     /**
@@ -431,12 +446,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             long smallAlloc = measureRangeTombstones(threadMXBean, 12);
             long smallBytes = lastInputBytes;
             long bigAlloc = measureRangeTombstones(threadMXBean, 96);
@@ -455,12 +466,7 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
                                      smallAlloc, bigAlloc, delta, extraBytes, perInputByte,
                                      rtPerInputByteCeiling()),
                        perInputByte <= rtPerInputByteCeiling());
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     /** Calibrated from measured 0.684 B/B — all test-env residual by JFR attribution
@@ -493,17 +499,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         }
         long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
         assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
-        lastInputBytes = 0;
-        for (SSTableReader sstable : cfs.getLiveSSTables())
-            lastInputBytes += sstable.onDiskLength();
-        long best = Long.MAX_VALUE;
-        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
-        {
-            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
-            if (i >= WARMUP_ITERATIONS)
-                best = Math.min(best, allocated);
-        }
-        return best;
+        captureLastInputBytes(cfs);
+        return measureBest(threadMXBean, cfs, gcBefore, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
     }
 
     /**
@@ -517,12 +514,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
                         "WITH compression = {'enabled': 'false'}");
             ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -538,26 +531,9 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
             long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
             assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
 
-            for (int i = 0; i < WARMUP_ITERATIONS; i++)
-                compactOnceMeasured(threadMXBean, cfs, gcBefore);
-
-            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
-            {
-                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
-                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
-                recording.start();
-                for (int i = 0; i < 30; i++)
-                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
-                recording.stop();
-                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc.jfr"));
-            }
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc.jfr"), 30, threadMXBean, cfs, gcBefore);
             logger.info("allocation profile dumped to /tmp/cursor-alloc.jfr");
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     /** Diagnostic, not a gate: JFR allocation profile over warmed cursor compactions of the
@@ -568,12 +544,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
 
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
                         "WITH compression = {'enabled': 'false'} AND gc_grace_seconds = 864000");
             ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -594,26 +566,9 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
             long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
             assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
 
-            for (int i = 0; i < WARMUP_ITERATIONS; i++)
-                compactOnceMeasured(threadMXBean, cfs, gcBefore);
-
-            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
-            {
-                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
-                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
-                recording.start();
-                for (int i = 0; i < 30; i++)
-                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
-                recording.stop();
-                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc-rt.jfr"));
-            }
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc-rt.jfr"), 30, threadMXBean, cfs, gcBefore);
             logger.info("allocation profile dumped to /tmp/cursor-alloc-rt.jfr");
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+        });
     }
 
     /** Diagnostic: JFR profile at large file sizes; dumps /tmp/cursor-alloc-large.jfr. */
@@ -623,12 +578,8 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
         com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
         Assume.assumeTrue(threadMXBean != null);
         String padding = "v".repeat(500);
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
-        DatabaseDescriptor.setCursorCompactionEnabled(true);
-        try
-        {
+        withMeasurementEnv(() -> {
+            DatabaseDescriptor.setCursorCompactionEnabled(true);
             createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
                         "WITH compression = {'enabled': 'false'}");
             ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -642,24 +593,9 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
             }
             long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
             assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
-            for (int i = 0; i < 2; i++)
-                compactOnceMeasured(threadMXBean, cfs, gcBefore);
-            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
-            {
-                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
-                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
-                recording.start();
-                for (int i = 0; i < 8; i++)
-                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
-                recording.stop();
-                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc-large.jfr"));
-            }
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
-            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
-        }
+
+            dumpAllocationProfile(java.nio.file.Path.of("/tmp/cursor-alloc-large.jfr"), 2, 8, threadMXBean, cfs, gcBefore);
+        });
     }
 
     private static com.sun.management.ThreadMXBean threadMXBean()

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -236,6 +236,72 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
     }
 
     /**
+     * Sparse rows: every other row omits a column, so the row carries a column-subset
+     * encoding instead of the all-columns flag. Exercises the per-row subset path in
+     * SSTableCursorReader (UnfilteredDescriptor.loadRow -> Columns.deserializeSubset ->
+     * CellCursor.init identity-cache miss), which the full-row scenario cannot see.
+     */
+    @Test
+    public void allocationDoesNotScaleWithSparseRows() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            long smallAlloc = measureSparse(threadMXBean, SMALL_PARTITIONS);
+            long bigAlloc = measureSparse(threadMXBean, SMALL_PARTITIONS * SCALE);
+            long delta = bigAlloc - smallAlloc;
+            logger.info("sparse-row cursor compaction allocation: small={}B big={}B delta={}B ceiling={}B",
+                        smallAlloc, bigAlloc, delta, CEILING_BYTES);
+            assertTrue(String.format("sparse-row cursor compaction allocation scales with data: " +
+                                     "%,dB -> %,dB, delta %,dB exceeds ceiling %,dB",
+                                     smallAlloc, bigAlloc, delta, CEILING_BYTES),
+                       delta <= CEILING_BYTES);
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    private long measureSparse(com.sun.management.ThreadMXBean threadMXBean, int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                {
+                    if (ck % 2 == 0)
+                        execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+                    else
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "val" + ck);
+                }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
+        {
+            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            if (i >= WARMUP_ITERATIONS)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /**
      * Diagnostic, not a gate: records JFR allocation events (with stacks) over many warmed
      * cursor compactions of the big table and dumps to /tmp/cursor-alloc.jfr for offline
      * attribution of the scaling allocation (jfr print + aggregation). Always passes.

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression gate for cursor compaction's GARBAGE-FREE property: steady-state heap
+ * allocation must not scale with the number of rows/cells compacted.
+ *
+ * Method: measure thread-allocated bytes (ThreadMXBean) around CompactionTask.execute for a
+ * SMALL table and a 10x BIG table (same row shape, warmed by prior iterations, min over
+ * several measured iterations to suppress transient noise), and assert the difference stays
+ * under a fixed ceiling.
+ *
+ * The ceiling is NOT zero. JFR decomposition of the measured baseline delta (~450KB at these
+ * sizes) shows it is entirely outside cursor-owned code:
+ * Ref$Debug stack captures (-Dcassandra.debugrefcount=true in the ant test JVM, build.xml —
+ * production default is false) scaling with buffer-chunk Ref churn, chunk-cache machinery
+ * scaling with data volume, and per-key metadata (bloom/summary). The cursor reader/writer/
+ * compactor hot loops contribute ZERO scaling allocation: ClusteringPrefix.Kind.values()'s
+ * per-call array allocation on the cursor's hot read/write paths is already eliminated
+ * upstream via Kind.fromOrdinal() (CASSANDRA-21528).
+ * Ceiling 512KB = measured 450KB + margin; run-to-run variance of the min-of-3 measurement
+ * is ~hundreds of bytes, so this trips at a regression of ~+60KB ≈ +6 bytes per row.
+ * JMH gc.alloc.rate.norm remains the precision instrument; this is the always-on tripwire.
+ *
+ * The differential harness cannot catch allocation regressions — output bytes are identical
+ * whether or not the path allocates — hence this separate gate.
+ */
+public class CursorCompactionAllocationGateTest extends DifferentialCompactionTester
+{
+    private static final int SMALL_ROWS_PER_PARTITION = 100;
+    private static final int SMALL_PARTITIONS = 6;
+    private static final int SCALE = 10;
+    private static final int WARMUP_ITERATIONS = 4;
+    private static final int MEASURED_ITERATIONS = 3;
+    private static final long CEILING_BYTES = 512 * 1024;
+
+    @Test
+    public void allocationDoesNotScaleWithRows() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue("thread allocation measurement unsupported on this JVM",
+                          threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            long smallAlloc = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS, true);
+            long bigAlloc = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS * SCALE, true);
+            long delta = bigAlloc - smallAlloc;
+
+            // iterator-path numbers measured purely for context in the log: the iterator
+            // allocates per row/cell BY DESIGN and is not gated
+            long smallIter = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS, false);
+            long bigIter = measureSteadyStateAllocation(threadMXBean, SMALL_PARTITIONS * SCALE, false);
+
+            logger.info("cursor compaction allocation: small={}B big={}B delta={}B ceiling={}B " +
+                        "(iterator path for context: small={}B big={}B delta={}B)",
+                        smallAlloc, bigAlloc, delta, CEILING_BYTES,
+                        smallIter, bigIter, bigIter - smallIter);
+            assertTrue(String.format("cursor compaction allocation scales with data: " +
+                                     "%,dB (small) -> %,dB (big), delta %,dB exceeds ceiling %,dB. " +
+                                     "A per-row/cell allocation has been introduced on the cursor hot path.",
+                                     smallAlloc, bigAlloc, delta, CEILING_BYTES),
+                       delta <= CEILING_BYTES);
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    private long measureSteadyStateAllocation(com.sun.management.ThreadMXBean threadMXBean, int partitions, boolean cursor) throws Exception
+    {
+        return measureSteadyStateAllocation(threadMXBean, partitions, cursor, 2, "val", WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+    }
+
+    private long measureSteadyStateAllocation(com.sun.management.ThreadMXBean threadMXBean, int partitions, boolean cursor,
+                                              int rounds, String valuePadding, int warmup, int measured) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < rounds; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                    execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, valuePadding + ck);
+            flush();
+        }
+
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        // guard against vacuous measurement: the gate is meaningless if the cursor run
+        // silently fell back to the iterator pipeline
+        if (cursor)
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+        lastInputBytes = 0;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            lastInputBytes += sstable.onDiskLength();
+
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < warmup + measured; i++)
+        {
+            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            if (i >= warmup)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /** Total on-disk input bytes of the most recent measureSteadyStateAllocation call. */
+    private long lastInputBytes;
+
+    /**
+     * Measurement at realistic file sizes (4 input sstables of ~10MB each, uncompressed):
+     * 192 partitions x 100 rows x ~520B rows per file vs a 10x-smaller small run. Logs the
+     * numbers for calibration; the scaling assertion uses a provisional ceiling of 4x the
+     * small-file gate's, pending calibration from logged runs.
+     */
+    @Test
+    public void allocationAtLargeFileSizes() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        String padding = "v".repeat(500);
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        try
+        {
+            // 4 rounds = 4 input files; big: 192 partitions * 100 rows * ~520B = ~10MB/file
+            long smallAlloc = measureSteadyStateAllocation(threadMXBean, 19, true, 4, padding, 2, 2);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureSteadyStateAllocation(threadMXBean, 192, true, 4, padding, 2, 2);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            long smallIter = measureSteadyStateAllocation(threadMXBean, 19, false, 4, padding, 2, 2);
+            long bigIter = measureSteadyStateAllocation(threadMXBean, 192, false, 4, padding, 2, 2);
+
+            logger.info("LARGE-FILE cursor compaction allocation (4 files, ~10MB each big): " +
+                        "cursor small={}B big={}B delta={}B over {}B extra input = {}B/B; " +
+                        "iterator small={}B big={}B delta={}B",
+                        smallAlloc, bigAlloc, delta, extraBytes, String.format("%.3f", perInputByte),
+                        smallIter, bigIter, bigIter - smallIter);
+            // The residual scales with data VOLUME, not row count: JFR decomposition at this
+            // scale = 62% Ref$Debug stack captures (test-env only,
+            // -Dcassandra.debugrefcount=true), chunk-cache machinery, per-compaction
+            // constants — ZERO cursor-owned sites. Measured ~0.27 B allocated per extra
+            // input byte in the test env; ceiling 0.5 B/B trips on any real per-element
+            // regression while absorbing volume-proportional test-env noise.
+            assertTrue(String.format("cursor allocation per input byte too high: %.3f B/B (delta %,dB over %,dB)",
+                                     perInputByte, delta, extraBytes),
+                       perInputByte <= 0.5);
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Compacts all live sstables on the cursor path, measuring ONLY execute(); restores inputs. */
+    private long compactOnceMeasured(com.sun.management.ThreadMXBean threadMXBean, ColumnFamilyStore cfs, long gcBefore) throws Exception
+    {
+        Set<SSTableReader> inputs = new HashSet<>(cfs.getLiveSSTables());
+        Set<Descriptor> liveBeforeDescs = new HashSet<>();
+        List<Descriptor> inputDescriptors = new ArrayList<>();
+        for (SSTableReader in : inputs)
+        {
+            liveBeforeDescs.add(in.descriptor);
+            inputDescriptors.add(in.descriptor);
+        }
+
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting", txn);
+        CompactionTask task = new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */);
+
+        long tid = Thread.currentThread().getId();
+        long before = threadMXBean.getThreadAllocatedBytes(tid);
+        task.execute(ActiveCompactionsTracker.NOOP);
+        long allocated = threadMXBean.getThreadAllocatedBytes(tid) - before;
+
+        List<SSTableReader> retainedInputClones = new ArrayList<>();
+        List<SSTableReader> outputs = identifyOutputs(cfs, liveBeforeDescs, liveBeforeDescs, retainedInputClones);
+        restoreAfterCompaction(cfs, outputs, retainedInputClones, inputDescriptors, inputs.size());
+        return allocated;
+    }
+
+    /**
+     * Diagnostic, not a gate: records JFR allocation events (with stacks) over many warmed
+     * cursor compactions of the big table and dumps to /tmp/cursor-alloc.jfr for offline
+     * attribution of the scaling allocation (jfr print + aggregation). Always passes.
+     */
+    @Test
+    public void recordAllocationProfile() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            int partitions = SMALL_PARTITIONS * SCALE;
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < partitions; pk++)
+                    for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "val" + ck);
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+
+            for (int i = 0; i < WARMUP_ITERATIONS; i++)
+                compactOnceMeasured(threadMXBean, cfs, gcBefore);
+
+            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
+            {
+                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
+                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
+                recording.start();
+                for (int i = 0; i < 30; i++)
+                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
+                recording.stop();
+                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc.jfr"));
+            }
+            logger.info("allocation profile dumped to /tmp/cursor-alloc.jfr");
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    /** Diagnostic: JFR profile at large file sizes; dumps /tmp/cursor-alloc-large.jfr. */
+    @Test
+    public void recordLargeFileAllocationProfile() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+        String padding = "v".repeat(500);
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck)) " +
+                        "WITH compression = {'enabled': 'false'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+            for (int round = 0; round < 4; round++)
+            {
+                for (long pk = 0; pk < 192; pk++)
+                    for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, padding + ck);
+                flush();
+            }
+            long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+            assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+            for (int i = 0; i < 2; i++)
+                compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            try (jdk.jfr.Recording recording = new jdk.jfr.Recording())
+            {
+                recording.enable("jdk.ObjectAllocationInNewTLAB").withStackTrace();
+                recording.enable("jdk.ObjectAllocationOutsideTLAB").withStackTrace();
+                recording.start();
+                for (int i = 0; i < 8; i++)
+                    compactOnceMeasured(threadMXBean, cfs, gcBefore);
+                recording.stop();
+                recording.dump(java.nio.file.Path.of("/tmp/cursor-alloc-large.jfr"));
+            }
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    private static com.sun.management.ThreadMXBean threadMXBean()
+    {
+        java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        if (!(bean instanceof com.sun.management.ThreadMXBean))
+            return null;
+        com.sun.management.ThreadMXBean sunBean = (com.sun.management.ThreadMXBean) bean;
+        if (!sunBean.isThreadAllocatedMemorySupported())
+            return null;
+        if (!sunBean.isThreadAllocatedMemoryEnabled())
+            sunBean.setThreadAllocatedMemoryEnabled(true);
+        return sunBean;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorCompactionAllocationGateTest.java
@@ -302,6 +302,116 @@ public class CursorCompactionAllocationGateTest extends DifferentialCompactionTe
     }
 
     /**
+     * Sparse rows in a >= 64-column superset: the column subset uses the LARGE-subset wire
+     * format (index vints, present- or missing-mode), which the reader historically decoded
+     * by materializing a fresh Columns per row — cascading through CellCursor.init's
+     * identity cache into a per-row toArray + AbstractType[] rebuild + O(columns) getType
+     * lookups. The small-superset gate (allocationDoesNotScaleWithSparseRows) cannot see
+     * this: its mask fast path only covers < 64 columns. Rows alternate present-mode
+     * (3 of 70 set) and missing-mode (67 of 70 set) so both wire modes are exercised.
+     */
+    @Test
+    public void allocationDoesNotScaleWithWideSchemaSparseRows() throws Exception
+    {
+        com.sun.management.ThreadMXBean threadMXBean = threadMXBean();
+        Assume.assumeTrue(threadMXBean != null);
+
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        boolean originalCursorEnabled = DatabaseDescriptor.cursorCompactionEnabled();
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        try
+        {
+            long smallAlloc = measureWideSparse(threadMXBean, SMALL_PARTITIONS);
+            long smallBytes = lastInputBytes;
+            long bigAlloc = measureWideSparse(threadMXBean, SMALL_PARTITIONS * SCALE);
+            long bigBytes = lastInputBytes;
+            long delta = bigAlloc - smallAlloc;
+            long extraBytes = bigBytes - smallBytes;
+            double perInputByte = (double) delta / extraBytes;
+            logger.info("wide-schema sparse-row cursor compaction allocation: small={}B big={}B delta={}B " +
+                        "over {}B extra input = {} B/B",
+                        smallAlloc, bigAlloc, delta, extraBytes, String.format("%.3f", perInputByte));
+            // Per INPUT BYTE calibration: the mixed 3-of-70 and
+            // 67-of-70 rows make multi-MB inputs whose volume-proportional test-env residual
+            // (Ref$Debug, chunk cache) dwarfs any fixed ceiling. Measured post-fix: ~0.37 B/B
+            // (BIG). The pre-fix per-row cascade (fresh Columns + CellCursor rebuild per
+            // sparse row) measured ~3.8 B/B; a leak of one small object per row costs
+            // ~+0.2 B/B at this row size and trips the ceiling with margin.
+            assertTrue(String.format("wide-schema (>=64 col) sparse-row cursor allocation per input byte too high: " +
+                                     "%.3f B/B (delta %,dB over %,dB extra input)",
+                                     perInputByte, delta, extraBytes),
+                       perInputByte <= 0.6);
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+            DatabaseDescriptor.setCursorCompactionEnabled(originalCursorEnabled);
+        }
+    }
+
+    private long measureWideSparse(com.sun.management.ThreadMXBean threadMXBean, int partitions) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(true);
+        int cols = 70;
+        StringBuilder schema = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int c = 0; c < cols; c++)
+            schema.append(", c").append(c).append(" bigint");
+        schema.append(", PRIMARY KEY (pk, ck)) WITH compression = {'enabled': 'false'}");
+        createTable(schema.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // missing-mode insert: 67 of 70 columns (3 missing -> missing-index encoding)
+        StringBuilder wide = new StringBuilder("INSERT INTO %s (pk, ck");
+        StringBuilder marks = new StringBuilder("?, ?");
+        for (int c = 0; c < cols - 3; c++)
+        {
+            wide.append(", c").append(c);
+            marks.append(", ?");
+        }
+        String wideInsert = wide.append(") VALUES (").append(marks).append(")").toString();
+        Object[] wideArgs = new Object[2 + cols - 3];
+        for (int c = 0; c < cols - 3; c++)
+            wideArgs[2 + c] = (long) c;
+
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < partitions; pk++)
+                for (long ck = 0; ck < SMALL_ROWS_PER_PARTITION; ck++)
+                {
+                    if (ck % 2 == 0)
+                    {
+                        // present-mode: rotating 3-column window
+                        int base = (int) ((ck * 3) % (cols - 2));
+                        execute("INSERT INTO %s (pk, ck, c" + base + ", c" + (base + 1) + ", c" + (base + 2) +
+                                ") VALUES (?, ?, ?, ?, ?)", pk, ck, ck, ck + 1, ck + 2);
+                    }
+                    else
+                    {
+                        wideArgs[0] = pk;
+                        wideArgs[1] = ck;
+                        execute(wideInsert, wideArgs);
+                    }
+                }
+            flush();
+        }
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        assertCursorPathWillRun(cfs, cfs.getLiveSSTables(), gcBefore);
+        lastInputBytes = 0;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            lastInputBytes += sstable.onDiskLength();
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURED_ITERATIONS; i++)
+        {
+            long allocated = compactOnceMeasured(threadMXBean, cfs, gcBefore);
+            if (i >= WARMUP_ITERATIONS)
+                best = Math.min(best, allocated);
+        }
+        return best;
+    }
+
+    /**
      * Garbage-free property for RANGE-TOMBSTONE-dense workloads: the marker
      * read/merge/write path runs on the ReusableDeletionTime pool and open-marker tracking,
      * which the row-centric gates barely touch. Each partition carries 300 bounded range

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.notifications.INotificationConsumer;
+import org.apache.cassandra.notifications.SSTableListChangedNotification;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the cursor compaction support matrix.
+ *
+ * Each increment of the cursor completion work flips
+ * its row here from unsupported to supported. A change in the gate's semantics — whether it decides on the
+ * schema, on an input sstable's header, or on the compaction the controller describes — that silently
+ * widens or narrows the fallback becomes a test failure instead of a silently different code path in
+ * production.
+ */
+public class CursorSupportMatrixTest extends CQLTester
+{
+    private TableMetadata metadataFor(String createTable)
+    {
+        createTable(createTable);
+        return getCurrentColumnFamilyStore().metadata();
+    }
+
+    private void assertSupported(String createTable)
+    {
+        TableMetadata metadata = metadataFor(createTable);
+        assertFalse("expected cursor-supported metadata: " + metadata,
+                    CursorCompactor.unsupportedMetadata(metadata));
+    }
+
+    private void assertUnsupported(String createTable)
+    {
+        TableMetadata metadata = metadataFor(createTable);
+        assertTrue("expected cursor-UNsupported metadata: " + metadata,
+                   CursorCompactor.unsupportedMetadata(metadata));
+    }
+
+    @Test
+    public void simpleTableSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    @Test
+    public void staticColumnsSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, s text static, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    @Test
+    public void noClusteringSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint PRIMARY KEY, v text)");
+    }
+
+    /** Frozen collections/tuples/UDTs are single cells: inside the supported surface. */
+    @Test
+    public void frozenCollectionsSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, " +
+                        "m frozen<map<text, bigint>>, l frozen<list<text>>, s frozen<set<int>>, " +
+                        "t frozen<tuple<int, text>>, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Frozen UDT as the CLUSTERING key: still a single cell, not a regular column. */
+    @Test
+    public void frozenUdtInClusteringKeySupported()
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        assertSupported("CREATE TABLE %s (pk bigint, ck frozen<" + udt + ">, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Frozen UDT as (part of) the PARTITION key. */
+    @Test
+    public void frozenUdtInPartitionKeySupported()
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        assertSupported("CREATE TABLE %s (pk frozen<" + udt + ">, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Frozen collections as (part of) the PRIMARY key, not just as regular columns. */
+    @Test
+    public void frozenCollectionInPrimaryKeySupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck frozen<list<int>>, v text, PRIMARY KEY (pk, ck))");
+        assertSupported("CREATE TABLE %s (pk frozen<set<text>>, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 2 flips these to supported. */
+    @Test
+    public void multiCellCollectionsUnsupported()
+    {
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, m map<text, bigint>, PRIMARY KEY (pk, ck))");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, l list<text>, PRIMARY KEY (pk, ck))");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, s set<int>, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 2 flips this to supported. */
+    @Test
+    public void multiCellUdtUnsupported()
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, u " + udt + ", PRIMARY KEY (pk, ck))");
+    }
+
+    /** Vector and duration are inside the supported surface (single-cell types). */
+    @Test
+    public void vectorAndDurationSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, vec vector<float, 3>, dur duration, " +
+                        "PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 5 flips this to supported. */
+    @Test
+    public void countersUnsupported()
+    {
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, c counter, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Out of scope for the current plan: indexes keep the iterator path. */
+    @Test
+    public void secondaryIndexUnsupported()
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        createIndex("CREATE INDEX ON %s (v)");
+        assertTrue("expected index to disqualify cursor compaction",
+                   CursorCompactor.unsupportedMetadata(getCurrentColumnFamilyStore().metadata()));
+    }
+
+    /**
+     * Why the cursor path must refuse this is at the gate, in {@code CursorCompactor.isSupported}'s
+     * ignore-gc-grace branch. What is test-specific is when the gate can be observed.
+     * <p>
+     * The set exists only for the duration of the force compaction:
+     * {@code forceCompactionKeysIgnoringGcGrace} populates it, hands the keys to {@code CompactionManager},
+     * and clears it in a finally block. The gate therefore has to be evaluated from inside that window,
+     * which is what the tracker subscriber below is for — the compaction's own sstable swap is published on
+     * the compaction thread while the caller is still blocked inside the force compaction, with the set
+     * populated.
+     */
+    @Test
+    public void ignoreGcGraceForAnyKeyUnsupported() throws Throwable
+    {
+        // cursor compaction only supports BIG output, so under a non-BIG format isSupported is false for
+        // every table and the assertions below could not tell the ignore-gc-grace gate apart
+        Assume.assumeTrue("requires the BIG sstable format", BigFormat.isSelected());
+
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // pk 1 is the key forcecompact will name, and its row deletion is what that compaction is asked to
+        // purge ahead of gc grace; pk 2 keeps the output non-empty whatever the purge decides about pk 1,
+        // so the observer below always has an output sstable to gate on
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 1, 'x')");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (2, 1, 'y')");
+        flush();
+        execute("DELETE FROM %s WHERE pk = 1 AND ck = 1");
+        flush();
+
+        // control: the same table, the same two sstables, with nothing ignoring gc grace, is supported —
+        // so the rejection observed below is attributable to the key set and to no other gate
+        assertEquals("expected one sstable per flush", 2, cfs.getLiveSSTables().size());
+        assertFalse("no key should ignore gc grace outside a force compaction",
+                    cfs.shouldIgnoreGcGraceForAnyKey());
+        assertTrue("expected a plain two-sstable table to be cursor-supported",
+                   isSupportedNow(cfs));
+
+        AtomicReference<Boolean> ignoredGcGraceInside = new AtomicReference<>();
+        AtomicReference<Boolean> supportedInside = new AtomicReference<>();
+        AtomicReference<Throwable> observerFailure = new AtomicReference<>();
+        INotificationConsumer observer = (notification, sender) ->
+        {
+            if (!(notification instanceof SSTableListChangedNotification))
+                return;
+            // record the first sstable swap only, and record the key set before anything else, so that a
+            // throw below cannot leave the window unaccounted for
+            if (!ignoredGcGraceInside.compareAndSet(null, cfs.shouldIgnoreGcGraceForAnyKey()))
+                return;
+            try
+            {
+                // the compaction strategy manager subscribes to the tracker in the ColumnFamilyStore
+                // constructor, so it precedes this observer and has already taken the swap and released
+                // its lock: on the commit path the live set here is the compaction's output, and it is
+                // safe to open scanners over it
+                supportedInside.set(isSupportedNow(cfs));
+            }
+            catch (Throwable t)
+            {
+                // Tracker merges a subscriber's throw into the compaction's own failure, which would say
+                // nothing about the gate; carry it out and rethrow it on the calling thread instead
+                observerFailure.set(t);
+            }
+        };
+
+        cfs.getTracker().subscribe(observer);
+        try
+        {
+            cfs.forceCompactionKeysIgnoringGcGrace("1");
+        }
+        finally
+        {
+            cfs.getTracker().unsubscribe(observer);
+        }
+
+        if (observerFailure.get() != null)
+            throw observerFailure.get();
+
+        // the scenario is only covering its subject while the force compaction really compacts something
+        // with the key set populated; assert both, so it cannot go quiet and still pass
+        assertNotNull("expected the force compaction to change the sstable list while the observer was " +
+                      "subscribed; with no compaction there is no window in which the gate is exercised",
+                      ignoredGcGraceInside.get());
+        assertTrue("expected the ignore-gc-grace key set to be populated for the duration of the force " +
+                   "compaction; if it is not, the rejection below is not attributable to this gate",
+                   ignoredGcGraceInside.get());
+
+        assertNotNull("expected the observer to have evaluated the gate", supportedInside.get());
+        assertFalse("cursor compaction must refuse a table while any key ignores gc grace: the iterator " +
+                    "suppresses row-level purging wholesale there and a streaming cursor cannot",
+                    supportedInside.get());
+
+        // and the gate reopens once the force compaction has cleared the set, using the very same helper
+        // that returned false inside the window, so that assertion cannot be vacuously false
+        assertFalse("expected the key set to be cleared when the force compaction returned",
+                    cfs.shouldIgnoreGcGraceForAnyKey());
+        assertTrue("expected the table to be cursor-supported again after the force compaction",
+                   isSupportedNow(cfs));
+    }
+
+    /**
+     * A DROPPED non-frozen collection is gone from the schema but still present in the header of
+     * every sstable written before the drop, still multi-cell. The metadata-level check cannot see
+     * it, so the gate has to screen the input headers too — otherwise the cell cursor, which has no
+     * complex framing, misparses those rows.
+     */
+    @Test
+    public void droppedCollectionUnsupportedFromHeaders() throws Exception
+    {
+        assertDroppedCollectionUnsupported("CREATE TABLE %s (pk bigint, ck bigint, m map<text, text>, " +
+                                           "v text, PRIMARY KEY (pk, ck))",
+                                           "INSERT INTO %s (pk, ck, m, v) VALUES (1, 1, {'a':'b'}, 'x')",
+                                           false);
+    }
+
+    /**
+     * Same hole via a dropped STATIC collection, which lands in header.columns(true) only — so a
+     * check that inspected regular columns alone would pass this test's regular-column sibling and
+     * still admit the misparse.
+     */
+    @Test
+    public void droppedStaticCollectionUnsupportedFromHeaders() throws Exception
+    {
+        assertDroppedCollectionUnsupported("CREATE TABLE %s (pk bigint, ck bigint, " +
+                                           "m map<text, text> static, v text, PRIMARY KEY (pk, ck))",
+                                           "INSERT INTO %s (pk, ck, m, v) VALUES (1, 1, {'a':'b'}, 'x')",
+                                           true);
+    }
+
+    private void assertDroppedCollectionUnsupported(String ddl, String insert, boolean isStatic) throws Exception
+    {
+        // cursor compaction only supports BIG output, so under a non-BIG format isSupported is
+        // false for every table and the assertion below could not tell the header check apart
+        Assume.assumeTrue("requires the BIG sstable format", BigFormat.isSelected());
+
+        createTable(ddl);
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        execute(insert);
+        flush();
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 2, 'y')");
+        flush();
+
+        execute("ALTER TABLE %s DROP m");
+
+        // the schema-level check is satisfied: the collection is no longer a current column
+        assertFalse("dropped collection should leave the metadata check satisfied, which is exactly " +
+                    "why the header check is needed",
+                    CursorCompactor.unsupportedMetadata(cfs.metadata()));
+
+        // ... but the pre-drop sstable still carries it, multi-cell, in its own header
+        boolean anyHeaderStillHasIt = false;
+        for (SSTableReader reader : cfs.getLiveSSTables())
+            for (ColumnMetadata column : reader.header.columns(isStatic))
+                anyHeaderStillHasIt |= column.isComplex();
+        assertTrue("expected a pre-drop sstable header to still list the collection as multi-cell",
+                   anyHeaderStillHasIt);
+
+        assertFalse("cursor compaction must refuse a table whose input headers still carry a " +
+                    "multi-cell column; the cursor cannot parse complex framing",
+                    isSupportedNow(cfs));
+
+        // Positive control on a separate table: isSupportedNow returns true for an equivalent table
+        // that never had a collection, so the rejection above is attributable to the dropped column
+        // and not to the harness, the format or any other gate. (The table under test cannot serve
+        // as its own pre-drop control: while the collection is still live the SCHEMA check rejects
+        // it, which is the very check the drop defeats.)
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore plain = getCurrentColumnFamilyStore();
+        plain.disableAutoCompaction();
+        // same shape as the table under test after its drop — same surviving columns, same two
+        // inserts and two flushes — so the only difference left is the dropped collection itself
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 1, 'x')");
+        flush();
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 2, 'y')");
+        flush();
+        assertTrue("expected a plain table with no dropped collection to be cursor-supported",
+                   isSupportedNow(plain));
+    }
+
+    private boolean isSupportedNow(ColumnFamilyStore cfs) throws Exception
+    {
+        Set<SSTableReader> inputs = cfs.getLiveSSTables();
+        try (CompactionController controller = new CompactionController(cfs, inputs, FBUtilities.nowInSeconds());
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            return CursorCompactor.isSupported(scanners, controller);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the cursor compaction support matrix at the metadata level.
+ *
+ * Each increment of the cursor completion work (see doc/cursor-compaction-plan.md) flips
+ * its row here from unsupported to supported. A change in `unsupportedMetadata` semantics
+ * that silently widens or narrows the fallback becomes a test failure instead of a silently
+ * different code path in production.
+ */
+public class CursorSupportMatrixTest extends CQLTester
+{
+    private TableMetadata metadataFor(String createTable)
+    {
+        createTable(createTable);
+        return getCurrentColumnFamilyStore().metadata();
+    }
+
+    private void assertSupported(String createTable)
+    {
+        TableMetadata metadata = metadataFor(createTable);
+        assertFalse("expected cursor-supported metadata: " + metadata,
+                    CursorCompactor.unsupportedMetadata(metadata));
+    }
+
+    private void assertUnsupported(String createTable)
+    {
+        TableMetadata metadata = metadataFor(createTable);
+        assertTrue("expected cursor-UNsupported metadata: " + metadata,
+                   CursorCompactor.unsupportedMetadata(metadata));
+    }
+
+    @Test
+    public void simpleTableSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    @Test
+    public void staticColumnsSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, s text static, ck bigint, v text, PRIMARY KEY (pk, ck))");
+    }
+
+    @Test
+    public void noClusteringSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint PRIMARY KEY, v text)");
+    }
+
+    /** Frozen collections/tuples/UDTs are single cells: inside the supported surface. */
+    @Test
+    public void frozenCollectionsSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, " +
+                        "m frozen<map<text, bigint>>, l frozen<list<text>>, s frozen<set<int>>, " +
+                        "t frozen<tuple<int, text>>, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 2 flips these to supported. */
+    @Test
+    public void multiCellCollectionsUnsupported()
+    {
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, m map<text, bigint>, PRIMARY KEY (pk, ck))");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, l list<text>, PRIMARY KEY (pk, ck))");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, s set<int>, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 2 flips this to supported. */
+    @Test
+    public void multiCellUdtUnsupported()
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, u " + udt + ", PRIMARY KEY (pk, ck))");
+    }
+
+    /** Increment 5 flips this to supported. */
+    @Test
+    public void countersUnsupported()
+    {
+        assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, c counter, PRIMARY KEY (pk, ck))");
+    }
+
+    /** Out of scope for the current plan: indexes keep the iterator path. */
+    @Test
+    public void secondaryIndexUnsupported()
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        createIndex("CREATE INDEX ON %s (v)");
+        assertTrue("expected index to disqualify cursor compaction",
+                   CursorCompactor.unsupportedMetadata(getCurrentColumnFamilyStore().metadata()));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
@@ -18,11 +18,22 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
+import java.util.ArrayList;
+import java.util.Set;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
 import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -124,5 +135,97 @@ public class CursorSupportMatrixTest extends CQLTester
         createIndex("CREATE INDEX ON %s (v)");
         assertTrue("expected index to disqualify cursor compaction",
                    CursorCompactor.unsupportedMetadata(getCurrentColumnFamilyStore().metadata()));
+    }
+
+    /**
+     * A DROPPED non-frozen collection is gone from the schema but still present in the header of
+     * every sstable written before the drop, still multi-cell. The metadata-level check cannot see
+     * it, so the gate has to screen the input headers too — otherwise the cell cursor, which has no
+     * complex framing, misparses those rows.
+     */
+    @Test
+    public void droppedCollectionUnsupportedFromHeaders() throws Exception
+    {
+        assertDroppedCollectionUnsupported("CREATE TABLE %s (pk bigint, ck bigint, m map<text, text>, " +
+                                           "v text, PRIMARY KEY (pk, ck))",
+                                           "INSERT INTO %s (pk, ck, m, v) VALUES (1, 1, {'a':'b'}, 'x')",
+                                           false);
+    }
+
+    /**
+     * Same hole via a dropped STATIC collection, which lands in header.columns(true) only — so a
+     * check that inspected regular columns alone would pass this test's regular-column sibling and
+     * still admit the misparse.
+     */
+    @Test
+    public void droppedStaticCollectionUnsupportedFromHeaders() throws Exception
+    {
+        assertDroppedCollectionUnsupported("CREATE TABLE %s (pk bigint, ck bigint, " +
+                                           "m map<text, text> static, v text, PRIMARY KEY (pk, ck))",
+                                           "INSERT INTO %s (pk, ck, m, v) VALUES (1, 1, {'a':'b'}, 'x')",
+                                           true);
+    }
+
+    private void assertDroppedCollectionUnsupported(String ddl, String insert, boolean isStatic) throws Exception
+    {
+        // cursor compaction only supports BIG output, so under a non-BIG format isSupported is
+        // false for every table and the assertion below could not tell the header check apart
+        Assume.assumeTrue("requires the BIG sstable format", BigFormat.isSelected());
+
+        createTable(ddl);
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        execute(insert);
+        flush();
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 2, 'y')");
+        flush();
+
+        execute("ALTER TABLE %s DROP m");
+
+        // the schema-level check is satisfied: the collection is no longer a current column
+        assertFalse("dropped collection should leave the metadata check satisfied, which is exactly " +
+                    "why the header check is needed",
+                    CursorCompactor.unsupportedMetadata(cfs.metadata()));
+
+        // ... but the pre-drop sstable still carries it, multi-cell, in its own header
+        boolean anyHeaderStillHasIt = false;
+        for (SSTableReader reader : cfs.getLiveSSTables())
+            for (ColumnMetadata column : reader.header.columns(isStatic))
+                anyHeaderStillHasIt |= column.isComplex();
+        assertTrue("expected a pre-drop sstable header to still list the collection as multi-cell",
+                   anyHeaderStillHasIt);
+
+        assertFalse("cursor compaction must refuse a table whose input headers still carry a " +
+                    "multi-cell column; the cursor cannot parse complex framing",
+                    isSupportedNow(cfs));
+
+        // Positive control on a separate table: isSupportedNow returns true for an equivalent table
+        // that never had a collection, so the rejection above is attributable to the dropped column
+        // and not to the harness, the format or any other gate. (The table under test cannot serve
+        // as its own pre-drop control: while the collection is still live the SCHEMA check rejects
+        // it, which is the very check the drop defeats.)
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore plain = getCurrentColumnFamilyStore();
+        plain.disableAutoCompaction();
+        // same shape as the table under test after its drop — same surviving columns, same two
+        // inserts and two flushes — so the only difference left is the dropped collection itself
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 1, 'x')");
+        flush();
+        execute("INSERT INTO %s (pk, ck, v) VALUES (1, 2, 'y')");
+        flush();
+        assertTrue("expected a plain table with no dropped collection to be cursor-supported",
+                   isSupportedNow(plain));
+    }
+
+    private boolean isSupportedNow(ColumnFamilyStore cfs) throws Exception
+    {
+        Set<SSTableReader> inputs = cfs.getLiveSSTables();
+        try (CompactionController controller = new CompactionController(cfs, inputs, FBUtilities.nowInSeconds());
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            return CursorCompactor.isSupported(scanners, controller);
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
@@ -101,6 +101,14 @@ public class CursorSupportMatrixTest extends CQLTester
         assertUnsupported("CREATE TABLE %s (pk bigint, ck bigint, u " + udt + ", PRIMARY KEY (pk, ck))");
     }
 
+    /** Vector and duration are inside the supported surface (single-cell types). */
+    @Test
+    public void vectorAndDurationSupported()
+    {
+        assertSupported("CREATE TABLE %s (pk bigint, ck bigint, vec vector<float, 3>, dur duration, " +
+                        "PRIMARY KEY (pk, ck))");
+    }
+
     /** Increment 5 flips this to supported. */
     @Test
     public void countersUnsupported()

--- a/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/CursorSupportMatrixTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Pins the cursor compaction support matrix at the metadata level.
  *
- * Each increment of the cursor completion work (see doc/cursor-compaction-plan.md) flips
+ * Each increment of the cursor completion work flips
  * its row here from unsupported to supported. A change in `unsupportedMetadata` semantics
  * that silently widens or narrows the fallback becomes a test failure instead of a silently
  * different code path in production.

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -1,0 +1,913 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.LongSupplier;
+import java.util.regex.Pattern;
+
+import com.google.common.io.ByteStreams;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assume;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CompactionPipelineCounts;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.IVerifier;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
+import org.apache.cassandra.tools.JsonTransformer;
+import org.apache.cassandra.tools.Util;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.OutputHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Differential test harness for cursor-based vs iterator-based compaction.
+ *
+ * Runs the SAME input sstables through both {@code IteratorCompactionPipeline} and
+ * {@code CursorCompactionPipeline} (via the full production {@link CompactionTask} path,
+ * selected by {@link DatabaseDescriptor#setCursorCompactionEnabled}), captures both outputs,
+ * and asserts equivalence at two levels:
+ *
+ *  1. BYTE level: every output component must be byte-identical. There is deliberately NO
+ *     exception mechanism — nothing is allowed to diverge; every divergence found to date
+ *     has been a bug in one of the paths.
+ *  2. LOGICAL level: a canonical JSON dump (sstabledump format) of every output sstable
+ *     must match exactly, and key stats metadata must match.
+ *
+ * Correctness invariants of the harness itself:
+ *  - inputs are byte-identical for both runs: the first run keeps originals on disk
+ *    ({@code keepOriginals=true}) and the harness restores the live set from the original
+ *    descriptors without rewriting anything.
+ *  - the same gcBefore is passed to both runs, so purge decisions cannot flip between runs.
+ *  - the cursor run asserts {@link CursorCompactor#isSupported} up front, and both runs assert
+ *    afterwards that the compaction really selected the pipeline they asked for: supportability
+ *    alone does not establish that, because pipeline selection also consults
+ *    {@code cursorCompactionEnabled}. A run that silently fell back would compare a path with
+ *    itself and pass.
+ *
+ * nowInSec for TTL expiry evaluation is taken inside CompactionTask per run; scenarios that
+ * need TTL expiry boundaries placed deterministically (rather than sleeping past them) should
+ * use {@link #taskWithFixedNow} or the {@code LongSupplier}-taking overloads below instead of
+ * relying on wall-clock timing.
+ */
+public abstract class DifferentialCompactionTester extends CQLTester
+{
+    /** Fixed "now" used for JSON dumps so rendering cannot depend on wall clock. */
+    private static final long DUMP_NOW_SEC = 0;
+
+    /**
+     * Opt-in only: preserves a failed comparison's captured sstables under scratch instead of
+     * deleting them, for local post-mortem. Off by default deliberately — a scratch dir left
+     * behind on every failure is exactly the kind of thing that fills up a CI disk, especially
+     * for the multi-GB burn scenarios (BigVolume, LargePartition).
+     */
+    private static final boolean KEEP_SCRATCH_ON_FAILURE =
+        CassandraRelevantProperties.TEST_DIFFERENTIAL_KEEP_SCRATCH_ON_FAILURE.getBoolean();
+
+    // sstabledump's "expired" fields come from WALL CLOCK, not the fixed nowInSec above
+    // (JsonTransformer), so the two paths' captures can render them differently; the flag is
+    // derived from expires_at, which is still compared.
+    private static final Pattern EXPIRED_FLAG =
+        Pattern.compile("\"expired\"\\s*:\\s*(true|false)");
+
+    /**
+     * The rendered form of a CELL tombstone, for absolute assertions over {@link #allJson}. Row,
+     * range, partition and complex-column deletions all go through {@code serializeDeletion}, which
+     * writes {@code marked_deleted} first, so this matches cell tombstones only.
+     */
+    protected static final String CELL_TOMBSTONE = "\"deletion_info\":{\"local_delete_time\"";
+
+    /**
+     * Scale mode for very large scenarios (millions of rows): the logical dump is streamed
+     * into a SHA-256 digest instead of being retained as a String, so capture memory stays
+     * flat regardless of row count. Byte comparison always streams. On a digest mismatch
+     * the byte-level comparison (which still reports exact offsets) is the debugging tool;
+     * rerun a reduced scenario without scale mode for a row-level JSON diff.
+     */
+    protected boolean scaleCapture()
+    {
+        return false;
+    }
+
+    public static final class CapturedSSTable
+    {
+        final Path dir;                 // copied component files, named by component (e.g. "Data.db")
+        final String json;              // canonical logical dump; a SHA-256 digest string in scale mode
+        final String statsSummary;
+        final SortedMap<String, Long> componentSizes = new TreeMap<>();
+
+        CapturedSSTable(Path dir, String json, String statsSummary)
+        {
+            this.dir = dir;
+            this.json = json;
+            this.statsSummary = statsSummary;
+        }
+    }
+
+    public static final class CapturedOutput
+    {
+        final List<CapturedSSTable> sstables = new ArrayList<>();
+    }
+
+    /**
+     * Concatenates the canonical logical dump of every captured output sstable — or, in scale mode
+     * ({@link #scaleCapture()}), the per-sstable SHA-256 DIGEST strings. Any assertion of the form
+     * {@code allJson(out).contains(...)} is therefore vacuous in scale mode; a scale scenario must
+     * assert through the typed fields of {@link CapturedSSTable} or through a real SELECT.
+     */
+    protected static String allJson(CapturedOutput out)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (CapturedSSTable s : out.sstables)
+            sb.append(s.json);
+        return sb.toString();
+    }
+
+    /**
+     * The rendered form of a text-typed cell holding {@code text}, for ABSOLUTE assertions over
+     * {@link #allJson} — i.e. for stating which value a merge must have kept, rather than only that
+     * the two paths agreed on one. Byte-equality cannot see a rule that both paths get wrong.
+     * <p>
+     * {@code JsonTransformer.serializeCell} emits cells as COMPACT objects, so the field name and its
+     * value are adjacent with no whitespace. Including the closing quote matters: without it,
+     * {@code cellValue("aaa1")} also matches {@code "aaa19"}.
+     */
+    protected static String cellValue(String text)
+    {
+        return "\"value\":\"" + text + '"';
+    }
+
+    /**
+     * NON-OVERLAPPING occurrences of {@code needle} in {@code haystack} — the scan resumes past each
+     * match, so {@code countOccurrences("aaaa", "aa")} is 2, not 3. Every needle used here is a
+     * {@code "field":"value"} form that cannot overlap itself; a caller whose needle can must not use
+     * this. Scenarios use it to pin how MANY cells a merge kept, so a loop of per-value assertions
+     * cannot pass by covering nothing.
+     */
+    protected static int countOccurrences(String haystack, String needle)
+    {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length()))
+            count++;
+        return count;
+    }
+
+    /**
+     * The latest local deletion time recorded by any of the given sstables that actually has one, for
+     * scenarios that need a {@code gcBefore} placed relative to their own tombstones instead of relative
+     * to the wall clock.
+     * <p>
+     * The guard is the point: an sstable with no deletions — or one holding any live cell at all —
+     * reports {@link Cell#NO_DELETION_TIME} ({@code Long.MAX_VALUE}) as its max, so reading the field
+     * bare and adding one silently overflows to {@code Long.MIN_VALUE} — a {@code gcBefore} that makes
+     * nothing anywhere purgeable, which a scenario asserting that tombstones were RETAINED passes for
+     * entirely the wrong reason. Fails instead if the scenario produced no deletion at all.
+     */
+    protected static long maxTombstoneLocalDeletionTime(Iterable<SSTableReader> sstables)
+    {
+        long max = Long.MIN_VALUE;
+        for (SSTableReader sstable : sstables)
+        {
+            long ldt = sstable.getSSTableMetadata().maxLocalDeletionTime;
+            if (ldt != Cell.NO_DELETION_TIME)
+                max = Math.max(max, ldt);
+        }
+        assertTrue("scenario produced no tombstone deletion times", max > 0 && max < Long.MAX_VALUE);
+        return max;
+    }
+
+    /** Creates the CompactionTask for one differential run. MUST honor keepOriginals=true. */
+    public interface TaskFactory
+    {
+        CompactionTask create(ColumnFamilyStore cfs, LifecycleTransaction txn, long gcBefore);
+    }
+
+    public static final TaskFactory DEFAULT_TASK = (cfs, txn, gcBefore) -> new CompactionTask(cfs, txn, gcBefore, true);
+
+    /**
+     * A TaskFactory that pins CompactionTask's internal TTL-expiry "now" to a fixed value
+     * instead of wall-clock time, so scenarios with short TTLs don't need to sleep past the
+     * expiry boundary. keepOriginals mirrors {@link #DEFAULT_TASK}.
+     */
+    public static TaskFactory taskWithFixedNow(long nowInSeconds)
+    {
+        return (cfs, txn, gcBefore) -> new CompactionTask(cfs, txn, gcBefore, true).setNowInSecondsSupplier(() -> nowInSeconds);
+    }
+
+    /**
+     * Pins the precondition of a fixed-now TTL scenario: at least one cell in the current live set
+     * really has expired relative to nowInSeconds. A pinned "now" does not advance with the wall
+     * clock while the scenario writes, so a scenario that derived it before its write phase and
+     * then outran it would keep passing while comparing only unexpired cells — silently dropping
+     * the mechanism it exists to cover. Derive the pinned value after the last flush and call this.
+     * <p>
+     * What it does NOT establish: that the specific cells a scenario's absolute assertions name are the
+     * expired ones. {@code minLocalDeletionTime} is fed by row, range and partition deletions as well as by
+     * TTL expiry, and a tombstone's local deletion time is always about its write second — hence always at
+     * or below a now pinned just past it. So a scenario carrying both a tombstone and a long TTL satisfies
+     * this while its expiring cells sit far above the pin. {@code StatsMetadata.minTTL} cannot close that:
+     * a plain cell contributes the no-TTL sentinel, so any sstable holding one reports the sentinel however
+     * many expiring cells it also holds. Keep the scenario's own absolute assertions doing that work.
+     */
+    protected void assertSomethingExpiredAt(ColumnFamilyStore cfs, long nowInSeconds)
+    {
+        long minLocalDeletionTime = Long.MAX_VALUE;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            minLocalDeletionTime = Math.min(minLocalDeletionTime, sstable.getSSTableMetadata().minLocalDeletionTime);
+        assertTrue("no cell in the live set has expired relative to the pinned now " + nowInSeconds +
+                   "; the earliest local deletion time on disk is " + minLocalDeletionTime,
+                   minLocalDeletionTime <= nowInSeconds);
+    }
+
+    /**
+     * Runs both compaction paths over the current live sstables of the table and asserts
+     * byte + logical equivalence of every output component.
+     */
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs) throws Exception
+    {
+        return assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK);
+    }
+
+    /**
+     * Variant for partial-set compactions (inputs is a subset of the live sstables; the rest
+     * stay live and participate in purge-overlap decisions) and for custom CompactionTask
+     * shapes (e.g. multi-output writers via an overridden getCompactionAwareWriter).
+     */
+    /** Returns the iterator-path capture so scenarios can assert structural expectations
+     *  (e.g. multi-output scenarios MUST verify more than one sstable was produced —
+     *  a scenario that does not exercise its mechanism passes vacuously). */
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
+                                                         Set<SSTableReader> inputs,
+                                                         TaskFactory taskFactory) throws Exception
+    {
+        return assertCursorMatchesIterator(cfs, inputs, taskFactory,
+                                           cfs.getDefaultGcBefore(FBUtilities.nowInSeconds()));
+    }
+
+    /**
+     * Variant with an explicit gcBefore: lets scenarios place purge decisions EXACTLY at the
+     * boundary (purge requires localDeletionTime < gcBefore) without controlling the wall
+     * clock — read the actual deletion time from the flushed sstable's stats, then run with
+     * gcBefore == ldt (retained) and gcBefore == ldt + 1 (purged).
+     */
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
+                                                         Set<SSTableReader> inputs,
+                                                         TaskFactory taskFactory,
+                                                         long gcBefore) throws Exception
+    {
+        Path scratch = Files.createTempDirectory("differential-compaction");
+
+        // Early open stays ENABLED here deliberately: keepOriginals=true with early open used
+        // to delete the originals (SSTableRewriter.moveStarts obsoleted fully-covered inputs
+        // unconditionally — now fixed and guarded by the flag), and this harness depends on
+        // the originals surviving, so every differential run doubles as the regression test.
+        //
+        // scratch holds byte-for-byte copies of every captured output sstable (both paths) — it is
+        // deleted as soon as the comparison that needs them is done, rather than accumulating for the
+        // lifetime of the test JVM: with hundreds of invocations per fork (e.g. the randomized soak),
+        // leaving cleanup to the temp-dir removal at JVM exit let disk usage grow unbounded over a
+        // single run.
+        //
+        // On FAILURE the copies are, by default, ALSO deleted: by then restoreAfterCompaction has
+        // already deleted the real output sstables, and a re-run writes fresh timestamps, so scratch
+        // would otherwise be the only reproducible evidence of what diverged — that matters most for a
+        // LOGICAL divergence, which fails before the byte loop and so carries no offsets or hex
+        // context in its message at all. But a scratch dir left behind on every failure is exactly the
+        // kind of thing that fills up a CI disk, especially for the multi-GB burn scenarios, so default
+        // to cleaning up regardless; KEEP_SCRATCH_ON_FAILURE opts a local debugging run into
+        // preserving it instead.
+        boolean passed = false;
+        try
+        {
+            CapturedOutput iterator = compactPath(cfs, inputs, false, gcBefore, scratch.resolve("iterator"), taskFactory);
+            // the input INSTANCES were replaced during restore; re-resolve the subset by descriptor
+            Set<Descriptor> inputDescs = new HashSet<>();
+            for (SSTableReader in : inputs)
+                inputDescs.add(in.descriptor);
+            Set<SSTableReader> reResolved = new HashSet<>();
+            for (SSTableReader live : cfs.getLiveSSTables())
+                if (inputDescs.contains(live.descriptor))
+                    reResolved.add(live);
+            assertEquals("input subset lost across restore", inputs.size(), reResolved.size());
+            CapturedOutput cursor = compactPath(cfs, reResolved, true, gcBefore, scratch.resolve("cursor"), taskFactory);
+            assertEquivalentOutputs(iterator, cursor);
+            passed = true;
+            return iterator;
+        }
+        finally
+        {
+            if (passed || !KEEP_SCRATCH_ON_FAILURE)
+            {
+                // never rethrown: an IOException here would replace the AssertionError carrying the
+                // whole divergence report (if any) with an unrelated "Unable to delete directory"
+                try
+                {
+                    FileUtils.deleteDirectory(scratch.toFile());
+                }
+                catch (IOException e)
+                {
+                    logger.warn("could not delete differential scratch directory {}", scratch, e);
+                }
+            }
+            else
+            {
+                logger.error("differential comparison failed; both paths' captured sstables kept at {}", scratch);
+            }
+        }
+    }
+
+    /**
+     * Differential at TWO generations: the normal differential first (gen 1), then the inputs
+     * are genuinely compacted through the CURSOR path and the differential runs again over the
+     * cursor-produced outputs (gen 2). What gen 2 adds is INPUT SHAPES no flush in these
+     * scenarios produces: {@link org.apache.cassandra.db.SerializationHeader#make} gives its output
+     * the union of the inputs' column supersets — wider than any one of them wherever the
+     * scenario's flushes wrote different columns — and an EncodingStats base merged from their
+     * StatsMetadata minima, which timestamps, local deletion times and TTLs are delta-encoded
+     * against. That base is a minimum and the deltas are unsigned, so it sits at or below every
+     * value in the output, and purge or merge can leave it strictly below every surviving row by
+     * dropping the row that held it. A flush strands its own minimum the same way, so what differs
+     * is the width of the merge the base is taken over. The commit step in between also runs with
+     * keepOriginals=false, the real obsoletion path, which the differential runs themselves never
+     * take.
+     *
+     * Gen 2 is NOT a backstop for write-side corruption. Like gen 1, it hands the SAME input
+     * bytes to both readers, so a defect the two interpret alike passes at either generation.
+     * What the cursor WRITER put on disk is pinned by gen 1's per-component byte comparison, its
+     * logical dump, and the extended verification run over every output.
+     *
+     * Returns the GEN-1 iterator capture: scenario structural assertions target gen 1, whose
+     * shape the scenario controls directly.
+     */
+    protected CapturedOutput assertCursorMatchesIteratorAcrossGenerations(ColumnFamilyStore cfs) throws Exception
+    {
+        return assertCursorMatchesIteratorAcrossGenerations(cfs, FBUtilities::nowInSeconds);
+    }
+
+    /**
+     * As above, but pins CompactionTask's internal TTL-expiry "now" to nowInSecondsSupplier
+     * for every run (both generations) instead of reading the wall clock, so scenarios with
+     * short TTLs don't need to sleep past the expiry boundary.
+     */
+    protected CapturedOutput assertCursorMatchesIteratorAcrossGenerations(ColumnFamilyStore cfs,
+                                                                          LongSupplier nowInSecondsSupplier) throws Exception
+    {
+        TaskFactory taskFactory = (c, txn, gcBefore) -> new CompactionTask(c, txn, gcBefore, true).setNowInSecondsSupplier(nowInSecondsSupplier);
+        CapturedOutput gen1 = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), taskFactory);
+
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        commitCompaction(cfs, cfs.getLiveSSTables(), true, gcBefore, nowInSecondsSupplier);
+        if (cfs.getLiveSSTables().isEmpty())
+            return gen1; // gen 1 purged everything; there are no gen-2 inputs
+
+        assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), taskFactory);
+        return gen1;
+    }
+
+    /**
+     * Commits one compaction over the given inputs through the selected path WITHOUT restore:
+     * the live set genuinely becomes the outputs. Used by the cross-generation rung so the
+     * second differential reads cursor-produced sstables.
+     */
+    protected void commitCompaction(ColumnFamilyStore cfs, Set<SSTableReader> inputs, boolean cursor, long gcBefore) throws Exception
+    {
+        commitCompaction(cfs, inputs, cursor, gcBefore, FBUtilities::nowInSeconds);
+    }
+
+    /** As above, but pins CompactionTask's internal TTL-expiry "now" to nowInSecondsSupplier. */
+    protected void commitCompaction(ColumnFamilyStore cfs, Set<SSTableReader> inputs, boolean cursor, long gcBefore,
+                                    LongSupplier nowInSecondsSupplier) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+        if (cursor)
+            assertCursorPathWillRun(cfs, inputs, gcBefore);
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting for commit", txn);
+        // Same reasoning as compactPath: isSupported is supportability, not execution. This
+        // commit feeds the cross-generation rung's gen-2 inputs, so a silent fallback here would
+        // mean gen 2 never actually re-reads cursor-written output at all.
+        CompactionPipelineCounts before = CompactionPipelineCounts.mark();
+        new CompactionTask(cfs, txn, gcBefore, false).setNowInSecondsSupplier(nowInSecondsSupplier).execute(ActiveCompactionsTracker.NOOP);
+        CompactionPipelineCounts.assertPipelineRan(cursor, before);
+    }
+
+    /**
+     * Runs one compaction path over the given input subset (non-participating live sstables
+     * stay live and feed purge-overlap decisions), captures the outputs, and restores the live
+     * set so the other path sees identical bytes.
+     */
+    protected CapturedOutput compactPath(ColumnFamilyStore cfs,
+                                         Set<SSTableReader> inputs,
+                                         boolean cursor,
+                                         long gcBefore,
+                                         Path scratch,
+                                         TaskFactory taskFactory) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+
+        assertFalse("scenario produced no input sstables", inputs.isEmpty());
+        Set<Descriptor> liveBeforeDescs = new HashSet<>();
+        int liveBeforeCount = 0;
+        for (SSTableReader live : cfs.getLiveSSTables())
+        {
+            liveBeforeDescs.add(live.descriptor);
+            liveBeforeCount++;
+        }
+        List<Descriptor> inputDescriptors = new ArrayList<>();
+        for (SSTableReader in : inputs)
+        {
+            assertTrue("input is not live", liveBeforeDescs.contains(in.descriptor));
+            inputDescriptors.add(in.descriptor);
+        }
+        Set<Descriptor> inputDescs = new HashSet<>(inputDescriptors);
+
+        if (cursor)
+            assertCursorPathWillRun(cfs, inputs, gcBefore);
+
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting", txn);
+        // assertCursorPathWillRun only asserts CursorCompactor.isSupported, which is
+        // supportability, not execution: AbstractCompactionPipeline.create also gates on
+        // DatabaseDescriptor.cursorCompactionEnabled(), which isSupported never reads. Without
+        // this, a scenario that silently fell back to the iterator path would compare the
+        // iterator's output against itself and pass trivially, never having exercised the
+        // cursor path at all.
+        CompactionPipelineCounts before = CompactionPipelineCounts.mark();
+        taskFactory.create(cfs, txn, gcBefore).execute(ActiveCompactionsTracker.NOOP);
+        CompactionPipelineCounts.assertPipelineRan(cursor, before);
+
+        // Outputs are identified by descriptor diff against the pre-compaction live set:
+        // with keepOriginals=true the originals (or early-open clones with moved starts) may
+        // remain live as DIFFERENT reader instances, and non-participating sstables are live
+        // throughout. Instance identity is never trusted here.
+        List<SSTableReader> retainedInputClones = new ArrayList<>();
+        List<SSTableReader> outputs = identifyOutputs(cfs, liveBeforeDescs, inputDescs, retainedInputClones);
+
+        CapturedOutput captured = new CapturedOutput();
+        int seq = 0;
+        for (SSTableReader out : outputs)
+            captured.sstables.add(capture(cfs, out, scratch.resolve("sstable-" + seq++)));
+
+        restoreAfterCompaction(cfs, outputs, retainedInputClones, inputDescriptors, liveBeforeCount);
+
+        return captured;
+    }
+
+    /**
+     * Delists + releases outputs and any retained input clones, deletes output files only,
+     * then reopens every input fresh from its descriptor so a subsequent run sees pristine
+     * full-range readers identical to this run's. Non-participating sstables are untouched.
+     */
+    protected void restoreAfterCompaction(ColumnFamilyStore cfs,
+                                          List<SSTableReader> outputs,
+                                          List<SSTableReader> retainedInputClones,
+                                          List<Descriptor> inputDescriptors,
+                                          int liveBeforeCount) throws Exception
+    {
+        List<Path> outputFiles = new ArrayList<>();
+        for (SSTableReader out : outputs)
+            for (Component c : out.descriptor.discoverComponents())
+                outputFiles.add(out.descriptor.fileFor(c).toPath());
+
+        Set<SSTableReader> toRemove = new HashSet<>(outputs);
+        toRemove.addAll(retainedInputClones);
+        cfs.getTracker().removeUnsafe(toRemove);
+        for (SSTableReader reader : toRemove)
+            reader.selfRef().release();
+        for (Path f : outputFiles)
+            Files.deleteIfExists(f);
+
+        List<SSTableReader> reopened = new ArrayList<>();
+        for (Descriptor desc : inputDescriptors)
+        {
+            if (!desc.fileFor(org.apache.cassandra.io.sstable.format.SSTableFormat.Components.DATA).exists())
+                fail("input sstable lost during compaction (keepOriginals violated?): " + desc +
+                     "\ndata dir contents:\n" + listDataDir(desc));
+            reopened.add(SSTableReader.open(cfs, desc));
+        }
+        cfs.getTracker().addInitialSSTables(reopened);
+        assertEquals("restore failed: live sstable count", liveBeforeCount, cfs.getLiveSSTables().size());
+    }
+
+    /** Output identification by before/after descriptor diff; see compactPath for rationale. */
+    protected static List<SSTableReader> identifyOutputs(ColumnFamilyStore cfs,
+                                                         Set<Descriptor> liveBeforeDescs,
+                                                         Set<Descriptor> inputDescs,
+                                                         List<SSTableReader> retainedInputClonesOut)
+    {
+        List<SSTableReader> outputs = new ArrayList<>();
+        for (SSTableReader reader : cfs.getLiveSSTables())
+        {
+            if (!liveBeforeDescs.contains(reader.descriptor))
+                outputs.add(reader);
+            else if (inputDescs.contains(reader.descriptor))
+                retainedInputClonesOut.add(reader);
+        }
+        outputs.sort(Comparator.comparing(SSTableReader::getFirst));
+        return outputs;
+    }
+
+    /**
+     * Guards against the silent-fallback trap: if the cursor path would not actually run for
+     * this scenario, the test would compare iterator vs iterator and pass vacuously. Uses the
+     * same isSupported check production uses, on equivalent scanners and controller.
+     */
+    protected void assertCursorPathWillRun(ColumnFamilyStore cfs, Set<SSTableReader> inputs, long gcBefore) throws Exception
+    {
+        assumeBigFormatSelected();
+        try (CompactionController controller = new CompactionController(cfs, inputs, gcBefore);
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            assertTrue("scenario is not supported by cursor compaction; this harness run would " +
+                       "silently compare iterator vs iterator. If unsupported-ness is intended, " +
+                       "assert it explicitly instead.",
+                       CursorCompactor.isSupported(scanners, controller));
+        }
+    }
+
+    /**
+     * Cursor compaction only supports BIG output (CursorCompactor.isSupported), so under a non-BIG
+     * format — `ant test-latest` selects BTI — every scenario in this suite would fail for a reason
+     * that is not a defect. Skip instead, and keep the supportability assertion for every other
+     * unsupported-ness reason so the iterator-vs-iterator trap still fires.
+     * <p>
+     * Separate from {@link #assertCursorPathWillRun} so a scenario that drives the harness from
+     * inside a callback can raise it OUTSIDE that callback. JUnit decides skip-versus-fail on the
+     * type it receives, so an AssumptionViolatedException crossing a broad catch that rewraps — as
+     * Harry's TestHelper.withRandom does — arrives as a failure.
+     */
+    protected static void assumeBigFormatSelected()
+    {
+        Assume.assumeTrue("cursor compaction requires the BIG sstable format; selected=" +
+                          DatabaseDescriptor.getSelectedSSTableFormat().name(),
+                          BigFormat.isSelected());
+    }
+
+    private static String listDataDir(Descriptor desc)
+    {
+        try (java.util.stream.Stream<Path> files = Files.list(desc.directory.toPath()))
+        {
+            StringBuilder sb = new StringBuilder();
+            files.sorted().forEach(p -> sb.append("  ").append(p.getFileName()).append('\n'));
+            return sb.toString();
+        }
+        catch (IOException e)
+        {
+            return "  <failed to list: " + e + ">";
+        }
+    }
+
+    private CapturedSSTable capture(ColumnFamilyStore cfs, SSTableReader sstable, Path dir) throws IOException
+    {
+        // 1. structural verification of the output. In scale mode the verifier's debug
+        // stream must be silenced: the extended index walk debug-logs EVERY index block
+        // (~560K lines for a >2GiB partition), and ant's junit formatter buffers all test
+        // output in memory — the log volume, not the verification, OOMs the fork.
+        OutputHandler verifyOutput = scaleCapture()
+            ? new OutputHandler.LogOutput() { @Override public void debug(String msg) {} }
+            : new OutputHandler.LogOutput();
+        try (IVerifier verifier = sstable.getVerifier(cfs, verifyOutput, false,
+                                                      IVerifier.options().invokeDiskFailurePolicy(true)
+                                                                         .extendedVerification(true).build()))
+        {
+            verifier.verify();
+        }
+
+        // 2. canonical logical dump
+        // JsonTransformer's "expired" fields are computed from WALL CLOCK
+        // (currentTimeMillis), ignoring the fixed nowInSec passed below — so byte-identical
+        // outputs can render differently when a localExpirationTime falls between the two
+        // paths' captures, which run seconds apart (materialized-view expired-liveness rows
+        // sit permanently on that boundary: their expiration IS the write second). The flag
+        // is derived from expires_at, which is still compared, so normalize it out.
+        String json;
+        if (scaleCapture())
+        {
+            // stream into a digest: capture memory stays flat at millions of rows
+            try (ISSTableScanner scanner = sstable.getScanner())
+            {
+                java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+                NormalizingDigestOutputStream out = new NormalizingDigestOutputStream(digest);
+                JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
+                                            sstable.metadata(), DUMP_NOW_SEC, out);
+                out.flushTail();
+                json = "sha256:" + org.apache.cassandra.utils.Hex.bytesToHex(digest.digest()) +
+                       " (" + out.bytesSeen + " bytes)";
+            }
+            catch (java.security.NoSuchAlgorithmException e)
+            {
+                throw new AssertionError(e);
+            }
+        }
+        else
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ISSTableScanner scanner = sstable.getScanner())
+            {
+                JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
+                                            sstable.metadata(), DUMP_NOW_SEC, baos);
+            }
+            json = EXPIRED_FLAG.matcher(baos.toString(StandardCharsets.UTF_8))
+                               .replaceAll("\"expired\":\"normalized\"");
+        }
+
+        // 3. stats spot-check summary
+        StatsMetadata stats = sstable.getSSTableMetadata();
+        String statsSummary = "minTimestamp=" + stats.minTimestamp +
+                              " maxTimestamp=" + stats.maxTimestamp +
+                              " minLocalDeletionTime=" + stats.minLocalDeletionTime +
+                              " maxLocalDeletionTime=" + stats.maxLocalDeletionTime +
+                              " estimatedKeys=" + sstable.estimatedKeys() +
+                              " totalRows=" + stats.totalRows +
+                              " totalColumnsSet=" + stats.totalColumnsSet +
+                              " encodingStats=" + sstable.header.stats();
+
+        // 4. copy components for byte comparison
+        Files.createDirectories(dir);
+        CapturedSSTable captured = new CapturedSSTable(dir, json, statsSummary);
+        for (Component c : sstable.descriptor.discoverComponents())
+        {
+            Path source = sstable.descriptor.fileFor(c).toPath();
+            Path target = dir.resolve(c.name());
+            Files.copy(source, target);
+            captured.componentSizes.put(c.name(), Files.size(target));
+        }
+        return captured;
+    }
+
+    protected void assertEquivalentOutputs(CapturedOutput iterator, CapturedOutput cursor)
+    {
+        assertEquals("output sstable count differs between paths", iterator.sstables.size(), cursor.sstables.size());
+        for (int i = 0; i < iterator.sstables.size(); i++)
+        {
+            CapturedSSTable it = iterator.sstables.get(i);
+            CapturedSSTable cu = cursor.sstables.get(i);
+
+            // logical first: a row-level diff is far more debuggable than a stats mismatch.
+            // In scale mode the dump is a digest — defer it below the byte comparison, which
+            // still localizes divergences to exact offsets.
+            boolean digestMode = it.json.startsWith("sha256:");
+            if (!digestMode && !it.json.equals(cu.json))
+                fail("LOGICAL divergence in output sstable " + i + " (iterator vs cursor):\n" + firstJsonDiff(it.json, cu.json) +
+                     "\niterator stats: " + it.statsSummary + "\ncursor stats:   " + cu.statsSummary);
+
+            assertEquals("stats summary divergence in output sstable " + i, it.statsSummary, cu.statsSummary);
+
+            SortedSet<String> components = new TreeSet<>();
+            components.addAll(it.componentSizes.keySet());
+            components.addAll(cu.componentSizes.keySet());
+            List<String> divergences = new ArrayList<>();
+            for (String comp : components)
+            {
+                Path a = it.dir.resolve(comp);
+                Path b = cu.dir.resolve(comp);
+                boolean hasA = Files.exists(a);
+                boolean hasB = Files.exists(b);
+                if (hasA != hasB)
+                {
+                    divergences.add(String.format("  %s: present only in %s path", comp, hasA ? "iterator" : "cursor"));
+                    continue;
+                }
+                if (!hasA)
+                    continue;
+                long firstDiff = firstFileDifference(a, b);
+                if (firstDiff < 0)
+                    continue;
+                divergences.add(describeFileDiff(comp, a, b, firstDiff));
+            }
+            if (!divergences.isEmpty())
+                fail("BYTE divergence in output sstable " + i + " (iterator vs cursor):\n" + String.join("\n", divergences) +
+                     "\nNothing is allowed to diverge: every divergence found to date has been a bug in one of the paths");
+
+            if (digestMode)
+                assertEquals("logical dump digest divergence in output sstable " + i +
+                             " (scale mode; rerun a reduced scenario without scale mode for a row-level diff)",
+                             it.json, cu.json);
+        }
+    }
+
+    /** Streaming comparison: -1 if byte-identical, else the offset of the first difference
+     *  (the shorter length when one file is a prefix of the other). */
+    private static long firstFileDifference(Path a, Path b)
+    {
+        try (java.io.InputStream ia = new java.io.BufferedInputStream(Files.newInputStream(a), 1 << 16);
+             java.io.InputStream ib = new java.io.BufferedInputStream(Files.newInputStream(b), 1 << 16))
+        {
+            byte[] bufA = new byte[1 << 16];
+            byte[] bufB = new byte[1 << 16];
+            long offset = 0;
+            while (true)
+            {
+                int readA = ia.readNBytes(bufA, 0, bufA.length);
+                int readB = ib.readNBytes(bufB, 0, bufB.length);
+                int common = Math.min(readA, readB);
+                int mismatch = java.util.Arrays.mismatch(bufA, 0, common, bufB, 0, common);
+                if (mismatch >= 0)
+                    return offset + mismatch;
+                if (readA != readB)
+                    return offset + common; // same prefix, different length
+                if (readA == 0)
+                    return -1;
+                offset += readA;
+            }
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String describeFileDiff(String component, Path a, Path b, long firstDiff)
+    {
+        try
+        {
+            return String.format("  %s: lengths %d vs %d, first divergence at offset %d%n    iterator: %s%n    cursor:   %s",
+                                 component, Files.size(a), Files.size(b), firstDiff,
+                                 hexContext(a, firstDiff), hexContext(b, firstDiff));
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String hexContext(Path file, long offset) throws IOException
+    {
+        long size = Files.size(file);
+        long from = Math.max(0, offset - 8);
+        int len = (int) Math.min(size - from, 32);
+        byte[] window = new byte[Math.max(len, 0)];
+        try (java.io.InputStream in = Files.newInputStream(file))
+        {
+            ByteStreams.skipFully(in, from);
+            in.readNBytes(window, 0, window.length);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < window.length; i++)
+        {
+            long abs = from + i;
+            if (abs == offset)
+                sb.append('[');
+            sb.append(String.format("%02x", window[i]));
+            if (abs == offset)
+                sb.append(']');
+            sb.append(' ');
+        }
+        if (from + window.length < size)
+            sb.append("...");
+        return sb.toString();
+    }
+
+    /**
+     * Streams a JSON dump into a digest, normalizing the wall-clock-derived "expired"
+     * fields. Buffers up to a line (toJsonLines emits one partition per line), but flushes
+     * oversized lines in bounded chunks so memory stays flat even for multi-GB partitions.
+     * The cut points are functions of CONTENT ONLY (buffer fill, not write() granularity), so
+     * two captures of identical bytes cut in identical places. The cut is NOT token-safe, though:
+     * a chunk boundary can fall inside an "expired":... token, and both halves then miss the
+     * pattern and go un-normalized — harmless while the two captures render that flag
+     * identically, a divergence if they do not (the two renderings differ in length, so it also
+     * shifts every later cut point). Only a line above FLUSH_THRESHOLD is cut at all, i.e. only
+     * the giant-partition scenario.
+     */
+    private static final class NormalizingDigestOutputStream extends java.io.OutputStream
+    {
+        private static final int FLUSH_THRESHOLD = 8 << 20;
+        private static final int TAIL_KEEP = 64; // > the longest normalized token
+
+        private final java.security.MessageDigest digest;
+        private final ByteArrayOutputStream line = new ByteArrayOutputStream();
+        long bytesSeen;
+
+        NormalizingDigestOutputStream(java.security.MessageDigest digest)
+        {
+            this.digest = digest;
+        }
+
+        @Override
+        public void write(int b)
+        {
+            line.write(b);
+            if (b == '\n')
+                flushTail();
+            else if (line.size() >= FLUSH_THRESHOLD)
+                flushChunk();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len)
+        {
+            for (int i = off; i < off + len; i++)
+                write(b[i]);
+        }
+
+        /** Digest all buffered content (end of a line or of the stream). */
+        void flushTail()
+        {
+            if (line.size() == 0)
+                return;
+            update(line.toByteArray(), line.size());
+            line.reset();
+        }
+
+        /** Digest all but the last TAIL_KEEP buffered bytes, so a token still incomplete at the end
+         *  of the buffer survives into the next write: TAIL_KEEP exceeds the longest token, so such
+         *  a token cannot have begun before the cut. */
+        private void flushChunk()
+        {
+            byte[] buffered = line.toByteArray();
+            int processed = buffered.length - TAIL_KEEP;
+            update(buffered, processed);
+            line.reset();
+            line.write(buffered, processed, TAIL_KEEP);
+        }
+
+        private void update(byte[] bytes, int length)
+        {
+            byte[] normalized = EXPIRED_FLAG.matcher(new String(bytes, 0, length, StandardCharsets.UTF_8))
+                                            .replaceAll("\"expired\":\"normalized\"")
+                                            .getBytes(StandardCharsets.UTF_8);
+            digest.update(normalized);
+            bytesSeen += normalized.length;
+        }
+    }
+
+    private static String firstJsonDiff(String a, String b)
+    {
+        String[] linesA = a.split("\n", -1);
+        String[] linesB = b.split("\n", -1);
+        int max = Math.max(linesA.length, linesB.length);
+        for (int i = 0; i < max; i++)
+        {
+            String la = i < linesA.length ? linesA[i] : "<missing>";
+            String lb = i < linesB.length ? linesB[i] : "<missing>";
+            if (!la.equals(lb))
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.append("first differing line ").append(i + 1).append(" of ").append(max).append(":\n");
+                for (int j = Math.max(0, i - 2); j < Math.min(max, i + 3); j++)
+                {
+                    String ja = j < linesA.length ? linesA[j] : "<missing>";
+                    String jb = j < linesB.length ? linesB[j] : "<missing>";
+                    sb.append(j == i ? ">>" : "  ").append(" iterator: ").append(ja).append('\n');
+                    sb.append(j == i ? ">>" : "  ").append(" cursor:   ").append(jb).append('\n');
+                }
+                return sb.toString();
+            }
+        }
+        return "(no line diff found despite string inequality — check line endings)";
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -143,7 +143,22 @@ public abstract class DifferentialCompactionTester extends CQLTester
                                                          Set<String> byteDiffAllowlist,
                                                          TaskFactory taskFactory) throws Exception
     {
-        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        return assertCursorMatchesIterator(cfs, inputs, byteDiffAllowlist, taskFactory,
+                                           cfs.getDefaultGcBefore(FBUtilities.nowInSeconds()));
+    }
+
+    /**
+     * Variant with an explicit gcBefore: lets scenarios place purge decisions EXACTLY at the
+     * boundary (purge requires localDeletionTime < gcBefore) without controlling the wall
+     * clock — read the actual deletion time from the flushed sstable's stats, then run with
+     * gcBefore == ldt (retained) and gcBefore == ldt + 1 (purged).
+     */
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
+                                                         Set<SSTableReader> inputs,
+                                                         Set<String> byteDiffAllowlist,
+                                                         TaskFactory taskFactory,
+                                                         long gcBefore) throws Exception
+    {
         Path scratch = Files.createTempDirectory("differential-compaction");
 
         // Early open must be off for keepOriginals to actually keep originals:

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -130,6 +130,15 @@ public abstract class DifferentialCompactionTester extends CQLTester
         final List<CapturedSSTable> sstables = new ArrayList<>();
     }
 
+    /** Concatenates the canonical logical dump of every captured output sstable. */
+    protected static String allJson(CapturedOutput out)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (CapturedSSTable s : out.sstables)
+            sb.append(s.json);
+        return sb.toString();
+    }
+
     /** Creates the CompactionTask for one differential run. MUST honor keepOriginals=true. */
     public interface TaskFactory
     {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -373,8 +373,14 @@ public abstract class DifferentialCompactionTester extends CQLTester
 
     private CapturedSSTable capture(ColumnFamilyStore cfs, SSTableReader sstable, Path dir) throws IOException
     {
-        // 1. structural verification of the output
-        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false,
+        // 1. structural verification of the output. In scale mode the verifier's debug
+        // stream must be silenced: the extended index walk debug-logs EVERY index block
+        // (~560K lines for a >2GiB partition), and ant's junit formatter buffers all test
+        // output in memory — the log volume, not the verification, OOMs the fork.
+        OutputHandler verifyOutput = scaleCapture()
+            ? new OutputHandler.LogOutput() { @Override public void debug(String msg) {} }
+            : new OutputHandler.LogOutput();
+        try (IVerifier verifier = sstable.getVerifier(cfs, verifyOutput, false,
                                                       IVerifier.options().invokeDiskFailurePolicy(true)
                                                                          .extendedVerification(true).build()))
         {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -573,10 +573,19 @@ public abstract class DifferentialCompactionTester extends CQLTester
         return sb.toString();
     }
 
-    /** Streams a JSON dump into a digest, normalizing the wall-clock-derived "expired"
-     *  fields line by line (toJsonLines emits one partition per line). */
+    /**
+     * Streams a JSON dump into a digest, normalizing the wall-clock-derived "expired"
+     * fields. Buffers up to a line (toJsonLines emits one partition per line), but flushes
+     * oversized lines in bounded chunks so memory stays flat even for multi-GB partitions:
+     * the chunk cut keeps a small unprocessed tail so a normalization token can never be
+     * split, and the cut points are functions of CONTENT ONLY (buffer fill, not write()
+     * granularity), so both captures digest identical normalized streams.
+     */
     private static final class NormalizingDigestOutputStream extends java.io.OutputStream
     {
+        private static final int FLUSH_THRESHOLD = 8 << 20;
+        private static final int TAIL_KEEP = 64; // > the longest normalized token
+
         private final java.security.MessageDigest digest;
         private final ByteArrayOutputStream line = new ByteArrayOutputStream();
         long bytesSeen;
@@ -592,36 +601,44 @@ public abstract class DifferentialCompactionTester extends CQLTester
             line.write(b);
             if (b == '\n')
                 flushTail();
+            else if (line.size() >= FLUSH_THRESHOLD)
+                flushChunk();
         }
 
         @Override
         public void write(byte[] b, int off, int len)
         {
-            int start = off;
-            int end = off + len;
-            for (int i = off; i < end; i++)
-            {
-                if (b[i] == '\n')
-                {
-                    line.write(b, start, i - start + 1);
-                    flushTail();
-                    start = i + 1;
-                }
-            }
-            if (start < end)
-                line.write(b, start, end - start);
+            for (int i = off; i < off + len; i++)
+                write(b[i]);
         }
 
+        /** Digest all buffered content (end of a line or of the stream). */
         void flushTail()
         {
             if (line.size() == 0)
                 return;
-            byte[] normalized = line.toString(StandardCharsets.UTF_8)
-                                    .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"")
-                                    .getBytes(StandardCharsets.UTF_8);
+            update(line.toByteArray(), line.size());
+            line.reset();
+        }
+
+        /** Digest all but the last TAIL_KEEP buffered bytes; the tail stays buffered so the
+         *  "expired":... token can never straddle a chunk cut. */
+        private void flushChunk()
+        {
+            byte[] buffered = line.toByteArray();
+            int processed = buffered.length - TAIL_KEEP;
+            update(buffered, processed);
+            line.reset();
+            line.write(buffered, processed, TAIL_KEEP);
+        }
+
+        private void update(byte[] bytes, int length)
+        {
+            byte[] normalized = new String(bytes, 0, length, StandardCharsets.UTF_8)
+                                .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"")
+                                .getBytes(StandardCharsets.UTF_8);
             digest.update(normalized);
             bytesSeen += normalized.length;
-            line.reset();
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -92,6 +92,12 @@ public abstract class DifferentialCompactionTester extends CQLTester
     /** Fixed "now" used for JSON dumps so rendering cannot depend on wall clock. */
     private static final long DUMP_NOW_SEC = 0;
 
+    // sstabledump's "expired" fields come from WALL CLOCK, not the fixed nowInSec above
+    // (JsonTransformer), so the two paths' captures can render them differently; the flag is
+    // derived from expires_at, which is still compared.
+    private static final java.util.regex.Pattern EXPIRED_FLAG =
+        java.util.regex.Pattern.compile("\"expired\"\\s*:\\s*(true|false)");
+
     /**
      * Scale mode for very large scenarios (millions of rows): the logical dump is streamed
      * into a SHA-256 digest instead of being retained as a String, so capture memory stays
@@ -422,7 +428,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
                                             sstable.metadata(), DUMP_NOW_SEC, baos);
             }
             json = baos.toString(StandardCharsets.UTF_8)
-                       .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"");
+                       .transform(s -> EXPIRED_FLAG.matcher(s).replaceAll("\"expired\":\"normalized\""));
         }
 
         // 3. stats spot-check summary
@@ -633,9 +639,9 @@ public abstract class DifferentialCompactionTester extends CQLTester
 
         private void update(byte[] bytes, int length)
         {
-            byte[] normalized = new String(bytes, 0, length, StandardCharsets.UTF_8)
-                                .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"")
-                                .getBytes(StandardCharsets.UTF_8);
+            byte[] normalized = EXPIRED_FLAG.matcher(new String(bytes, 0, length, StandardCharsets.UTF_8))
+                                            .replaceAll("\"expired\":\"normalized\"")
+                                            .getBytes(StandardCharsets.UTF_8);
             digest.update(normalized);
             bytesSeen += normalized.length;
         }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -69,8 +69,9 @@ import static org.junit.Assert.fail;
  * selected by {@link DatabaseDescriptor#setCursorCompactionEnabled}), captures both outputs,
  * and asserts equivalence at two levels:
  *
- *  1. BYTE level: every output component must be byte-identical, unless the component is
- *     in the explicit allowlist of known/justified divergences.
+ *  1. BYTE level: every output component must be byte-identical. There is deliberately NO
+ *     exception mechanism — nothing is allowed to diverge; every divergence found to date
+ *     has been a bug in one of the paths.
  *  2. LOGICAL level: a canonical JSON dump (sstabledump format) of every output sstable
  *     must match exactly, and key stats metadata must match.
  *
@@ -133,13 +134,11 @@ public abstract class DifferentialCompactionTester extends CQLTester
 
     /**
      * Runs both compaction paths over the current live sstables of the table and asserts
-     * byte + logical equivalence. The byteDiffAllowlist contains component names (e.g.
-     * "Statistics.db") that are permitted to differ at the byte level; logical equivalence
-     * is always enforced.
+     * byte + logical equivalence of every output component.
      */
-    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs, Set<String> byteDiffAllowlist) throws Exception
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs) throws Exception
     {
-        return assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), byteDiffAllowlist, DEFAULT_TASK);
+        return assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK);
     }
 
     /**
@@ -152,10 +151,9 @@ public abstract class DifferentialCompactionTester extends CQLTester
      *  a scenario that does not exercise its mechanism passes vacuously). */
     protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
                                                          Set<SSTableReader> inputs,
-                                                         Set<String> byteDiffAllowlist,
                                                          TaskFactory taskFactory) throws Exception
     {
-        return assertCursorMatchesIterator(cfs, inputs, byteDiffAllowlist, taskFactory,
+        return assertCursorMatchesIterator(cfs, inputs, taskFactory,
                                            cfs.getDefaultGcBefore(FBUtilities.nowInSeconds()));
     }
 
@@ -167,7 +165,6 @@ public abstract class DifferentialCompactionTester extends CQLTester
      */
     protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
                                                          Set<SSTableReader> inputs,
-                                                         Set<String> byteDiffAllowlist,
                                                          TaskFactory taskFactory,
                                                          long gcBefore) throws Exception
     {
@@ -190,7 +187,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
                     reResolved.add(live);
             assertEquals("input subset lost across restore", inputs.size(), reResolved.size());
             CapturedOutput cursor = compactPath(cfs, reResolved, true, gcBefore, scratch.resolve("cursor"), taskFactory);
-            assertEquivalentOutputs(iterator, cursor, byteDiffAllowlist);
+            assertEquivalentOutputs(iterator, cursor);
             return iterator;
         }
     }
@@ -206,17 +203,16 @@ public abstract class DifferentialCompactionTester extends CQLTester
      * Returns the GEN-1 iterator capture: scenario structural assertions target gen 1, whose
      * shape the scenario controls directly.
      */
-    protected CapturedOutput assertCursorMatchesIteratorAcrossGenerations(ColumnFamilyStore cfs,
-                                                                          Set<String> byteDiffAllowlist) throws Exception
+    protected CapturedOutput assertCursorMatchesIteratorAcrossGenerations(ColumnFamilyStore cfs) throws Exception
     {
-        CapturedOutput gen1 = assertCursorMatchesIterator(cfs, byteDiffAllowlist);
+        CapturedOutput gen1 = assertCursorMatchesIterator(cfs);
 
         long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
         commitCompaction(cfs, cfs.getLiveSSTables(), true, gcBefore);
         if (cfs.getLiveSSTables().isEmpty())
             return gen1; // gen 1 purged everything; there are no gen-2 inputs
 
-        assertCursorMatchesIterator(cfs, byteDiffAllowlist);
+        assertCursorMatchesIterator(cfs);
         return gen1;
     }
 
@@ -447,7 +443,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
         return captured;
     }
 
-    protected void assertEquivalentOutputs(CapturedOutput iterator, CapturedOutput cursor, Set<String> byteDiffAllowlist)
+    protected void assertEquivalentOutputs(CapturedOutput iterator, CapturedOutput cursor)
     {
         assertEquals("output sstable count differs between paths", iterator.sstables.size(), cursor.sstables.size());
         for (int i = 0; i < iterator.sstables.size(); i++)
@@ -477,8 +473,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
                 boolean hasB = Files.exists(b);
                 if (hasA != hasB)
                 {
-                    if (!byteDiffAllowlist.contains(comp))
-                        divergences.add(String.format("  %s: present only in %s path", comp, hasA ? "iterator" : "cursor"));
+                    divergences.add(String.format("  %s: present only in %s path", comp, hasA ? "iterator" : "cursor"));
                     continue;
                 }
                 if (!hasA)
@@ -486,13 +481,11 @@ public abstract class DifferentialCompactionTester extends CQLTester
                 long firstDiff = firstFileDifference(a, b);
                 if (firstDiff < 0)
                     continue;
-                if (byteDiffAllowlist.contains(comp))
-                    continue; // logical equivalence still asserted
                 divergences.add(describeFileDiff(comp, a, b, firstDiff));
             }
             if (!divergences.isEmpty())
                 fail("BYTE divergence in output sstable " + i + " (iterator vs cursor):\n" + String.join("\n", divergences) +
-                     "\nIf a divergence is benign it must be added to the allowlist with a justifying comment next to the allowlist entry");
+                     "\nNothing is allowed to diverge: every divergence found to date has been a bug in one of the paths");
 
             if (digestMode)
                 assertEquals("logical dump digest divergence in output sstable " + i +

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -35,6 +35,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Assume;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
@@ -51,6 +52,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.IVerifier;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.tools.JsonTransformer;
 import org.apache.cassandra.tools.Util;
@@ -374,6 +376,14 @@ public abstract class DifferentialCompactionTester extends CQLTester
      */
     protected void assertCursorPathWillRun(ColumnFamilyStore cfs, Set<SSTableReader> inputs, long gcBefore) throws Exception
     {
+        // Cursor compaction only supports BIG output (CursorCompactor.isSupported), so under a
+        // non-BIG format — `ant test-latest` selects BTI — every scenario in this suite would fail
+        // the assertion below for a reason that is not a defect. Skip instead, and keep the
+        // assertion for every other unsupported-ness reason so the iterator-vs-iterator trap
+        // still fires.
+        Assume.assumeTrue("cursor compaction requires the BIG sstable format; selected=" +
+                          DatabaseDescriptor.getSelectedSSTableFormat().name(),
+                          BigFormat.isSelected());
         try (CompactionController controller = new CompactionController(cfs, inputs, gcBefore);
              AbstractCompactionStrategy.ScannerList scanners =
                  cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -34,6 +34,8 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.apache.commons.io.FileUtils;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -190,6 +192,13 @@ public abstract class DifferentialCompactionTester extends CQLTester
         // to delete the originals (SSTableRewriter.moveStarts obsoleted fully-covered inputs
         // unconditionally — now fixed and guarded by the flag), and this harness depends on
         // the originals surviving, so every differential run doubles as the regression test.
+        //
+        // scratch holds byte-for-byte copies of every captured output sstable (both paths) —
+        // it is deleted as soon as the comparison that needs them is done, win or lose, rather
+        // than accumulating for the lifetime of the test JVM: with hundreds of invocations per
+        // fork (e.g. the randomized soak), leaving cleanup to the temp-dir removal at JVM exit
+        // let disk usage grow unbounded over a single run.
+        try
         {
             CapturedOutput iterator = compactPath(cfs, inputs, false, gcBefore, scratch.resolve("iterator"), taskFactory);
             // the input INSTANCES were replaced during restore; re-resolve the subset by descriptor
@@ -204,6 +213,10 @@ public abstract class DifferentialCompactionTester extends CQLTester
             CapturedOutput cursor = compactPath(cfs, reResolved, true, gcBefore, scratch.resolve("cursor"), taskFactory);
             assertEquivalentOutputs(iterator, cursor);
             return iterator;
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(scratch.toFile());
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.IVerifier;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
+import org.apache.cassandra.tools.JsonTransformer;
+import org.apache.cassandra.tools.Util;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.OutputHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Differential test harness for cursor-based vs iterator-based compaction.
+ *
+ * Runs the SAME input sstables through both {@code IteratorCompactionPipeline} and
+ * {@code CursorCompactionPipeline} (via the full production {@link CompactionTask} path,
+ * selected by {@link DatabaseDescriptor#setCursorCompactionEnabled}), captures both outputs,
+ * and asserts equivalence at two levels:
+ *
+ *  1. BYTE level: every output component must be byte-identical, unless the component is
+ *     in the explicit allowlist of known/justified divergences.
+ *  2. LOGICAL level: a canonical JSON dump (sstabledump format) of every output sstable
+ *     must match exactly, and key stats metadata must match.
+ *
+ * Correctness invariants of the harness itself:
+ *  - inputs are byte-identical for both runs: the first run keeps originals on disk
+ *    ({@code keepOriginals=true}) and the harness restores the live set from the original
+ *    descriptors without rewriting anything.
+ *  - the same gcBefore is passed to both runs, so purge decisions cannot flip between runs.
+ *  - the cursor run asserts {@link CursorCompactor#isSupported} up front: a scenario that
+ *    silently falls back to the iterator path is a test bug, not a pass.
+ *
+ * Known limitation (journaled in doc/cursor-compaction-plan.md): nowInSec for TTL expiry
+ * evaluation is taken inside CompactionTask per run; scenarios must not place TTL expiry
+ * boundaries within seconds of the test run.
+ */
+public abstract class DifferentialCompactionTester extends CQLTester
+{
+    /** Fixed "now" used for JSON dumps so rendering cannot depend on wall clock. */
+    private static final long DUMP_NOW_SEC = 0;
+
+    public static final class CapturedSSTable
+    {
+        final Path dir;                 // copied component files, named by component (e.g. "Data.db")
+        final String json;              // canonical logical dump
+        final String statsSummary;
+        final SortedMap<String, Long> componentSizes = new TreeMap<>();
+
+        CapturedSSTable(Path dir, String json, String statsSummary)
+        {
+            this.dir = dir;
+            this.json = json;
+            this.statsSummary = statsSummary;
+        }
+    }
+
+    public static final class CapturedOutput
+    {
+        final List<CapturedSSTable> sstables = new ArrayList<>();
+    }
+
+    /**
+     * Runs both compaction paths over the current live sstables of the table and asserts
+     * byte + logical equivalence. The byteDiffAllowlist contains component names (e.g.
+     * "Statistics.db") that are permitted to differ at the byte level; logical equivalence
+     * is always enforced.
+     */
+    protected void assertCursorMatchesIterator(ColumnFamilyStore cfs, Set<String> byteDiffAllowlist) throws Exception
+    {
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        Path scratch = Files.createTempDirectory("differential-compaction");
+
+        // Early open must be off for keepOriginals to actually keep originals:
+        // SSTableRewriter.moveStarts() obsoletes fully-covered originals regardless of the
+        // keepOriginals flag (only the bulk obsoleteOriginals() call is guarded by it).
+        // Early open affects read availability during compaction, not final output bytes,
+        // so disabling it does not weaken the differential comparison.
+        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
+        try
+        {
+            CapturedOutput iterator = compactPath(cfs, false, gcBefore, scratch.resolve("iterator"));
+            CapturedOutput cursor = compactPath(cfs, true, gcBefore, scratch.resolve("cursor"));
+            assertEquivalentOutputs(iterator, cursor, byteDiffAllowlist);
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
+        }
+    }
+
+    /**
+     * Runs one compaction path over the current live sstables, captures the outputs, and
+     * restores the live set to the original inputs so the other path sees identical bytes.
+     */
+    protected CapturedOutput compactPath(ColumnFamilyStore cfs, boolean cursor, long gcBefore, Path scratch) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+
+        Set<SSTableReader> inputs = ImmutableSet.copyOf(cfs.getLiveSSTables());
+        assertFalse("scenario produced no input sstables", inputs.isEmpty());
+        List<Descriptor> inputDescriptors = new ArrayList<>();
+        for (SSTableReader in : inputs)
+            inputDescriptors.add(in.descriptor);
+
+        if (cursor)
+            assertCursorPathWillRun(cfs, inputs, gcBefore);
+
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting", txn);
+        new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */).execute(ActiveCompactionsTracker.NOOP);
+
+        // IMPORTANT: with keepOriginals=true the originals (or early-open clones of them, with
+        // moved starts) may remain in the live set as DIFFERENT reader instances. Outputs must
+        // therefore be identified by descriptor, never by instance, or the harness would treat
+        // retained originals as outputs and delete the input files.
+        Set<Descriptor> inputDescs = new HashSet<>(inputDescriptors);
+        List<SSTableReader> liveAfter = new ArrayList<>(cfs.getLiveSSTables());
+        List<SSTableReader> outputs = new ArrayList<>();
+        for (SSTableReader reader : liveAfter)
+            if (!inputDescs.contains(reader.descriptor))
+                outputs.add(reader);
+        outputs.sort(Comparator.comparing(SSTableReader::getFirst));
+
+        CapturedOutput captured = new CapturedOutput();
+        List<Path> outputFiles = new ArrayList<>();
+        int seq = 0;
+        for (SSTableReader out : outputs)
+        {
+            captured.sstables.add(capture(cfs, out, scratch.resolve("sstable-" + seq++)));
+            for (Component c : out.descriptor.discoverComponents())
+                outputFiles.add(out.descriptor.fileFor(c).toPath());
+        }
+
+        // Restore: clear the whole live set (outputs AND any retained/moved-start originals),
+        // delete output files only, then reopen every input fresh from its descriptor so the
+        // second run sees pristine full-range readers identical to the first run's.
+        cfs.getTracker().removeUnsafe(new HashSet<>(liveAfter));
+        for (SSTableReader reader : liveAfter)
+            reader.selfRef().release();
+        for (Path f : outputFiles)
+            Files.deleteIfExists(f);
+
+        List<SSTableReader> reopened = new ArrayList<>();
+        for (Descriptor desc : inputDescriptors)
+        {
+            if (!desc.fileFor(org.apache.cassandra.io.sstable.format.SSTableFormat.Components.DATA).exists())
+                fail("input sstable lost during compaction (keepOriginals violated?): " + desc +
+                     "\ndata dir contents:\n" + listDataDir(desc));
+            reopened.add(SSTableReader.open(cfs, desc));
+        }
+        cfs.getTracker().addInitialSSTables(reopened);
+        assertEquals("restore failed: live sstable count", inputs.size(), cfs.getLiveSSTables().size());
+
+        return captured;
+    }
+
+    /**
+     * Guards against the silent-fallback trap: if the cursor path would not actually run for
+     * this scenario, the test would compare iterator vs iterator and pass vacuously. Uses the
+     * same isSupported check production uses, on equivalent scanners and controller.
+     */
+    private void assertCursorPathWillRun(ColumnFamilyStore cfs, Set<SSTableReader> inputs, long gcBefore) throws Exception
+    {
+        try (CompactionController controller = new CompactionController(cfs, inputs, gcBefore);
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            assertTrue("scenario is not supported by cursor compaction; this harness run would " +
+                       "silently compare iterator vs iterator. If unsupported-ness is intended, " +
+                       "assert it explicitly instead.",
+                       CursorCompactor.isSupported(scanners, controller));
+        }
+    }
+
+    private static String listDataDir(Descriptor desc)
+    {
+        try (java.util.stream.Stream<Path> files = Files.list(desc.directory.toPath()))
+        {
+            StringBuilder sb = new StringBuilder();
+            files.sorted().forEach(p -> sb.append("  ").append(p.getFileName()).append('\n'));
+            return sb.toString();
+        }
+        catch (IOException e)
+        {
+            return "  <failed to list: " + e + ">";
+        }
+    }
+
+    private CapturedSSTable capture(ColumnFamilyStore cfs, SSTableReader sstable, Path dir) throws IOException
+    {
+        // 1. structural verification of the output
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false,
+                                                      IVerifier.options().invokeDiskFailurePolicy(true)
+                                                                         .extendedVerification(true).build()))
+        {
+            verifier.verify();
+        }
+
+        // 2. canonical logical dump
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ISSTableScanner scanner = sstable.getScanner())
+        {
+            JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
+                                        sstable.metadata(), DUMP_NOW_SEC, baos);
+        }
+        String json = baos.toString(StandardCharsets.UTF_8);
+
+        // 3. stats spot-check summary
+        StatsMetadata stats = sstable.getSSTableMetadata();
+        String statsSummary = "minTimestamp=" + stats.minTimestamp +
+                              " maxTimestamp=" + stats.maxTimestamp +
+                              " minLocalDeletionTime=" + stats.minLocalDeletionTime +
+                              " maxLocalDeletionTime=" + stats.maxLocalDeletionTime +
+                              " estimatedKeys=" + sstable.estimatedKeys() +
+                              " totalRows=" + stats.totalRows +
+                              " totalColumnsSet=" + stats.totalColumnsSet +
+                              " encodingStats=" + sstable.header.stats();
+
+        // 4. copy components for byte comparison
+        Files.createDirectories(dir);
+        CapturedSSTable captured = new CapturedSSTable(dir, json, statsSummary);
+        for (Component c : sstable.descriptor.discoverComponents())
+        {
+            Path source = sstable.descriptor.fileFor(c).toPath();
+            Path target = dir.resolve(c.name());
+            Files.copy(source, target);
+            captured.componentSizes.put(c.name(), Files.size(target));
+        }
+        return captured;
+    }
+
+    protected void assertEquivalentOutputs(CapturedOutput iterator, CapturedOutput cursor, Set<String> byteDiffAllowlist)
+    {
+        assertEquals("output sstable count differs between paths", iterator.sstables.size(), cursor.sstables.size());
+        for (int i = 0; i < iterator.sstables.size(); i++)
+        {
+            CapturedSSTable it = iterator.sstables.get(i);
+            CapturedSSTable cu = cursor.sstables.get(i);
+
+            assertEquals("stats summary divergence in output sstable " + i, it.statsSummary, cu.statsSummary);
+
+            if (!it.json.equals(cu.json))
+                fail("LOGICAL divergence in output sstable " + i + " (iterator vs cursor):\n" + firstJsonDiff(it.json, cu.json) +
+                     "\niterator stats: " + it.statsSummary + "\ncursor stats:   " + cu.statsSummary);
+
+            SortedSet<String> components = new TreeSet<>();
+            components.addAll(it.componentSizes.keySet());
+            components.addAll(cu.componentSizes.keySet());
+            List<String> divergences = new ArrayList<>();
+            for (String comp : components)
+            {
+                byte[] a = readComponent(it.dir, comp);
+                byte[] b = readComponent(cu.dir, comp);
+                if (java.util.Arrays.equals(a, b))
+                    continue;
+                if (byteDiffAllowlist.contains(comp))
+                    continue; // logical equivalence already asserted above
+                divergences.add(describeByteDiff(comp, a, b));
+            }
+            if (!divergences.isEmpty())
+                fail("BYTE divergence in output sstable " + i + " (iterator vs cursor):\n" + String.join("\n", divergences) +
+                     "\nIf a divergence is benign it must be added to the allowlist WITH justification in doc/cursor-compaction-plan.md");
+        }
+    }
+
+    private static byte[] readComponent(Path dir, String component)
+    {
+        try
+        {
+            Path p = dir.resolve(component);
+            return Files.exists(p) ? Files.readAllBytes(p) : null;
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String describeByteDiff(String component, byte[] a, byte[] b)
+    {
+        if (a == null || b == null)
+            return String.format("  %s: present only in %s path", component, a == null ? "cursor" : "iterator");
+        int firstDiff = -1;
+        int max = Math.min(a.length, b.length);
+        for (int i = 0; i < max; i++)
+        {
+            if (a[i] != b[i]) { firstDiff = i; break; }
+        }
+        if (firstDiff == -1)
+            firstDiff = max; // same prefix, different length
+        return String.format("  %s: lengths %d vs %d, first divergence at offset %d%n    iterator: %s%n    cursor:   %s",
+                             component, a.length, b.length, firstDiff,
+                             hexContext(a, firstDiff), hexContext(b, firstDiff));
+    }
+
+    private static String hexContext(byte[] bytes, int offset)
+    {
+        int from = Math.max(0, offset - 8);
+        int to = Math.min(bytes.length, offset + 24);
+        StringBuilder sb = new StringBuilder();
+        for (int i = from; i < to; i++)
+        {
+            if (i == offset)
+                sb.append('[');
+            sb.append(String.format("%02x", bytes[i]));
+            if (i == offset)
+                sb.append(']');
+            sb.append(' ');
+        }
+        if (to < bytes.length)
+            sb.append("...");
+        return sb.toString();
+    }
+
+    private static String firstJsonDiff(String a, String b)
+    {
+        String[] linesA = a.split("\n", -1);
+        String[] linesB = b.split("\n", -1);
+        int max = Math.max(linesA.length, linesB.length);
+        for (int i = 0; i < max; i++)
+        {
+            String la = i < linesA.length ? linesA[i] : "<missing>";
+            String lb = i < linesB.length ? linesB[i] : "<missing>";
+            if (!la.equals(lb))
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.append("first differing line ").append(i + 1).append(" of ").append(max).append(":\n");
+                for (int j = Math.max(0, i - 2); j < Math.min(max, i + 3); j++)
+                {
+                    String ja = j < linesA.length ? linesA[j] : "<missing>";
+                    String jb = j < linesB.length ? linesB[j] : "<missing>";
+                    sb.append(j == i ? ">>" : "  ").append(" iterator: ").append(ja).append('\n');
+                    sb.append(j == i ? ">>" : "  ").append(" cursor:   ").append(jb).append('\n');
+                }
+                return sb.toString();
+            }
+        }
+        return "(no line diff found despite string inequality — check line endings)";
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -380,7 +380,14 @@ public abstract class DifferentialCompactionTester extends CQLTester
             JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
                                         sstable.metadata(), DUMP_NOW_SEC, baos);
         }
-        String json = baos.toString(StandardCharsets.UTF_8);
+        // JsonTransformer's "expired" fields are computed from WALL CLOCK
+        // (currentTimeMillis), ignoring the fixed nowInSec passed above — so byte-identical
+        // outputs can render differently when a localExpirationTime falls between the two
+        // paths' captures, which run seconds apart (materialized-view expired-liveness rows
+        // sit permanently on that boundary: their expiration IS the write second). The flag
+        // is derived from expires_at, which is still compared, so normalize it out.
+        String json = baos.toString(StandardCharsets.UTF_8)
+                          .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"");
 
         // 3. stats spot-check summary
         StatsMetadata stats = sstable.getSSTableMetadata();

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -34,8 +34,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import com.google.common.collect.ImmutableSet;
-
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -113,13 +111,37 @@ public abstract class DifferentialCompactionTester extends CQLTester
         final List<CapturedSSTable> sstables = new ArrayList<>();
     }
 
+    /** Creates the CompactionTask for one differential run. MUST honor keepOriginals=true. */
+    public interface TaskFactory
+    {
+        CompactionTask create(ColumnFamilyStore cfs, LifecycleTransaction txn, long gcBefore);
+    }
+
+    public static final TaskFactory DEFAULT_TASK = (cfs, txn, gcBefore) -> new CompactionTask(cfs, txn, gcBefore, true);
+
     /**
      * Runs both compaction paths over the current live sstables of the table and asserts
      * byte + logical equivalence. The byteDiffAllowlist contains component names (e.g.
      * "Statistics.db") that are permitted to differ at the byte level; logical equivalence
      * is always enforced.
      */
-    protected void assertCursorMatchesIterator(ColumnFamilyStore cfs, Set<String> byteDiffAllowlist) throws Exception
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs, Set<String> byteDiffAllowlist) throws Exception
+    {
+        return assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), byteDiffAllowlist, DEFAULT_TASK);
+    }
+
+    /**
+     * Variant for partial-set compactions (inputs is a subset of the live sstables; the rest
+     * stay live and participate in purge-overlap decisions) and for custom CompactionTask
+     * shapes (e.g. multi-output writers via an overridden getCompactionAwareWriter).
+     */
+    /** Returns the iterator-path capture so scenarios can assert structural expectations
+     *  (e.g. multi-output scenarios MUST verify more than one sstable was produced —
+     *  a scenario that does not exercise its mechanism passes vacuously). */
+    protected CapturedOutput assertCursorMatchesIterator(ColumnFamilyStore cfs,
+                                                         Set<SSTableReader> inputs,
+                                                         Set<String> byteDiffAllowlist,
+                                                         TaskFactory taskFactory) throws Exception
     {
         long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
         Path scratch = Files.createTempDirectory("differential-compaction");
@@ -133,9 +155,19 @@ public abstract class DifferentialCompactionTester extends CQLTester
         DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
         try
         {
-            CapturedOutput iterator = compactPath(cfs, false, gcBefore, scratch.resolve("iterator"));
-            CapturedOutput cursor = compactPath(cfs, true, gcBefore, scratch.resolve("cursor"));
+            CapturedOutput iterator = compactPath(cfs, inputs, false, gcBefore, scratch.resolve("iterator"), taskFactory);
+            // the input INSTANCES were replaced during restore; re-resolve the subset by descriptor
+            Set<Descriptor> inputDescs = new HashSet<>();
+            for (SSTableReader in : inputs)
+                inputDescs.add(in.descriptor);
+            Set<SSTableReader> reResolved = new HashSet<>();
+            for (SSTableReader live : cfs.getLiveSSTables())
+                if (inputDescs.contains(live.descriptor))
+                    reResolved.add(live);
+            assertEquals("input subset lost across restore", inputs.size(), reResolved.size());
+            CapturedOutput cursor = compactPath(cfs, reResolved, true, gcBefore, scratch.resolve("cursor"), taskFactory);
             assertEquivalentOutputs(iterator, cursor, byteDiffAllowlist);
+            return iterator;
         }
         finally
         {
@@ -144,36 +176,57 @@ public abstract class DifferentialCompactionTester extends CQLTester
     }
 
     /**
-     * Runs one compaction path over the current live sstables, captures the outputs, and
-     * restores the live set to the original inputs so the other path sees identical bytes.
+     * Runs one compaction path over the given input subset (non-participating live sstables
+     * stay live and feed purge-overlap decisions), captures the outputs, and restores the live
+     * set so the other path sees identical bytes.
      */
-    protected CapturedOutput compactPath(ColumnFamilyStore cfs, boolean cursor, long gcBefore, Path scratch) throws Exception
+    protected CapturedOutput compactPath(ColumnFamilyStore cfs,
+                                         Set<SSTableReader> inputs,
+                                         boolean cursor,
+                                         long gcBefore,
+                                         Path scratch,
+                                         TaskFactory taskFactory) throws Exception
     {
         DatabaseDescriptor.setCursorCompactionEnabled(cursor);
 
-        Set<SSTableReader> inputs = ImmutableSet.copyOf(cfs.getLiveSSTables());
         assertFalse("scenario produced no input sstables", inputs.isEmpty());
+        Set<Descriptor> liveBeforeDescs = new HashSet<>();
+        int liveBeforeCount = 0;
+        for (SSTableReader live : cfs.getLiveSSTables())
+        {
+            liveBeforeDescs.add(live.descriptor);
+            liveBeforeCount++;
+        }
         List<Descriptor> inputDescriptors = new ArrayList<>();
         for (SSTableReader in : inputs)
+        {
+            assertTrue("input is not live", liveBeforeDescs.contains(in.descriptor));
             inputDescriptors.add(in.descriptor);
+        }
+        Set<Descriptor> inputDescs = new HashSet<>(inputDescriptors);
 
         if (cursor)
             assertCursorPathWillRun(cfs, inputs, gcBefore);
 
         LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
         assertNotNull("unable to mark inputs compacting", txn);
-        new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */).execute(ActiveCompactionsTracker.NOOP);
+        taskFactory.create(cfs, txn, gcBefore).execute(ActiveCompactionsTracker.NOOP);
 
-        // IMPORTANT: with keepOriginals=true the originals (or early-open clones of them, with
-        // moved starts) may remain in the live set as DIFFERENT reader instances. Outputs must
-        // therefore be identified by descriptor, never by instance, or the harness would treat
-        // retained originals as outputs and delete the input files.
-        Set<Descriptor> inputDescs = new HashSet<>(inputDescriptors);
+        // Outputs are identified by descriptor diff against the pre-compaction live set:
+        // with keepOriginals=true the originals (or early-open clones with moved starts) may
+        // remain live as DIFFERENT reader instances, and non-participating sstables are live
+        // throughout. Instance identity is never trusted here.
         List<SSTableReader> liveAfter = new ArrayList<>(cfs.getLiveSSTables());
         List<SSTableReader> outputs = new ArrayList<>();
+        List<SSTableReader> retainedInputClones = new ArrayList<>();
         for (SSTableReader reader : liveAfter)
-            if (!inputDescs.contains(reader.descriptor))
+        {
+            if (!liveBeforeDescs.contains(reader.descriptor))
                 outputs.add(reader);
+            else if (inputDescs.contains(reader.descriptor))
+                retainedInputClones.add(reader);
+            // else: non-participant — leave completely untouched
+        }
         outputs.sort(Comparator.comparing(SSTableReader::getFirst));
 
         CapturedOutput captured = new CapturedOutput();
@@ -186,11 +239,13 @@ public abstract class DifferentialCompactionTester extends CQLTester
                 outputFiles.add(out.descriptor.fileFor(c).toPath());
         }
 
-        // Restore: clear the whole live set (outputs AND any retained/moved-start originals),
-        // delete output files only, then reopen every input fresh from its descriptor so the
-        // second run sees pristine full-range readers identical to the first run's.
-        cfs.getTracker().removeUnsafe(new HashSet<>(liveAfter));
-        for (SSTableReader reader : liveAfter)
+        // Restore: delist + release outputs and any retained input clones, delete output files
+        // only, then reopen every input fresh from its descriptor so the second run sees
+        // pristine full-range readers identical to the first run's.
+        Set<SSTableReader> toRemove = new HashSet<>(outputs);
+        toRemove.addAll(retainedInputClones);
+        cfs.getTracker().removeUnsafe(toRemove);
+        for (SSTableReader reader : toRemove)
             reader.selfRef().release();
         for (Path f : outputFiles)
             Files.deleteIfExists(f);
@@ -204,7 +259,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
             reopened.add(SSTableReader.open(cfs, desc));
         }
         cfs.getTracker().addInitialSSTables(reopened);
-        assertEquals("restore failed: live sstable count", inputs.size(), cfs.getLiveSSTables().size());
+        assertEquals("restore failed: live sstable count", liveBeforeCount, cfs.getLiveSSTables().size());
 
         return captured;
     }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -91,6 +91,18 @@ public abstract class DifferentialCompactionTester extends CQLTester
     /** Fixed "now" used for JSON dumps so rendering cannot depend on wall clock. */
     private static final long DUMP_NOW_SEC = 0;
 
+    /**
+     * Scale mode for very large scenarios (millions of rows): the logical dump is streamed
+     * into a SHA-256 digest instead of being retained as a String, so capture memory stays
+     * flat regardless of row count. Byte comparison always streams. On a digest mismatch
+     * the byte-level comparison (which still reports exact offsets) is the debugging tool;
+     * rerun a reduced scenario without scale mode for a row-level JSON diff.
+     */
+    protected boolean scaleCapture()
+    {
+        return false;
+    }
+
     public static final class CapturedSSTable
     {
         final Path dir;                 // copied component files, named by component (e.g. "Data.db")
@@ -374,20 +386,42 @@ public abstract class DifferentialCompactionTester extends CQLTester
         }
 
         // 2. canonical logical dump
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ISSTableScanner scanner = sstable.getScanner())
-        {
-            JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
-                                        sstable.metadata(), DUMP_NOW_SEC, baos);
-        }
         // JsonTransformer's "expired" fields are computed from WALL CLOCK
-        // (currentTimeMillis), ignoring the fixed nowInSec passed above — so byte-identical
+        // (currentTimeMillis), ignoring the fixed nowInSec passed below — so byte-identical
         // outputs can render differently when a localExpirationTime falls between the two
         // paths' captures, which run seconds apart (materialized-view expired-liveness rows
         // sit permanently on that boundary: their expiration IS the write second). The flag
         // is derived from expires_at, which is still compared, so normalize it out.
-        String json = baos.toString(StandardCharsets.UTF_8)
-                          .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"");
+        String json;
+        if (scaleCapture())
+        {
+            // stream into a digest: capture memory stays flat at millions of rows
+            try (ISSTableScanner scanner = sstable.getScanner())
+            {
+                java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+                NormalizingDigestOutputStream out = new NormalizingDigestOutputStream(digest);
+                JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
+                                            sstable.metadata(), DUMP_NOW_SEC, out);
+                out.flushTail();
+                json = "sha256:" + org.apache.cassandra.utils.Hex.bytesToHex(digest.digest()) +
+                       " (" + out.bytesSeen + " bytes)";
+            }
+            catch (java.security.NoSuchAlgorithmException e)
+            {
+                throw new AssertionError(e);
+            }
+        }
+        else
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ISSTableScanner scanner = sstable.getScanner())
+            {
+                JsonTransformer.toJsonLines(scanner, Util.iterToStream(scanner), true, false,
+                                            sstable.metadata(), DUMP_NOW_SEC, baos);
+            }
+            json = baos.toString(StandardCharsets.UTF_8)
+                       .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"");
+        }
 
         // 3. stats spot-check summary
         StatsMetadata stats = sstable.getSSTableMetadata();
@@ -421,11 +455,15 @@ public abstract class DifferentialCompactionTester extends CQLTester
             CapturedSSTable it = iterator.sstables.get(i);
             CapturedSSTable cu = cursor.sstables.get(i);
 
-            assertEquals("stats summary divergence in output sstable " + i, it.statsSummary, cu.statsSummary);
-
-            if (!it.json.equals(cu.json))
+            // logical first: a row-level diff is far more debuggable than a stats mismatch.
+            // In scale mode the dump is a digest — defer it below the byte comparison, which
+            // still localizes divergences to exact offsets.
+            boolean digestMode = it.json.startsWith("sha256:");
+            if (!digestMode && !it.json.equals(cu.json))
                 fail("LOGICAL divergence in output sstable " + i + " (iterator vs cursor):\n" + firstJsonDiff(it.json, cu.json) +
                      "\niterator stats: " + it.statsSummary + "\ncursor stats:   " + cu.statsSummary);
+
+            assertEquals("stats summary divergence in output sstable " + i, it.statsSummary, cu.statsSummary);
 
             SortedSet<String> components = new TreeSet<>();
             components.addAll(it.componentSizes.keySet());
@@ -433,26 +471,60 @@ public abstract class DifferentialCompactionTester extends CQLTester
             List<String> divergences = new ArrayList<>();
             for (String comp : components)
             {
-                byte[] a = readComponent(it.dir, comp);
-                byte[] b = readComponent(cu.dir, comp);
-                if (java.util.Arrays.equals(a, b))
+                Path a = it.dir.resolve(comp);
+                Path b = cu.dir.resolve(comp);
+                boolean hasA = Files.exists(a);
+                boolean hasB = Files.exists(b);
+                if (hasA != hasB)
+                {
+                    if (!byteDiffAllowlist.contains(comp))
+                        divergences.add(String.format("  %s: present only in %s path", comp, hasA ? "iterator" : "cursor"));
+                    continue;
+                }
+                if (!hasA)
+                    continue;
+                long firstDiff = firstFileDifference(a, b);
+                if (firstDiff < 0)
                     continue;
                 if (byteDiffAllowlist.contains(comp))
-                    continue; // logical equivalence already asserted above
-                divergences.add(describeByteDiff(comp, a, b));
+                    continue; // logical equivalence still asserted
+                divergences.add(describeFileDiff(comp, a, b, firstDiff));
             }
             if (!divergences.isEmpty())
                 fail("BYTE divergence in output sstable " + i + " (iterator vs cursor):\n" + String.join("\n", divergences) +
                      "\nIf a divergence is benign it must be added to the allowlist with a justifying comment next to the allowlist entry");
+
+            if (digestMode)
+                assertEquals("logical dump digest divergence in output sstable " + i +
+                             " (scale mode; rerun a reduced scenario without scale mode for a row-level diff)",
+                             it.json, cu.json);
         }
     }
 
-    private static byte[] readComponent(Path dir, String component)
+    /** Streaming comparison: -1 if byte-identical, else the offset of the first difference
+     *  (the shorter length when one file is a prefix of the other). */
+    private static long firstFileDifference(Path a, Path b)
     {
-        try
+        try (java.io.InputStream ia = new java.io.BufferedInputStream(Files.newInputStream(a), 1 << 16);
+             java.io.InputStream ib = new java.io.BufferedInputStream(Files.newInputStream(b), 1 << 16))
         {
-            Path p = dir.resolve(component);
-            return Files.exists(p) ? Files.readAllBytes(p) : null;
+            byte[] bufA = new byte[1 << 16];
+            byte[] bufB = new byte[1 << 16];
+            long offset = 0;
+            while (true)
+            {
+                int readA = ia.readNBytes(bufA, 0, bufA.length);
+                int readB = ib.readNBytes(bufB, 0, bufB.length);
+                int common = Math.min(readA, readB);
+                int mismatch = java.util.Arrays.mismatch(bufA, 0, common, bufB, 0, common);
+                if (mismatch >= 0)
+                    return offset + mismatch;
+                if (readA != readB)
+                    return offset + common; // same prefix, different length
+                if (readA == 0)
+                    return -1;
+                offset += readA;
+            }
         }
         catch (IOException e)
         {
@@ -460,40 +532,97 @@ public abstract class DifferentialCompactionTester extends CQLTester
         }
     }
 
-    private static String describeByteDiff(String component, byte[] a, byte[] b)
+    private static String describeFileDiff(String component, Path a, Path b, long firstDiff)
     {
-        if (a == null || b == null)
-            return String.format("  %s: present only in %s path", component, a == null ? "cursor" : "iterator");
-        int firstDiff = -1;
-        int max = Math.min(a.length, b.length);
-        for (int i = 0; i < max; i++)
+        try
         {
-            if (a[i] != b[i]) { firstDiff = i; break; }
+            return String.format("  %s: lengths %d vs %d, first divergence at offset %d%n    iterator: %s%n    cursor:   %s",
+                                 component, Files.size(a), Files.size(b), firstDiff,
+                                 hexContext(a, firstDiff), hexContext(b, firstDiff));
         }
-        if (firstDiff == -1)
-            firstDiff = max; // same prefix, different length
-        return String.format("  %s: lengths %d vs %d, first divergence at offset %d%n    iterator: %s%n    cursor:   %s",
-                             component, a.length, b.length, firstDiff,
-                             hexContext(a, firstDiff), hexContext(b, firstDiff));
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
     }
 
-    private static String hexContext(byte[] bytes, int offset)
+    private static String hexContext(Path file, long offset) throws IOException
     {
-        int from = Math.max(0, offset - 8);
-        int to = Math.min(bytes.length, offset + 24);
-        StringBuilder sb = new StringBuilder();
-        for (int i = from; i < to; i++)
+        long size = Files.size(file);
+        long from = Math.max(0, offset - 8);
+        int len = (int) Math.min(size - from, 32);
+        byte[] window = new byte[Math.max(len, 0)];
+        try (java.io.InputStream in = Files.newInputStream(file))
         {
-            if (i == offset)
+            in.skipNBytes(from);
+            in.readNBytes(window, 0, window.length);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < window.length; i++)
+        {
+            long abs = from + i;
+            if (abs == offset)
                 sb.append('[');
-            sb.append(String.format("%02x", bytes[i]));
-            if (i == offset)
+            sb.append(String.format("%02x", window[i]));
+            if (abs == offset)
                 sb.append(']');
             sb.append(' ');
         }
-        if (to < bytes.length)
+        if (from + window.length < size)
             sb.append("...");
         return sb.toString();
+    }
+
+    /** Streams a JSON dump into a digest, normalizing the wall-clock-derived "expired"
+     *  fields line by line (toJsonLines emits one partition per line). */
+    private static final class NormalizingDigestOutputStream extends java.io.OutputStream
+    {
+        private final java.security.MessageDigest digest;
+        private final ByteArrayOutputStream line = new ByteArrayOutputStream();
+        long bytesSeen;
+
+        NormalizingDigestOutputStream(java.security.MessageDigest digest)
+        {
+            this.digest = digest;
+        }
+
+        @Override
+        public void write(int b)
+        {
+            line.write(b);
+            if (b == '\n')
+                flushTail();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len)
+        {
+            int start = off;
+            int end = off + len;
+            for (int i = off; i < end; i++)
+            {
+                if (b[i] == '\n')
+                {
+                    line.write(b, start, i - start + 1);
+                    flushTail();
+                    start = i + 1;
+                }
+            }
+            if (start < end)
+                line.write(b, start, end - start);
+        }
+
+        void flushTail()
+        {
+            if (line.size() == 0)
+                return;
+            byte[] normalized = line.toString(StandardCharsets.UTF_8)
+                                    .replaceAll("\"expired\"\\s*:\\s*(true|false)", "\"expired\":\"normalized\"")
+                                    .getBytes(StandardCharsets.UTF_8);
+            digest.update(normalized);
+            bytesSeen += normalized.length;
+            line.reset();
+        }
     }
 
     private static String firstJsonDiff(String a, String b)

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -184,6 +184,46 @@ public abstract class DifferentialCompactionTester extends CQLTester
     }
 
     /**
+     * Differential at TWO generations: the normal differential first (gen 1), then the inputs
+     * are genuinely compacted through the CURSOR path and the differential runs again over the
+     * cursor-produced outputs (gen 2). Write-side corruption that only manifests when the next
+     * merge re-reads the output — a bug class where a flag is decided after its byte is
+     * already written, desyncing the FOLLOWING compaction rather than its own — fails gen 2
+     * loudly here instead of surviving until production recompacts.
+     *
+     * Returns the GEN-1 iterator capture: scenario structural assertions target gen 1, whose
+     * shape the scenario controls directly.
+     */
+    protected CapturedOutput assertCursorMatchesIteratorAcrossGenerations(ColumnFamilyStore cfs,
+                                                                          Set<String> byteDiffAllowlist) throws Exception
+    {
+        CapturedOutput gen1 = assertCursorMatchesIterator(cfs, byteDiffAllowlist);
+
+        long gcBefore = cfs.getDefaultGcBefore(FBUtilities.nowInSeconds());
+        commitCompaction(cfs, cfs.getLiveSSTables(), true, gcBefore);
+        if (cfs.getLiveSSTables().isEmpty())
+            return gen1; // gen 1 purged everything; there are no gen-2 inputs
+
+        assertCursorMatchesIterator(cfs, byteDiffAllowlist);
+        return gen1;
+    }
+
+    /**
+     * Commits one compaction over the given inputs through the selected path WITHOUT restore:
+     * the live set genuinely becomes the outputs. Used by the cross-generation rung so the
+     * second differential reads cursor-produced sstables.
+     */
+    protected void commitCompaction(ColumnFamilyStore cfs, Set<SSTableReader> inputs, boolean cursor, long gcBefore) throws Exception
+    {
+        DatabaseDescriptor.setCursorCompactionEnabled(cursor);
+        if (cursor)
+            assertCursorPathWillRun(cfs, inputs, gcBefore);
+        LifecycleTransaction txn = cfs.getTracker().tryModify(inputs, OperationType.COMPACTION);
+        assertNotNull("unable to mark inputs compacting for commit", txn);
+        new CompactionTask(cfs, txn, gcBefore, false).execute(ActiveCompactionsTracker.NOOP);
+    }
+
+    /**
      * Runs one compaction path over the given input subset (non-participating live sstables
      * stay live and feed purge-overlap decisions), captures the outputs, and restores the live
      * set so the other path sees identical bytes.

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -162,13 +162,10 @@ public abstract class DifferentialCompactionTester extends CQLTester
         Path scratch = Files.createTempDirectory("differential-compaction");
 
         // Early open must be off for keepOriginals to actually keep originals:
-        // SSTableRewriter.moveStarts() obsoletes fully-covered originals regardless of the
-        // keepOriginals flag (only the bulk obsoleteOriginals() call is guarded by it).
-        // Early open affects read availability during compaction, not final output bytes,
-        // so disabling it does not weaken the differential comparison.
-        int originalPreemptiveOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(-1);
-        try
+        // Early open stays ENABLED here deliberately: keepOriginals=true with early open used
+        // to delete the originals (SSTableRewriter.moveStarts obsoleted fully-covered inputs
+        // unconditionally — now fixed and guarded by the flag), and this harness depends on
+        // the originals surviving, so every differential run doubles as the regression test.
         {
             CapturedOutput iterator = compactPath(cfs, inputs, false, gcBefore, scratch.resolve("iterator"), taskFactory);
             // the input INSTANCES were replaced during restore; re-resolve the subset by descriptor
@@ -183,10 +180,6 @@ public abstract class DifferentialCompactionTester extends CQLTester
             CapturedOutput cursor = compactPath(cfs, reResolved, true, gcBefore, scratch.resolve("cursor"), taskFactory);
             assertEquivalentOutputs(iterator, cursor, byteDiffAllowlist);
             return iterator;
-        }
-        finally
-        {
-            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(originalPreemptiveOpen);
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DifferentialCompactionTester.java
@@ -82,7 +82,7 @@ import static org.junit.Assert.fail;
  *  - the cursor run asserts {@link CursorCompactor#isSupported} up front: a scenario that
  *    silently falls back to the iterator path is a test bug, not a pass.
  *
- * Known limitation (journaled in doc/cursor-compaction-plan.md): nowInSec for TTL expiry
+ * Known limitation: nowInSec for TTL expiry
  * evaluation is taken inside CompactionTask per run; scenarios must not place TTL expiry
  * boundaries within seconds of the test run.
  */
@@ -231,32 +231,35 @@ public abstract class DifferentialCompactionTester extends CQLTester
         // with keepOriginals=true the originals (or early-open clones with moved starts) may
         // remain live as DIFFERENT reader instances, and non-participating sstables are live
         // throughout. Instance identity is never trusted here.
-        List<SSTableReader> liveAfter = new ArrayList<>(cfs.getLiveSSTables());
-        List<SSTableReader> outputs = new ArrayList<>();
         List<SSTableReader> retainedInputClones = new ArrayList<>();
-        for (SSTableReader reader : liveAfter)
-        {
-            if (!liveBeforeDescs.contains(reader.descriptor))
-                outputs.add(reader);
-            else if (inputDescs.contains(reader.descriptor))
-                retainedInputClones.add(reader);
-            // else: non-participant — leave completely untouched
-        }
-        outputs.sort(Comparator.comparing(SSTableReader::getFirst));
+        List<SSTableReader> outputs = identifyOutputs(cfs, liveBeforeDescs, inputDescs, retainedInputClones);
 
         CapturedOutput captured = new CapturedOutput();
-        List<Path> outputFiles = new ArrayList<>();
         int seq = 0;
         for (SSTableReader out : outputs)
-        {
             captured.sstables.add(capture(cfs, out, scratch.resolve("sstable-" + seq++)));
+
+        restoreAfterCompaction(cfs, outputs, retainedInputClones, inputDescriptors, liveBeforeCount);
+
+        return captured;
+    }
+
+    /**
+     * Delists + releases outputs and any retained input clones, deletes output files only,
+     * then reopens every input fresh from its descriptor so a subsequent run sees pristine
+     * full-range readers identical to this run's. Non-participating sstables are untouched.
+     */
+    protected void restoreAfterCompaction(ColumnFamilyStore cfs,
+                                          List<SSTableReader> outputs,
+                                          List<SSTableReader> retainedInputClones,
+                                          List<Descriptor> inputDescriptors,
+                                          int liveBeforeCount) throws Exception
+    {
+        List<Path> outputFiles = new ArrayList<>();
+        for (SSTableReader out : outputs)
             for (Component c : out.descriptor.discoverComponents())
                 outputFiles.add(out.descriptor.fileFor(c).toPath());
-        }
 
-        // Restore: delist + release outputs and any retained input clones, delete output files
-        // only, then reopen every input fresh from its descriptor so the second run sees
-        // pristine full-range readers identical to the first run's.
         Set<SSTableReader> toRemove = new HashSet<>(outputs);
         toRemove.addAll(retainedInputClones);
         cfs.getTracker().removeUnsafe(toRemove);
@@ -275,8 +278,24 @@ public abstract class DifferentialCompactionTester extends CQLTester
         }
         cfs.getTracker().addInitialSSTables(reopened);
         assertEquals("restore failed: live sstable count", liveBeforeCount, cfs.getLiveSSTables().size());
+    }
 
-        return captured;
+    /** Output identification by before/after descriptor diff; see compactPath for rationale. */
+    protected static List<SSTableReader> identifyOutputs(ColumnFamilyStore cfs,
+                                                         Set<Descriptor> liveBeforeDescs,
+                                                         Set<Descriptor> inputDescs,
+                                                         List<SSTableReader> retainedInputClonesOut)
+    {
+        List<SSTableReader> outputs = new ArrayList<>();
+        for (SSTableReader reader : cfs.getLiveSSTables())
+        {
+            if (!liveBeforeDescs.contains(reader.descriptor))
+                outputs.add(reader);
+            else if (inputDescs.contains(reader.descriptor))
+                retainedInputClonesOut.add(reader);
+        }
+        outputs.sort(Comparator.comparing(SSTableReader::getFirst));
+        return outputs;
     }
 
     /**
@@ -284,7 +303,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
      * this scenario, the test would compare iterator vs iterator and pass vacuously. Uses the
      * same isSupported check production uses, on equivalent scanners and controller.
      */
-    private void assertCursorPathWillRun(ColumnFamilyStore cfs, Set<SSTableReader> inputs, long gcBefore) throws Exception
+    protected void assertCursorPathWillRun(ColumnFamilyStore cfs, Set<SSTableReader> inputs, long gcBefore) throws Exception
     {
         try (CompactionController controller = new CompactionController(cfs, inputs, gcBefore);
              AbstractCompactionStrategy.ScannerList scanners =
@@ -384,7 +403,7 @@ public abstract class DifferentialCompactionTester extends CQLTester
             }
             if (!divergences.isEmpty())
                 fail("BYTE divergence in output sstable " + i + " (iterator vs cursor):\n" + String.join("\n", divergences) +
-                     "\nIf a divergence is benign it must be added to the allowlist WITH justification in doc/cursor-compaction-plan.md");
+                     "\nIf a divergence is benign it must be added to the allowlist with a justifying comment next to the allowlist entry");
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DroppedColumnDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DroppedColumnDifferentialCompactionTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Dropped-column scenarios: the iterator path discards cells (and complex deletions) of a
+ * dropped column at deserialization when their timestamp is at or before the drop
+ * (UnfilteredSerializer.readSimpleColumn/readComplexColumn via DeserializationHelper.isDropped /
+ * isDroppedComplexDeletion). The cursor path must filter identically, or dropped data survives
+ * cursor compaction and is resurrected by ALTER TABLE ... ADD of the same column.
+ *
+ * Timestamp determinism: ClientState timestamps are strictly increasing per node, so a write
+ * executed before ALTER TABLE DROP always carries a timestamp strictly below droppedTime;
+ * writes that must survive the drop use an explicit far-future USING TIMESTAMP.
+ */
+public class DroppedColumnDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    /** Far in the future relative to any wall-clock droppedTime (year ~2100, microseconds). */
+    private static final long FUTURE_TS = 4102444800_000000L;
+
+    @Test
+    public void droppedRegularColumn() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "dropped-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+
+        // second generation written after the drop, overlapping the first
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 5; ck < 15; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck + 100);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /**
+     * Cells written with a timestamp ABOVE droppedTime survive compaction on both paths
+     * (isDropped is timestamp-gated, not column-gated) — pins the comparison direction.
+     */
+    @Test
+    public void cellsNewerThanDropRetained() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?) USING TIMESTAMP " + FUTURE_TS,
+                    ck, ck, "survives-" + ck);
+        // and some cells that do not survive
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v2) VALUES (1, ?, ?)", ck, "dropped-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (2, ?, ?)", ck, ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /** DROP then ADD: pre-drop cells are filtered, post-re-add cells survive — the resurrection shape. */
+    @Test
+    public void droppedColumnReAdded() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?)", ck, ck, "old-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+        alterTable("ALTER TABLE %s ADD v2 text");
+
+        for (long ck = 5; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck, v2) VALUES (0, ?, ?)", ck, "new-" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    @Test
+    public void droppedStaticColumn() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s text static, ck bigint, v1 bigint, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 5; pk++)
+        {
+            execute("INSERT INTO %s (pk, s) VALUES (?, ?)", pk, "static-" + pk);
+            for (long ck = 0; ck < 5; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        }
+        flush();
+
+        alterTable("ALTER TABLE %s DROP s");
+
+        for (long pk = 0; pk < 5; pk++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, 99L, 99L);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /**
+     * A cell timestamped exactly {@link LivenessInfo#NO_TIMESTAMP}, in an sstable whose header carries a
+     * dropped column. Long.MIN_VALUE is simultaneously that sentinel, {@code DeletionTime.LIVE}'s
+     * {@code markedForDeleteAt}, and the cursor's "no drop horizon" sentinel, so the value walks into three
+     * independent collisions on its way through a compaction: the active deletion must not shadow the cell at
+     * either of the merge's two deletion checks, and the drop filter must not discard it. The iterator path
+     * keeps it on all counts.
+     *
+     * These are CALL-SITE pins, which is why this is a differential scenario and not only a unit test: a
+     * rule-level test can gate the drop rule or the deletion rule in isolation but stay green if a call site
+     * inlines the bare, unguarded comparison again. Those call sites are reached under different conditions,
+     * so the scenario writes both shapes:
+     *
+     *  - the single-source check, after the winner is chosen, needs only one copy of the cell;
+     *  - the cross-source check, inside the merge loop's COMPARE arm, is reached only when two or more
+     *    sources carry the same column of the same row at an equal timestamp. Partitions 1 and 2 supply that,
+     *    with the two values in opposite order, because under unfixed code the surviving value would be
+     *    whichever source the merge visits first — so one of the two partitions must diverge whichever order
+     *    that is.
+     *
+     * The timestamp is unreachable through CQL — {@code cql3.RowUpdateBuilder}'s constructor rejects it for
+     * every modification statement and {@code QueryOptions} rejects it at the native protocol, both because
+     * the engine uses that value for "absence of timestamp". It is NOT blocked by the encoding: a cell
+     * timestamp is written as an unsigned vint delta from the header's {@code minTimestamp} and read back by
+     * adding, inverses mod 2^64 for any base, so it round-trips through an sstable exactly.
+     * {@code PartitionUpdate.simpleBuilder} carries no such guard, which is what makes this constructible.
+     */
+    @Test
+    public void noTimestampCellSurvivesBothSentinelCollisions() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // ordinary rows, so the sstable's timestamp stats do not consist solely of the sentinel, and so v2
+        // exists on disk to be dropped below
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?)", ck, ck, "v2-" + ck);
+
+        // v1 is never dropped, and no deletion covers these rows. The long argument after the metadata is a
+        // PARTITION KEY, not a timestamp: each sentinel cell lands in its own partition, disjoint from the
+        // pk=0 rows above.
+        writeSentinelTimestampCell(cfs, 1L, 7L);
+        writeSentinelTimestampCell(cfs, 2L, 8L);
+        flush();
+
+        // makes THIS sstable's header carry a dropped column, so sstableHasDroppedColumns is true and the
+        // horizon array is consulted for every cell read from it — v1's included
+        alterTable("ALTER TABLE %s DROP v2");
+
+        // the same two cells again with the values swapped, in a second sstable, so each of partitions 1
+        // and 2 has the sentinel cell in two sources and the merge must compare their values
+        writeSentinelTimestampCell(cfs, 1L, 8L);
+        writeSentinelTimestampCell(cfs, 2L, 7L);
+
+        for (long ck = 10; ck < 20; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (0, ?, ?)", ck, ck);
+        flush();
+
+        // Preconditions, both on ONE sstable. Asserting them separately would pass with the sentinel cells in
+        // an sstable whose header carries no dropped column, which leaves the drop-filter half silently dead:
+        // the horizon array is only built for an sstable that has one.
+        assertTrue("no input sstable carries both a NO_TIMESTAMP cell and a dropped column in its header, "
+                   + "so the drop filter is never applied to the cell this scenario is about",
+                   cfs.getLiveSSTables().stream()
+                      .anyMatch(s -> s.getMinTimestamp() == LivenessInfo.NO_TIMESTAMP
+                                     && s.header.columns().size() > cfs.metadata().regularAndStaticColumns().size()));
+        assertEquals("the sentinel cells must sit in two sources for the cross-source check to be reached",
+                     2, cfs.getLiveSSTables().stream()
+                           .filter(s -> s.getMinTimestamp() == LivenessInfo.NO_TIMESTAMP).count());
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    private void writeSentinelTimestampCell(ColumnFamilyStore cfs, long partitionKey, long value)
+    {
+        PartitionUpdate.SimpleBuilder update = PartitionUpdate.simpleBuilder(cfs.metadata(), partitionKey);
+        update.row(0L).timestamp(LivenessInfo.NO_TIMESTAMP).add("v1", value);
+        new Mutation(update.build()).apply();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/DroppedColumnDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/DroppedColumnDifferentialCompactionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+/**
+ * Dropped-column scenarios: the iterator path discards cells (and complex deletions) of a
+ * dropped column at deserialization when their timestamp is at or before the drop
+ * (UnfilteredSerializer.readSimpleColumn/readComplexColumn via DeserializationHelper.isDropped /
+ * isDroppedComplexDeletion). The cursor path must filter identically, or dropped data survives
+ * cursor compaction and is resurrected by ALTER TABLE ... ADD of the same column.
+ *
+ * Timestamp determinism: ClientState timestamps are strictly increasing per node, so a write
+ * executed before ALTER TABLE DROP always carries a timestamp strictly below droppedTime;
+ * writes that must survive the drop use an explicit far-future USING TIMESTAMP.
+ */
+public class DroppedColumnDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    /** Far in the future relative to any wall-clock droppedTime (year ~2100, microseconds). */
+    private static final long FUTURE_TS = 4102444800_000000L;
+
+    @Test
+    public void droppedRegularColumn() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, ck, "dropped-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+
+        // second generation written after the drop, overlapping the first
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 5; ck < 15; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck + 100);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /**
+     * Cells written with a timestamp ABOVE droppedTime survive compaction on both paths
+     * (isDropped is timestamp-gated, not column-gated) — pins the comparison direction.
+     */
+    @Test
+    public void cellsNewerThanDropRetained() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?) USING TIMESTAMP " + FUTURE_TS,
+                    ck, ck, "survives-" + ck);
+        // and some cells that do not survive
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v2) VALUES (1, ?, ?)", ck, "dropped-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (2, ?, ?)", ck, ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /** DROP then ADD: pre-drop cells are filtered, post-re-add cells survive — the resurrection shape. */
+    @Test
+    public void droppedColumnReAdded() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (0, ?, ?, ?)", ck, ck, "old-" + ck);
+        flush();
+
+        alterTable("ALTER TABLE %s DROP v2");
+        alterTable("ALTER TABLE %s ADD v2 text");
+
+        for (long ck = 5; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck, v2) VALUES (0, ?, ?)", ck, "new-" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    @Test
+    public void droppedStaticColumn() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s text static, ck bigint, v1 bigint, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 5; pk++)
+        {
+            execute("INSERT INTO %s (pk, s) VALUES (?, ?)", pk, "static-" + pk);
+            for (long ck = 0; ck < 5; ck++)
+                execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        }
+        flush();
+
+        alterTable("ALTER TABLE %s DROP s");
+
+        for (long pk = 0; pk < 5; pk++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", pk, 99L, 99L);
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -1,0 +1,1167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigTableReader;
+import org.apache.cassandra.io.sstable.format.big.RowIndexEntry;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Edge-case corpus for the differential cursor-vs-iterator compaction harness, covering the
+ * CURRENTLY SUPPORTED cursor compaction surface (see CursorCompactor.isSupported). Every
+ * scenario here must run the cursor path for real — the harness fails loudly on silent
+ * fallback. Scenarios for unsupported shapes belong in CursorSupportMatrixTest instead.
+ *
+ * Every scenario runs the differential at TWO generations (see
+ * assertCursorMatchesIteratorAcrossGenerations): gen 2 re-reads genuinely cursor-produced
+ * outputs, so every scenario is also decoded from input shapes only a compaction produces. It is
+ * not a write-side backstop; gen 1's byte comparison is.
+ */
+public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    /**
+     * Static-column table where some partitions have NO static values: an empty static row is
+     * written for those partitions but must not be counted in stats (totalRows/totalColumnsSet).
+     * Found by the randomized soak; the original staticRows scenario gave every
+     * partition static data and so never produced an empty static row.
+     */
+    @Test
+    public void emptyStaticRows() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s1 text static, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 8; pk++)
+            {
+                // only even partitions ever get a static value
+                if (pk % 2 == 0)
+                    execute("INSERT INTO %s (pk, s1, ck, v) VALUES (?, ?, ?, ?)", pk, "static" + pk, (long) round, "v" + round);
+                else
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, (long) round, "v" + round);
+            }
+            flush();
+        }
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: the empty static rows written for the four odd partitions must not be counted.
+        // 8 partitions x 2 clusterings = 16 regular rows, plus one NON-empty static row for each of
+        // the 4 even partitions = 20. statsSummary carries totalRows, so an over-count shared by both
+        // paths would pass byte-equality and fail here.
+        assertEquals("expected a single compaction output", 1, out.sstables.size());
+        assertTrue("an absent static row was counted: expected totalRows=20 (16 regular + 4 " +
+                   "non-empty static), got: " + out.sstables.get(0).statsSummary,
+                   out.sstables.get(0).statsSummary.contains("totalRows=20 "));
+        // totalColumnsSet is unaffected by that defect — an empty static row contributes zero columns —
+        // so pinning it keeps that half of the claim honest: 16 regular v cells + 4 static s1 cells.
+        assertTrue("expected totalColumnsSet=20, got: " + out.sstables.get(0).statsSummary,
+                   out.sstables.get(0).statsSummary.contains("totalColumnsSet=20 "));
+    }
+
+    /** Reversed clustering order changes on-disk ordering and bound comparisons. */
+    @Test
+    public void descendingClustering() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC)");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 5; pk++)
+                for (long ck = 0; ck < 30; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "v" + ck);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", (long) round, 5L, 15L);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Multi-component clusterings: mixed types, shared prefixes, per-component bounds. */
+    @Test
+    public void compositeClustering() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck1 text, ck2 int, ck3 bigint, v text, " +
+                    "PRIMARY KEY (pk, ck1, ck2, ck3))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String[] names = { "alpha", "beta", "gamma", "" /* empty string component */ };
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 4; pk++)
+                for (String ck1 : names)
+                    for (int ck2 = 0; ck2 < 5; ck2++)
+                        execute("INSERT INTO %s (pk, ck1, ck2, ck3, v) VALUES (?, ?, ?, ?, ?)",
+                                pk, ck1, ck2, (long) round, "v" + round);
+            // prefix range delete: full ck1, partial (ck1, ck2) prefix
+            execute("DELETE FROM %s WHERE pk = ? AND ck1 = ?", (long) round, "beta");
+            execute("DELETE FROM %s WHERE pk = ? AND ck1 = ? AND ck2 >= ? AND ck2 < ?",
+                    (long) round, "gamma", 1, 4);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Wide partition crossing column-index block boundaries (indexed RowIndexEntry path). */
+    @Test
+    public void widePartitionCrossingIndexBlocks() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(200);
+        // two sstables, each with the same single wide partition (~4000 rows * ~200B >> 64KiB index block)
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 4000; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, padding + "-" + round + "-" + ck);
+            // plus range tombstones inside the wide partition
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, round * 500L, round * 500L + 250L);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Partition that crosses the column-index block threshold exactly once: the index has one
+     * cut block plus a tail. Iterator promotes the index (2 entries); exercises the cursor's
+     * promotion decision boundary (rowIndexEntriesOffsets.size() <= 1 check happens before the
+     * tail block is added).
+     */
+    @Test
+    public void partitionCrossingOneIndexBlock() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(200);
+        // ~6KB partition: crosses the test config's column_index_size (4KiB) exactly once,
+        // producing one cut block plus a tail — the index promotion boundary
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 30; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, padding + "-" + round);
+            // pk 2 stays well UNDER the threshold: the sub-threshold control, without which this
+            // scenario would pass on "large partitions get an index" rather than on the boundary
+            for (long ck = 0; ck < 3; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, ck, "small-" + round);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: the cross-generation rung leaves the CURSOR-produced output live, so the promoted
+        // index can be read back directly. The iterator promotes when the total block count INCLUDING
+        // the tail exceeds one (RowIndexEntry.create); a merge that decides before counting the tail
+        // leaves a partition crossing the threshold exactly once with no promoted index at all, and no
+        // intra-partition seeks. Byte-equality pins this via Index.db only while the reference stays
+        // correct, so the promotion is stated here directly.
+        assertEquals("the cross-generation rung should leave one cursor-produced output",
+                     1, cfs.getLiveSSTables().size());
+        SSTableReader output = cfs.getLiveSSTables().iterator().next();
+        assertEquals("a partition crossing column_index_size exactly once must be promoted with the " +
+                     "cut block AND its tail", 2, blockCount(output, 1L));
+        assertEquals("a partition well under column_index_size must not be promoted", 0,
+                     blockCount(output, 2L));
+    }
+
+    /** Promoted index block count for {@code pk} in {@code sstable}; 0 when the partition is not indexed. */
+    private static int blockCount(SSTableReader sstable, long pk)
+    {
+        RowIndexEntry entry = ((BigTableReader) sstable).getRowIndexEntry(sstable.decorateKey(ByteBufferUtil.bytes(pk)),
+                                                                         SSTableReader.Operator.EQ);
+        assertNotNull("expected pk " + pk + " to be present in " + sstable.descriptor, entry);
+        return entry.blockCount();
+    }
+
+    /** Overlapping range tombstones across sstables: boundary markers must merge identically. */
+    @Test
+    public void overlappingRangeTombstones() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 3; pk++)
+            for (long ck = 0; ck < 100; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        flush();
+
+        // sstable 2: ranges [10, 50), [60, 70]
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 10 AND ck < 50");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 60 AND ck <= 70");
+        flush();
+
+        // sstable 3: ranges overlapping/adjacent to sstable 2's: [30, 65), (70, 80]
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 30 AND ck < 65");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck > 70 AND ck <= 80");
+        // and exact adjacency in another partition: [10,20) then [20,30)
+        execute("DELETE FROM %s WHERE pk = 1 AND ck >= 10 AND ck < 20");
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 1 AND ck >= 20 AND ck < 30");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Frozen collections and tuples are single cells and inside the supported surface. */
+    @Test
+    public void frozenCollections() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, " +
+                    "m frozen<map<text, bigint>>, l frozen<list<text>>, s frozen<set<int>>, " +
+                    "t frozen<tuple<int, text>>, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 5; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, m, l, s, t) VALUES (?, ?, ?, ?, ?, (?, ?))",
+                            pk, ck,
+                            map("k" + round, ck, "x", (long) round),
+                            list("a" + round, "b" + ck),
+                            set((int) ck, round, 42),
+                            round, "tup" + ck);
+            execute("DELETE m FROM %s WHERE pk = ? AND ck = ?", 0L, (long) round);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Partition keys larger than 128 bytes: every other scenario in this suite uses an 8-byte
+     * bigint pk, which never exercises anything beyond the smallest possible key. Partition keys
+     * are length-prefixed with an unsigned SHORT (not a vint), so there is no 128-byte encoding
+     * boundary here the way there is for clustering/cell values — this scenario instead pins
+     * that large (100s-1000s of bytes) partition keys round-trip correctly through the cursor's
+     * partition-key copy/compare/index paths, which nothing else in this suite reaches.
+     */
+    @Test
+    public void largePartitionKey() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk text, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String[] pks = { "k".repeat(200), "m".repeat(500), "z".repeat(1000) };
+        for (int round = 0; round < 3; round++)
+        {
+            for (String pk : pks)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "round" + round + "-" + ck);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", pks[1], 2L, 5L);
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+        // and that the keys really are large: shrinking pks would leave the scenario passing while
+        // its name and javadoc still claimed 100s-1000s of bytes
+        assertTrue("the 1000-byte partition key is not in the output",
+                   allJson(out).contains("z".repeat(1000)));
+    }
+
+    /** Composite partition key whose components individually stay small but sum past 128 bytes. */
+    @Test
+    public void largeCompositePartitionKey() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk1 text, pk2 text, ck bigint, v text, PRIMARY KEY ((pk1, pk2), ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String a = "a".repeat(100);
+        String b = "b".repeat(100);
+        for (int round = 0; round < 3; round++)
+        {
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk1, pk2, ck, v) VALUES (?, ?, ?, ?)", a, b, ck, "v" + round + "-" + ck);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk1 = ? AND pk2 = ? AND ck >= ? AND ck < ?", a, b, 2L, 6L);
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+        assertTrue("the 100-byte composite key components are not in the output",
+                   allJson(out).contains(a) && allJson(out).contains(b));
+    }
+
+    /**
+     * Clustering column values straddling the 1-byte/2-byte vint length-prefix boundary (128
+     * bytes) — timestampTiesDifferentLengthValues below pins this boundary for regular VALUES,
+     * but the clustering block's own per-component length vints (readUnfilteredClustering) are
+     * never exercised at the boundary anywhere else in this suite.
+     */
+    @Test
+    public void largeClusteringColumn() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck text, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // 127/128/129: astride the one-byte/two-byte vint length-prefix boundary; 300: well past it
+        String[] cks = { "a".repeat(127), "b".repeat(128), "c".repeat(129), "d".repeat(300) };
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 3; pk++)
+                for (String ck : cks)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = 0 AND ck = ?", cks[1]);
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+        // the boundary value specifically: 128 bytes is the 1-byte/2-byte vint length-prefix step
+        assertTrue("the 128-byte clustering value is not in the output",
+                   allJson(out).contains("b".repeat(128)));
+    }
+
+    /** Frozen UDT as the CLUSTERING key (not just a regular column, as in frozenCollections above). */
+    @Test
+    public void frozenUdtInClusteringKey() throws Exception
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        createTable("CREATE TABLE %s (pk bigint, ck frozen<" + udt + ">, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 4; pk++)
+                for (int i = 0; i < 5; i++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, userType("a", i, "b", "b" + i), "v" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = 0 AND ck = ?", userType("a", 2, "b", "b2"));
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Frozen UDT as (part of) the PARTITION key. */
+    @Test
+    public void frozenUdtInPartitionKey() throws Exception
+    {
+        String udt = createType("CREATE TYPE %s (a int, b text)");
+        createTable("CREATE TABLE %s (pk frozen<" + udt + ">, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (int i = 0; i < 4; i++)
+                for (long ck = 0; ck < 5; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", userType("a", i, "b", "p" + i), ck, "v" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", userType("a", 1, "b", "p1"), 1L, 3L);
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Frozen collection as the CLUSTERING key (not just a regular column, as in frozenCollections above). */
+    @Test
+    public void frozenCollectionInClusteringKey() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck frozen<list<int>>, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 4; pk++)
+                for (int i = 0; i < 5; i++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, list(i, i + 1, i + 2), "v" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = 0 AND ck = ?", list(2, 3, 4));
+        flush();
+
+        assertEquals("expected four overlapping inputs; a lost flush() would degrade this to a single-sstable rewrite",
+                     4, cfs.getLiveSSTables().size());
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** TTLs: live expiring cells and already-expired cells (expiry far from run boundaries). */
+    @Test
+    public void expiringCells() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // long TTLs: alive during both runs
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 86400", pk, ck, "a" + ck, "b" + ck);
+        flush();
+
+        // short TTLs: expired well before either run
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?) USING TTL 1", 1L, ck, "expired" + ck);
+        // mixed: row with one TTL'd and one permanent cell
+        for (long ck = 0; ck < 10; ck++)
+            execute("UPDATE %s USING TTL 86400 SET v1 = ? WHERE pk = ? AND ck = ?", "ttl" + ck, 2L, ck);
+        flush();
+
+        // fixed "now" two seconds past the LAST write, so the TTL=1 cells have expired relative to
+        // it however long the write phase took, while the 86400s TTLs stay comfortably alive
+        long fixedNow = FBUtilities.nowInSeconds() + 2;
+        assertSomethingExpiredAt(cfs, fixedNow);
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, () -> fixedNow);
+    }
+
+    /** Same-timestamp conflicting writes: reconciliation must tie-break identically. */
+    @Test
+    public void timestampTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 20; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "aaa" + ck);
+        flush();
+
+        for (long ck = 0; ck < 20; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "zzz" + ck);
+        flush();
+
+        // tombstone vs write at the same timestamp: delete wins
+        execute("DELETE FROM %s USING TIMESTAMP 2000 WHERE pk = 1 AND ck = 5");
+        for (long ck = 4; ck < 7; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 2000", 1L, ck, "tie" + ck);
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: at equal timestamps the GREATER raw value wins — the value compare
+        // Cells.resolveRegular falls through to when the shared decision table returns COMPARE — so
+        // every "zzz" beats its "aaa" partner. A merge with that comparison inverted keeps the "aaa"
+        // partner, which byte equality cannot see if both paths share the inversion.
+        // ck 4..6 are excluded: they are overwritten at ts 2000 and ck 5 is row-deleted there, so
+        // their survivor is decided by timestamp, not by the value rule under test.
+        String json = allJson(out);
+        for (long ck = 0; ck < 20; ck++)
+        {
+            if (ck >= 4 && ck <= 6)
+                continue;
+            assertTrue("the greater value must win the same-timestamp tie at ck " + ck,
+                       json.contains(cellValue("zzz" + ck)));
+            assertFalse("the lexicographically smaller value won the same-timestamp tie at ck " + ck,
+                        json.contains(cellValue("aaa" + ck)));
+        }
+        assertEquals("expected one surviving zzz value per tie the loop above covers, or it is " +
+                     "covering fewer ties than it claims",
+                     17, countOccurrences(json, "\"value\":\"zzz"));
+    }
+
+    /**
+     * Same-timestamp ties between values of DIFFERENT LENGTHS: the reference tie-break
+     * (the value compare Cells.resolveRegular falls through to when the shared decision table
+     * returns COMPARE, i.e. ValueAccessor.compare) is plain unsigned lexicographic on the RAW value
+     * bytes, where a comparison of the WIRE form would see
+     * the leading length vint first and order by LENGTH (the vint's first byte encodes it).
+     * The timestampTies pin above uses equal-length values and cannot see the difference.
+     * Covers both directions and the 1-byte/2-byte vint boundary (length 128).
+     */
+    @Test
+    public void timestampTiesDifferentLengthValues() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // raw order: "z" > "aa"; wire order: len 1 < len 2 — the reference keeps "z"
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "z");
+        // vint-boundary variant: raw keeps the 100-char "b..."; wire would pick the
+        // 200-char "a..." (len 100 = one-byte vint 0x64, len 200 = two-byte vint 0x81 0x48)
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "b".repeat(100));
+        flush();
+
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "aa");
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "a".repeat(200));
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: the reference compares RAW value bytes, so "z" (0x7a) beats "aa" (0x61 0x61) and
+        // the 100-char "b" run beats the 200-char "a" run. A comparison over the WIRE form would see
+        // the leading length vint first and order by length, picking the other winner in both pairs.
+        // It only shows up where the two orderings disagree, which is what this scenario arranges.
+        String json = allJson(out);
+        assertEquals("the shorter-but-greater value must win all four ties", 4,
+                     countOccurrences(json, cellValue("z")));
+        assertFalse("length ordering won over raw-byte ordering: the longer \"aa\" survived",
+                    json.contains(cellValue("aa")));
+        assertEquals("the shorter-but-greater value must win all four vint-boundary ties", 4,
+                     countOccurrences(json, cellValue("b".repeat(100))));
+        assertFalse("length ordering won over raw-byte ordering at the vint boundary: the 200-char " +
+                    "value survived", json.contains(cellValue("a".repeat(200))));
+    }
+
+    /** Newer partition deletion shadowing older data across several sstables. */
+    @Test
+    public void shadowedPartitions() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 6; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = 2");
+        execute("DELETE FROM %s WHERE pk = 3");
+        // resurrection after the partition delete
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, 0L, "alive-again");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Single-input compaction: pure rewrite, no merge. */
+    @Test
+    public void singleInputSSTable() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 2 AND ck < 6");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Many inputs: 8-way merge exercises the merge heap harder than the usual 2-4. */
+    @Test
+    public void eightWayMerge() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 8; round++)
+        {
+            // partial, interleaved coverage: each sstable covers a sliding window
+            for (long pk = round; pk < round + 6; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "c" + ck);
+            if (round % 2 == 0)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?", (long) round, 3L);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Disjoint inputs: no overlapping partitions, pure concatenation. */
+    @Test
+    public void disjointInputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = round * 100; pk < round * 100 + 10; pk++)
+                for (long ck = 0; ck < 5; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Empty (zero-length) values are valid and distinct from null; both must survive merge. */
+    @Test
+    public void emptyAndNullValues() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 blob, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 1L, ck, "value" + ck, ByteBufferUtil.bytes("cafe"));
+        flush();
+
+        // empty-string / empty-blob overwrites
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 1L, ck, "", ByteBufferUtil.EMPTY_BYTE_BUFFER);
+        // null overwrites (cell tombstones)
+        for (long ck = 5; ck < 8; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Empty clustering values on a DESC (reversed) clustering column, found by the randomized
+     * soak (seed 99303954147053). Every base type sorts empty before
+     * values, so a reversed column sorts empty AFTER values (ReversedType swaps operands
+     * around the base comparison). The cursor path's raw clustering comparison decided
+     * empty-vs-valued purely from the serialized flag bits, ignoring reversal:
+     *  - same-partition variant: rows with empty and valued clusterings for the SAME pk in
+     *    different sstables merge in the wrong order (Data.db divergence — corruption class);
+     *  - cross-partition variant: the global covered-clustering max picks the wrong row
+     *    (Statistics.db divergence — what the soak caught).
+     */
+    @Test
+    public void emptyClusteringValuesDescending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC)");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // sstable 1: valued clusterings for pk 1 (same-partition variant) and pk 2 (the
+        // lexically-largest valued rows, cross-partition variant)
+        for (long ck = 1; ck <= 5; ck++)
+        {
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "p1v" + ck);
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, ck * 1000, "p2v" + ck);
+        }
+        flush();
+
+        // sstable 2: EMPTY clustering values — same partition as pk 1's valued rows (the
+        // merge must order empty AFTER values under DESC), plus an empty-only partition
+        // (the global max clustering must be the empty value, not pk 2's large bigints)
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p1empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p3empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: under DESC the reversed type sorts an EMPTY component AFTER valued ones, so pk 1's
+        // empty-clustering row must be emitted last in its partition. The dump is in sstable order, so
+        // comparing positions states the merge order directly. Byte-equality cannot see this if both
+        // paths share the ordering, and a comparison derived from the serialized flag bits alone
+        // ignores reversal.
+        assertEmptyClusteringOrder(allJson(out), true);
+    }
+
+    /**
+     * Asserts where pk 1's empty-clustering row sits relative to its smallest valued clustering.
+     * Under DESC (reversed) empty sorts after values; under ASC it sorts before them. Both scenarios
+     * write the same shape, so the pair is what stops a fix from over-applying the reversal flip or
+     * from dropping the null guard that keeps nulls type-independent.
+     */
+    private static void assertEmptyClusteringOrder(String json, boolean descending)
+    {
+        int emptyAt = json.indexOf(cellValue("p1empty"));
+        // ck 1 is the smallest valued clustering, so it is emitted LAST under DESC and FIRST under ASC
+        int smallestValuedAt = json.indexOf(cellValue("p1v1"));
+        assertTrue("the scenario stopped writing its empty-clustering row", emptyAt >= 0);
+        assertTrue("the scenario stopped writing its smallest valued clustering", smallestValuedAt >= 0);
+        if (descending)
+            assertTrue("under DESC an empty clustering component sorts AFTER valued ones, but the " +
+                       "merge emitted it first", emptyAt > smallestValuedAt);
+        else
+            assertTrue("under ASC an empty clustering component sorts BEFORE valued ones, but the " +
+                       "merge emitted it last", emptyAt < smallestValuedAt);
+    }
+
+    /** ASC counterpart of emptyClusteringValuesDescending: empty sorts BEFORE values on a
+     *  non-reversed column; pins the unflipped flag ordering. */
+    @Test
+    public void emptyClusteringValuesAscending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 1; ck <= 5; ck++)
+        {
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "p1v" + ck);
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, -ck * 1000, "p2v" + ck);
+        }
+        flush();
+
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p1empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p3empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE, and the control half of the pair: without reversal the empty component sorts
+        // FIRST, so a fix that flipped unconditionally would fail here while the DESC scenario passed.
+        assertEmptyClusteringOrder(allJson(out), false);
+    }
+
+    /**
+     * Row liveness shapes: UPDATE-built rows carry NO primary-key liveness (different row
+     * flags than INSERT-built rows), primary-key-only INSERTs carry liveness and ZERO cells,
+     * and merges must reconcile liveness presence/absence across sstables exactly.
+     */
+    @Test
+    public void rowLivenessShapes() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // UPDATE-built rows (no liveness) and liveness-only rows in sstable 1
+        for (long ck = 0; ck < 10; ck++)
+            execute("UPDATE %s SET v1 = ?, v2 = ? WHERE pk = ? AND ck = ?", "u" + ck, "w" + ck, 1L, ck);
+        for (long ck = 10; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck) VALUES (?, ?)", 1L, ck);
+        flush();
+
+        // sstable 2: INSERT onto UPDATE-rows (liveness arrives later), cell tombstones onto
+        // liveness-only rows (row must survive on liveness alone), and a cell delete that strips
+        // every cell from an UPDATE-row — which leaves a row with no liveness and two cell
+        // tombstones, NOT an absent row: the table takes the default 10-day gc_grace, so the
+        // tombstones' localDeletionTime sits far above the gcBefore this runs at and both paths
+        // emit them. The vanishing shape needs a gcBefore above that localDeletionTime, which the
+        // explicit-gcBefore overload of assertCursorMatchesIterator can supply.
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", 1L, ck, "i" + ck);
+        for (long ck = 10; ck < 13; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
+        execute("DELETE v1, v2 FROM %s WHERE pk = ? AND ck = ?", 1L, 5L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Row-level TTL (INSERT USING TTL sets liveness TTL + cell TTLs) merged against
+     * cell-level TTL (UPDATE USING TTL sets only cell TTLs) and against plain writes;
+     * includes same-timestamp expiring-vs-expiring writes whose TTLs differ, which
+     * CellLivenessInfo.resolveSameTimestampTie settles on its greater-localDeletionTime branch:
+     * both sides carry one,
+     * so the GREATER wins — here the TTL 100000 cell, written in the EARLIER sstable. The branch
+     * below it (equal
+     * expiration times, differing TTLs, LOWER TTL wins) is NOT covered: expiration is
+     * nowInSec + ttl, so reaching it from CQL against a live clock would need the two
+     * same-timestamp writes separated by EXACTLY the TTL difference in wall-clock seconds. Any
+     * other spacing leaves the expirations differing, and the greater-expiration branch decides
+     * first.
+     */
+    @Test
+    public void rowAndCellTtlMix() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // ck 9..11 are deliberately NOT written here: the tie under test is at TIMESTAMP 5000, and a
+        // wall-clock write to the same cell dominates it on timestamp before any tie-break is
+        // consulted, which would leave the tie constructed but discarded.
+        for (long ck = 0; ck < 9; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 86400", 1L, ck, "a" + ck, "b" + ck);
+        flush();
+
+        // cell-level TTL different from the row TTL; plain overwrites clearing TTLs;
+        // expiring-vs-expiring same-timestamp ties with different TTLs
+        for (long ck = 0; ck < 6; ck++)
+            execute("UPDATE %s USING TTL 172800 SET v1 = ? WHERE pk = ? AND ck = ?", "c" + ck, 1L, ck);
+        for (long ck = 6; ck < 9; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", 1L, ck, "plain" + ck);
+        for (long ck = 9; ck < 12; ck++)
+            execute("UPDATE %s USING TTL 100000 AND TIMESTAMP 5000 SET v2 = ? WHERE pk = ? AND ck = ?", "t1" + ck, 1L, ck);
+        flush();
+
+        for (long ck = 9; ck < 12; ck++)
+            execute("UPDATE %s USING TTL 50000 AND TIMESTAMP 5000 SET v2 = ? WHERE pk = ? AND ck = ?", "t2" + ck, 1L, ck);
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: byte equality cannot see a tie-break both paths get wrong, so the surviving value
+        // is stated outright. A merge resolving a same-timestamp expiring pair by write order, or by the
+        // lower localExpirationTime, keeps "t2..".
+        String json = allJson(out);
+        for (long ck = 9; ck < 12; ck++)
+        {
+            assertTrue("the greater localExpirationTime must win the same-timestamp expiring tie at ck " + ck,
+                       json.contains(cellValue("t1" + ck)));
+            assertFalse("the lower localExpirationTime won the same-timestamp expiring tie at ck " + ck,
+                        json.contains(cellValue("t2" + ck)));
+        }
+        // Pins the loop from the other side: three ties, three survivors. The negative assertions above
+        // are all satisfied by an output that dropped the rows entirely.
+        assertEquals("expected one greater-localExpirationTime winner per tie", 3, countOccurrences(json, "\"value\":\"t1"));
+    }
+
+    /**
+     * Expiring-vs-live cells at the SAME timestamp, both directions across sstables: the
+     * CASSANDRA-14592 rule — an expiring (or deleted) cell beats a live one on timestamp
+     * tie regardless of value. Implemented in
+     * CellLivenessInfo.resolveSameTimestampTie's tombstone-or-expiring-beats-live branch; this pins
+     * it at the differential level (timestampTies only covered live-vs-live and delete-vs-live).
+     */
+    @Test
+    public void expiringVsLiveTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // direction 1: live first, expiring second
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "zzz-live" + ck);
+        // direction 2 partition: expiring first
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000 AND TTL 86400", 2L, ck, "aaa-ttl" + ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000 AND TTL 86400", 1L, ck, "aaa-ttl" + ck);
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "zzz-live" + ck);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Cell TOMBSTONE vs EXPIRING cell at the SAME timestamp: the shared decision table
+     * (CellLivenessInfo.resolveSameTimestampTie, which Cells.resolveRegular defers to) gives the
+     * tombstone the tie, BEFORE any localDeletionTime comparison. This is the one same-timestamp pairing where both
+     * sides carry a localExpirationTime (tombstone: deletion second; expiring: expiry
+     * second), so a resolver that classifies "tombstone" by the presence of a
+     * localExpirationTime rather than by the absence of a TTL never reaches that branch and
+     * falls through to the ldt compare,
+     * which the expiring cell's future expiry second wins: deleted data resurrected
+     * until the TTL lapses. Both flush orders and both tombstone shapes
+     * (UPDATE SET v = null, DELETE v) across distinct partitions.
+     */
+    @Test
+    public void tombstoneVsExpiringTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // pk 1: tombstone flushed first, expiring second; tombstone via UPDATE SET null
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TIMESTAMP 5000 SET v = null WHERE pk = ? AND ck = ?", 1L, ck);
+        // pk 2: expiring flushed first, tombstone second; tombstone via DELETE column
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TTL 86400 AND TIMESTAMP 5000 SET v = ? WHERE pk = ? AND ck = ?", "live" + ck, 2L, ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TTL 86400 AND TIMESTAMP 5000 SET v = ? WHERE pk = ? AND ck = ?", "live" + ck, 1L, ck);
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE v FROM %s USING TIMESTAMP 5000 WHERE pk = ? AND ck = ?", 2L, ck);
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIteratorAcrossGenerations(cfs);
+
+        // ABSOLUTE: the tombstone must win every tie, in both flush orders. Byte-equality cannot see
+        // this, and a merge that never reaches the rule picks the expiring cell, resurrecting deleted
+        // data together with its value.
+        String json = allJson(out);
+        for (long ck = 0; ck < 5; ck++)
+            assertFalse("an expiring cell won a same-timestamp tie against a tombstone at ck " + ck +
+                        ", which resurrects deleted data", json.contains(cellValue("live" + ck)));
+        assertEquals("expected one surviving cell tombstone per tie, over both flush orders",
+                     10, countOccurrences(json, CELL_TOMBSTONE));
+        // The survivor is a tombstone, not a TTL'd cell: an expiring cell would render a ttl field,
+        // and nothing else in this scenario carries one.
+        assertFalse("a survivor still carries a TTL, so an expiring cell won a tie",
+                    json.contains("\"ttl\":"));
+    }
+
+    /** Vector and duration columns: fixed-dimension float vectors and the
+     *  variable-length duration encoding as ordinary single cells, overwritten and
+     *  null-overwritten (cell tombstone) across sstables. */
+    @Test
+    public void vectorAndDuration() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, vec vector<float, 3>, dur duration, v text, " +
+                    "PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, vec, dur, v) VALUES (?, ?, [1.5, 2.5, " + ck + ".0], 2h30m, ?)",
+                    1L, ck, "v" + ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, vec, dur, v) VALUES (?, ?, [9.0, 8.0, 7.0], 45s500ms, ?)",
+                    1L, ck, "w" + ck);
+        // null overwrites: cell tombstones for vector and duration cells
+        execute("INSERT INTO %s (pk, ck, vec, dur) VALUES (?, ?, null, null)", 1L, 7L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Fixed-length values LARGER than the cursor's 4KiB copy buffer. A {@code vector<float, 1536>} — a
+     * mainstream embedding width — is 6144 bytes, and unlike a variable-length value it carries no
+     * length vint, so the copy cannot be driven off the wire length. Covers a value spanning several
+     * chunks, one landing exactly on the buffer boundary ({@code vector<float, 1024>} is 4096), a
+     * same-timestamp tie ACROSS sstables so the value also travels through the compactor's temp
+     * buffers rather than straight to the writer, and a null overwrite of an oversized column.
+     */
+    @Test
+    public void fixedLengthValuesLargerThanCopyBuffer() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, big vector<float, 1536>, " +
+                    "exact vector<float, 1024>, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 4; ck++)
+        {
+            // ck 2 is written only by the same-timestamp inserts below. An auto-timestamp write
+            // here would reconcile with them in the memtable and win, and the merge would then
+            // resolve on timestamp and never reach the value comparison.
+            if (ck == 2)
+                continue;
+            execute("INSERT INTO %s (pk, ck, big, exact, v) VALUES (?, ?, ?, ?, ?)",
+                    1L, ck, floats(1536, ck), floats(1024, ck), "v" + ck);
+        }
+        // ck 2: one half of a same-timestamp tie. It must be in a DIFFERENT sstable from its
+        // partner, or the memtable reconciles the two before either reaches disk and the merge
+        // resolves on timestamp instead of reaching the value comparison.
+        execute("INSERT INTO %s (pk, ck, big, exact) VALUES (?, ?, ?, ?) USING TIMESTAMP 5000",
+                1L, 2L, floats(1536, 7), floats(1024, 7));
+        flush();
+
+        // ck 0..1: overwritten at a later timestamp, so the winner is copied straight through
+        for (long ck = 0; ck < 2; ck++)
+            execute("INSERT INTO %s (pk, ck, big, exact, v) VALUES (?, ?, ?, ?, ?)",
+                    1L, ck, floats(1536, ck + 100), floats(1024, ck + 100), "w" + ck);
+        // ck 2: the other half of the tie, so both oversized values are buffered and compared
+        execute("INSERT INTO %s (pk, ck, big, exact) VALUES (?, ?, ?, ?) USING TIMESTAMP 5000",
+                1L, 2L, floats(1536, 8), floats(1024, 8));
+        // ck 3: null overwrite -> cell tombstone on an oversized fixed-length column
+        execute("INSERT INTO %s (pk, ck, big) VALUES (?, ?, null)", 1L, 3L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Deterministic float vector of the given dimension; dimension * 4 bytes on the wire. */
+    private Vector<Float> floats(int dimension, long salt)
+    {
+        float[] v = new float[dimension];
+        for (int i = 0; i < dimension; i++)
+            v[i] = i + salt;
+        return vector(v);
+    }
+
+    /**
+     * More than 64 regular columns: rows lacking columns switch from the 64-bit-mask
+     * column-subset encoding to the structurally different large-subset wire format —
+     * byte-compared here for the first time; previously only the old simple-suite
+     * exercised it without comparing the paths against each other.
+     */
+    @Test
+    public void over64Columns() throws Exception
+    {
+        StringBuilder ddl = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int i = 0; i < 70; i++)
+            ddl.append(", c").append(i).append(" int");
+        ddl.append(", PRIMARY KEY (pk, ck))");
+        createTable(ddl.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // sparse rows: each ck sets a sliding 10-column window (subset encoding for >64 columns)
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 14; ck++)
+            {
+                StringBuilder stmt = new StringBuilder("INSERT INTO %s (pk, ck");
+                int base = (int) ck * 5 + round * 3;
+                for (int i = 0; i < 10; i++)
+                    stmt.append(", c").append((base + i) % 70);
+                stmt.append(") VALUES (?, ?");
+                for (int i = 0; i < 10; i++)
+                    stmt.append(", ").append(base + i);
+                stmt.append(')');
+                execute(stmt.toString(), 1L, ck);
+            }
+            // one full row per round: the HAS_ALL_COLUMNS path next to large subsets
+            StringBuilder full = new StringBuilder("INSERT INTO %s (pk, ck");
+            for (int i = 0; i < 70; i++)
+                full.append(", c").append(i);
+            full.append(") VALUES (?, ?");
+            for (int i = 0; i < 70; i++)
+                full.append(", ").append(i);
+            full.append(')');
+            execute(full.toString(), 1L, 99L);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * OPEN-ENDED (single-sided) range tombstones: DELETE with only a lower or upper
+     * clustering bound produces markers whose other side is the unbounded partition edge —
+     * zero-component TOP/BOTTOM bounds, the same empty-prefix region bound-kind comparisons
+     * and covered-clustering stats exercise. Open RTs nest with each other, overlap bounded
+     * RTs and rows across sstables, and one partition is open-RT-only.
+     * Previously covered only probabilistically by the widened soak.
+     */
+    @Test
+    public void openEndedRangeTombstones() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 1; pk <= 2; pk++)
+            for (long ck = 0; ck < 30; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, 10L, 20L); // bounded, for interleave
+        flush();
+
+        // open-ended deletes: up to TOP, down from BOTTOM, nested opens, and an RT-only partition
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, 25L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck > ?", 1L, 27L);  // nests inside the >= 25 open range
+        execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", 2L, 4L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 3L, 0L);  // partition with ONLY an open RT
+        flush();
+
+        // resurrection inside open-deleted ranges with newer timestamps
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 26L, "resurrected");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, 2L, "resurrected");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** DESC counterpart: single-sided bounds invert in on-disk clustering order, so the
+     *  open edge swaps between TOP and BOTTOM relative to the CQL bound direction. */
+    @Test
+    public void openEndedRangeTombstonesDescending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC) AND gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 30; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "v" + ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, 25L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", 1L, 4L);
+        flush();
+
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 27L, "resurrected");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * ODD superset size at the subset-encoding mode boundary: with 71 columns, the encoder
+     * and decoder must agree on present-index vs missing-index
+     * mode at exactly presentCount == 35 (the integer-division boundary of supersetCount/2).
+     * Rows at 34/35/36 present columns straddle the boundary from both sides.
+     */
+    @Test
+    public void over64ColumnsOddSupersetBoundary() throws Exception
+    {
+        StringBuilder ddl = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int i = 0; i < 71; i++)
+            ddl.append(", c").append(i).append(" int");
+        ddl.append(", PRIMARY KEY (pk, ck))");
+        createTable(ddl.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 2; round++)
+        {
+            long ck = 0;
+            for (int present : new int[]{ 34, 35, 36, 70 })
+            {
+                StringBuilder stmt = new StringBuilder("INSERT INTO %s (pk, ck");
+                for (int i = 0; i < present; i++)
+                    stmt.append(", c").append((i + round) % 71); // shift per round so the merge unions
+                stmt.append(") VALUES (?, ?");
+                for (int i = 0; i < present; i++)
+                    stmt.append(", ").append(i);
+                stmt.append(')');
+                execute(stmt.toString(), 1L, ck++);
+            }
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -37,7 +36,6 @@ import org.apache.cassandra.utils.ByteBufferUtil;
  */
 public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     /**
      * Static-column table where some partitions have NO static values: an empty static row is
@@ -65,7 +63,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Reversed clustering order changes on-disk ordering and bound comparisons. */
@@ -86,7 +84,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Multi-component clusterings: mixed types, shared prefixes, per-component bounds. */
@@ -113,7 +111,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Wide partition crossing column-index block boundaries (indexed RowIndexEntry path). */
@@ -135,7 +133,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -161,7 +159,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Overlapping range tombstones across sstables: boundary markers must merge identically. */
@@ -193,7 +191,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("DELETE FROM %s WHERE pk = 1 AND ck >= 20 AND ck < 30");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Frozen collections and tuples are single cells and inside the supported surface. */
@@ -220,7 +218,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** TTLs: live expiring cells and already-expired cells (expiry far from run boundaries). */
@@ -247,7 +245,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 
         Thread.sleep(2000); // let the short TTLs expire well before the first run
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Same-timestamp conflicting writes: reconciliation must tie-break identically. */
@@ -272,7 +270,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 2000", 1L, ck, "tie" + ck);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Newer partition deletion shadowing older data across several sstables. */
@@ -297,7 +295,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, 0L, "alive-again");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Single-input compaction: pure rewrite, no merge. */
@@ -314,7 +312,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("DELETE FROM %s WHERE pk = 0 AND ck >= 2 AND ck < 6");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Many inputs: 8-way merge exercises the merge heap harder than the usual 2-4. */
@@ -336,7 +334,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Disjoint inputs: no overlapping partitions, pure concatenation. */
@@ -355,7 +353,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Empty (zero-length) values are valid and distinct from null; both must survive merge. */
@@ -378,7 +376,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -417,7 +415,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** ASC counterpart of emptyClusteringValuesDescending: empty sorts BEFORE values on a
@@ -441,7 +439,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -473,7 +471,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("DELETE v1, v2 FROM %s WHERE pk = ? AND ck = ?", 1L, 5L);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -507,7 +505,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("UPDATE %s USING TTL 50000 AND TIMESTAMP 5000 SET v2 = ? WHERE pk = ? AND ck = ?", "t2" + ck, 1L, ck);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -537,7 +535,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "zzz-live" + ck);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** Vector and duration columns: fixed-dimension float vectors and the
@@ -563,7 +561,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, vec, dur) VALUES (?, ?, null, null)", 1L, 7L);
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -610,7 +608,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -647,7 +645,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, 2L, "resurrected");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /** DESC counterpart: single-sided bounds invert in on-disk clustering order, so the
@@ -671,7 +669,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 27L, "resurrected");
         flush();
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
     /**
@@ -708,6 +706,6 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -273,6 +273,39 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
+    /**
+     * Same-timestamp ties between values of DIFFERENT LENGTHS: the reference tie-break
+     * (Cells.resolveRegular rule (e) -> ValueAccessor.compare) is plain unsigned
+     * lexicographic on the RAW value bytes, where a comparison of the WIRE form would see
+     * the leading length vint first and order by LENGTH (the vint's first byte encodes it).
+     * The timestampTies pin above uses equal-length values and cannot see the difference.
+     * Covers both directions and the 1-byte/2-byte vint boundary (length 128).
+     */
+    @Test
+    public void timestampTiesDifferentLengthValues() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // raw order: "z" > "aa"; wire order: len 1 < len 2 — the reference keeps "z"
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "z");
+        // vint-boundary variant: raw keeps the 100-char "b..."; wire would pick the
+        // 200-char "a..." (len 100 = one-byte vint 0x64, len 200 = two-byte vint 0x81 0x48)
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "b".repeat(100));
+        flush();
+
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "aa");
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "a".repeat(200));
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
     /** Newer partition deletion shadowing older data across several sstables. */
     @Test
     public void shadowedPartitions() throws Exception

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+/**
+ * Edge-case corpus for the differential cursor-vs-iterator compaction harness, covering the
+ * CURRENTLY SUPPORTED cursor compaction surface (see CursorCompactor.isSupported). Every
+ * scenario here must run the cursor path for real — the harness fails loudly on silent
+ * fallback. Scenarios for unsupported shapes belong in CursorSupportMatrixTest instead.
+ */
+public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    /** Reversed clustering order changes on-disk ordering and bound comparisons. */
+    @Test
+    public void descendingClustering() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC)");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 5; pk++)
+                for (long ck = 0; ck < 30; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "v" + ck);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", (long) round, 5L, 15L);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Multi-component clusterings: mixed types, shared prefixes, per-component bounds. */
+    @Test
+    public void compositeClustering() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck1 text, ck2 int, ck3 bigint, v text, " +
+                    "PRIMARY KEY (pk, ck1, ck2, ck3))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String[] names = { "alpha", "beta", "gamma", "" /* empty string component */ };
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 4; pk++)
+                for (String ck1 : names)
+                    for (int ck2 = 0; ck2 < 5; ck2++)
+                        execute("INSERT INTO %s (pk, ck1, ck2, ck3, v) VALUES (?, ?, ?, ?, ?)",
+                                pk, ck1, ck2, (long) round, "v" + round);
+            // prefix range delete: full ck1, partial (ck1, ck2) prefix
+            execute("DELETE FROM %s WHERE pk = ? AND ck1 = ?", (long) round, "beta");
+            execute("DELETE FROM %s WHERE pk = ? AND ck1 = ? AND ck2 >= ? AND ck2 < ?",
+                    (long) round, "gamma", 1, 4);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Wide partition crossing column-index block boundaries (indexed RowIndexEntry path). */
+    @Test
+    public void widePartitionCrossingIndexBlocks() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(200);
+        // two sstables, each with the same single wide partition (~4000 rows * ~200B >> 64KiB index block)
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 4000; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, padding + "-" + round + "-" + ck);
+            // plus range tombstones inside the wide partition
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, round * 500L, round * 500L + 250L);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /**
+     * Partition that crosses the column-index block threshold exactly once: the index has one
+     * cut block plus a tail. Iterator promotes the index (2 entries); exercises the cursor's
+     * promotion decision boundary (rowIndexEntriesOffsets.size() <= 1 check happens before the
+     * tail block is added).
+     */
+    @Test
+    public void partitionCrossingOneIndexBlock() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(200);
+        // ~6KB partition: crosses the test config's column_index_size (4KiB) exactly once,
+        // producing one cut block plus a tail — the index promotion boundary
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 30; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, padding + "-" + round);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Overlapping range tombstones across sstables: boundary markers must merge identically. */
+    @Test
+    public void overlappingRangeTombstones() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 3; pk++)
+            for (long ck = 0; ck < 100; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        flush();
+
+        // sstable 2: ranges [10, 50), [60, 70]
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 10 AND ck < 50");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 60 AND ck <= 70");
+        flush();
+
+        // sstable 3: ranges overlapping/adjacent to sstable 2's: [30, 65), (70, 80]
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 30 AND ck < 65");
+        execute("DELETE FROM %s WHERE pk = 0 AND ck > 70 AND ck <= 80");
+        // and exact adjacency in another partition: [10,20) then [20,30)
+        execute("DELETE FROM %s WHERE pk = 1 AND ck >= 10 AND ck < 20");
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = 1 AND ck >= 20 AND ck < 30");
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Frozen collections and tuples are single cells and inside the supported surface. */
+    @Test
+    public void frozenCollections() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, " +
+                    "m frozen<map<text, bigint>>, l frozen<list<text>>, s frozen<set<int>>, " +
+                    "t frozen<tuple<int, text>>, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 5; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, m, l, s, t) VALUES (?, ?, ?, ?, ?, (?, ?))",
+                            pk, ck,
+                            map("k" + round, ck, "x", (long) round),
+                            list("a" + round, "b" + ck),
+                            set((int) ck, round, 42),
+                            round, "tup" + ck);
+            execute("DELETE m FROM %s WHERE pk = ? AND ck = ?", 0L, (long) round);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** TTLs: live expiring cells and already-expired cells (expiry far from run boundaries). */
+    @Test
+    public void expiringCells() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // long TTLs: alive during both runs
+        for (long pk = 0; pk < 5; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 86400", pk, ck, "a" + ck, "b" + ck);
+        flush();
+
+        // short TTLs: expired well before either run
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?) USING TTL 1", 1L, ck, "expired" + ck);
+        // mixed: row with one TTL'd and one permanent cell
+        for (long ck = 0; ck < 10; ck++)
+            execute("UPDATE %s USING TTL 86400 SET v1 = ? WHERE pk = ? AND ck = ?", "ttl" + ck, 2L, ck);
+        flush();
+
+        Thread.sleep(2000); // let the short TTLs expire well before the first run
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Same-timestamp conflicting writes: reconciliation must tie-break identically. */
+    @Test
+    public void timestampTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 20; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "aaa" + ck);
+        flush();
+
+        for (long ck = 0; ck < 20; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "zzz" + ck);
+        flush();
+
+        // tombstone vs write at the same timestamp: delete wins
+        execute("DELETE FROM %s USING TIMESTAMP 2000 WHERE pk = 1 AND ck = 5");
+        for (long ck = 4; ck < 7; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 2000", 1L, ck, "tie" + ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Newer partition deletion shadowing older data across several sstables. */
+    @Test
+    public void shadowedPartitions() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 6; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round);
+            flush();
+        }
+        execute("DELETE FROM %s WHERE pk = 2");
+        execute("DELETE FROM %s WHERE pk = 3");
+        // resurrection after the partition delete
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, 0L, "alive-again");
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Single-input compaction: pure rewrite, no merge. */
+    @Test
+    public void singleInputSSTable() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        execute("DELETE FROM %s WHERE pk = 0 AND ck >= 2 AND ck < 6");
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Many inputs: 8-way merge exercises the merge heap harder than the usual 2-4. */
+    @Test
+    public void eightWayMerge() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 8; round++)
+        {
+            // partial, interleaved coverage: each sstable covers a sliding window
+            for (long pk = round; pk < round + 6; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "c" + ck);
+            if (round % 2 == 0)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?", (long) round, 3L);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Disjoint inputs: no overlapping partitions, pure concatenation. */
+    @Test
+    public void disjointInputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = round * 100; pk < round * 100 + 10; pk++)
+                for (long ck = 0; ck < 5; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** Empty (zero-length) values are valid and distinct from null; both must survive merge. */
+    @Test
+    public void emptyAndNullValues() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 blob, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 1L, ck, "value" + ck, ByteBufferUtil.bytes("cafe"));
+        flush();
+
+        // empty-string / empty-blob overwrites
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", 1L, ck, "", ByteBufferUtil.EMPTY_BYTE_BUFFER);
+        // null overwrites (cell tombstones)
+        for (long ck = 5; ck < 8; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -538,6 +538,43 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 
+    /**
+     * Cell TOMBSTONE vs EXPIRING cell at the SAME timestamp: rule (b) of the reference
+     * decision table (Cells.resolveRegular) — the tombstone wins the tie, BEFORE any
+     * localDeletionTime comparison. This is the one same-timestamp pairing where both
+     * sides carry a localExpirationTime (tombstone: deletion second; expiring: expiry
+     * second), so a resolver that classifies "tombstone" via the loose
+     * ReusableLivenessInfo.isExpiring() predicate (true for tombstones too) never
+     * fires rule (b) and falls through to the ldt compare,
+     * which the expiring cell's future expiry second wins: deleted data resurrected
+     * until the TTL lapses. Both flush orders and both tombstone shapes
+     * (UPDATE SET v = null, DELETE v) across distinct partitions.
+     */
+    @Test
+    public void tombstoneVsExpiringTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // pk 1: tombstone flushed first, expiring second; tombstone via UPDATE SET null
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TIMESTAMP 5000 SET v = null WHERE pk = ? AND ck = ?", 1L, ck);
+        // pk 2: expiring flushed first, tombstone second; tombstone via DELETE column
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TTL 86400 AND TIMESTAMP 5000 SET v = ? WHERE pk = ? AND ck = ?", "live" + ck, 2L, ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("UPDATE %s USING TTL 86400 AND TIMESTAMP 5000 SET v = ? WHERE pk = ? AND ck = ?", "live" + ck, 1L, ck);
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE v FROM %s USING TIMESTAMP 5000 WHERE pk = ? AND ck = ?", 2L, ck);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
     /** Vector and duration columns: fixed-dimension float vectors and the
      *  variable-length duration encoding as ordinary single cells, overwritten and
      *  null-overwritten (cell tombstone) across sstables. */

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -614,6 +614,67 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
     }
 
     /**
+     * OPEN-ENDED (single-sided) range tombstones: DELETE with only a lower or upper
+     * clustering bound produces markers whose other side is the unbounded partition edge —
+     * zero-component TOP/BOTTOM bounds, the same empty-prefix region bound-kind comparisons
+     * and covered-clustering stats exercise. Open RTs nest with each other, overlap bounded
+     * RTs and rows across sstables, and one partition is open-RT-only.
+     * Previously covered only probabilistically by the widened soak.
+     */
+    @Test
+    public void openEndedRangeTombstones() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 1; pk <= 2; pk++)
+            for (long ck = 0; ck < 30; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + ck);
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, 10L, 20L); // bounded, for interleave
+        flush();
+
+        // open-ended deletes: up to TOP, down from BOTTOM, nested opens, and an RT-only partition
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, 25L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck > ?", 1L, 27L);  // nests inside the >= 25 open range
+        execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", 2L, 4L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 3L, 0L);  // partition with ONLY an open RT
+        flush();
+
+        // resurrection inside open-deleted ranges with newer timestamps
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 26L, "resurrected");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, 2L, "resurrected");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /** DESC counterpart: single-sided bounds invert in on-disk clustering order, so the
+     *  open edge swaps between TOP and BOTTOM relative to the CQL bound direction. */
+    @Test
+    public void openEndedRangeTombstonesDescending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC) AND gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 30; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "v" + ck);
+        flush();
+
+        execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, 25L);
+        execute("DELETE FROM %s WHERE pk = ? AND ck <= ?", 1L, 4L);
+        flush();
+
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 27L, "resurrected");
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /**
      * ODD superset size at the subset-encoding mode boundary: with 71 columns, the encoder
      * and decoder must agree on present-index vs missing-index
      * mode at exactly presentCount == 35 (the integer-division boundary of supersetCount/2).

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -576,9 +576,9 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
      * decision table (Cells.resolveRegular) — the tombstone wins the tie, BEFORE any
      * localDeletionTime comparison. This is the one same-timestamp pairing where both
      * sides carry a localExpirationTime (tombstone: deletion second; expiring: expiry
-     * second), so a resolver that classifies "tombstone" via the loose
-     * ReusableLivenessInfo.isExpiring() predicate (true for tombstones too) never
-     * fires rule (b) and falls through to the ldt compare,
+     * second), so a resolver that classifies "tombstone" by the presence of a
+     * localExpirationTime rather than by the absence of a TTL never fires rule (b) and
+     * falls through to the ldt compare,
      * which the expiring cell's future expiry second wins: deleted data resurrected
      * until the TTL lapses. Both flush orders and both tombstone shapes
      * (UPDATE SET v = null, DELETE v) across distinct partitions.
@@ -632,6 +632,62 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         flush();
 
         assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /**
+     * Fixed-length values LARGER than the cursor's 4KiB copy buffer. A {@code vector<float, 1536>} — a
+     * mainstream embedding width — is 6144 bytes, and unlike a variable-length value it carries no
+     * length vint, so the copy cannot be driven off the wire length. Covers a value spanning several
+     * chunks, one landing exactly on the buffer boundary ({@code vector<float, 1024>} is 4096), a
+     * same-timestamp tie ACROSS sstables so the value also travels through the compactor's temp
+     * buffers rather than straight to the writer, and a null overwrite of an oversized column.
+     */
+    @Test
+    public void fixedLengthValuesLargerThanCopyBuffer() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, big vector<float, 1536>, " +
+                    "exact vector<float, 1024>, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 4; ck++)
+        {
+            // ck 2 is written only by the same-timestamp inserts below. An auto-timestamp write
+            // here would reconcile with them in the memtable and win, and the merge would then
+            // resolve on timestamp and never reach the value comparison.
+            if (ck == 2)
+                continue;
+            execute("INSERT INTO %s (pk, ck, big, exact, v) VALUES (?, ?, ?, ?, ?)",
+                    1L, ck, floats(1536, ck), floats(1024, ck), "v" + ck);
+        }
+        // ck 2: one half of a same-timestamp tie. It must be in a DIFFERENT sstable from its
+        // partner, or the memtable reconciles the two before either reaches disk and the merge
+        // resolves on timestamp instead of reaching the value comparison.
+        execute("INSERT INTO %s (pk, ck, big, exact) VALUES (?, ?, ?, ?) USING TIMESTAMP 5000",
+                1L, 2L, floats(1536, 7), floats(1024, 7));
+        flush();
+
+        // ck 0..1: overwritten at a later timestamp, so the winner is copied straight through
+        for (long ck = 0; ck < 2; ck++)
+            execute("INSERT INTO %s (pk, ck, big, exact, v) VALUES (?, ?, ?, ?, ?)",
+                    1L, ck, floats(1536, ck + 100), floats(1024, ck + 100), "w" + ck);
+        // ck 2: the other half of the tie, so both oversized values are buffered and compared
+        execute("INSERT INTO %s (pk, ck, big, exact) VALUES (?, ?, ?, ?) USING TIMESTAMP 5000",
+                1L, 2L, floats(1536, 8), floats(1024, 8));
+        // ck 3: null overwrite -> cell tombstone on an oversized fixed-length column
+        execute("INSERT INTO %s (pk, ck, big) VALUES (?, ?, null)", 1L, 3L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
+    }
+
+    /** Deterministic float vector of the given dimension; dimension * 4 bytes on the wire. */
+    private Vector<Float> floats(int dimension, long salt)
+    {
+        float[] v = new float[dimension];
+        for (int i = 0; i < dimension; i++)
+            v[i] = i + salt;
+        return vector(v);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -376,4 +376,67 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 
         assertCursorMatchesIterator(cfs, ALLOWLIST);
     }
+
+    /**
+     * Empty clustering values on a DESC (reversed) clustering column, found by the randomized
+     * soak (seed 99303954147053). Every base type sorts empty before
+     * values, so a reversed column sorts empty AFTER values (ReversedType swaps operands
+     * around the base comparison). The cursor path's raw clustering comparison decided
+     * empty-vs-valued purely from the serialized flag bits, ignoring reversal:
+     *  - same-partition variant: rows with empty and valued clusterings for the SAME pk in
+     *    different sstables merge in the wrong order (Data.db divergence — corruption class);
+     *  - cross-partition variant: the global covered-clustering max picks the wrong row
+     *    (Statistics.db divergence — what the soak caught).
+     */
+    @Test
+    public void emptyClusteringValuesDescending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH CLUSTERING ORDER BY (ck DESC)");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // sstable 1: valued clusterings for pk 1 (same-partition variant) and pk 2 (the
+        // lexically-largest valued rows, cross-partition variant)
+        for (long ck = 1; ck <= 5; ck++)
+        {
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "p1v" + ck);
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, ck * 1000, "p2v" + ck);
+        }
+        flush();
+
+        // sstable 2: EMPTY clustering values — same partition as pk 1's valued rows (the
+        // merge must order empty AFTER values under DESC), plus an empty-only partition
+        // (the global max clustering must be the empty value, not pk 2's large bigints)
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p1empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p3empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    /** ASC counterpart of emptyClusteringValuesDescending: empty sorts BEFORE values on a
+     *  non-reversed column; pins the unflipped flag ordering. */
+    @Test
+    public void emptyClusteringValuesAscending() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 1; ck <= 5; ck++)
+        {
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ck, "p1v" + ck);
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 2L, -ck * 1000, "p2v" + ck);
+        }
+        flush();
+
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p1empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, ByteBufferUtil.EMPTY_BYTE_BUFFER, "p3empty");
+        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
+        flush();
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -443,4 +443,100 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 
         assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
+
+    /**
+     * Row liveness shapes: UPDATE-built rows carry NO primary-key liveness (different row
+     * flags than INSERT-built rows), primary-key-only INSERTs carry liveness and ZERO cells,
+     * and merges must reconcile liveness presence/absence across sstables exactly.
+     */
+    @Test
+    public void rowLivenessShapes() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // UPDATE-built rows (no liveness) and liveness-only rows in sstable 1
+        for (long ck = 0; ck < 10; ck++)
+            execute("UPDATE %s SET v1 = ?, v2 = ? WHERE pk = ? AND ck = ?", "u" + ck, "w" + ck, 1L, ck);
+        for (long ck = 10; ck < 15; ck++)
+            execute("INSERT INTO %s (pk, ck) VALUES (?, ?)", 1L, ck);
+        flush();
+
+        // sstable 2: INSERT onto UPDATE-rows (liveness arrives later), cell tombstones onto
+        // liveness-only rows (row must survive on liveness alone), cell delete that empties
+        // an UPDATE-row entirely (no liveness + no cells = row vanishes)
+        for (long ck = 0; ck < 4; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", 1L, ck, "i" + ck);
+        for (long ck = 10; ck < 13; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
+        execute("DELETE v1, v2 FROM %s WHERE pk = ? AND ck = ?", 1L, 5L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /**
+     * Row-level TTL (INSERT USING TTL sets liveness TTL + cell TTLs) merged against
+     * cell-level TTL (UPDATE USING TTL sets only cell TTLs) and against plain writes;
+     * includes same-timestamp expiring writes whose TTLs differ (rules (c)/(d) of the
+     * resolveRegular decision table run off localExpirationTime/ttl, not just timestamps).
+     */
+    @Test
+    public void rowAndCellTtlMix() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 text, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 12; ck++)
+            execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 86400", 1L, ck, "a" + ck, "b" + ck);
+        flush();
+
+        // cell-level TTL different from the row TTL; plain overwrites clearing TTLs;
+        // expiring-vs-expiring same-timestamp ties with different TTLs
+        for (long ck = 0; ck < 6; ck++)
+            execute("UPDATE %s USING TTL 172800 SET v1 = ? WHERE pk = ? AND ck = ?", "c" + ck, 1L, ck);
+        for (long ck = 6; ck < 9; ck++)
+            execute("INSERT INTO %s (pk, ck, v1) VALUES (?, ?, ?)", 1L, ck, "plain" + ck);
+        for (long ck = 9; ck < 12; ck++)
+            execute("UPDATE %s USING TTL 100000 AND TIMESTAMP 5000 SET v2 = ? WHERE pk = ? AND ck = ?", "t1" + ck, 1L, ck);
+        flush();
+
+        for (long ck = 9; ck < 12; ck++)
+            execute("UPDATE %s USING TTL 50000 AND TIMESTAMP 5000 SET v2 = ? WHERE pk = ? AND ck = ?", "t2" + ck, 1L, ck);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /**
+     * Expiring-vs-live cells at the SAME timestamp, both directions across sstables: the
+     * CASSANDRA-14592 rule — an expiring (or deleted) cell beats a live one on timestamp
+     * tie regardless of value. Implemented in resolveRegular rule (a); this pins it at the
+     * differential level (timestampTies only covered live-vs-live and delete-vs-live).
+     */
+    @Test
+    public void expiringVsLiveTies() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // direction 1: live first, expiring second
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 1L, ck, "zzz-live" + ck);
+        // direction 2 partition: expiring first
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000 AND TTL 86400", 2L, ck, "aaa-ttl" + ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000 AND TTL 86400", 1L, ck, "aaa-ttl" + ck);
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 1000", 2L, ck, "zzz-live" + ck);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -35,6 +35,35 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 {
     private static final Set<String> ALLOWLIST = Set.of();
 
+    /**
+     * Static-column table where some partitions have NO static values: an empty static row is
+     * written for those partitions but must not be counted in stats (totalRows/totalColumnsSet).
+     * Found by the randomized soak; the original staticRows scenario gave every
+     * partition static data and so never produced an empty static row.
+     */
+    @Test
+    public void emptyStaticRows() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s1 text static, ck bigint, v text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 8; pk++)
+            {
+                // only even partitions ever get a static value
+                if (pk % 2 == 0)
+                    execute("INSERT INTO %s (pk, s1, ck, v) VALUES (?, ?, ?, ?)", pk, "static" + pk, (long) round, "v" + round);
+                else
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, (long) round, "v" + round);
+            }
+            flush();
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
     /** Reversed clustering order changes on-disk ordering and bound comparisons. */
     @Test
     public void descendingClustering() throws Exception

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -30,6 +30,10 @@ import org.apache.cassandra.utils.ByteBufferUtil;
  * CURRENTLY SUPPORTED cursor compaction surface (see CursorCompactor.isSupported). Every
  * scenario here must run the cursor path for real — the harness fails loudly on silent
  * fallback. Scenarios for unsupported shapes belong in CursorSupportMatrixTest instead.
+ *
+ * Every scenario runs the differential at TWO generations (see
+ * assertCursorMatchesIteratorAcrossGenerations): gen 2 re-compacts genuinely cursor-produced
+ * outputs, so write-side corruption that only the NEXT merge can see fails here.
  */
 public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTester
 {
@@ -61,7 +65,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Reversed clustering order changes on-disk ordering and bound comparisons. */
@@ -82,7 +86,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Multi-component clusterings: mixed types, shared prefixes, per-component bounds. */
@@ -109,7 +113,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Wide partition crossing column-index block boundaries (indexed RowIndexEntry path). */
@@ -131,7 +135,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /**
@@ -157,7 +161,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Overlapping range tombstones across sstables: boundary markers must merge identically. */
@@ -189,7 +193,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("DELETE FROM %s WHERE pk = 1 AND ck >= 20 AND ck < 30");
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Frozen collections and tuples are single cells and inside the supported surface. */
@@ -216,7 +220,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** TTLs: live expiring cells and already-expired cells (expiry far from run boundaries). */
@@ -243,7 +247,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 
         Thread.sleep(2000); // let the short TTLs expire well before the first run
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Same-timestamp conflicting writes: reconciliation must tie-break identically. */
@@ -268,7 +272,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 2000", 1L, ck, "tie" + ck);
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Newer partition deletion shadowing older data across several sstables. */
@@ -293,7 +297,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 3L, 0L, "alive-again");
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Single-input compaction: pure rewrite, no merge. */
@@ -310,7 +314,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("DELETE FROM %s WHERE pk = 0 AND ck >= 2 AND ck < 6");
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Many inputs: 8-way merge exercises the merge heap harder than the usual 2-4. */
@@ -332,7 +336,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Disjoint inputs: no overlapping partitions, pure concatenation. */
@@ -351,7 +355,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             flush();
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** Empty (zero-length) values are valid and distinct from null; both must survive merge. */
@@ -374,7 +378,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
             execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, null, null)", 1L, ck);
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /**
@@ -413,7 +417,7 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 
     /** ASC counterpart of emptyClusteringValuesDescending: empty sorts BEFORE values on a
@@ -437,6 +441,6 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
         execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", 1L, 3L, "p1v3-overwrite");
         flush();
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/EdgeCaseDifferentialCompactionTest.java
@@ -539,4 +539,114 @@ public class EdgeCaseDifferentialCompactionTest extends DifferentialCompactionTe
 
         assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
     }
+
+    /** Vector and duration columns: fixed-dimension float vectors and the
+     *  variable-length duration encoding as ordinary single cells, overwritten and
+     *  null-overwritten (cell tombstone) across sstables. */
+    @Test
+    public void vectorAndDuration() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, vec vector<float, 3>, dur duration, v text, " +
+                    "PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long ck = 0; ck < 10; ck++)
+            execute("INSERT INTO %s (pk, ck, vec, dur, v) VALUES (?, ?, [1.5, 2.5, " + ck + ".0], 2h30m, ?)",
+                    1L, ck, "v" + ck);
+        flush();
+
+        for (long ck = 0; ck < 5; ck++)
+            execute("INSERT INTO %s (pk, ck, vec, dur, v) VALUES (?, ?, [9.0, 8.0, 7.0], 45s500ms, ?)",
+                    1L, ck, "w" + ck);
+        // null overwrites: cell tombstones for vector and duration cells
+        execute("INSERT INTO %s (pk, ck, vec, dur) VALUES (?, ?, null, null)", 1L, 7L);
+        flush();
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /**
+     * More than 64 regular columns: rows lacking columns switch from the 64-bit-mask
+     * column-subset encoding to the structurally different large-subset wire format —
+     * byte-compared here for the first time; previously only the old simple-suite
+     * exercised it without comparing the paths against each other.
+     */
+    @Test
+    public void over64Columns() throws Exception
+    {
+        StringBuilder ddl = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int i = 0; i < 70; i++)
+            ddl.append(", c").append(i).append(" int");
+        ddl.append(", PRIMARY KEY (pk, ck))");
+        createTable(ddl.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // sparse rows: each ck sets a sliding 10-column window (subset encoding for >64 columns)
+        for (int round = 0; round < 2; round++)
+        {
+            for (long ck = 0; ck < 14; ck++)
+            {
+                StringBuilder stmt = new StringBuilder("INSERT INTO %s (pk, ck");
+                int base = (int) ck * 5 + round * 3;
+                for (int i = 0; i < 10; i++)
+                    stmt.append(", c").append((base + i) % 70);
+                stmt.append(") VALUES (?, ?");
+                for (int i = 0; i < 10; i++)
+                    stmt.append(", ").append(base + i);
+                stmt.append(')');
+                execute(stmt.toString(), 1L, ck);
+            }
+            // one full row per round: the HAS_ALL_COLUMNS path next to large subsets
+            StringBuilder full = new StringBuilder("INSERT INTO %s (pk, ck");
+            for (int i = 0; i < 70; i++)
+                full.append(", c").append(i);
+            full.append(") VALUES (?, ?");
+            for (int i = 0; i < 70; i++)
+                full.append(", ").append(i);
+            full.append(')');
+            execute(full.toString(), 1L, 99L);
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+
+    /**
+     * ODD superset size at the subset-encoding mode boundary: with 71 columns, the encoder
+     * and decoder must agree on present-index vs missing-index
+     * mode at exactly presentCount == 35 (the integer-division boundary of supersetCount/2).
+     * Rows at 34/35/36 present columns straddle the boundary from both sides.
+     */
+    @Test
+    public void over64ColumnsOddSupersetBoundary() throws Exception
+    {
+        StringBuilder ddl = new StringBuilder("CREATE TABLE %s (pk bigint, ck bigint");
+        for (int i = 0; i < 71; i++)
+            ddl.append(", c").append(i).append(" int");
+        ddl.append(", PRIMARY KEY (pk, ck))");
+        createTable(ddl.toString());
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 2; round++)
+        {
+            long ck = 0;
+            for (int present : new int[]{ 34, 35, 36, 70 })
+            {
+                StringBuilder stmt = new StringBuilder("INSERT INTO %s (pk, ck");
+                for (int i = 0; i < present; i++)
+                    stmt.append(", c").append((i + round) % 71); // shift per round so the merge unions
+                stmt.append(") VALUES (?, ?");
+                for (int i = 0; i < present; i++)
+                    stmt.append(", ").append(i);
+                stmt.append(')');
+                execute(stmt.toString(), 1L, ck++);
+            }
+            flush();
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.harry.ColumnSpec;
+import org.apache.cassandra.harry.SchemaSpec;
+import org.apache.cassandra.harry.dsl.HistoryBuilder;
+import org.apache.cassandra.harry.dsl.HistoryBuilderHelper;
+import org.apache.cassandra.harry.execution.CQLTesterVisitExecutor;
+import org.apache.cassandra.harry.execution.CQLVisitExecutor;
+import org.apache.cassandra.harry.execution.DataTracker;
+import org.apache.cassandra.harry.model.QuiescentChecker;
+import org.apache.cassandra.harry.op.Visit;
+
+import static org.apache.cassandra.harry.checker.TestHelper.withRandom;
+
+/**
+ * Harry-driven differential soak: deep probabilistic tombstone/overwrite histories (the
+ * workload shapes Harry's DSL is strongest at — interleaved row/column/range/partition
+ * deletes against overlapping inserts) executed through plain CQL in this JVM, flushed into
+ * several sstables, then both compaction paths compared byte-for-byte. The differential
+ * harness is the oracle, so no Harry read-validation visits are issued.
+ *
+ * Schema uses simple types only (the currently supported cursor surface; Harry cannot
+ * generate multi-cell columns yet — ColumnSpec TODOs). Reversed clustering included.
+ */
+public class HarryDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final AtomicInteger idGen = new AtomicInteger(0);
+
+    private static final int PARTITIONS = 30;
+    private static final int ROWS = 20;
+    private static final int REG_COLS = 5;
+    private static final int ROUNDS = 3;
+    private static final int OPS_PER_ROUND = 120;
+
+    @Test
+    public void harryTombstoneHistories() throws Throwable
+    {
+        // Raised out here, not inside the callback: withRandom catches Throwable and rewraps it,
+        // so an assumption violated inside would reach JUnit as a failure instead of a skip.
+        assumeBigFormatSelected();
+
+        long seed = System.currentTimeMillis();
+        logger.info("harryTombstoneHistories seed={}", seed);
+        withRandom(seed, rng -> {
+            String ks = "harry_diff_ks" + idGen.incrementAndGet();
+            String table = "tbl" + idGen.incrementAndGet();
+            SchemaSpec schema = new SchemaSpec(rng.next(),
+                                               1000,
+                                               ks,
+                                               table,
+                                               Arrays.asList(ColumnSpec.pk("pk1", ColumnSpec.asciiType),
+                                                             ColumnSpec.pk("pk2", ColumnSpec.int64Type)),
+                                               Arrays.asList(ColumnSpec.ck("ck1", ColumnSpec.asciiType, false),
+                                                             ColumnSpec.ck("ck2", ColumnSpec.int64Type, true)),
+                                               Arrays.asList(ColumnSpec.regularColumn("r1", ColumnSpec.asciiType),
+                                                             ColumnSpec.regularColumn("r2", ColumnSpec.int64Type),
+                                                             ColumnSpec.regularColumn("r3", ColumnSpec.doubleType),
+                                                             ColumnSpec.regularColumn("r4", ColumnSpec.int32Type),
+                                                             ColumnSpec.regularColumn("r5", ColumnSpec.textType)),
+                                               Arrays.asList(ColumnSpec.staticColumn("s1", ColumnSpec.asciiType),
+                                                             ColumnSpec.staticColumn("s2", ColumnSpec.int64Type)));
+
+            schemaChange(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = " +
+                                       "{'class': 'SimpleStrategy', 'replication_factor': '1'}", ks));
+            createTable(schema.compile());
+            ColumnFamilyStore cfs = Keyspace.open(ks).getColumnFamilyStore(table);
+            cfs.disableAutoCompaction();
+
+            HistoryBuilder history = new HistoryBuilder(schema.valueGenerators);
+
+            for (int round = 0; round < ROUNDS; round++)
+            {
+                for (int op = 0; op < OPS_PER_ROUND; op++)
+                {
+                    int pd = rng.nextInt(0, PARTITIONS);
+                    int row = rng.nextInt(0, ROWS);
+                    int kind = rng.nextInt(0, 100);
+                    if (kind < 70)
+                        history.insert(pd, row);
+                    else if (kind < 80)
+                        history.deleteRow(pd, row);
+                    else if (kind < 88)
+                    {
+                        int lower = rng.nextInt(0, ROWS);
+                        int upper = rng.nextInt(lower, 2 * ROWS);
+                        history.deleteRowRange(pd, lower, upper,
+                                               rng.nextInt(schema.clusteringKeys.size()),
+                                               rng.nextBoolean(),
+                                               rng.nextBoolean());
+                    }
+                    else if (kind < 96)
+                        HistoryBuilderHelper.deleteRandomColumns(schema, pd, row, rng, history);
+                    else
+                        history.deletePartition(pd);
+                }
+                history.customThrowing(() -> flush(ks, table), "flush round");
+            }
+
+            replay(schema, history);
+
+            assertCursorMatchesIterator(cfs);
+        });
+    }
+
+    private void replay(SchemaSpec schema, HistoryBuilder history)
+    {
+        DataTracker tracker = new DataTracker.SequentialDataTracker();
+        CQLVisitExecutor executor =
+            new CQLTesterVisitExecutor(schema, tracker,
+                                       new QuiescentChecker(schema.valueGenerators, tracker, history),
+                                       statement -> execute(statement.cql(), statement.bindings()));
+        for (Visit visit : history)
+            executor.execute(visit);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.harry.ColumnSpec;
+import org.apache.cassandra.harry.SchemaSpec;
+import org.apache.cassandra.harry.dsl.HistoryBuilder;
+import org.apache.cassandra.harry.dsl.HistoryBuilderHelper;
+import org.apache.cassandra.harry.execution.CQLTesterVisitExecutor;
+import org.apache.cassandra.harry.execution.CQLVisitExecutor;
+import org.apache.cassandra.harry.execution.DataTracker;
+import org.apache.cassandra.harry.model.QuiescentChecker;
+import org.apache.cassandra.harry.op.Visit;
+
+import static org.apache.cassandra.harry.checker.TestHelper.withRandom;
+
+/**
+ * Harry-driven differential soak: deep probabilistic tombstone/overwrite histories (the
+ * workload shapes Harry's DSL is strongest at — interleaved row/column/range/partition
+ * deletes against overlapping inserts) executed through plain CQL in this JVM, flushed into
+ * several sstables, then both compaction paths compared byte-for-byte. The differential
+ * harness is the oracle, so no Harry read-validation visits are issued.
+ *
+ * Schema uses simple types only (the currently supported cursor surface; Harry cannot
+ * generate multi-cell columns yet — ColumnSpec TODOs). Reversed clustering included.
+ */
+public class HarryDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+    private static final AtomicInteger idGen = new AtomicInteger(0);
+
+    private static final int PARTITIONS = 30;
+    private static final int ROWS = 20;
+    private static final int REG_COLS = 5;
+    private static final int ROUNDS = 3;
+    private static final int OPS_PER_ROUND = 120;
+
+    @Test
+    public void harryTombstoneHistories() throws Throwable
+    {
+        long seed = System.currentTimeMillis();
+        logger.info("harryTombstoneHistories seed={}", seed);
+        withRandom(seed, rng -> {
+            String ks = "harry_diff_ks" + idGen.incrementAndGet();
+            String table = "tbl" + idGen.incrementAndGet();
+            SchemaSpec schema = new SchemaSpec(rng.next(),
+                                               1000,
+                                               ks,
+                                               table,
+                                               Arrays.asList(ColumnSpec.pk("pk1", ColumnSpec.asciiType),
+                                                             ColumnSpec.pk("pk2", ColumnSpec.int64Type)),
+                                               Arrays.asList(ColumnSpec.ck("ck1", ColumnSpec.asciiType, false),
+                                                             ColumnSpec.ck("ck2", ColumnSpec.int64Type, true)),
+                                               Arrays.asList(ColumnSpec.regularColumn("r1", ColumnSpec.asciiType),
+                                                             ColumnSpec.regularColumn("r2", ColumnSpec.int64Type),
+                                                             ColumnSpec.regularColumn("r3", ColumnSpec.doubleType),
+                                                             ColumnSpec.regularColumn("r4", ColumnSpec.int32Type),
+                                                             ColumnSpec.regularColumn("r5", ColumnSpec.textType)),
+                                               Arrays.asList(ColumnSpec.staticColumn("s1", ColumnSpec.asciiType),
+                                                             ColumnSpec.staticColumn("s2", ColumnSpec.int64Type)));
+
+            schemaChange(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = " +
+                                       "{'class': 'SimpleStrategy', 'replication_factor': '1'}", ks));
+            createTable(schema.compile());
+            ColumnFamilyStore cfs = Keyspace.open(ks).getColumnFamilyStore(table);
+            cfs.disableAutoCompaction();
+
+            HistoryBuilder history = new HistoryBuilder(schema.valueGenerators);
+
+            for (int round = 0; round < ROUNDS; round++)
+            {
+                for (int op = 0; op < OPS_PER_ROUND; op++)
+                {
+                    int pd = rng.nextInt(0, PARTITIONS);
+                    int row = rng.nextInt(0, ROWS);
+                    int kind = rng.nextInt(0, 100);
+                    if (kind < 70)
+                        history.insert(pd, row);
+                    else if (kind < 80)
+                        history.deleteRow(pd, row);
+                    else if (kind < 88)
+                    {
+                        int lower = rng.nextInt(0, ROWS);
+                        int upper = rng.nextInt(lower, 2 * ROWS);
+                        history.deleteRowRange(pd, lower, upper,
+                                               rng.nextInt(schema.clusteringKeys.size()),
+                                               rng.nextBoolean(),
+                                               rng.nextBoolean());
+                    }
+                    else if (kind < 96)
+                        HistoryBuilderHelper.deleteRandomColumns(schema, pd, row, rng, history);
+                    else
+                        history.deletePartition(pd);
+                }
+                history.customThrowing(() -> flush(ks, table), "flush round");
+            }
+
+            replay(schema, history);
+
+            assertCursorMatchesIterator(cfs, ALLOWLIST);
+        });
+    }
+
+    private void replay(SchemaSpec schema, HistoryBuilder history)
+    {
+        DataTracker tracker = new DataTracker.SequentialDataTracker();
+        CQLVisitExecutor executor =
+            new CQLTesterVisitExecutor(schema, tracker,
+                                       new QuiescentChecker(schema.valueGenerators, tracker, history),
+                                       statement -> execute(statement.cql(), statement.bindings()));
+        for (Visit visit : history)
+            executor.execute(visit);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/HarryDifferentialCompactionTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.db.compaction.differential;
 
 import java.util.Arrays;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -50,7 +49,6 @@ import static org.apache.cassandra.harry.checker.TestHelper.withRandom;
  */
 public class HarryDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
     private static final AtomicInteger idGen = new AtomicInteger(0);
 
     private static final int PARTITIONS = 30;
@@ -121,7 +119,7 @@ public class HarryDifferentialCompactionTest extends DifferentialCompactionTeste
 
             replay(schema, history);
 
-            assertCursorMatchesIterator(cfs, ALLOWLIST);
+            assertCursorMatchesIterator(cfs);
         });
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+/**
+ * ONE giant partition, merged from many inputs — sized for the POSITIONAL boundaries that
+ * row count alone never touches:
+ *
+ *  - intra-partition offsets crossing Integer.MAX_VALUE (2GiB) — int casts and vint widths
+ *    on the partition-relative position arithmetic (previousUnfilteredSize chains, header
+ *    lengths, index block offsets);
+ *  - the promoted index at hundreds of thousands of index blocks in a single partition,
+ *    orders of magnitude past the scale the index-promotion logic is normally exercised at;
+ *  - small partitions on BOTH sides of the giant one, so per-partition state demonstrably
+ *    resets after the monster.
+ *
+ * Parameters (defaults are CI-sane: ~1M rows, ~160MB partition, still ~40K index blocks at
+ * the 4KiB test column_index_size). The 2GiB boundary run:
+ *
+ *   ant testsome -Dtest.name=...LargePartitionDifferentialCompactionTest \
+ *       -Dtest.timeout=14400000 \
+ *       -Dtest.jvm.args="-Dcassandra.test.differential.largepartition.sstables=8
+ *                        -Dcassandra.test.differential.largepartition.rows_per_sstable=1200000
+ *                        -Dcassandra.test.differential.largepartition.value_padding=240"
+ *
+ * That is ~9.6M rows at ~280B/row: a ~2.6GiB single partition. Peak disk for the full
+ * two-generation differential (inputs + live output + four captured output copies) is
+ * roughly 7x the partition size. The memtable may auto-flush large rounds, so the sstables
+ * parameter is a minimum input count, which the differential does not care about.
+ */
+public class LargePartitionDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    private static final int SSTABLES =
+        Integer.getInteger("cassandra.test.differential.largepartition.sstables", 4);
+    private static final int ROWS_PER_SSTABLE =
+        Integer.getInteger("cassandra.test.differential.largepartition.rows_per_sstable", 250_000);
+    private static final String VALUE_PADDING =
+        "p".repeat(Integer.getInteger("cassandra.test.differential.largepartition.value_padding", 120));
+    /** Half-window overlap between rounds: every output row in the overlap merges from two inputs. */
+    private static final long CK_STRIDE = Math.max(1, ROWS_PER_SSTABLE / 2);
+
+    @Override
+    protected boolean scaleCapture()
+    {
+        return true;
+    }
+
+    @Test
+    public void giantPartition() throws Throwable
+    {
+        logger.info("large-partition parameters: sstables={} rowsPerSSTable={} valuePadding={}B " +
+                    "-> ~{} rows in one partition, ~{}MB serialized",
+                    SSTABLES, ROWS_PER_SSTABLE, VALUE_PADDING.length(),
+                    (long) SSTABLES * ROWS_PER_SSTABLE,
+                    (long) SSTABLES * ROWS_PER_SSTABLE * (40 + VALUE_PADDING.length()) / (1 << 20));
+
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, " +
+                    "PRIMARY KEY (pk, ck)) WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String insert = "INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)";
+        String insertTtl = insert + " USING TTL 86400";
+        String insertTs = insert + " USING TIMESTAMP 5000";
+
+        for (int round = 0; round < SSTABLES; round++)
+        {
+            long ckBase = round * CK_STRIDE;
+
+            // small partitions on both sides of the giant one, every round
+            execute(insert, 0L, (long) round, (long) round, "side" + round);
+            execute(insert, 2L, (long) round, (long) round, "side" + round);
+
+            for (int j = 0; j < ROWS_PER_SSTABLE; j++)
+            {
+                long ck = ckBase + j;
+                long v1 = ck * 31 + round;
+                String v2 = j % 31 == 30 ? null : "v" + round + "_" + ck + VALUE_PADDING;
+                if (j % 7 == 3)
+                    execute(insertTtl, 1L, ck, v1, v2);
+                else if (j % 13 == 7)
+                    execute(insertTs, 1L, ck, v1, "tie" + round + "_" + ck + VALUE_PADDING);
+                else
+                    execute(insert, 1L, ck, v1, v2);
+            }
+
+            // tombstones at various depths of the giant partition: bounded ranges inside
+            // this round's window, an open-ended slice off its tail, scattered row deletes
+            for (int i = 0; i < 10; i++)
+            {
+                long start = ckBase + (long) i * (ROWS_PER_SSTABLE / 12);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= ? AND ck < ?", 1L, start, start + 7);
+            }
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= ?", 1L, ckBase + ROWS_PER_SSTABLE - 11);
+            for (int i = 0; i < 20; i++)
+                execute("DELETE FROM %s WHERE pk = ? AND ck = ?", 1L, ckBase + (long) i * (ROWS_PER_SSTABLE / 21));
+
+            flush();
+            logger.info("large-partition round {}/{} flushed", round + 1, SSTABLES);
+        }
+
+        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
@@ -36,17 +36,22 @@ import org.apache.cassandra.db.ColumnFamilyStore;
  *    resets after the monster.
  *
  * Parameters (defaults are CI-sane: ~1M rows, ~160MB partition, still ~40K index blocks at
- * the 4KiB test column_index_size). The 2GiB boundary run:
+ * the 4KiB test column_index_size). The MERGED partition size is what crosses boundaries:
+ * with the default half-window overlap, distinct rows = (sstables-1) * ck_stride +
+ * rows_per_sstable — NOT sstables * rows_per_sstable (an earlier "2.6GiB" boundary run
+ * conflated pre-merge input rows with merged output rows and only reached ~1.4GiB).
+ * The true 2GiB boundary run uses DISJOINT windows (ck_stride = rows_per_sstable):
  *
  *   ant testsome -Dtest.name=...LargePartitionDifferentialCompactionTest \
  *       -Dtest.timeout=14400000 \
  *       -Dtest.jvm.args="-Dcassandra.test.differential.largepartition.sstables=8
- *                        -Dcassandra.test.differential.largepartition.rows_per_sstable=1200000
- *                        -Dcassandra.test.differential.largepartition.value_padding=240"
+ *                        -Dcassandra.test.differential.largepartition.rows_per_sstable=1100000
+ *                        -Dcassandra.test.differential.largepartition.value_padding=240
+ *                        -Dcassandra.test.differential.largepartition.ck_stride=1100000"
  *
- * That is ~9.6M rows at ~280B/row: a ~2.6GiB single partition. Peak disk for the full
- * two-generation differential (inputs + live output + four captured output copies) is
- * roughly 7x the partition size. The memtable may auto-flush large rounds, so the sstables
+ * That is ~8.8M distinct rows at ~280B/row: a ~2.4GiB single MERGED partition. Peak disk for
+ * the full two-generation differential (inputs + live output + four captured output copies)
+ * is roughly 7x the partition size. The memtable may auto-flush large rounds, so the sstables
  * parameter is a minimum input count, which the differential does not care about.
  */
 public class LargePartitionDifferentialCompactionTest extends DifferentialCompactionTester
@@ -58,8 +63,13 @@ public class LargePartitionDifferentialCompactionTest extends DifferentialCompac
         Integer.getInteger("cassandra.test.differential.largepartition.rows_per_sstable", 250_000);
     private static final String VALUE_PADDING =
         "p".repeat(Integer.getInteger("cassandra.test.differential.largepartition.value_padding", 120));
-    /** Half-window overlap between rounds: every output row in the overlap merges from two inputs. */
-    private static final long CK_STRIDE = Math.max(1, ROWS_PER_SSTABLE / 2);
+    /**
+     * Window stride between rounds. Default: half-window overlap, so every output row in the
+     * overlap merges from two inputs. Set equal to rows_per_sstable for DISJOINT windows,
+     * which maximizes the merged partition size (the 2GiB boundary run).
+     */
+    private static final long CK_STRIDE = Math.max(1,
+        Integer.getInteger("cassandra.test.differential.largepartition.ck_stride", ROWS_PER_SSTABLE / 2));
 
     @Override
     protected boolean scaleCapture()
@@ -70,11 +80,12 @@ public class LargePartitionDifferentialCompactionTest extends DifferentialCompac
     @Test
     public void giantPartition() throws Throwable
     {
-        logger.info("large-partition parameters: sstables={} rowsPerSSTable={} valuePadding={}B " +
-                    "-> ~{} rows in one partition, ~{}MB serialized",
-                    SSTABLES, ROWS_PER_SSTABLE, VALUE_PADDING.length(),
-                    (long) SSTABLES * ROWS_PER_SSTABLE,
-                    (long) SSTABLES * ROWS_PER_SSTABLE * (40 + VALUE_PADDING.length()) / (1 << 20));
+        long distinctRows = (long) (SSTABLES - 1) * CK_STRIDE + ROWS_PER_SSTABLE;
+        logger.info("large-partition parameters: sstables={} rowsPerSSTable={} ckStride={} valuePadding={}B " +
+                    "-> ~{} distinct rows in one merged partition, ~{}MB serialized",
+                    SSTABLES, ROWS_PER_SSTABLE, CK_STRIDE, VALUE_PADDING.length(),
+                    distinctRows,
+                    distinctRows * (40 + VALUE_PADDING.length()) / (1 << 20));
 
         createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, " +
                     "PRIMARY KEY (pk, ck)) WITH gc_grace_seconds = 864000");

--- a/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/LargePartitionDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -52,7 +51,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
  */
 public class LargePartitionDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     private static final int SSTABLES =
         Integer.getInteger("cassandra.test.differential.largepartition.sstables", 4);
@@ -123,6 +121,6 @@ public class LargePartitionDifferentialCompactionTest extends DifferentialCompac
             logger.info("large-partition round {}/{} flushed", round + 1, SSTABLES);
         }
 
-        assertCursorMatchesIteratorAcrossGenerations(cfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(cfs);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
@@ -1,0 +1,448 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import java.nio.ByteBuffer;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.BTreeRow;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.btree.BTree;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Differential coverage for MATERIALIZED VIEW tables: view tables are admitted
+ * by the cursor gate (no isView rejection) and compact through the same pipelines, but their
+ * row shapes are view-specific — strict liveness (CursorCompactor.enforceStrictLiveness
+ * mirrors PurgeFunction), view-generated row tombstones when a base row moves between view
+ * partitions, and expired-liveness markers. Shadowable row deletions (deprecated since 4.0,
+ * CASSANDRA-11500) can still appear on old view data written before that deprecation — nothing
+ * currently produces new ones, so {@link #shadowableRowDeletion} constructs them directly.
+ */
+public class MaterializedViewDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    @BeforeClass
+    public static void startup()
+    {
+        requireNetwork();
+    }
+
+    @Test
+    public void materializedViewTable() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT pk, ck, v1 FROM %s " +
+                                 "WHERE pk IS NOT NULL AND ck IS NOT NULL AND v1 IS NOT NULL " +
+                                 "PRIMARY KEY (v1, pk, ck)");
+        ColumnFamilyStore viewCfs = getColumnFamilyStore(KEYSPACE, view);
+        viewCfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 6; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, pk * 100 + ck, "x" + ck);
+        flush(KEYSPACE, view);
+
+        // view-partition moves (v1 changes: old view row dies via view tombstone, new row
+        // appears) and base-row deletes (view row tombstones)
+        for (long pk = 0; pk < 6; pk += 2)
+        {
+            execute("UPDATE %s SET v1 = ? WHERE pk = ? AND ck = ?", pk * 100 + 77, pk, 0L);
+            execute("DELETE FROM %s WHERE pk = ? AND ck = ?", pk, 1L);
+        }
+        flush(KEYSPACE, view);
+
+        // a second wave of moves on already-moved rows: tombstones meeting tombstones
+        execute("UPDATE %s SET v1 = ? WHERE pk = ? AND ck = ?", 999L, 0L, 0L);
+        flush(KEYSPACE, view);
+
+        assertCursorMatchesIteratorAcrossGenerations(viewCfs);
+    }
+
+    /**
+     * MV + TTL: the view-generated row liveness must track the base row's TTL, including
+     * across a view-partition move (v1 changes -> old view row dies, new one carries its own
+     * TTL). Recent bugs in this area (CASSANDRA-21152) motivate dedicated coverage rather
+     * than relying on materializedViewTable's TTL-free scenario.
+     */
+    @Test
+    public void materializedViewWithTTL() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT pk, ck, v1 FROM %s " +
+                                 "WHERE pk IS NOT NULL AND ck IS NOT NULL AND v1 IS NOT NULL " +
+                                 "PRIMARY KEY (v1, pk, ck)");
+        ColumnFamilyStore viewCfs = getColumnFamilyStore(KEYSPACE, view);
+        viewCfs.disableAutoCompaction();
+
+        long writeTimeSec = FBUtilities.nowInSeconds();
+
+        // short-TTL rows: base row AND its view row will have expired by fixedNow below
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 6; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 1", pk, ck, pk * 100 + ck, "x" + ck);
+        flush(KEYSPACE, view);
+
+        // long-TTL rows: still alive at fixedNow, exercises live-TTL view rows alongside dead ones
+        for (long pk = 10; pk < 16; pk++)
+            for (long ck = 0; ck < 6; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?) USING TTL 86400", pk, ck, pk * 100 + ck, "y" + ck);
+        flush(KEYSPACE, view);
+
+        // view-partition move on a short-TTL row, itself given a new (long) TTL: the old view
+        // row's move-tombstone and its own now-irrelevant short TTL race the new view row's
+        // fresh long TTL — the MV+TTL interaction CASSANDRA-21152-style bugs live in
+        for (long pk = 0; pk < 6; pk += 2)
+            execute("UPDATE %s USING TTL 86400 SET v1 = ? WHERE pk = ? AND ck = ?", pk * 100 + 77, pk, 0L);
+        flush(KEYSPACE, view);
+
+        long fixedNow = writeTimeSec + 3; // past the short TTLs' expiry; long TTLs still alive
+        assertCursorMatchesIteratorAcrossGenerations(viewCfs, () -> fixedNow);
+    }
+
+    /**
+     * A shadowable row deletion that the merged primary-key liveness SHADOWS: the compaction merge
+     * ({@link Row.Merger#merge}) clears such a deletion to LIVE before it becomes the row's active
+     * deletion, so the row keeps its liveness AND the cells the deletion would otherwise have shadowed,
+     * and the output carries no row deletion and no {@code HAS_SHADOWABLE_DELETION} extension flag.
+     * <p>
+     * The three pieces are in three sstables on purpose. A shadowable deletion never meets a
+     * superseding liveness inside one memtable: {@code BTreeRow.Builder.build} applies
+     * {@code isShadowedBy} itself, and {@code addRowDeletion}/{@code addPrimaryKeyLivenessInfo}
+     * drop shadowed data outright. The compaction merge is the only place the two can meet.
+     * <p>
+     * The deletion's LOCAL deletion time is {@code nowInSeconds()} rather than a small constant so
+     * it sits above {@code gcBefore} and is not purgeable — a purgeable deletion is cleared by the
+     * purger on both paths, and the scenario would pass while covering nothing.
+     */
+    @Test
+    public void shadowableRowDeletionShadowedByRowLiveness() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v2 text, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        writeShadowableRowDeletion(cfs, 1L, 1L, 100L, FBUtilities.nowInSeconds());
+        flush();
+
+        // a cell the deletion would drop: its timestamp is below the deletion's
+        execute("UPDATE %s USING TIMESTAMP 50 SET v2 = 'keepme' WHERE pk = 1 AND ck = 1");
+        flush();
+
+        // the primary-key liveness that shadows the deletion (200 > 100)
+        execute("INSERT INTO %s (pk, ck) VALUES (1, 1) USING TIMESTAMP 200");
+        flush();
+
+        assertEquals("the three pieces must meet in the compaction merge, not in a memtable",
+                     3, cfs.getLiveSSTables().size());
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs);
+        String json = allJson(out);
+        // nothing else in this scenario writes a deletion, so any marked_deleted is the shadowed one
+        assertFalse("the shadowed row deletion survived into the output: " + json,
+                    json.contains("\"marked_deleted\""));
+        assertEquals("the cell the shadowed deletion would have dropped is missing: " + json,
+                     1, countOccurrences(json, cellValue("keepme")));
+    }
+
+    /**
+     * Shadowable row deletions predate CASSANDRA-11500 and nothing since produces new ones, but
+     * old data can still carry the flag on either a static or a non-static row — and, for a
+     * non-static row, whether or not it's the partition's first unfiltered (the reader's three
+     * flag-dispatch methods used to treat extended flags as static-only there). Not constructible
+     * through CQL — {@code Row.Deletion.shadowable(...)} has to be called directly.
+     */
+    @Test
+    public void shadowableRowDeletion() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, s1 bigint static, v1 bigint, PRIMARY KEY (pk, ck))");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // static row, shadowable deletion: the partition's first unfiltered
+        writeShadowableStaticRowDeletion(cfs, 1L, 100L);
+        execute("INSERT INTO %s (pk, ck, v1) VALUES (1, 0, 0)");
+        execute("INSERT INTO %s (pk, ck, v1) VALUES (1, 2, 2)");
+        // regular row, shadowable deletion, NOT first in the partition (ck=1, between the two above)
+        writeShadowableRowDeletion(cfs, 1L, 1L, 200L);
+        flush();
+
+        // second generation: a live write to the same static row, postdating the shadowable
+        // deletion — the merge must let both survive and coexist in the output (the deletion
+        // doesn't purge a cell that postdates it) across sstables, not just copy a single source
+        // through
+        execute("INSERT INTO %s (pk, ck, s1, v1) VALUES (1, 0, 5, 99)");
+        flush();
+
+        assertCursorMatchesIterator(cfs);
+    }
+
+    /**
+     * Strict liveness ({@code TableMetadata.enforceStrictLiveness()}, true exactly for a view whose
+     * primary key contains a base non-PK column) is NOT "drop every row with no primary-key liveness".
+     * {@link org.apache.cassandra.db.rows.BTreeRow#purge} reaches its strict-liveness drop only past
+     * {@code hasDeletion(nowInSec)}, i.e. {@code nowInSec >= minLocalDeletionTime} of the merged row.
+     * A row whose merged form has empty primary-key liveness, a live row deletion and only cells that
+     * are live at {@code nowInSec} has {@code minLocalDeletionTime == Cell.MAX_DELETION_TIME}, so purge
+     * returns it untouched — row and cells. One dead cell (a tombstone, or an expiring cell past its
+     * expiry) pulls {@code minLocalDeletionTime} to or below {@code nowInSec} and the whole row goes,
+     * live cells included.
+     * <p>
+     * Both halves are asserted, because "keep everything" and "drop everything" each satisfy only one
+     * of them, and each half is built twice: once from a SINGLE sstable, and once merged across two, so
+     * the cursor path's cell walk runs the multi-source case too — several rounds of the cell sort, cells
+     * from both sources reaching one output row through the rewound cursors, and, for the drop half, the
+     * dead cell in the SECOND source and a later column, so the walk has to get past a live cell to find
+     * it.
+     * <p>
+     * The rows are constructed directly against the VIEW's ColumnFamilyStore because view maintenance
+     * cannot produce this shape — no view row {@code ViewUpdateGenerator} writes has empty primary-key
+     * liveness AND a live row deletion AND cells; every route to an empty merged liveness either carries
+     * its own deletion or leaves the reference's {@code hasDeletion} guard open anyway. The shape still
+     * has to merge correctly, though: the reader builds its column arrays from the sstable header, so
+     * any row shape that can be on disk — legacy view data, a repaired or streamed sstable — reaches
+     * this merge.
+     */
+    @Test
+    public void strictLivenessKeepsARowWithNoDeletionAtNow() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, v3 text, v4 text, PRIMARY KEY (pk, ck))");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT pk, ck, v1, v2, v3, v4 FROM %s " +
+                                 "WHERE pk IS NOT NULL AND ck IS NOT NULL AND v1 IS NOT NULL " +
+                                 "PRIMARY KEY (v1, pk, ck)");
+        ColumnFamilyStore viewCfs = getColumnFamilyStore(KEYSPACE, view);
+        viewCfs.disableAutoCompaction();
+        assertTrue("v1 is a base non-PK column in the view PK, so the view must enforce strict liveness",
+                   viewCfs.metadata().enforceStrictLiveness());
+
+        // a normal view row, through real view maintenance, sharing the view partition below
+        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (1, 1, 5, 'normal')");
+        flush(KEYSPACE, view);
+
+        long nowInSec = FBUtilities.nowInSeconds();
+        TableMetadata metadata = viewCfs.metadata();
+
+        // FIRST source of the two-source rows, alongside both single-source rows
+        Row.Builder keptOne = livenessFreeViewRow(2L, 2L);
+        addLiveCell(keptOne, metadata, "v2", "keptFromOneSource");
+        applyViewRow(viewCfs, 5L, keptOne.build());
+
+        Row.Builder droppedOne = livenessFreeViewRow(3L, 3L);
+        addLiveCell(droppedOne, metadata, "v2", "droppedFromOneSource");
+        addCellTombstone(droppedOne, metadata, "v3", nowInSec);
+        applyViewRow(viewCfs, 5L, droppedOne.build());
+
+        Row.Builder keptMergedA = livenessFreeViewRow(4L, 4L);
+        addLiveCell(keptMergedA, metadata, "v2", "keptMergedFirst");
+        applyViewRow(viewCfs, 5L, keptMergedA.build());
+
+        Row.Builder droppedMergedA = livenessFreeViewRow(6L, 6L);
+        addLiveCell(droppedMergedA, metadata, "v2", "droppedMergedFirst");
+        applyViewRow(viewCfs, 5L, droppedMergedA.build());
+        flush(KEYSPACE, view);
+
+        // SECOND source: same clusterings, different columns, so these rows merge two sources
+        Row.Builder keptMergedB = livenessFreeViewRow(4L, 4L);
+        addLiveCell(keptMergedB, metadata, "v3", "keptMergedSecond");
+        addLiveCell(keptMergedB, metadata, "v4", "keptMergedThird");
+        applyViewRow(viewCfs, 5L, keptMergedB.build());
+
+        Row.Builder droppedMergedB = livenessFreeViewRow(6L, 6L);
+        addLiveCell(droppedMergedB, metadata, "v3", "droppedMergedSecond");
+        addCellTombstone(droppedMergedB, metadata, "v4", nowInSec);
+        applyViewRow(viewCfs, 5L, droppedMergedB.build());
+        flush(KEYSPACE, view);
+
+        assertEquals("the constructed rows must reach the compaction merge from their own sstables",
+                     3, viewCfs.getLiveSSTables().size());
+        // non-vacuity for the DROP halves: a deletion time at or below nowInSec really is on disk, and
+        // nothing else in this scenario writes one, so it is a cell tombstone; and it is above gcBefore,
+        // so the purger cannot remove it before the merge decides the row
+        assertSomethingExpiredAt(viewCfs, nowInSec);
+        // Against the gcBefore the harness will actually derive, sampled the way it derives it. Comparing
+        // against getDefaultGcBefore(nowInSec) instead would reduce to gc_grace_seconds >= 0 and assert
+        // nothing at all.
+        assertTrue("the cell tombstones must NOT be purgeable, or the purger removes them before the "
+                   + "merge decides the row and they cannot decide a strict-liveness drop",
+                   nowInSec >= viewCfs.getDefaultGcBefore(FBUtilities.nowInSeconds()));
+
+        CapturedOutput out = assertCursorMatchesIterator(viewCfs);
+        String json = allJson(out);
+        assertEquals("the single-source row with no deletion at now lost its cell: " + json,
+                     1, countOccurrences(json, cellValue("keptFromOneSource")));
+        assertEquals("the two-source row with no deletion at now lost a cell: " + json,
+                     1, countOccurrences(json, cellValue("keptMergedFirst")));
+        assertEquals("the two-source row with no deletion at now lost a cell: " + json,
+                     1, countOccurrences(json, cellValue("keptMergedSecond")));
+        assertEquals("the two-source row with no deletion at now lost a cell: " + json,
+                     1, countOccurrences(json, cellValue("keptMergedThird")));
+        assertEquals("the single-source row carrying a cell tombstone survived strict liveness: " + json,
+                     0, countOccurrences(json, cellValue("droppedFromOneSource")));
+        assertEquals("the two-source row carrying a cell tombstone survived strict liveness: " + json,
+                     0, countOccurrences(json, cellValue("droppedMergedFirst")));
+        assertEquals("the two-source row carrying a cell tombstone survived strict liveness: " + json,
+                     0, countOccurrences(json, cellValue("droppedMergedSecond")));
+        assertEquals("the view-maintained row is missing: " + json,
+                     1, countOccurrences(json, cellValue("normal")));
+    }
+
+    /**
+     * The other way the reference's {@code hasDeletion(nowInSec)} guard opens for a row strict liveness
+     * then drops: not through a cell, but because the PURGER cleared the row's liveness or its row
+     * deletion. Whichever it cleared was, before it ran, a term of the merged row's
+     * {@code minLocalDeletionTime} at or below {@code nowInSec} — an expired liveness contributes its
+     * expiration time, a row deletion contributes {@code Long.MIN_VALUE} — so the row is dropped without
+     * any cell needing to be dead.
+     * <p>
+     * Both clearances are built, each with a LIVE cell that must go with the row, and a control row that
+     * neither clearance touches and that therefore keeps its cell. Without the purger half of the
+     * cursor's condition, the cell walk finds only live cells in all three and keeps all three, so the
+     * two dropped cells are what makes this scenario able to fail.
+     * <p>
+     * {@code gcBefore} is placed one second past the local deletion time the rows were built with, which
+     * is what makes both clearances fire; the assertions are their own non-vacuity check, since a
+     * clearance that did not fire leaves a non-empty liveness or a live-superseding deletion and the row
+     * is written with its cell.
+     */
+    @Test
+    public void strictLivenessDropsARowThePurgerEmptied() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT pk, ck, v1, v2 FROM %s " +
+                                 "WHERE pk IS NOT NULL AND ck IS NOT NULL AND v1 IS NOT NULL " +
+                                 "PRIMARY KEY (v1, pk, ck)");
+        ColumnFamilyStore viewCfs = getColumnFamilyStore(KEYSPACE, view);
+        viewCfs.disableAutoCompaction();
+        assertTrue("v1 is a base non-PK column in the view PK, so the view must enforce strict liveness",
+                   viewCfs.metadata().enforceStrictLiveness());
+
+        execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (1, 1, 5, 'normal')");
+        flush(KEYSPACE, view);
+
+        // every deletion time in this scenario, so one gcBefore purges all of them
+        long localDeletionTime = FBUtilities.nowInSeconds();
+        TableMetadata metadata = viewCfs.metadata();
+
+        // expiring primary-key liveness, expired at the pinned now and purgeable at gcBefore
+        Row.Builder purgedLiveness = livenessFreeViewRow(2L, 2L);
+        purgedLiveness.addPrimaryKeyLivenessInfo(LivenessInfo.withExpirationTime(100L, 1, localDeletionTime));
+        addLiveCell(purgedLiveness, metadata, "v2", "purgedLivenessCell");
+        applyViewRow(viewCfs, 5L, purgedLiveness.build());
+
+        // row deletion, purgeable at gcBefore, with a live cell above its timestamp so the cell survives
+        // the active deletion and only the strict-liveness drop can remove it
+        Row.Builder purgedDeletion = livenessFreeViewRow(3L, 3L);
+        purgedDeletion.addRowDeletion(Row.Deletion.regular(DeletionTime.build(100L, localDeletionTime)));
+        addLiveCell(purgedDeletion, metadata, "v2", "purgedDeletionCell");
+        applyViewRow(viewCfs, 5L, purgedDeletion.build());
+
+        // control: no liveness, no deletion, one live cell -- nothing for the purger to clear, so the
+        // reference's guard stays shut and the row is kept
+        Row.Builder untouched = livenessFreeViewRow(4L, 4L);
+        addLiveCell(untouched, metadata, "v2", "untouchedCell");
+        applyViewRow(viewCfs, 5L, untouched.build());
+        flush(KEYSPACE, view);
+
+        assertEquals("the constructed rows must reach the compaction merge from their own sstable",
+                     2, viewCfs.getLiveSSTables().size());
+
+        long gcBefore = localDeletionTime + 1;
+        long pinnedNow = localDeletionTime + 60; // past the liveness expiry, well below any live cell's
+        CapturedOutput out = assertCursorMatchesIterator(viewCfs, viewCfs.getLiveSSTables(),
+                                                         taskWithFixedNow(pinnedNow), gcBefore);
+        String json = allJson(out);
+        assertEquals("the row whose liveness the purger cleared kept its cell: " + json,
+                     0, countOccurrences(json, cellValue("purgedLivenessCell")));
+        assertEquals("the row whose deletion the purger cleared kept its cell: " + json,
+                     0, countOccurrences(json, cellValue("purgedDeletionCell")));
+        assertEquals("the control row, which the purger cleared nothing on, lost its cell: " + json,
+                     1, countOccurrences(json, cellValue("untouchedCell")));
+        assertEquals("the view-maintained row is missing: " + json,
+                     1, countOccurrences(json, cellValue("normal")));
+    }
+
+    /** A view-row builder with no primary-key liveness and no row deletion, at view clustering (pk, ck). */
+    private Row.Builder livenessFreeViewRow(long pk, long ck)
+    {
+        Row.Builder builder = BTreeRow.unsortedBuilder();
+        builder.newRow(Clustering.make(LongType.instance.decompose(pk), LongType.instance.decompose(ck)));
+        return builder;
+    }
+
+    private void addLiveCell(Row.Builder builder, TableMetadata metadata, String column, String value)
+    {
+        builder.addCell(BufferCell.live(metadata.getColumn(ByteBufferUtil.bytes(column)),
+                                        200L, UTF8Type.instance.decompose(value)));
+    }
+
+    /**
+     * A cell tombstone whose local deletion time is {@code nowInSec} and so sits above the default
+     * {@code gcBefore} — unpurgeable, which is what lets it decide its row's fate instead of being purged
+     * away before the merge gets there.
+     */
+    private void addCellTombstone(Row.Builder builder, TableMetadata metadata, String column, long nowInSec)
+    {
+        builder.addCell(BufferCell.tombstone(metadata.getColumn(ByteBufferUtil.bytes(column)), 200L, nowInSec));
+    }
+
+    private void applyViewRow(ColumnFamilyStore viewCfs, long v1, Row row)
+    {
+        new Mutation(PartitionUpdate.singleRowUpdate(viewCfs.metadata(), LongType.instance.decompose(v1), row)).apply();
+    }
+
+    private void writeShadowableStaticRowDeletion(ColumnFamilyStore cfs, long pk, long timestamp)
+    {
+        Row staticRow = BTreeRow.create(Clustering.STATIC_CLUSTERING, LivenessInfo.EMPTY,
+                                        Row.Deletion.shadowable(DeletionTime.build(timestamp, 1000)), BTree.empty());
+        ByteBuffer key = LongType.instance.decompose(pk);
+        new Mutation(PartitionUpdate.singleRowUpdate(cfs.metadata(), key, staticRow)).apply();
+    }
+
+    private void writeShadowableRowDeletion(ColumnFamilyStore cfs, long pk, long ck, long timestamp)
+    {
+        writeShadowableRowDeletion(cfs, pk, ck, timestamp, 1000L);
+    }
+
+    private void writeShadowableRowDeletion(ColumnFamilyStore cfs, long pk, long ck, long timestamp, long localDeletionTime)
+    {
+        Clustering<?> clustering = Clustering.make(ByteBufferUtil.bytes(ck));
+        Row row = BTreeRow.create(clustering, LivenessInfo.EMPTY,
+                                  Row.Deletion.shadowable(DeletionTime.build(timestamp, localDeletionTime)), BTree.empty());
+        ByteBuffer key = LongType.instance.decompose(pk);
+        new Mutation(PartitionUpdate.singleRowUpdate(cfs.metadata(), key, row)).apply();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,7 +35,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
  */
 public class MaterializedViewDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     @BeforeClass
     public static void startup()
@@ -72,6 +70,6 @@ public class MaterializedViewDifferentialCompactionTest extends DifferentialComp
         execute("UPDATE %s SET v1 = ? WHERE pk = ? AND ck = ?", 999L, 0L, 0L);
         flush(KEYSPACE, view);
 
-        assertCursorMatchesIteratorAcrossGenerations(viewCfs, ALLOWLIST);
+        assertCursorMatchesIteratorAcrossGenerations(viewCfs);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MaterializedViewDifferentialCompactionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+/**
+ * Differential coverage for MATERIALIZED VIEW tables: view tables are admitted
+ * by the cursor gate (no isView rejection) and compact through the same pipelines, but their
+ * row shapes are view-specific — strict liveness (CursorCompactor.enforceStrictLiveness
+ * mirrors PurgeFunction), view-generated row tombstones when a base row moves between view
+ * partitions, and expired-liveness markers. Shadowable row deletions do NOT appear: modern
+ * view maintenance stopped producing them (CASSANDRA-13409) and the cursor reader fail-louds
+ * if legacy data ever carries the flag.
+ */
+public class MaterializedViewDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    @BeforeClass
+    public static void startup()
+    {
+        requireNetwork();
+    }
+
+    @Test
+    public void materializedViewTable() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v1 bigint, v2 text, PRIMARY KEY (pk, ck))");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT pk, ck, v1 FROM %s " +
+                                 "WHERE pk IS NOT NULL AND ck IS NOT NULL AND v1 IS NOT NULL " +
+                                 "PRIMARY KEY (v1, pk, ck)");
+        ColumnFamilyStore viewCfs = getColumnFamilyStore(KEYSPACE, view);
+        viewCfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 6; ck++)
+                execute("INSERT INTO %s (pk, ck, v1, v2) VALUES (?, ?, ?, ?)", pk, ck, pk * 100 + ck, "x" + ck);
+        flush(KEYSPACE, view);
+
+        // view-partition moves (v1 changes: old view row dies via view tombstone, new row
+        // appears) and base-row deletes (view row tombstones)
+        for (long pk = 0; pk < 6; pk += 2)
+        {
+            execute("UPDATE %s SET v1 = ? WHERE pk = ? AND ck = ?", pk * 100 + 77, pk, 0L);
+            execute("DELETE FROM %s WHERE pk = ? AND ck = ?", pk, 1L);
+        }
+        flush(KEYSPACE, view);
+
+        // a second wave of moves on already-moved rows: tombstones meeting tombstones
+        execute("UPDATE %s SET v1 = ? WHERE pk = ? AND ck = ?", 999L, 0L, 0L);
+        flush(KEYSPACE, view);
+
+        assertCursorMatchesIteratorAcrossGenerations(viewCfs, ALLOWLIST);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Multi-output compactions: a size-capped CompactionAwareWriter forces writer switches at
+ * partition boundaries, so one compaction produces several sstables. Both pipelines receive
+ * the same writer type (CursorCompactionPipeline and IteratorCompactionPipeline both call
+ * task.getCompactionAwareWriter); the differential assertion requires the SAME number of
+ * outputs with byte-identical components pairwise — divergent switch decisions would show up
+ * as a count mismatch, divergent per-output finalization (first/last keys, promoted index,
+ * stats) as component diffs.
+ */
+public class MultiOutputDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    /** CompactionTask whose writer switches outputs once the current one exceeds maxBytes. */
+    private static TaskFactory sizeCapped(long maxBytes)
+    {
+        return (cfs, txn, gcBefore) -> new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */)
+        {
+            @Override
+            public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs,
+                                                                  Directories directories,
+                                                                  ILifecycleTransaction transaction,
+                                                                  Set<SSTableReader> nonExpiredSSTables)
+            {
+                return new MaxSSTableSizeWriter(cfs, directories, transaction, nonExpiredSSTables,
+                                                maxBytes, 0, true /* keepOriginals */);
+            }
+        };
+    }
+
+    /** Many small partitions split across several outputs. */
+    @Test
+    public void manyPartitionsSplitAcrossOutputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(100);
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 40; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + round + "-" + ck);
+            flush();
+        }
+
+        // ~40 partitions * ~1KB each; 8KB cap => several outputs, switch points mid-stream
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+
+    /** Tombstones and static rows crossing output boundaries. */
+    @Test
+    public void tombstonesAndStaticsAcrossOutputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s text static, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "y".repeat(100);
+        for (long pk = 0; pk < 30; pk++)
+        {
+            if (pk % 3 == 0)
+                execute("INSERT INTO %s (pk, s, ck, v) VALUES (?, ?, ?, ?)", pk, "static" + pk, 0L, padding);
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + ck);
+        }
+        flush();
+
+        // second sstable: range tombstones inside many partitions + some partition deletes
+        for (long pk = 0; pk < 30; pk += 2)
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 3 AND ck < 7", pk);
+        execute("DELETE FROM %s WHERE pk = 5");
+        execute("DELETE FROM %s WHERE pk = 15");
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+
+    /** One output ending exactly at a wide partition boundary, the next starting fresh. */
+    @Test
+    public void widePartitionsForceFrequentSwitches() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "z".repeat(300);
+        // each partition ~6KB > cap/2: nearly every partition triggers a switch decision
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 12; pk++)
+                for (long ck = 0; ck < 20; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + round);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 5 AND ck < 15", (long) round);
+            flush();
+        }
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
@@ -44,7 +44,6 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
  */
 public class MultiOutputDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     /** CompactionTask whose writer switches outputs once the current one exceeds maxBytes. */
     private static TaskFactory sizeCapped(long maxBytes)
@@ -82,7 +81,7 @@ public class MultiOutputDifferentialCompactionTest extends DifferentialCompactio
         }
 
         // ~40 partitions * ~1KB each; 8KB cap => several outputs, switch points mid-stream
-        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
         assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
                    out.sstables.size() >= 2);
     }
@@ -113,7 +112,7 @@ public class MultiOutputDifferentialCompactionTest extends DifferentialCompactio
         execute("DELETE FROM %s WHERE pk = 15");
         flush();
 
-        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
         assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
                    out.sstables.size() >= 2);
     }
@@ -138,7 +137,7 @@ public class MultiOutputDifferentialCompactionTest extends DifferentialCompactio
             flush();
         }
 
-        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), sizeCapped(8 * 1024));
         assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
                    out.sstables.size() >= 2);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/MultiOutputDifferentialCompactionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.compaction.CompactionTask;
+import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+/**
+ * Multi-output compactions: a size-capped CompactionAwareWriter forces writer switches at
+ * partition boundaries, so one compaction produces several sstables. Both pipelines receive
+ * the same writer type (CursorCompactionPipeline and IteratorCompactionPipeline both call
+ * task.getCompactionAwareWriter); the differential assertion requires the SAME number of
+ * outputs with byte-identical components pairwise — divergent switch decisions would show up
+ * as a count mismatch, divergent per-output finalization (first/last keys, promoted index,
+ * stats) as component diffs.
+ */
+public class MultiOutputDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    /** CompactionTask whose writer switches outputs once the current one exceeds maxBytes. */
+    private static TaskFactory sizeCapped(long maxBytes)
+    {
+        return (cfs, txn, gcBefore) -> new CompactionTask(cfs, txn, gcBefore, true /* keepOriginals */)
+        {
+            @Override
+            public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs,
+                                                                  Directories directories,
+                                                                  ILifecycleTransaction transaction,
+                                                                  Set<SSTableReader> nonExpiredSSTables)
+            {
+                return new MaxSSTableSizeWriter(cfs, directories, transaction, nonExpiredSSTables,
+                                                maxBytes, 0, true /* keepOriginals */);
+            }
+        };
+    }
+
+    /** Many small partitions split across several outputs. */
+    @Test
+    public void manyPartitionsSplitAcrossOutputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "x".repeat(100);
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 40; pk++)
+                for (long ck = 0; ck < 10; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + round + "-" + ck);
+            flush();
+        }
+
+        // ~40 partitions * ~1KB each; 8KB cap => several outputs, switch points mid-stream
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+
+    /** Tombstones and static rows crossing output boundaries. */
+    @Test
+    public void tombstonesAndStaticsAcrossOutputs() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, s text static, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000 AND compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "y".repeat(100);
+        for (long pk = 0; pk < 30; pk++)
+        {
+            if (pk % 3 == 0)
+                execute("INSERT INTO %s (pk, s, ck, v) VALUES (?, ?, ?, ?)", pk, "static" + pk, 0L, padding);
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + ck);
+        }
+        flush();
+
+        // second sstable: range tombstones inside many partitions + some partition deletes
+        for (long pk = 0; pk < 30; pk += 2)
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 3 AND ck < 7", pk);
+        execute("DELETE FROM %s WHERE pk = 5");
+        execute("DELETE FROM %s WHERE pk = 15");
+        flush();
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+
+    /** One output ending exactly at a wide partition boundary, the next starting fresh. */
+    @Test
+    public void widePartitionsForceFrequentSwitches() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH compression = {'enabled': 'false'}");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        String padding = "z".repeat(300);
+        // each partition ~6KB > cap/2: nearly every partition triggers a switch decision
+        for (int round = 0; round < 2; round++)
+        {
+            for (long pk = 0; pk < 12; pk++)
+                for (long ck = 0; ck < 20; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, padding + round);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 5 AND ck < 15", (long) round);
+            flush();
+        }
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, sizeCapped(8 * 1024));
+        assertTrue("scenario must produce multiple outputs to test anything, got " + out.sstables.size(),
+                   out.sstables.size() >= 2);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Partial-set compactions: only a subset of the live sstables participates, and the purge
+ * evaluator must consult overlapping NON-participating sstables before dropping tombstones
+ * (CompactionController.getPurgeEvaluator / CursorCompactor's shouldPurge). The differential
+ * assertion is agnostic to which outcome is correct — both paths must simply agree, byte for
+ * byte. All writes use explicit timestamps so purge decisions are deterministic.
+ */
+public class PartialSetDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    /** Flushes and returns the sstable that flush produced; tracks flush order explicitly. */
+    private SSTableReader flushAndTrack(ColumnFamilyStore cfs, List<SSTableReader> flushed) throws Throwable
+    {
+        Set<SSTableReader> before = new HashSet<>(cfs.getLiveSSTables());
+        flush();
+        List<SSTableReader> fresh = new ArrayList<>(cfs.getLiveSSTables());
+        fresh.removeAll(before);
+        if (fresh.size() != 1)
+            throw new AssertionError("expected exactly one new sstable from flush, got " + fresh.size());
+        flushed.add(fresh.get(0));
+        return fresh.get(0);
+    }
+
+    /**
+     * Tombstones whose purge is BLOCKED by an overlapping non-participant: the partition also
+     * exists in a non-compacting sstable with OLDER timestamps, so the tombstone must survive
+     * the partial compaction in both paths.
+     */
+    @Test
+    public void purgeBlockedByOverlappingNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A: data at ts=100
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "a" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: row + partition tombstones at ts=200
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C (non-participant): same partitions with OLDER data (ts=50) — purging the
+        // ts=200 tombstones would resurrect this data, so the evaluator must block it
+        for (long pk = 1; pk <= 2; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 50", pk, ck, "old" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // purge boundary: gcBefore strictly past sstable B's tombstones, read from its own stats
+        long gcBefore = maxTombstoneLocalDeletionTime(List.of(flushed.get(1))) + 1;
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), DEFAULT_TASK, gcBefore);
+        // non-vacuousness: the overlap must have actually BLOCKED the purge
+        assertTrue("expected ts=200 tombstones retained because of the overlapping non-participant",
+                   allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /**
+     * Tombstones whose purge is ALLOWED despite a non-participant existing: the non-compacting
+     * sstable holds entirely different partitions, so nothing blocks the drop. Both paths must
+     * purge identically (and drop the emptied partitions).
+     */
+    @Test
+    public void purgeAllowedWithDisjointNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A: data at ts=100 for pk 0-5
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "a" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: tombstones at ts=200 for pk 1-2
+        for (long ck = 0; ck < 10; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C (non-participant): DIFFERENT partitions only (pk 100-105)
+        for (long pk = 100; pk < 106; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 50", pk, ck, "other" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // purge boundary: gcBefore strictly past sstable B's tombstones, read from its own stats
+        long gcBefore = maxTombstoneLocalDeletionTime(List.of(flushed.get(1))) + 1;
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), DEFAULT_TASK, gcBefore);
+        // non-vacuousness: with no overlap on those keys, the tombstones must actually purge
+        assertFalse("expected ts=200 tombstones purged (disjoint non-participant cannot block)",
+                    allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /**
+     * Compacting newer sstables while the OLDEST (holding the shadowed data) stays out:
+     * tombstones must be retained because the overlapping non-participant holds data they
+     * still shadow.
+     */
+    @Test
+    public void tombstonesRetainedOverShadowedNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A (will be the non-participant): the data being shadowed, ts=100
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "base" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: tombstones at ts=200 over A's data
+        for (long ck = 0; ck < 10; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 3 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 4");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C: unrelated newer writes, merges with B
+        for (long pk = 0; pk < 6; pk++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 300", pk, 20L, "new");
+        flushAndTrack(cfs, flushed);
+
+        // purge boundary: gcBefore strictly past sstable B's tombstones, read from its own stats
+        long gcBefore = maxTombstoneLocalDeletionTime(List.of(flushed.get(1))) + 1;
+
+        // compact B+C, leaving A (the shadowed data) out
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(1, 3)), DEFAULT_TASK, gcBefore);
+        // non-vacuousness: tombstones still shadow A's data and must survive
+        assertTrue("expected ts=200 tombstones retained over the shadowed non-participant",
+                   allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
@@ -41,14 +41,6 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 public class PartialSetDifferentialCompactionTest extends DifferentialCompactionTester
 {
 
-    private static String allJson(CapturedOutput out)
-    {
-        StringBuilder sb = new StringBuilder();
-        for (CapturedSSTable s : out.sstables)
-            sb.append(s.json);
-        return sb.toString();
-    }
-
     /** Flushes and returns the sstable that flush produced; tracks flush order explicitly. */
     private SSTableReader flushAndTrack(ColumnFamilyStore cfs, List<SSTableReader> flushed) throws Throwable
     {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
@@ -40,7 +40,6 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
  */
 public class PartialSetDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     private static String allJson(CapturedOutput out)
     {
@@ -98,7 +97,7 @@ public class PartialSetDifferentialCompactionTest extends DifferentialCompaction
 
         Thread.sleep(1100); // deletion local times strictly in the past for both runs
 
-        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), ALLOWLIST, DEFAULT_TASK);
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), DEFAULT_TASK);
         // non-vacuousness: the overlap must have actually BLOCKED the purge
         assertTrue("expected ts=200 tombstones retained because of the overlapping non-participant",
                    allJson(out).contains("\"marked_deleted\":\"200\""));
@@ -138,7 +137,7 @@ public class PartialSetDifferentialCompactionTest extends DifferentialCompaction
 
         Thread.sleep(1100);
 
-        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), ALLOWLIST, DEFAULT_TASK);
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), DEFAULT_TASK);
         // non-vacuousness: with no overlap on those keys, the tombstones must actually purge
         assertFalse("expected ts=200 tombstones purged (disjoint non-participant cannot block)",
                     allJson(out).contains("\"marked_deleted\":\"200\""));
@@ -178,7 +177,7 @@ public class PartialSetDifferentialCompactionTest extends DifferentialCompaction
         Thread.sleep(1100);
 
         // compact B+C, leaving A (the shadowed data) out
-        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(1, 3)), ALLOWLIST, DEFAULT_TASK);
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(1, 3)), DEFAULT_TASK);
         // non-vacuousness: tombstones still shadow A's data and must survive
         assertTrue("expected ts=200 tombstones retained over the shadowed non-participant",
                    allJson(out).contains("\"marked_deleted\":\"200\""));

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PartialSetDifferentialCompactionTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+/**
+ * Partial-set compactions: only a subset of the live sstables participates, and the purge
+ * evaluator must consult overlapping NON-participating sstables before dropping tombstones
+ * (CompactionController.getPurgeEvaluator / CursorCompactor's shouldPurge). The differential
+ * assertion is agnostic to which outcome is correct — both paths must simply agree, byte for
+ * byte. All writes use explicit timestamps so purge decisions are deterministic.
+ */
+public class PartialSetDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    private static String allJson(CapturedOutput out)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (CapturedSSTable s : out.sstables)
+            sb.append(s.json);
+        return sb.toString();
+    }
+
+    /** Flushes and returns the sstable that flush produced; tracks flush order explicitly. */
+    private SSTableReader flushAndTrack(ColumnFamilyStore cfs, List<SSTableReader> flushed) throws Throwable
+    {
+        Set<SSTableReader> before = new HashSet<>(cfs.getLiveSSTables());
+        flush();
+        List<SSTableReader> fresh = new ArrayList<>(cfs.getLiveSSTables());
+        fresh.removeAll(before);
+        if (fresh.size() != 1)
+            throw new AssertionError("expected exactly one new sstable from flush, got " + fresh.size());
+        flushed.add(fresh.get(0));
+        return fresh.get(0);
+    }
+
+    /**
+     * Tombstones whose purge is BLOCKED by an overlapping non-participant: the partition also
+     * exists in a non-compacting sstable with OLDER timestamps, so the tombstone must survive
+     * the partial compaction in both paths.
+     */
+    @Test
+    public void purgeBlockedByOverlappingNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A: data at ts=100
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "a" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: row + partition tombstones at ts=200
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C (non-participant): same partitions with OLDER data (ts=50) — purging the
+        // ts=200 tombstones would resurrect this data, so the evaluator must block it
+        for (long pk = 1; pk <= 2; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 50", pk, ck, "old" + ck);
+        flushAndTrack(cfs, flushed);
+
+        Thread.sleep(1100); // deletion local times strictly in the past for both runs
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), ALLOWLIST, DEFAULT_TASK);
+        // non-vacuousness: the overlap must have actually BLOCKED the purge
+        assertTrue("expected ts=200 tombstones retained because of the overlapping non-participant",
+                   allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /**
+     * Tombstones whose purge is ALLOWED despite a non-participant existing: the non-compacting
+     * sstable holds entirely different partitions, so nothing blocks the drop. Both paths must
+     * purge identically (and drop the emptied partitions).
+     */
+    @Test
+    public void purgeAllowedWithDisjointNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A: data at ts=100 for pk 0-5
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "a" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: tombstones at ts=200 for pk 1-2
+        for (long ck = 0; ck < 10; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C (non-participant): DIFFERENT partitions only (pk 100-105)
+        for (long pk = 100; pk < 106; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 50", pk, ck, "other" + ck);
+        flushAndTrack(cfs, flushed);
+
+        Thread.sleep(1100);
+
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(0, 2)), ALLOWLIST, DEFAULT_TASK);
+        // non-vacuousness: with no overlap on those keys, the tombstones must actually purge
+        assertFalse("expected ts=200 tombstones purged (disjoint non-participant cannot block)",
+                    allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /**
+     * Compacting newer sstables while the OLDEST (holding the shadowed data) stays out:
+     * tombstones must be retained because the overlapping non-participant holds data they
+     * still shadow.
+     */
+    @Test
+    public void tombstonesRetainedOverShadowedNonParticipant() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        List<SSTableReader> flushed = new ArrayList<>();
+        // sstable A (will be the non-participant): the data being shadowed, ts=100
+        for (long pk = 0; pk < 6; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "base" + ck);
+        flushAndTrack(cfs, flushed);
+
+        // sstable B: tombstones at ts=200 over A's data
+        for (long ck = 0; ck < 10; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 3 AND ck = ?", ck);
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 4");
+        flushAndTrack(cfs, flushed);
+
+        // sstable C: unrelated newer writes, merges with B
+        for (long pk = 0; pk < 6; pk++)
+            execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 300", pk, 20L, "new");
+        flushAndTrack(cfs, flushed);
+
+        Thread.sleep(1100);
+
+        // compact B+C, leaving A (the shadowed data) out
+        CapturedOutput out = assertCursorMatchesIterator(cfs, new HashSet<>(flushed.subList(1, 3)), ALLOWLIST, DEFAULT_TASK);
+        // non-vacuousness: tombstones still shadow A's data and must survive
+        assertTrue("expected ts=200 tombstones retained over the shadowed non-participant",
+                   allJson(out).contains("\"marked_deleted\":\"200\""));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exact purge-boundary scenarios plus configuration-axis variants (compression algorithms,
+ * compaction disk access mode). Purge requires localDeletionTime < gcBefore; instead of
+ * freezing the clock, scenarios read the REAL deletion time from the flushed sstable's stats
+ * and pass an explicit gcBefore placed exactly at, and one past, that boundary.
+ */
+public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompactionTester
+{
+
+    /** gcBefore exactly AT the tombstone's deletion time: NOT purgeable (strict less-than). */
+    @Test
+    public void boundaryExactlyAtDeletionTime() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 4; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "v" + ck);
+        flush();
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1");
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2 AND ck = ?", ck);
+        flush();
+
+        // an sstable holding any live cell reports the NO_DELETION sentinel (Long.MAX_VALUE) as its
+        // max local deletion time, so the helper skips those and takes the max over the rest; here
+        // that is the deletes-only sstable's single deletion second
+        long maxLdt = maxTombstoneLocalDeletionTime(cfs.getLiveSSTables());
+
+        // boundary: ldt == gcBefore -> NOT purgeable (purge requires ldt < gcBefore)
+        CapturedOutput at = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, maxLdt);
+        assertTrue("tombstones at exactly gcBefore must be retained",
+                   allJson(at).contains("\"marked_deleted\":\"200\""));
+
+        // one past: ldt < gcBefore -> purgeable, shadowed data and tombstones both gone
+        CapturedOutput past = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, maxLdt + 1);
+        assertFalse("tombstones strictly before gcBefore must purge",
+                    allJson(past).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /** Same differential flow under direct I/O for the compaction read path. */
+    @Test
+    public void directDiskAccessMode() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 10; pk++)
+                for (long ck = 0; ck < 15; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "v" + ck);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 3 AND ck < 9", (long) round);
+            flush();
+        }
+
+        DiskAccessMode original = DatabaseDescriptor.getCompactionReadDiskAccessMode();
+        DatabaseDescriptor.setCompactionReadDiskAccessMode(DiskAccessMode.direct);
+        try
+        {
+            assertCursorMatchesIterator(cfs);
+        }
+        finally
+        {
+            DatabaseDescriptor.setCompactionReadDiskAccessMode(original);
+        }
+    }
+
+    /** Output equivalence must hold for every compressor, not just the default LZ4. */
+    @Test
+    public void compressionVariants() throws Exception
+    {
+        for (String compression : new String[]{ "ZstdCompressor", "DeflateCompressor", "SnappyCompressor" })
+        {
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                        "WITH gc_grace_seconds = 864000 AND compression = {'class': '" + compression + "'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < 8; pk++)
+                    for (long ck = 0; ck < 10; ck++)
+                        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, compression + round + ck);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= 2 AND ck < 6", (long) round);
+                flush();
+            }
+
+            assertCursorMatchesIterator(cfs);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
@@ -38,14 +38,6 @@ import static org.junit.Assert.assertTrue;
 public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompactionTester
 {
 
-    private static String allJson(CapturedOutput out)
-    {
-        StringBuilder sb = new StringBuilder();
-        for (CapturedSSTable s : out.sstables)
-            sb.append(s.json);
-        return sb.toString();
-    }
-
     /** gcBefore exactly AT the tombstone's deletion time: NOT purgeable (strict less-than). */
     @Test
     public void boundaryExactlyAtDeletionTime() throws Exception

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config.DiskAccessMode;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exact purge-boundary scenarios plus configuration-axis variants (compression algorithms,
+ * compaction disk access mode). Purge requires localDeletionTime < gcBefore; instead of
+ * freezing the clock, scenarios read the REAL deletion time from the flushed sstable's stats
+ * and pass an explicit gcBefore placed exactly at, and one past, that boundary.
+ */
+public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    private static String allJson(CapturedOutput out)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (CapturedSSTable s : out.sstables)
+            sb.append(s.json);
+        return sb.toString();
+    }
+
+    /** gcBefore exactly AT the tombstone's deletion time: NOT purgeable (strict less-than). */
+    @Test
+    public void boundaryExactlyAtDeletionTime() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 0");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (long pk = 0; pk < 4; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP 100", pk, ck, "v" + ck);
+        flush();
+        execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 1");
+        for (long ck = 0; ck < 5; ck++)
+            execute("DELETE FROM %s USING TIMESTAMP 200 WHERE pk = 2 AND ck = ?", ck);
+        flush();
+
+        // sstables with no tombstones report the NO_DELETION sentinel (Long.MAX_VALUE) as their
+        // max local deletion time — use the min across sstables that DO have deletions, which
+        // for this scenario is the single deletion second of the tombstone-only sstable
+        long maxLdt = Long.MIN_VALUE;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            long ldt = sstable.getSSTableMetadata().maxLocalDeletionTime;
+            if (ldt != Long.MAX_VALUE)
+                maxLdt = Math.max(maxLdt, ldt);
+        }
+        assertTrue("scenario produced no tombstone deletion times", maxLdt > 0 && maxLdt < Long.MAX_VALUE);
+
+        // boundary: ldt == gcBefore -> NOT purgeable (purge requires ldt < gcBefore)
+        CapturedOutput at = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, DEFAULT_TASK, maxLdt);
+        assertTrue("tombstones at exactly gcBefore must be retained",
+                   allJson(at).contains("\"marked_deleted\":\"200\""));
+
+        // one past: ldt < gcBefore -> purgeable, shadowed data and tombstones both gone
+        CapturedOutput past = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, DEFAULT_TASK, maxLdt + 1);
+        assertFalse("tombstones strictly before gcBefore must purge",
+                    allJson(past).contains("\"marked_deleted\":\"200\""));
+    }
+
+    /** Same differential flow under direct I/O for the compaction read path. */
+    @Test
+    public void directDiskAccessMode() throws Exception
+    {
+        createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                    "WITH gc_grace_seconds = 864000");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (int round = 0; round < 3; round++)
+        {
+            for (long pk = 0; pk < 10; pk++)
+                for (long ck = 0; ck < 15; ck++)
+                    execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "r" + round + "v" + ck);
+            execute("DELETE FROM %s WHERE pk = ? AND ck >= 3 AND ck < 9", (long) round);
+            flush();
+        }
+
+        DiskAccessMode original = DatabaseDescriptor.getCompactionReadDiskAccessMode();
+        DatabaseDescriptor.setCompactionReadDiskAccessMode(DiskAccessMode.direct);
+        try
+        {
+            assertCursorMatchesIterator(cfs, ALLOWLIST);
+        }
+        finally
+        {
+            DatabaseDescriptor.setCompactionReadDiskAccessMode(original);
+        }
+    }
+
+    /** Output equivalence must hold for every compressor, not just the default LZ4. */
+    @Test
+    public void compressionVariants() throws Exception
+    {
+        for (String compression : new String[]{ "ZstdCompressor", "DeflateCompressor", "SnappyCompressor" })
+        {
+            createTable("CREATE TABLE %s (pk bigint, ck bigint, v text, PRIMARY KEY (pk, ck)) " +
+                        "WITH gc_grace_seconds = 864000 AND compression = {'class': '" + compression + "'}");
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.disableAutoCompaction();
+
+            for (int round = 0; round < 2; round++)
+            {
+                for (long pk = 0; pk < 8; pk++)
+                    for (long ck = 0; ck < 10; ck++)
+                        execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, compression + round + ck);
+                execute("DELETE FROM %s WHERE pk = ? AND ck >= 2 AND ck < 6", (long) round);
+                flush();
+            }
+
+            assertCursorMatchesIterator(cfs, ALLOWLIST);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/PurgeBoundaryDifferentialCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db.compaction.differential;
 
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -38,7 +37,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompactionTester
 {
-    private static final Set<String> ALLOWLIST = Set.of();
 
     private static String allJson(CapturedOutput out)
     {
@@ -79,12 +77,12 @@ public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompact
         assertTrue("scenario produced no tombstone deletion times", maxLdt > 0 && maxLdt < Long.MAX_VALUE);
 
         // boundary: ldt == gcBefore -> NOT purgeable (purge requires ldt < gcBefore)
-        CapturedOutput at = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, DEFAULT_TASK, maxLdt);
+        CapturedOutput at = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, maxLdt);
         assertTrue("tombstones at exactly gcBefore must be retained",
                    allJson(at).contains("\"marked_deleted\":\"200\""));
 
         // one past: ldt < gcBefore -> purgeable, shadowed data and tombstones both gone
-        CapturedOutput past = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), ALLOWLIST, DEFAULT_TASK, maxLdt + 1);
+        CapturedOutput past = assertCursorMatchesIterator(cfs, cfs.getLiveSSTables(), DEFAULT_TASK, maxLdt + 1);
         assertFalse("tombstones strictly before gcBefore must purge",
                     allJson(past).contains("\"marked_deleted\":\"200\""));
     }
@@ -111,7 +109,7 @@ public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompact
         DatabaseDescriptor.setCompactionReadDiskAccessMode(DiskAccessMode.direct);
         try
         {
-            assertCursorMatchesIterator(cfs, ALLOWLIST);
+            assertCursorMatchesIterator(cfs);
         }
         finally
         {
@@ -139,7 +137,7 @@ public class PurgeBoundaryDifferentialCompactionTest extends DifferentialCompact
                 flush();
             }
 
-            assertCursorMatchesIterator(cfs, ALLOWLIST);
+            assertCursorMatchesIterator(cfs);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -1,0 +1,602 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
+import org.quicktheories.impl.JavaRandom;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.apache.cassandra.utils.AbstractTypeGenerators.TypeGenBuilder;
+import org.apache.cassandra.utils.AbstractTypeGenerators.ValueDomain;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.CassandraGenerators;
+import org.apache.cassandra.utils.CassandraGenerators.TableMetadataBuilder;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Generators;
+
+import static org.apache.cassandra.utils.Generators.IDENTIFIER_GEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Randomized soak for the cursor-vs-iterator differential harness: random schemas restricted to
+ * the currently supported cursor compaction surface (the same unsupportedMetadata filter
+ * production uses), random multi-round workloads with overwrites and deletes flushed into
+ * overlapping sstables, then byte+logical differential comparison of both compaction paths.
+ *
+ * Workload space: INSERT / UPDATE (no row liveness) / primary-key-only INSERT (liveness, no
+ * cells) / INSERT USING TTL (long-lived, far from the expiry boundary) / explicit USING
+ * TIMESTAMP collisions from a small pool (same-timestamp tie-breaks); null values on
+ * non-key columns (cell tombstones on simple columns; mapped to empty buffers on clustering
+ * columns); row deletes, partition deletes, single-sided and prefix range deletes,
+ * multi-column cell deletes, static cell deletes. Composite partition keys (1-2 components).
+ * Plus one designated same-timestamp tie per example — one primary key rewritten once per round
+ * at a single timestamp — so the tie-break is reached without depending on the random draw.
+ *
+ * Example count is property-gated: -Dcassandra.test.differential.examples=N (default
+ * {@value #DEFAULT_EXAMPLES}; the pre-JIRA validation run uses thousands).
+ *
+ * Reproducing a failure: every failure message is wrapped in a seed; rerun with
+ * -Dcassandra.test.differential.seed=N (the failing seed becomes example 0), or plug it
+ * into {@code withFixedSeed} below.
+ *
+ * Known coverage gaps (deliberate, covered by the deterministic corpus): EMPTY_BYTES value
+ * domain (invalid CQL for some generated multi-cell shapes), collection-element deletes
+ * (DELETE m['k'] needs element values of the right type), expired TTLs (timing-dependent).
+ */
+public class RandomDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    static
+    {
+        // make sure generated blobs are deterministic per seed
+        CassandraRelevantProperties.TEST_BLOB_SHARED_SEED.setInt(42);
+    }
+
+    private static final int DEFAULT_EXAMPLES = 10;
+    private static final int EXAMPLES = CassandraRelevantProperties.TEST_DIFFERENTIAL_EXAMPLES.getInt(DEFAULT_EXAMPLES);
+
+    /** Long enough that expiry can never fall between the two differential runs. */
+    private static final int SOAK_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+    /**
+     * Base of the small explicit-timestamp pool, deliberately ABOVE the wall clock. CQL timestamps are
+     * MICROSECONDS since the epoch, so a pool near 1e6 is 1970 and loses on timestamp to every wall-clock
+     * write this workload makes to the same primary key — which leaves the tie-break under test unable to
+     * influence an output byte at all. Derived from the clock rather than written as a literal so it
+     * cannot silently fall behind it, and truncated to a whole day so that all runs on the same day share
+     * one pool and a pinned seed still reproduces the same timestamps. A year of headroom covers a long
+     * soak and a skewed clock; no guardrail rejects a future timestamp (maximum_timestamp_warn_threshold
+     * and maximum_timestamp_fail_threshold both default to null). The consequence to accept is that
+     * wall-clock DELETEs no longer shadow these rows, which is unavoidable: a tie-break can only be
+     * observed if the tied writes win.
+     */
+    private static final long TIE_POOL_BASE =
+        TimeUnit.DAYS.toMicros(TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis()) + 365);
+
+    /** Width of the pool the random workload draws from; the designated tie sits just above it. */
+    private static final int TIE_POOL_WIDTH = 3;
+
+    @Test
+    public void randomizedDifferential() throws Throwable
+    {
+        // a zero or negative example count would make SeedRunner.run iterate zero times and the
+        // test pass having compared nothing
+        assertTrue("cassandra.test.differential.examples must be > 0, got " + EXAMPLES, EXAMPLES > 0);
+        long nowMicros = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
+        assertTrue("the explicit-timestamp pool must sit above the wall clock: TIE_POOL_BASE=" +
+                   TIE_POOL_BASE + " nowMicros=" + nowMicros, TIE_POOL_BASE > nowMicros);
+        new SeedRunner(EXAMPLES).run(this::runOneExample);
+    }
+
+    private void runOneExample(long seed) throws Throwable
+    {
+        JavaRandom qtRandom = new JavaRandom(seed);
+        Random workload = new Random(seed);
+
+        Gen<String> udtName = Generators.unique(IDENTIFIER_GEN);
+        TypeGenBuilder safePrimary = AbstractTypeGenerators.withoutUnsafeEquality().withUDTNames(udtName);
+        TableMetadata metadata;
+        do
+        {
+            metadata = new TableMetadataBuilder()
+                       .withKeyspaceName(KEYSPACE)
+                       .withTableKinds(TableMetadata.Kind.REGULAR)
+                       .withKnownMemtables()
+                       .withDefaultTypeGen(AbstractTypeGenerators.builder()
+                                                                 .withoutEmpty()
+                                                                 .withMaxDepth(2)
+                                                                 .withDefaultSetKey(safePrimary)
+                                                                 .withoutTypeKinds(AbstractTypeGenerators.TypeKind.COUNTER)
+                                                                 .withUDTNames(udtName))
+                       .withPartitionColumnsBetween(1, 2)
+                       .withPrimaryColumnTypeGen(new TypeGenBuilder(safePrimary).withMaxDepth(1))
+                       .withClusteringColumnsBetween(0, 3)
+                       .withRegularColumnsBetween(1, 5)
+                       .withStaticColumnsBetween(0, 2)
+                       .build(qtRandom);
+        }
+        // Same filter production uses to route to the cursor pipeline.
+        // Also rejects invalid CQL the generator can produce: static columns require
+        // clustering columns.
+        while (CursorCompactor.unsupportedMetadata(metadata)
+               || (metadata.clusteringColumns().isEmpty() && !metadata.staticColumns().isEmpty()));
+
+        maybeCreateUDTs(metadata);
+        String createTableCql = metadata.toCqlString(true, false, false)
+                                        .replaceAll("org.apache.cassandra.db.marshal.", "");
+        logger.info("randomizedDifferential seed={} schema:\n{}", seed, createTableCql);
+        createTable(KEYSPACE, createTableCql);
+        // the CQL embeds the generator's table name; createTable's returned name is not it
+        ColumnFamilyStore cfs = getColumnFamilyStore(KEYSPACE, metadata.name);
+        cfs.disableAutoCompaction();
+
+        // ~12% of non-key values are null: cell tombstones on simple columns. The data
+        // generator maps null to an empty buffer on clustering columns (null clustering is
+        // invalid; empty is legal and exercises the empty-vs-valued clustering comparison)
+        // and never applies the domain to partition keys.
+        Gen<ValueDomain> valueDomains = SourceDSL.integers().between(0, 99)
+                                                 .map(i -> i < 12 ? ValueDomain.NULL : ValueDomain.NORMAL);
+        Gen<ByteBuffer[]> dataGen = CassandraGenerators.data(metadata, valueDomains);
+
+        int partitionColumnCount = metadata.partitionKeyColumns().size();
+        int clusteringColumnCount = metadata.clusteringColumns().size();
+        int primaryColumnCount = partitionColumnCount + clusteringColumnCount;
+        String insertStmt = insertStmt(metadata);
+        String deleteRowStmt = deleteStmt(metadata, primaryColumnCount);
+        String deletePartitionStmt = deleteStmt(metadata, partitionColumnCount);
+
+        // select-order index of every column, for UPDATE/cell-delete binding
+        Map<String, Integer> selectOrderIndex = new HashMap<>();
+        {
+            Iterator<ColumnMetadata> it = metadata.allColumnsInSelectOrder();
+            for (int i = 0; it.hasNext(); i++)
+                selectOrderIndex.put(it.next().name.toString(), i);
+        }
+        List<ColumnMetadata> regularColumns = ImmutableList.copyOf(metadata.regularColumns());
+        List<ColumnMetadata> staticColumns = ImmutableList.copyOf(metadata.staticColumns());
+
+        List<ByteBuffer[]> rows = new ArrayList<>();
+        int rounds = 2 + workload.nextInt(3); // 2-4 sstables
+        // which round wins the designated tie; see the arrangement loop below
+        int tieWinnerOffset = workload.nextInt(rounds);
+
+        // One DETERMINISTIC cross-sstable same-timestamp tie per example: the same primary key written
+        // once per round with fresh values at one timestamp, so the tie-break is reached in EVERY example
+        // instead of only when the random draw happens to collide on a key. Its timestamp sits just above
+        // the pool the random workload draws from, so a pooled write that lands on the same key (low
+        // cardinality key types make that likely) loses on timestamp rather than joining the tie; and the
+        // whole pool being above the wall clock means no wall-clock write or delete can shadow it either.
+        // Never added to `rows`, so none of the delete loops below can target it.
+        long tieTimestamp = TIE_POOL_BASE + TIE_POOL_WIDTH;
+        // no value domain: every tie candidate is a live cell, so the winner is decided by the value
+        // comparison alone and not by the tombstone-or-expiring-beats-live branch
+        // (Cells.java:97-98) on a NULL column
+        Gen<ByteBuffer[]> tieDataGen = CassandraGenerators.data(metadata, null);
+        ByteBuffer[] tieKey = tieDataGen.generate(qtRandom);
+        List<ByteBuffer[]> tieWrites = new ArrayList<>();
+        for (int round = 0; round < rounds; round++)
+        {
+            ByteBuffer[] tieRow = tieDataGen.generate(qtRandom);
+            System.arraycopy(tieKey, 0, tieRow, 0, primaryColumnCount);
+            tieWrites.add(tieRow);
+        }
+        // Spread the winners ACROSS rounds: column c's greatest bytes are arranged into round
+        // (c + tieWinnerOffset) % rounds. Leaving the maxima wherever the generator put them makes the
+        // assertion below bite only by luck (a merge that kept the last writer agrees with the rule about
+        // 1/rounds of the time per column); putting them all in ONE round would instead make a merge that
+        // kept that round pass every time. Spread, no rule of the form "always keep sstable k" can agree
+        // with the real rule on a schema with two or more regular columns, and the per-example offset
+        // means it cannot agree on a single-regular-column schema either without getting lucky in every
+        // example. Drawn from `workload`, so a pinned seed still reproduces the arrangement.
+        for (int c = 0; c < regularColumns.size(); c++)
+        {
+            int valueIndex = selectOrderIndex.get(regularColumns.get(c).name.toString());
+            int winner = (c + tieWinnerOffset) % rounds;
+            for (int round = 0; round < rounds; round++)
+            {
+                if (round != winner
+                    && ByteBufferUtil.compareUnsigned(tieWrites.get(round)[valueIndex],
+                                                      tieWrites.get(winner)[valueIndex]) > 0)
+                {
+                    ByteBuffer greater = tieWrites.get(round)[valueIndex];
+                    tieWrites.get(round)[valueIndex] = tieWrites.get(winner)[valueIndex];
+                    tieWrites.get(winner)[valueIndex] = greater;
+                }
+            }
+        }
+
+        for (int round = 0; round < rounds; round++)
+        {
+            // Watermark taken at ROUND start: the explicit-timestamp branch below draws its overwrite
+            // target from `rows` BELOW this index only, i.e. from a key written in an EARLIER round.
+            // Drawing from all of `rows` — which is appended to on every iteration, including earlier
+            // iterations of this round — lets both writes land in one memtable, where the memtable
+            // reconciles them and the compactor's tie-break is never reached.
+            int rowsBeforeThisRound = rows.size();
+            int inserts = 15 + workload.nextInt(26); // 15-40 rows
+            for (int i = 0; i < inserts; i++)
+            {
+                ByteBuffer[] row = dataGen.generate(qtRandom);
+                boolean overwrite = !rows.isEmpty() && workload.nextInt(100) < 30;
+                if (overwrite)
+                {
+                    // overwrite: keep a previously used primary key, fresh non-key values —
+                    // this is what makes the merge actually reconcile rather than concatenate
+                    ByteBuffer[] prev = rows.get(workload.nextInt(rows.size()));
+                    System.arraycopy(prev, 0, row, 0, primaryColumnCount);
+                }
+
+                int mode = workload.nextInt(100);
+                if (overwrite && rowsBeforeThisRound > 0 && workload.nextInt(100) < 40)
+                {
+                    // explicit-timestamp collision candidate: re-keyed onto a row from an EARLIER round,
+                    // and stamped from a pool offset DERIVED from the primary key so that two pooled
+                    // writes to one key land on the SAME timestamp rather than merely being ordered by it.
+                    // The pair that ties is two pooled writes; the earlier-round target only guarantees
+                    // this write is in a later sstable than the row it re-keys onto, which is what lets a
+                    // tie form across sstables instead of inside one memtable. Guaranteed coverage comes
+                    // from the designated tie below, not from this draw.
+                    ByteBuffer[] prev = rows.get(workload.nextInt(rowsBeforeThisRound));
+                    System.arraycopy(prev, 0, row, 0, primaryColumnCount);
+                    long ts = TIE_POOL_BASE + Math.floorMod(primaryKeyHash(row, primaryColumnCount), TIE_POOL_WIDTH);
+                    execute(insertStmt + " USING TIMESTAMP " + ts, (Object[]) row);
+                }
+                else if (mode < 15 && !regularColumns.isEmpty())
+                {
+                    // UPDATE: writes cells without primary-key liveness (different row flags)
+                    execute(updateStmt(metadata, regularColumns),
+                            updateParams(row, regularColumns, selectOrderIndex, primaryColumnCount));
+                }
+                else if (mode < 22)
+                {
+                    // primary-key-only INSERT: row liveness with zero cells
+                    execute(pkOnlyInsertStmt(metadata), (Object[]) Arrays.copyOf(row, primaryColumnCount));
+                }
+                else if (mode < 30)
+                {
+                    // long TTL: liveness info with ttl + expiration far from the runs
+                    execute(insertStmt + " USING TTL " + SOAK_TTL_SECONDS, (Object[]) row);
+                }
+                else
+                {
+                    execute(insertStmt, (Object[]) row);
+                }
+                rows.add(row);
+            }
+
+            // row deletes against known keys
+            for (int i = 0; i < 3 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                execute(deleteRowStmt, (Object[]) Arrays.copyOf(victim, primaryColumnCount));
+            }
+
+            // range deletes (clustering tables only): single-sided slices and clustering-prefix
+            // deletes against known keys; single-sided bounds cannot produce inverted ranges
+            for (int i = 0; i < 2 && clusteringColumnCount > 0 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                if (clusteringColumnCount >= 2 && workload.nextBoolean())
+                {
+                    // prefix delete: equality on a strict prefix of the clustering columns
+                    int depth = 1 + workload.nextInt(clusteringColumnCount - 1);
+                    execute(deleteStmt(metadata, partitionColumnCount + depth),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount + depth));
+                }
+                else
+                {
+                    int eqDepth = workload.nextInt(clusteringColumnCount);
+                    String op = new String[]{ ">=", ">", "<=", "<" }[workload.nextInt(4)];
+                    execute(rangeDeleteStmt(metadata, eqDepth, op),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount + eqDepth + 1));
+                }
+            }
+
+            // cell deletes: random subset of regular columns at a known row; occasionally a
+            // static cell delete instead
+            for (int i = 0; i < 2 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                if (!staticColumns.isEmpty() && workload.nextInt(100) < 30)
+                {
+                    ColumnMetadata col = staticColumns.get(workload.nextInt(staticColumns.size()));
+                    execute(cellDeleteStmt(metadata, List.of(col), partitionColumnCount),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount));
+                }
+                else
+                {
+                    List<ColumnMetadata> subset = randomSubset(regularColumns, workload);
+                    execute(cellDeleteStmt(metadata, subset, primaryColumnCount),
+                            (Object[]) Arrays.copyOf(victim, primaryColumnCount));
+                }
+            }
+
+            // occasional partition delete
+            if (workload.nextInt(100) < 40 && !rows.isEmpty())
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                execute(deletePartitionStmt, (Object[]) Arrays.copyOf(victim, partitionColumnCount));
+            }
+
+            // the designated tie: the same primary key, the same timestamp, fresh values, once per round
+            execute(insertStmt + " USING TIMESTAMP " + tieTimestamp, (Object[]) tieWrites.get(round));
+
+            flush(KEYSPACE, metadata.name);
+        }
+
+        assertCursorMatchesIterator(cfs);
+
+        // The tie candidates must be in DIFFERENT sstables: two writes to one key inside a single
+        // memtable are reconciled by the memtable and the compactor's tie-break is never reached. One tie
+        // write per round and one flush per round makes that structural, and the input count observes the
+        // flush half of it: autocompaction is off and an auto-flush can only ADD sstables, so moving the
+        // per-round flush to after the round loop fails here. (Dropping the flush outright fails earlier,
+        // in compactPath's "scenario produced no input sstables"; and hoisting the tie write out of the
+        // round loop is caught by the per-column assertion below, not by this one.)
+        int inputSSTables = cfs.getLiveSSTables().size();
+        assertTrue("one flush per round must leave one input sstable per round, got " + inputSSTables +
+                   " for " + rounds + " rounds", inputSSTables >= rounds);
+        // The differential restores its own inputs, so commit one real cursor compaction and read the tied
+        // row back out of it: querying before this would merge the inputs at READ time and say nothing
+        // about what compaction wrote.
+        commitCompaction(cfs, cfs.getLiveSSTables(), true, cfs.getDefaultGcBefore(FBUtilities.nowInSeconds()));
+        UntypedResultSet tieResult = execute(selectStmt(metadata, regularColumns),
+                                            (Object[]) Arrays.copyOf(tieKey, primaryColumnCount));
+        assertEquals("the designated tie row must survive compaction: it is written above the wall clock, " +
+                     "so no wall-clock write or delete in this example can shadow it", 1, tieResult.size());
+        UntypedResultSet.Row survivor = tieResult.one();
+        // ABSOLUTE, per column: at equal timestamps the GREATER raw value bytes win (the last rule of
+        // resolveRegular). Every candidate is a live cell and every regular column is a simple one —
+        // unsupportedMetadata refuses complex columns — so the rule reduces to an unsigned byte compare.
+        // The winners were arranged into different rounds per column, so a merge that resolved this tie by
+        // write order fails on any column whose candidate values are not all equal — a low-cardinality
+        // column type can make them equal, which costs an example rather than producing a false failure.
+        // Byte equality between the two paths cannot see a rule they both get wrong.
+        for (ColumnMetadata col : regularColumns)
+        {
+            int valueIndex = selectOrderIndex.get(col.name.toString());
+            ByteBuffer expected = tieWrites.get(0)[valueIndex];
+            for (ByteBuffer[] candidate : tieWrites)
+                if (ByteBufferUtil.compareUnsigned(candidate[valueIndex], expected) > 0)
+                    expected = candidate[valueIndex];
+            assertEquals("the greater raw value bytes must win the same-timestamp tie on " + col.name +
+                         " (" + tieWrites.size() + " candidates at timestamp " + tieTimestamp + ')',
+                         expected, survivor.getBytes(col.name.toString()));
+        }
+    }
+
+    /** Appends {@code columns[i].name}, joined by separator. */
+    private static void appendNames(StringBuilder sb, List<ColumnMetadata> columns, String separator)
+    {
+        for (int i = 0; i < columns.size(); i++)
+        {
+            if (i > 0) sb.append(separator);
+            sb.append(columns.get(i).name.toCQLString());
+        }
+    }
+
+    /** Appends "name = ?" equality predicates over columns, joined by separator. */
+    private static void appendEqPredicates(StringBuilder sb, List<ColumnMetadata> columns, String separator)
+    {
+        for (int i = 0; i < columns.size(); i++)
+        {
+            if (i > 0) sb.append(separator);
+            sb.append(columns.get(i).name.toCQLString()).append(" = ?");
+        }
+    }
+
+    /** Appends {@code count} "?" placeholders, joined by ", ". */
+    private static void appendPlaceholders(StringBuilder sb, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append('?');
+        }
+    }
+
+    private static String insertStmt(TableMetadata metadata)
+    {
+        List<ColumnMetadata> cols = ImmutableList.copyOf(metadata.allColumnsInSelectOrder());
+        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
+        appendNames(sb, cols, ", ");
+        sb.append(") VALUES (");
+        appendPlaceholders(sb, cols.size());
+        return sb.append(')').toString();
+    }
+
+    /** INSERT binding only the primary key columns: row liveness without any cells. */
+    private static String pkOnlyInsertStmt(TableMetadata metadata)
+    {
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
+        appendNames(sb, keys, ", ");
+        sb.append(") VALUES (");
+        appendPlaceholders(sb, keys.size());
+        return sb.append(')').toString();
+    }
+
+    /** UPDATE setting every regular column: cells without primary-key liveness. */
+    private static String updateStmt(TableMetadata metadata, List<ColumnMetadata> regularColumns)
+    {
+        StringBuilder sb = new StringBuilder("UPDATE ").append(metadata).append(" SET ");
+        appendEqPredicates(sb, regularColumns, ", ");
+        sb.append(" WHERE ");
+        appendEqPredicates(sb, primaryKeyColumns(metadata), " AND ");
+        return sb.toString();
+    }
+
+    private static Object[] updateParams(ByteBuffer[] row, List<ColumnMetadata> regularColumns,
+                                         Map<String, Integer> selectOrderIndex, int primaryColumnCount)
+    {
+        Object[] params = new Object[regularColumns.size() + primaryColumnCount];
+        for (int i = 0; i < regularColumns.size(); i++)
+            params[i] = row[selectOrderIndex.get(regularColumns.get(i).name.toString())];
+        for (int i = 0; i < primaryColumnCount; i++)
+            params[regularColumns.size() + i] = row[i];
+        return params;
+    }
+
+    /** DELETE col1, col2 FROM t WHERE first {@code keyColumnCount} primary key columns bound. */
+    private static String cellDeleteStmt(TableMetadata metadata, List<ColumnMetadata> columns, int keyColumnCount)
+    {
+        StringBuilder sb = new StringBuilder("DELETE ");
+        appendNames(sb, columns, ", ");
+        sb.append(" FROM ").append(metadata).append(" WHERE ");
+        appendEqPredicates(sb, primaryKeyColumns(metadata).subList(0, keyColumnCount), " AND ");
+        return sb.toString();
+    }
+
+    /**
+     * DELETE with equality on the partition key plus the first {@code eqDepth} clustering
+     * columns, and a single-sided {@code op} bound on clustering column {@code eqDepth}.
+     */
+    private static String rangeDeleteStmt(TableMetadata metadata, int eqDepth, String op)
+    {
+        StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        int partitionColumnCount = metadata.partitionKeyColumns().size();
+        int bound = partitionColumnCount + eqDepth;
+        appendEqPredicates(sb, keys.subList(0, bound), " AND ");
+        sb.append(" AND ").append(keys.get(bound).name.toCQLString()).append(' ').append(op).append(" ?");
+        return sb.toString();
+    }
+
+    private static List<ColumnMetadata> primaryKeyColumns(TableMetadata metadata)
+    {
+        return ImmutableList.<ColumnMetadata>builder()
+                            .addAll(metadata.partitionKeyColumns())
+                            .addAll(metadata.clusteringColumns())
+                            .build();
+    }
+
+    private static List<ColumnMetadata> randomSubset(List<ColumnMetadata> columns, Random workload)
+    {
+        List<ColumnMetadata> shuffled = new ArrayList<>(columns);
+        java.util.Collections.shuffle(shuffled, workload);
+        return shuffled.subList(0, 1 + workload.nextInt(shuffled.size()));
+    }
+
+    /** DELETE with the first {@code keyColumnCount} primary key columns bound (partition or full row). */
+    private static String deleteStmt(TableMetadata metadata, int keyColumnCount)
+    {
+        StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
+        appendEqPredicates(sb, primaryKeyColumns(metadata).subList(0, keyColumnCount), " AND ");
+        return sb.toString();
+    }
+
+    /** SELECT of {@code columns} at one fully-bound primary key. */
+    private static String selectStmt(TableMetadata metadata, List<ColumnMetadata> columns)
+    {
+        StringBuilder sb = new StringBuilder("SELECT ");
+        appendNames(sb, columns, ", ");
+        sb.append(" FROM ").append(metadata).append(" WHERE ");
+        appendEqPredicates(sb, primaryKeyColumns(metadata), " AND ");
+        return sb.toString();
+    }
+
+    /**
+     * Content hash of a row's primary key. Stable across writes that share a primary key, which is what
+     * lets the explicit-timestamp pool offset be a function of the key: two pooled writes to one key must
+     * land on the SAME timestamp, or the pool only orders them and no tie is ever formed.
+     * <p>
+     * {@code ByteBuffer.hashCode} is content-based but position-relative, so this is only stable because
+     * the bound buffers are never consumed: CQLTester pre-converts every parameter with
+     * {@code BytesType.decompose}, whose serializer duplicates the caller's buffer.
+     */
+    private static int primaryKeyHash(ByteBuffer[] row, int primaryColumnCount)
+    {
+        return Arrays.hashCode(Arrays.copyOf(row, primaryColumnCount));
+    }
+
+    /** Seed chaining copied from RandomSchemaTest so failures reproduce the same way. */
+    private static final class SeedRunner
+    {
+        private static final long multiplier = 0x5DEECE66DL;
+        private static final long addend = 0xBL;
+        private static final long mask = (1L << 48) - 1;
+
+        private long seed = CassandraRelevantProperties.TEST_DIFFERENTIAL_SEED.getLong(System.currentTimeMillis());
+        private final int examples;
+
+        SeedRunner(int examples)
+        {
+            this.examples = examples;
+        }
+
+        /** Dead code on purpose: plug a failing seed in here to reproduce. */
+        @SuppressWarnings("unused")
+        SeedRunner withFixedSeed(long seed)
+        {
+            this.seed = seed;
+            return this;
+        }
+
+        interface SeededTest
+        {
+            void run(long seed) throws Throwable;
+        }
+
+        void run(SeededTest test) throws Throwable
+        {
+            for (int i = 0; i < examples; i++)
+            {
+                if (i > 0)
+                    seed = (seed * multiplier + addend) & mask;
+                try
+                {
+                    test.run(seed);
+                }
+                catch (AssumptionViolatedException a)
+                {
+                    // an Assume skip has to stay a skip: JUnit decides skip-vs-fail on the type
+                    // thrown, not on its cause, so wrapping this below would turn the soak red
+                    throw a;
+                }
+                catch (Throwable t)
+                {
+                    // keep the cause's detail in the message: junit XML only preserves the
+                    // top-level message reliably
+                    throw new AssertionError("Failure for seed " + seed + " (example " + i + "): " + t.getMessage(), t);
+                }
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -21,8 +21,10 @@ package org.apache.cassandra.db.compaction.differential;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -30,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
 import org.quicktheories.impl.JavaRandom;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -39,6 +42,7 @@ import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractTypeGenerators;
 import org.apache.cassandra.utils.AbstractTypeGenerators.TypeGenBuilder;
+import org.apache.cassandra.utils.AbstractTypeGenerators.ValueDomain;
 import org.apache.cassandra.utils.CassandraGenerators;
 import org.apache.cassandra.utils.CassandraGenerators.TableMetadataBuilder;
 import org.apache.cassandra.utils.Generators;
@@ -51,11 +55,23 @@ import static org.apache.cassandra.utils.Generators.IDENTIFIER_GEN;
  * production uses), random multi-round workloads with overwrites and deletes flushed into
  * overlapping sstables, then byte+logical differential comparison of both compaction paths.
  *
- * Reproducing a failure: every failure message is wrapped in a seed; plug it into
- * {@code withFixedSeed} below.
+ * Workload space: INSERT / UPDATE (no row liveness) / primary-key-only INSERT (liveness, no
+ * cells) / INSERT USING TTL (long-lived, far from the expiry boundary) / explicit USING
+ * TIMESTAMP collisions from a small pool (same-timestamp tie-breaks); null values on
+ * non-key columns (cell tombstones on simple columns; mapped to empty buffers on clustering
+ * columns); row deletes, partition deletes, single-sided and prefix range deletes,
+ * multi-column cell deletes, static cell deletes. Composite partition keys (1-2 components).
  *
- * Known coverage gaps (deliberate): null/empty
- * value domains and range deletes are exercised by the deterministic corpus only.
+ * Example count is property-gated: -Dcassandra.test.differential.examples=N (default
+ * {@value #DEFAULT_EXAMPLES}; the pre-JIRA validation run uses thousands).
+ *
+ * Reproducing a failure: every failure message is wrapped in a seed; rerun with
+ * -Dcassandra.test.differential.seed=N (the failing seed becomes example 0), or plug it
+ * into {@code withFixedSeed} below.
+ *
+ * Known coverage gaps (deliberate, covered by the deterministic corpus): EMPTY_BYTES value
+ * domain (invalid CQL for some generated multi-cell shapes), collection-element deletes
+ * (DELETE m['k'] needs element values of the right type), expired TTLs (timing-dependent).
  */
 public class RandomDifferentialCompactionTest extends DifferentialCompactionTester
 {
@@ -66,7 +82,11 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     }
 
     private static final Set<String> ALLOWLIST = Set.of();
-    private static final int EXAMPLES = 10;
+    private static final int DEFAULT_EXAMPLES = 10;
+    private static final int EXAMPLES = Integer.getInteger("cassandra.test.differential.examples", DEFAULT_EXAMPLES);
+
+    /** Long enough that expiry can never fall between the two differential runs. */
+    private static final int SOAK_TTL_SECONDS = 30 * 24 * 60 * 60;
 
     @Test
     public void randomizedDifferential() throws Throwable
@@ -94,15 +114,14 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
                                                                  .withDefaultSetKey(safePrimary)
                                                                  .withoutTypeKinds(AbstractTypeGenerators.TypeKind.COUNTER)
                                                                  .withUDTNames(udtName))
-                       .withPartitionColumnsCount(1)
+                       .withPartitionColumnsBetween(1, 2)
                        .withPrimaryColumnTypeGen(new TypeGenBuilder(safePrimary).withMaxDepth(1))
                        .withClusteringColumnsBetween(0, 3)
                        .withRegularColumnsBetween(1, 5)
                        .withStaticColumnsBetween(0, 2)
                        .build(qtRandom);
         }
-        // Same filter production uses to route to the cursor pipeline. When increment 2 lands
-        // (multi-cell columns), this loop disappears and the generator space widens.
+        // Same filter production uses to route to the cursor pipeline.
         // Also rejects invalid CQL the generator can produce: static columns require
         // clustering columns.
         while (CursorCompactor.unsupportedMetadata(metadata)
@@ -117,12 +136,34 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         ColumnFamilyStore cfs = getColumnFamilyStore(KEYSPACE, metadata.name);
         cfs.disableAutoCompaction();
 
-        Gen<ByteBuffer[]> dataGen = CassandraGenerators.data(metadata, ignore -> AbstractTypeGenerators.ValueDomain.NORMAL);
+        // ~12% of non-key values are null: cell tombstones on simple columns. The data
+        // generator maps null to an empty buffer on clustering columns (null clustering is
+        // invalid; empty is legal and exercises the empty-vs-valued clustering comparison)
+        // and never applies the domain to partition keys.
+        Gen<ValueDomain> valueDomains = SourceDSL.integers().between(0, 99)
+                                                 .map(i -> i < 12 ? ValueDomain.NULL : ValueDomain.NORMAL);
+        Gen<ByteBuffer[]> dataGen = CassandraGenerators.data(metadata, valueDomains);
+
         int partitionColumnCount = metadata.partitionKeyColumns().size();
-        int primaryColumnCount = partitionColumnCount + metadata.clusteringColumns().size();
+        int clusteringColumnCount = metadata.clusteringColumns().size();
+        int primaryColumnCount = partitionColumnCount + clusteringColumnCount;
         String insertStmt = insertStmt(metadata);
         String deleteRowStmt = deleteStmt(metadata, primaryColumnCount);
         String deletePartitionStmt = deleteStmt(metadata, partitionColumnCount);
+
+        // select-order index of every column, for UPDATE/cell-delete binding
+        Map<String, Integer> selectOrderIndex = new HashMap<>();
+        {
+            Iterator<ColumnMetadata> it = metadata.allColumnsInSelectOrder();
+            for (int i = 0; it.hasNext(); i++)
+                selectOrderIndex.put(it.next().name.toString(), i);
+        }
+        List<ColumnMetadata> regularColumns = ImmutableList.copyOf(metadata.regularColumns());
+        List<ColumnMetadata> staticColumns = ImmutableList.copyOf(metadata.staticColumns());
+
+        // small explicit-timestamp pool: cross-sstable same-timestamp conflicts on
+        // overwritten primary keys exercise the reconciliation tie-break rules
+        long tiePoolBase = 1_000_000;
 
         List<ByteBuffer[]> rows = new ArrayList<>();
         int rounds = 2 + workload.nextInt(3); // 2-4 sstables
@@ -132,14 +173,43 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
             for (int i = 0; i < inserts; i++)
             {
                 ByteBuffer[] row = dataGen.generate(qtRandom);
-                if (!rows.isEmpty() && workload.nextInt(100) < 30)
+                boolean overwrite = !rows.isEmpty() && workload.nextInt(100) < 30;
+                if (overwrite)
                 {
                     // overwrite: keep a previously used primary key, fresh non-key values —
                     // this is what makes the merge actually reconcile rather than concatenate
                     ByteBuffer[] prev = rows.get(workload.nextInt(rows.size()));
                     System.arraycopy(prev, 0, row, 0, primaryColumnCount);
                 }
-                execute(insertStmt, (Object[]) row);
+
+                int mode = workload.nextInt(100);
+                if (overwrite && workload.nextInt(100) < 40)
+                {
+                    // explicit-timestamp collision candidate: two writes to the same primary
+                    // key with the same timestamp force the same-ts tie-break path
+                    long ts = tiePoolBase + workload.nextInt(3);
+                    execute(insertStmt + " USING TIMESTAMP " + ts, (Object[]) row);
+                }
+                else if (mode < 15 && !regularColumns.isEmpty())
+                {
+                    // UPDATE: writes cells without primary-key liveness (different row flags)
+                    execute(updateStmt(metadata, regularColumns),
+                            updateParams(row, regularColumns, selectOrderIndex, primaryColumnCount));
+                }
+                else if (mode < 22)
+                {
+                    // primary-key-only INSERT: row liveness with zero cells
+                    execute(pkOnlyInsertStmt(metadata), (Object[]) Arrays.copyOf(row, primaryColumnCount));
+                }
+                else if (mode < 30)
+                {
+                    // long TTL: liveness info with ttl + expiration far from the runs
+                    execute(insertStmt + " USING TTL " + SOAK_TTL_SECONDS, (Object[]) row);
+                }
+                else
+                {
+                    execute(insertStmt, (Object[]) row);
+                }
                 rows.add(row);
             }
 
@@ -149,6 +219,47 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
                 ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
                 execute(deleteRowStmt, (Object[]) Arrays.copyOf(victim, primaryColumnCount));
             }
+
+            // range deletes (clustering tables only): single-sided slices and clustering-prefix
+            // deletes against known keys; single-sided bounds cannot produce inverted ranges
+            for (int i = 0; i < 2 && clusteringColumnCount > 0 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                if (clusteringColumnCount >= 2 && workload.nextBoolean())
+                {
+                    // prefix delete: equality on a strict prefix of the clustering columns
+                    int depth = 1 + workload.nextInt(clusteringColumnCount - 1);
+                    execute(deleteStmt(metadata, partitionColumnCount + depth),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount + depth));
+                }
+                else
+                {
+                    int eqDepth = workload.nextInt(clusteringColumnCount);
+                    String op = new String[]{ ">=", ">", "<=", "<" }[workload.nextInt(4)];
+                    execute(rangeDeleteStmt(metadata, eqDepth, op),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount + eqDepth + 1));
+                }
+            }
+
+            // cell deletes: random subset of regular columns at a known row; occasionally a
+            // static cell delete instead
+            for (int i = 0; i < 2 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                if (!staticColumns.isEmpty() && workload.nextInt(100) < 30)
+                {
+                    ColumnMetadata col = staticColumns.get(workload.nextInt(staticColumns.size()));
+                    execute(cellDeleteStmt(metadata, List.of(col), partitionColumnCount),
+                            (Object[]) Arrays.copyOf(victim, partitionColumnCount));
+                }
+                else
+                {
+                    List<ColumnMetadata> subset = randomSubset(regularColumns, workload);
+                    execute(cellDeleteStmt(metadata, subset, primaryColumnCount),
+                            (Object[]) Arrays.copyOf(victim, primaryColumnCount));
+                }
+            }
+
             // occasional partition delete
             if (workload.nextInt(100) < 40 && !rows.isEmpty())
             {
@@ -179,14 +290,113 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         return sb.append(')').toString();
     }
 
+    /** INSERT binding only the primary key columns: row liveness without any cells. */
+    private static String pkOnlyInsertStmt(TableMetadata metadata)
+    {
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
+        for (int i = 0; i < keys.size(); i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append(keys.get(i).name.toCQLString());
+        }
+        sb.append(") VALUES (");
+        for (int i = 0; i < keys.size(); i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append('?');
+        }
+        return sb.append(')').toString();
+    }
+
+    /** UPDATE setting every regular column: cells without primary-key liveness. */
+    private static String updateStmt(TableMetadata metadata, List<ColumnMetadata> regularColumns)
+    {
+        StringBuilder sb = new StringBuilder("UPDATE ").append(metadata).append(" SET ");
+        for (int i = 0; i < regularColumns.size(); i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append(regularColumns.get(i).name.toCQLString()).append(" = ?");
+        }
+        sb.append(" WHERE ");
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        for (int i = 0; i < keys.size(); i++)
+        {
+            if (i > 0) sb.append(" AND ");
+            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
+        }
+        return sb.toString();
+    }
+
+    private static Object[] updateParams(ByteBuffer[] row, List<ColumnMetadata> regularColumns,
+                                         Map<String, Integer> selectOrderIndex, int primaryColumnCount)
+    {
+        Object[] params = new Object[regularColumns.size() + primaryColumnCount];
+        for (int i = 0; i < regularColumns.size(); i++)
+            params[i] = row[selectOrderIndex.get(regularColumns.get(i).name.toString())];
+        for (int i = 0; i < primaryColumnCount; i++)
+            params[regularColumns.size() + i] = row[i];
+        return params;
+    }
+
+    /** DELETE col1, col2 FROM t WHERE first {@code keyColumnCount} primary key columns bound. */
+    private static String cellDeleteStmt(TableMetadata metadata, List<ColumnMetadata> columns, int keyColumnCount)
+    {
+        StringBuilder sb = new StringBuilder("DELETE ");
+        for (int i = 0; i < columns.size(); i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append(columns.get(i).name.toCQLString());
+        }
+        sb.append(" FROM ").append(metadata).append(" WHERE ");
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        for (int i = 0; i < keyColumnCount; i++)
+        {
+            if (i > 0) sb.append(" AND ");
+            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * DELETE with equality on the partition key plus the first {@code eqDepth} clustering
+     * columns, and a single-sided {@code op} bound on clustering column {@code eqDepth}.
+     */
+    private static String rangeDeleteStmt(TableMetadata metadata, int eqDepth, String op)
+    {
+        StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
+        int partitionColumnCount = metadata.partitionKeyColumns().size();
+        int bound = partitionColumnCount + eqDepth;
+        for (int i = 0; i < bound; i++)
+        {
+            if (i > 0) sb.append(" AND ");
+            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
+        }
+        sb.append(" AND ").append(keys.get(bound).name.toCQLString()).append(' ').append(op).append(" ?");
+        return sb.toString();
+    }
+
+    private static List<ColumnMetadata> primaryKeyColumns(TableMetadata metadata)
+    {
+        return ImmutableList.<ColumnMetadata>builder()
+                            .addAll(metadata.partitionKeyColumns())
+                            .addAll(metadata.clusteringColumns())
+                            .build();
+    }
+
+    private static List<ColumnMetadata> randomSubset(List<ColumnMetadata> columns, Random workload)
+    {
+        List<ColumnMetadata> shuffled = new ArrayList<>(columns);
+        java.util.Collections.shuffle(shuffled, workload);
+        return shuffled.subList(0, 1 + workload.nextInt(shuffled.size()));
+    }
+
     /** DELETE with the first {@code keyColumnCount} primary key columns bound (partition or full row). */
     private static String deleteStmt(TableMetadata metadata, int keyColumnCount)
     {
         StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
-        List<ColumnMetadata> keys = ImmutableList.<ColumnMetadata>builder()
-                                                 .addAll(metadata.partitionKeyColumns())
-                                                 .addAll(metadata.clusteringColumns())
-                                                 .build();
+        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
         for (int i = 0; i < keyColumnCount; i++)
         {
             if (i > 0) sb.append(" AND ");
@@ -202,7 +412,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         private static final long addend = 0xBL;
         private static final long mask = (1L << 48) - 1;
 
-        private long seed = System.currentTimeMillis();
+        private long seed = Long.getLong("cassandra.test.differential.seed", System.currentTimeMillis());
         private final int examples;
 
         SeedRunner(int examples)

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.differential;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import org.quicktheories.core.Gen;
+import org.quicktheories.impl.JavaRandom;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.apache.cassandra.utils.AbstractTypeGenerators.TypeGenBuilder;
+import org.apache.cassandra.utils.CassandraGenerators;
+import org.apache.cassandra.utils.CassandraGenerators.TableMetadataBuilder;
+import org.apache.cassandra.utils.Generators;
+
+import static org.apache.cassandra.utils.Generators.IDENTIFIER_GEN;
+
+/**
+ * Randomized soak for the cursor-vs-iterator differential harness: random schemas restricted to
+ * the currently supported cursor compaction surface (the same unsupportedMetadata filter
+ * production uses), random multi-round workloads with overwrites and deletes flushed into
+ * overlapping sstables, then byte+logical differential comparison of both compaction paths.
+ *
+ * Reproducing a failure: every failure message is wrapped in a seed; plug it into
+ * {@code withFixedSeed} below.
+ *
+ * Known coverage gaps (deliberate, journaled in doc/cursor-compaction-plan.md): null/empty
+ * value domains and range deletes are exercised by the deterministic corpus only.
+ */
+public class RandomDifferentialCompactionTest extends DifferentialCompactionTester
+{
+    static
+    {
+        // make sure generated blobs are deterministic per seed
+        CassandraRelevantProperties.TEST_BLOB_SHARED_SEED.setInt(42);
+    }
+
+    private static final Set<String> ALLOWLIST = Set.of();
+    private static final int EXAMPLES = 10;
+
+    @Test
+    public void randomizedDifferential() throws Throwable
+    {
+        new SeedRunner(EXAMPLES).run(this::runOneExample);
+    }
+
+    private void runOneExample(long seed) throws Throwable
+    {
+        JavaRandom qtRandom = new JavaRandom(seed);
+        Random workload = new Random(seed);
+
+        Gen<String> udtName = Generators.unique(IDENTIFIER_GEN);
+        TypeGenBuilder safePrimary = AbstractTypeGenerators.withoutUnsafeEquality().withUDTNames(udtName);
+        TableMetadata metadata;
+        do
+        {
+            metadata = new TableMetadataBuilder()
+                       .withKeyspaceName(KEYSPACE)
+                       .withTableKinds(TableMetadata.Kind.REGULAR)
+                       .withKnownMemtables()
+                       .withDefaultTypeGen(AbstractTypeGenerators.builder()
+                                                                 .withoutEmpty()
+                                                                 .withMaxDepth(2)
+                                                                 .withDefaultSetKey(safePrimary)
+                                                                 .withoutTypeKinds(AbstractTypeGenerators.TypeKind.COUNTER)
+                                                                 .withUDTNames(udtName))
+                       .withPartitionColumnsCount(1)
+                       .withPrimaryColumnTypeGen(new TypeGenBuilder(safePrimary).withMaxDepth(1))
+                       .withClusteringColumnsBetween(0, 3)
+                       .withRegularColumnsBetween(1, 5)
+                       .withStaticColumnsBetween(0, 2)
+                       .build(qtRandom);
+        }
+        // Same filter production uses to route to the cursor pipeline. When increment 2 lands
+        // (multi-cell columns), this loop disappears and the generator space widens.
+        // Also rejects invalid CQL the generator can produce: static columns require
+        // clustering columns.
+        while (CursorCompactor.unsupportedMetadata(metadata)
+               || (metadata.clusteringColumns().isEmpty() && !metadata.staticColumns().isEmpty()));
+
+        maybeCreateUDTs(metadata);
+        String createTableCql = metadata.toCqlString(true, false, false)
+                                        .replaceAll("org.apache.cassandra.db.marshal.", "");
+        logger.info("randomizedDifferential seed={} schema:\n{}", seed, createTableCql);
+        createTable(KEYSPACE, createTableCql);
+        // the CQL embeds the generator's table name; createTable's returned name is not it
+        ColumnFamilyStore cfs = getColumnFamilyStore(KEYSPACE, metadata.name);
+        cfs.disableAutoCompaction();
+
+        Gen<ByteBuffer[]> dataGen = CassandraGenerators.data(metadata, ignore -> AbstractTypeGenerators.ValueDomain.NORMAL);
+        int partitionColumnCount = metadata.partitionKeyColumns().size();
+        int primaryColumnCount = partitionColumnCount + metadata.clusteringColumns().size();
+        String insertStmt = insertStmt(metadata);
+        String deleteRowStmt = deleteStmt(metadata, primaryColumnCount);
+        String deletePartitionStmt = deleteStmt(metadata, partitionColumnCount);
+
+        List<ByteBuffer[]> rows = new ArrayList<>();
+        int rounds = 2 + workload.nextInt(3); // 2-4 sstables
+        for (int round = 0; round < rounds; round++)
+        {
+            int inserts = 15 + workload.nextInt(26); // 15-40 rows
+            for (int i = 0; i < inserts; i++)
+            {
+                ByteBuffer[] row = dataGen.generate(qtRandom);
+                if (!rows.isEmpty() && workload.nextInt(100) < 30)
+                {
+                    // overwrite: keep a previously used primary key, fresh non-key values —
+                    // this is what makes the merge actually reconcile rather than concatenate
+                    ByteBuffer[] prev = rows.get(workload.nextInt(rows.size()));
+                    System.arraycopy(prev, 0, row, 0, primaryColumnCount);
+                }
+                execute(insertStmt, (Object[]) row);
+                rows.add(row);
+            }
+
+            // row deletes against known keys
+            for (int i = 0; i < 3 && !rows.isEmpty(); i++)
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                execute(deleteRowStmt, (Object[]) Arrays.copyOf(victim, primaryColumnCount));
+            }
+            // occasional partition delete
+            if (workload.nextInt(100) < 40 && !rows.isEmpty())
+            {
+                ByteBuffer[] victim = rows.get(workload.nextInt(rows.size()));
+                execute(deletePartitionStmt, (Object[]) Arrays.copyOf(victim, partitionColumnCount));
+            }
+            flush(KEYSPACE, metadata.name);
+        }
+
+        assertCursorMatchesIterator(cfs, ALLOWLIST);
+    }
+
+    private static String insertStmt(TableMetadata metadata)
+    {
+        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
+        Iterator<ColumnMetadata> cols = metadata.allColumnsInSelectOrder();
+        while (cols.hasNext())
+        {
+            sb.append(cols.next().name.toCQLString());
+            if (cols.hasNext()) sb.append(", ");
+        }
+        sb.append(") VALUES (");
+        for (int i = 0; i < metadata.columns().size(); i++)
+        {
+            if (i > 0) sb.append(", ");
+            sb.append('?');
+        }
+        return sb.append(')').toString();
+    }
+
+    /** DELETE with the first {@code keyColumnCount} primary key columns bound (partition or full row). */
+    private static String deleteStmt(TableMetadata metadata, int keyColumnCount)
+    {
+        StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
+        List<ColumnMetadata> keys = ImmutableList.<ColumnMetadata>builder()
+                                                 .addAll(metadata.partitionKeyColumns())
+                                                 .addAll(metadata.clusteringColumns())
+                                                 .build();
+        for (int i = 0; i < keyColumnCount; i++)
+        {
+            if (i > 0) sb.append(" AND ");
+            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
+        }
+        return sb.toString();
+    }
+
+    /** Seed chaining copied from RandomSchemaTest so failures reproduce the same way. */
+    private static final class SeedRunner
+    {
+        private static final long multiplier = 0x5DEECE66DL;
+        private static final long addend = 0xBL;
+        private static final long mask = (1L << 48) - 1;
+
+        private long seed = System.currentTimeMillis();
+        private final int examples;
+
+        SeedRunner(int examples)
+        {
+            this.examples = examples;
+        }
+
+        /** Dead code on purpose: plug a failing seed in here to reproduce. */
+        @SuppressWarnings("unused")
+        SeedRunner withFixedSeed(long seed)
+        {
+            this.seed = seed;
+            return this;
+        }
+
+        interface SeededTest
+        {
+            void run(long seed) throws Throwable;
+        }
+
+        void run(SeededTest test) throws Throwable
+        {
+            for (int i = 0; i < examples; i++)
+            {
+                if (i > 0)
+                    seed = (seed * multiplier + addend) & mask;
+                try
+                {
+                    test.run(seed);
+                }
+                catch (Throwable t)
+                {
+                    // keep the cause's detail in the message: junit XML only preserves the
+                    // top-level message reliably
+                    throw new AssertionError("Failure for seed " + seed + " (example " + i + "): " + t.getMessage(), t);
+                }
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -54,7 +54,7 @@ import static org.apache.cassandra.utils.Generators.IDENTIFIER_GEN;
  * Reproducing a failure: every failure message is wrapped in a seed; plug it into
  * {@code withFixedSeed} below.
  *
- * Known coverage gaps (deliberate, journaled in doc/cursor-compaction-plan.md): null/empty
+ * Known coverage gaps (deliberate): null/empty
  * value domains and range deletes are exercised by the deterministic corpus only.
  */
 public class RandomDifferentialCompactionTest extends DifferentialCompactionTester

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -81,7 +80,6 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         CassandraRelevantProperties.TEST_BLOB_SHARED_SEED.setInt(42);
     }
 
-    private static final Set<String> ALLOWLIST = Set.of();
     private static final int DEFAULT_EXAMPLES = 10;
     private static final int EXAMPLES = Integer.getInteger("cassandra.test.differential.examples", DEFAULT_EXAMPLES);
 
@@ -269,7 +267,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
             flush(KEYSPACE, metadata.name);
         }
 
-        assertCursorMatchesIterator(cfs, ALLOWLIST);
+        assertCursorMatchesIterator(cfs);
     }
 
     private static String insertStmt(TableMetadata metadata)

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -28,8 +28,9 @@ import java.util.Map;
 import java.util.Random;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
 
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
 import org.quicktheories.core.Gen;
 import org.quicktheories.generators.SourceDSL;
 import org.quicktheories.impl.JavaRandom;
@@ -47,6 +48,7 @@ import org.apache.cassandra.utils.CassandraGenerators.TableMetadataBuilder;
 import org.apache.cassandra.utils.Generators;
 
 import static org.apache.cassandra.utils.Generators.IDENTIFIER_GEN;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Randomized soak for the cursor-vs-iterator differential harness: random schemas restricted to
@@ -81,7 +83,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     }
 
     private static final int DEFAULT_EXAMPLES = 10;
-    private static final int EXAMPLES = Integer.getInteger("cassandra.test.differential.examples", DEFAULT_EXAMPLES);
+    private static final int EXAMPLES = CassandraRelevantProperties.TEST_DIFFERENTIAL_EXAMPLES.getInt(DEFAULT_EXAMPLES);
 
     /** Long enough that expiry can never fall between the two differential runs. */
     private static final int SOAK_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -89,6 +91,9 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     @Test
     public void randomizedDifferential() throws Throwable
     {
+        // a zero or negative example count would make SeedRunner.run iterate zero times and the
+        // test pass having compared nothing
+        assertTrue("cassandra.test.differential.examples must be > 0, got " + EXAMPLES, EXAMPLES > 0);
         new SeedRunner(EXAMPLES).run(this::runOneExample);
     }
 
@@ -397,7 +402,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         private static final long addend = 0xBL;
         private static final long mask = (1L << 48) - 1;
 
-        private long seed = Long.getLong("cassandra.test.differential.seed", System.currentTimeMillis());
+        private long seed = CassandraRelevantProperties.TEST_DIFFERENTIAL_SEED.getLong(System.currentTimeMillis());
         private final int examples;
 
         SeedRunner(int examples)
@@ -427,6 +432,12 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
                 try
                 {
                     test.run(seed);
+                }
+                catch (AssumptionViolatedException a)
+                {
+                    // an Assume skip has to stay a skip: JUnit decides skip-vs-fail on the type
+                    // thrown, not on its cause, so wrapping this below would turn the soak red
+                    throw a;
                 }
                 catch (Throwable t)
                 {

--- a/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/differential/RandomDifferentialCompactionTest.java
@@ -270,21 +270,43 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         assertCursorMatchesIterator(cfs);
     }
 
-    private static String insertStmt(TableMetadata metadata)
+    /** Appends {@code columns[i].name}, joined by separator. */
+    private static void appendNames(StringBuilder sb, List<ColumnMetadata> columns, String separator)
     {
-        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
-        Iterator<ColumnMetadata> cols = metadata.allColumnsInSelectOrder();
-        while (cols.hasNext())
+        for (int i = 0; i < columns.size(); i++)
         {
-            sb.append(cols.next().name.toCQLString());
-            if (cols.hasNext()) sb.append(", ");
+            if (i > 0) sb.append(separator);
+            sb.append(columns.get(i).name.toCQLString());
         }
-        sb.append(") VALUES (");
-        for (int i = 0; i < metadata.columns().size(); i++)
+    }
+
+    /** Appends "name = ?" equality predicates over columns, joined by separator. */
+    private static void appendEqPredicates(StringBuilder sb, List<ColumnMetadata> columns, String separator)
+    {
+        for (int i = 0; i < columns.size(); i++)
+        {
+            if (i > 0) sb.append(separator);
+            sb.append(columns.get(i).name.toCQLString()).append(" = ?");
+        }
+    }
+
+    /** Appends {@code count} "?" placeholders, joined by ", ". */
+    private static void appendPlaceholders(StringBuilder sb, int count)
+    {
+        for (int i = 0; i < count; i++)
         {
             if (i > 0) sb.append(", ");
             sb.append('?');
         }
+    }
+
+    private static String insertStmt(TableMetadata metadata)
+    {
+        List<ColumnMetadata> cols = ImmutableList.copyOf(metadata.allColumnsInSelectOrder());
+        StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
+        appendNames(sb, cols, ", ");
+        sb.append(") VALUES (");
+        appendPlaceholders(sb, cols.size());
         return sb.append(')').toString();
     }
 
@@ -293,17 +315,9 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     {
         List<ColumnMetadata> keys = primaryKeyColumns(metadata);
         StringBuilder sb = new StringBuilder("INSERT INTO ").append(metadata).append(" (");
-        for (int i = 0; i < keys.size(); i++)
-        {
-            if (i > 0) sb.append(", ");
-            sb.append(keys.get(i).name.toCQLString());
-        }
+        appendNames(sb, keys, ", ");
         sb.append(") VALUES (");
-        for (int i = 0; i < keys.size(); i++)
-        {
-            if (i > 0) sb.append(", ");
-            sb.append('?');
-        }
+        appendPlaceholders(sb, keys.size());
         return sb.append(')').toString();
     }
 
@@ -311,18 +325,9 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     private static String updateStmt(TableMetadata metadata, List<ColumnMetadata> regularColumns)
     {
         StringBuilder sb = new StringBuilder("UPDATE ").append(metadata).append(" SET ");
-        for (int i = 0; i < regularColumns.size(); i++)
-        {
-            if (i > 0) sb.append(", ");
-            sb.append(regularColumns.get(i).name.toCQLString()).append(" = ?");
-        }
+        appendEqPredicates(sb, regularColumns, ", ");
         sb.append(" WHERE ");
-        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
-        for (int i = 0; i < keys.size(); i++)
-        {
-            if (i > 0) sb.append(" AND ");
-            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
-        }
+        appendEqPredicates(sb, primaryKeyColumns(metadata), " AND ");
         return sb.toString();
     }
 
@@ -341,18 +346,9 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     private static String cellDeleteStmt(TableMetadata metadata, List<ColumnMetadata> columns, int keyColumnCount)
     {
         StringBuilder sb = new StringBuilder("DELETE ");
-        for (int i = 0; i < columns.size(); i++)
-        {
-            if (i > 0) sb.append(", ");
-            sb.append(columns.get(i).name.toCQLString());
-        }
+        appendNames(sb, columns, ", ");
         sb.append(" FROM ").append(metadata).append(" WHERE ");
-        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
-        for (int i = 0; i < keyColumnCount; i++)
-        {
-            if (i > 0) sb.append(" AND ");
-            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
-        }
+        appendEqPredicates(sb, primaryKeyColumns(metadata).subList(0, keyColumnCount), " AND ");
         return sb.toString();
     }
 
@@ -366,11 +362,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
         List<ColumnMetadata> keys = primaryKeyColumns(metadata);
         int partitionColumnCount = metadata.partitionKeyColumns().size();
         int bound = partitionColumnCount + eqDepth;
-        for (int i = 0; i < bound; i++)
-        {
-            if (i > 0) sb.append(" AND ");
-            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
-        }
+        appendEqPredicates(sb, keys.subList(0, bound), " AND ");
         sb.append(" AND ").append(keys.get(bound).name.toCQLString()).append(' ').append(op).append(" ?");
         return sb.toString();
     }
@@ -394,12 +386,7 @@ public class RandomDifferentialCompactionTest extends DifferentialCompactionTest
     private static String deleteStmt(TableMetadata metadata, int keyColumnCount)
     {
         StringBuilder sb = new StringBuilder("DELETE FROM ").append(metadata).append(" WHERE ");
-        List<ColumnMetadata> keys = primaryKeyColumns(metadata);
-        for (int i = 0; i < keyColumnCount; i++)
-        {
-            if (i > 0) sb.append(" AND ");
-            sb.append(keys.get(i).name.toCQLString()).append(" = ?");
-        }
+        appendEqPredicates(sb, primaryKeyColumns(metadata).subList(0, keyColumnCount), " AND ");
         return sb.toString();
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionColumnDeleteAndPurgeTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionColumnDeleteAndPurgeTest.java
@@ -62,7 +62,7 @@ public class CompactionColumnDeleteAndPurgeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
@@ -99,7 +99,7 @@ public class CompactionColumnDeleteAndPurgeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         TestHelper.verifyAndPrint(cfs, sstable);
 
@@ -149,7 +149,7 @@ public class CompactionColumnDeleteAndPurgeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         TestHelper.verifyAndPrint(cfs, sstable);
 
@@ -202,7 +202,7 @@ public class CompactionColumnDeleteAndPurgeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(2000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         TestHelper.verifyAndPrint(cfs, sstable);
         UnfilteredRowIterator partition = sstable.getScanner().next();
@@ -251,7 +251,7 @@ public class CompactionColumnDeleteAndPurgeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         TestHelper.verifyAndPrint(cfs, sstable);
         // Expected:{"table kind":"REGULAR","partition":{"key":["0"],"position":31},"rows":[{"type":"static_block",

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionColumnTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionColumnTest.java
@@ -63,7 +63,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":11},"rows":[{"type":"row","position":11,"clustering":[0,0],"cells":[{"name":"c1","deletion_info":{"local_delete_time":"2025-03-12T11:32:18Z"},"tstamp":"1970-01-01T00:00:00.000001Z"}]}]}
@@ -121,7 +121,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -196,7 +196,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -308,7 +308,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         // We expect:
         // 1,1,c1=1,c3=1
@@ -371,7 +371,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected:{"table kind":"REGULAR","partition":{"key":["0"],"position":31},"rows":[{"type":"static_block","position":31,"cells":[{"name":"sc1","value":111,"tstamp":"1970-01-01T00:00:00.000001Z"},{"name":"sc2","value":222,"tstamp":"1970-01-01T00:00:00.000001Z"}]},{"type":"row","position":31,"clustering":[0,0],"liveness_info":{"tstamp":"1970-01-01T00:00:00.000001Z"},"cells":[{"name":"c1","deletion_info":{"local_delete_time":"2025-01-25T08:48:55Z"},"tstamp":"1970-01-01T00:00:00.000002Z"},{"name":"c2","deletion_info":{"local_delete_time":"2025-01-25T08:48:55Z"},"tstamp":"1970-01-01T00:00:00.000002Z"}]}]}
@@ -422,7 +422,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -475,7 +475,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(2000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         UnfilteredRowIterator partition = sstable.getScanner().next();
@@ -526,7 +526,7 @@ public class CompactionColumnTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected:{"table kind":"REGULAR","partition":{"key":["0"],"position":31},"rows":[{"type":"static_block","position":31,"cells":[{"name":"sc1","value":111,"tstamp":"1970-01-01T00:00:00.000001Z"},{"name":"sc2","value":222,"tstamp":"1970-01-01T00:00:00.000001Z"}]},{"type":"row","position":31,"clustering":[0,0],"liveness_info":{"tstamp":"1970-01-01T00:00:00.000001Z"},"cells":[{"name":"c1","deletion_info":{"local_delete_time":"2025-01-25T08:48:55Z"},"tstamp":"1970-01-01T00:00:00.000002Z"},{"name":"c2","deletion_info":{"local_delete_time":"2025-01-25T08:48:55Z"},"tstamp":"1970-01-01T00:00:00.000002Z"}]}]}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionCoveredClusteringTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionCoveredClusteringTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.simple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
+
+import static org.apache.cassandra.utils.TestHelper.verifyAndPrint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The clustering that reaches the metadata collector when a partition closes must be the last
+ * unfiltered actually <em>written</em>, not the last one read.
+ * <p>
+ * A cursor holds a single {@code UnfilteredDescriptor} and overwrites it in place on every read,
+ * including reads of unfiltereds that then merge away and never reach the output. So the value fed
+ * to {@code MetadataCollector.updateClusteringValues} at partition close has to be a snapshot taken
+ * at write time; a live reference to the cursor's descriptor describes whatever was read last, which
+ * for a partition whose tail is shadowed away is a clustering the output does not contain. The
+ * covered-clustering slice in {@code Statistics.db} then claims a range wider than the sstable holds.
+ * <p>
+ * The scenario below builds exactly that shape and asserts the resulting bound absolutely, on the
+ * committed output. Absolutely rather than comparatively, because what the collector was told is
+ * invisible to everything a compaction returns: the finalized covered-clustering slice is the only
+ * place it surfaces, and the differential suite — which does cover the divergence, through
+ * {@code Statistics.db} byte identity — can only say the two paths agree, never which of them is
+ * right. All four parameter rows assert the same constants, so the two iterator rows are the oracle
+ * for the two cursor rows.
+ */
+public class CompactionCoveredClusteringTest extends SimpleCompactionTest
+{
+    /** Rows at this timestamp outlive the delete and are written. */
+    private static final long SURVIVING_TIMESTAMP = 2000;
+    /** The partition delete: newer than the tail, older than the surviving head. */
+    private static final long DELETE_TIMESTAMP = 1000;
+    /** Rows at this timestamp are shadowed by the delete and written by neither path. */
+    private static final long SHADOWED_TIMESTAMP = 500;
+
+    /** Clusterings 0..4 survive; 5..9 are shadowed. The INPUT sstable's largest clustering is 9. */
+    private static final int LAST_SURVIVING_CK = 4;
+    private static final int LAST_SHADOWED_CK = 9;
+
+    @Test
+    public void testCoveredClusteringStopsAtLastWrittenRow() throws Throwable
+    {
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : " +
+                                         "'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        String table = createTable(keyspace, "CREATE TABLE %s (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        execute("use " + keyspace + ";");
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(ColumnFamilyStore::disableAutoCompaction));
+
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        // One partition, ten rows in clustering order: the head outlives the delete, the tail does not.
+        for (int ck = 0; ck <= LAST_SHADOWED_CK; ck++)
+            execute("INSERT INTO " + table + " (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP ?",
+                    1, ck, ck, ck <= LAST_SURVIVING_CK ? SURVIVING_TIMESTAMP : SHADOWED_TIMESTAMP);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+
+        // The rows the merge must read and drop really are on disk, out to the largest clustering.
+        // Without this the scenario could stop covering its subject silently: if the tail never
+        // reached an sstable there would be nothing for a stale descriptor to describe.
+        assertEquals("the scenario needs one input sstable holding the whole partition",
+                     1, cfs.getLiveSSTables().size());
+        SSTableReader input = cfs.getLiveSSTables().iterator().next();
+        assertEquals("all ten rows must reach that one sstable", 10, input.getSSTableMetadata().totalRows);
+        assertCoveredClustering("input", input, 0, LAST_SHADOWED_CK);
+
+        // The delete has to land in its OWN sstable. Issued into the same memtable as the rows it
+        // shadows, it would reconcile them away before anything was written and the compaction would
+        // never see the tail at all.
+        execute("DELETE FROM " + table + " USING TIMESTAMP ? WHERE pk = ?", DELETE_TIMESTAMP, 1);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        assertEquals("the delete must be a second sstable, not a memtable reconciliation",
+                     2, cfs.getLiveSSTables().size());
+
+        assertCursorPathWillRun(cfs);
+        majorCompact(cfs);
+
+        assertEquals("expected a single compaction output", 1, cfs.getLiveSSTables().size());
+        SSTableReader output = cfs.getLiveSSTables().iterator().next();
+
+        // ck 5..9 were read by the merge and written by neither path, so the covered clustering must
+        // end at ck 4 — the last row written — and not at ck 9, the last row read.
+        assertCoveredClustering("output", output, 0, LAST_SURVIVING_CK);
+
+        assertOutputContents(output);
+        assertRowsIgnoringOrder(execute("SELECT pk, ck, v FROM " + table),
+                                row(1, 0, 0), row(1, 1, 1), row(1, 2, 2), row(1, 3, 3), row(1, 4, 4));
+
+        // For suite consistency only: extended verification never looks at the covered clustering,
+        // and its one comparator check is gated on a promoted index, which a five-row partition does
+        // not have. It adds no coverage of the bound asserted above.
+        verifyAndPrint(cfs, output);
+    }
+
+    /**
+     * Asserts the covered-clustering slice the writer finalized for this sstable spans exactly the
+     * given single-component bounds. {@code getSSTableMetadata()} hands back that finalized
+     * {@code StatsMetadata} rather than re-reading it, and the same slice is what gets serialized
+     * into {@code Statistics.db}.
+     */
+    private static void assertCoveredClustering(String role, SSTableReader sstable, int expectedMin, int expectedMax)
+    {
+        StatsMetadata stats = sstable.getSSTableMetadata();
+        assertEquals(role + " covered clustering start must have the table's one clustering component",
+                     1, stats.coveredClustering.start().size());
+        assertEquals(role + " covered clustering end must have the table's one clustering component",
+                     1, stats.coveredClustering.end().size());
+        assertEquals(role + " covered clustering must start at the smallest clustering written",
+                     expectedMin, (int) Int32Type.instance.compose(stats.coveredClustering.start().bufferAt(0)));
+        assertEquals(role + " covered clustering must end at the largest clustering WRITTEN, not the " +
+                     "largest one read",
+                     expectedMax, (int) Int32Type.instance.compose(stats.coveredClustering.end().bufferAt(0)));
+    }
+
+    /**
+     * Corroborates that ck 4 really is the last clustering in the output and ck 9 really is absent:
+     * the shadowing delete survived the merge, and the rows it shadows did not. Without this the
+     * covered-clustering assertion above could be satisfied by an output that simply dropped the tail
+     * for some other reason — a purge, say — in which case nothing was ever "read but not written".
+     */
+    private static void assertOutputContents(SSTableReader output)
+    {
+        List<Integer> clusterings = new ArrayList<>();
+        try (ISSTableScanner scanner = output.getScanner())
+        {
+            assertTrue("expected the compacted partition in the output", scanner.hasNext());
+            UnfilteredRowIterator partition = scanner.next();
+            assertFalse("the shadowing partition delete must survive the merge; if it purged, the " +
+                        "tail was not dropped by shadowing", partition.partitionLevelDeletion().isLive());
+            assertEquals("the surviving partition delete must be the one this scenario issued",
+                         DELETE_TIMESTAMP, partition.partitionLevelDeletion().markedForDeleteAt());
+            while (partition.hasNext())
+            {
+                Unfiltered unfiltered = partition.next();
+                assertTrue("expected only rows in the output partition, got " + unfiltered.kind(),
+                           unfiltered.isRow());
+                clusterings.add(Int32Type.instance.compose(unfiltered.clustering().bufferAt(0)));
+            }
+            assertFalse("expected exactly one partition in the output", scanner.hasNext());
+        }
+        assertEquals("the shadowed tail must be absent and the head present, in clustering order",
+                     List.of(0, 1, 2, 3, 4), clusterings);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteAndPurgePKTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteAndPurgePKTest.java
@@ -52,7 +52,7 @@ public class CompactionDeleteAndPurgePKTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         // even with GC period 0, needs some time
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
 
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
@@ -84,7 +84,7 @@ public class CompactionDeleteAndPurgePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
@@ -130,7 +130,7 @@ public class CompactionDeleteAndPurgePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
@@ -161,7 +161,7 @@ public class CompactionDeleteAndPurgePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -227,7 +227,7 @@ public class CompactionDeleteAndPurgePKTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteAndPurgeRowTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteAndPurgeRowTest.java
@@ -64,7 +64,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
@@ -97,7 +97,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
 
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
@@ -137,7 +137,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(2000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -183,7 +183,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
 
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
@@ -225,7 +225,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
@@ -267,7 +267,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -340,7 +340,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())
@@ -443,7 +443,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())
@@ -553,7 +553,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())
@@ -630,7 +630,7 @@ public class CompactionDeleteAndPurgeRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(1000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeletePKTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeletePKTest.java
@@ -52,7 +52,7 @@ public class CompactionDeletePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -93,7 +93,7 @@ public class CompactionDeletePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -149,7 +149,7 @@ public class CompactionDeletePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -191,7 +191,7 @@ public class CompactionDeletePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -257,7 +257,7 @@ public class CompactionDeletePKTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteRowRangeTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteRowRangeTest.java
@@ -63,7 +63,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR",
@@ -126,7 +126,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR",
@@ -202,7 +202,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected:  {"table kind":"REGULAR","partition":{"key":["0"],"position":11},"rows":[
@@ -276,7 +276,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected:  {"table kind":"REGULAR","partition":{"key":["0"],"position":11},"rows":[
@@ -356,7 +356,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected:  {"table kind":"REGULAR","partition":{"key":["0"],"position":11},"rows":[
@@ -416,7 +416,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":31},"rows":
@@ -484,7 +484,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -533,7 +533,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -605,7 +605,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -704,7 +704,7 @@ public class CompactionDeleteRowRangeTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // {"table kind":"REGULAR","partition":{"key":["2"],"position":31},

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteRowTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDeleteRowTest.java
@@ -61,7 +61,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -107,7 +107,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -155,7 +155,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
         Thread.sleep(2000);
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -232,7 +232,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         // Expected: {"table kind":"REGULAR","partition":{"key":["0"],"position":27,"deletion_info":{"marked_deleted":"2025-01-14T11:20:37.220Z","local_delete_time":"2025-01-14T11:20:37Z"}},"rows":[]}
@@ -281,7 +281,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -336,7 +336,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 
@@ -410,7 +410,7 @@ public class CompactionDeleteRowTest extends SimpleCompactionTest
 
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         try(ISSTableScanner scanner = sstable.getScanner())

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDisabledBloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionDisabledBloomFilterTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.simple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
+
+import static org.apache.cassandra.utils.TestHelper.verifyAndPrint;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Compaction of a table with bloom filters disabled. {@code bloom_filter_fp_chance = 1.0} is the
+ * documented way to switch them off: {@code FilterFactory} then returns its {@code AlwaysPresent}
+ * singleton, which is an {@code IFilter} but NOT a {@code BloomFilter}. The BIG cursor index writer
+ * must not assume the concrete class — the iterator path goes through the {@code IFilter} interface,
+ * where {@code add()} is a no-op — and a writer that casts unconditionally throws
+ * {@code ClassCastException}, so the table cannot be cursor-compacted at all.
+ * <p>
+ * This scenario belongs here rather than in the differential suite because the defect it guards is
+ * caught by the compaction *completing*, not by comparing the two paths' output bytes: a
+ * {@code ClassCastException} fails any test that runs the cursor path over such a table. No
+ * differential scenario disables the filter, so nothing byte-compares this shape — and it does not
+ * need to: a compaction that throws is not a divergence, and the filter both paths write is the
+ * same empty one. Here the merged rows are asserted through CQL and extended verification runs over
+ * the output.
+ */
+public class CompactionDisabledBloomFilterTest extends SimpleCompactionTest
+{
+    @Test
+    public void testCompactionWithBloomFilterDisabled() throws Throwable
+    {
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : " +
+                                         "'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        String table = createTable(keyspace, "CREATE TABLE %s ( pk bigint, ck bigint, v1 bigint, " +
+                                             "PRIMARY KEY(pk, ck)) WITH bloom_filter_fp_chance = 1.0");
+        execute("use " + keyspace + ";");
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(ColumnFamilyStore::disableAutoCompaction));
+
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        // two overlapping generations: pk 5..9 exist in both, so the output is a genuine merge
+        for (long pk = 0; pk < 10; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO " + table + " (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        for (long pk = 5; pk < 15; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                execute("INSERT INTO " + table + " (pk, ck, v1) VALUES (?, ?, ?)", pk, ck, ck + 100);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+
+        assertEquals("the scenario needs two input sstables so that compaction merges rather than " +
+                     "skipping", 2, cfs.getLiveSSTables().size());
+        for (SSTableReader input : cfs.getLiveSSTables())
+            assertFilterDisabled(input);
+        assertCursorPathWillRun(cfs);
+
+        majorCompact(cfs);
+
+        assertEquals("expected a single compaction output", 1, cfs.getLiveSSTables().size());
+        SSTableReader output = cfs.getLiveSSTables().iterator().next();
+        assertFilterDisabled(output);
+
+        // 15 partitions of 10 rows; pk 5..14 carry second-generation values, pk 5..9 by winning the merge
+        List<Object[]> expected = new ArrayList<>();
+        for (long pk = 0; pk < 15; pk++)
+            for (long ck = 0; ck < 10; ck++)
+                expected.add(new Object[]{ pk, ck, pk >= 5 ? ck + 100 : ck });
+        assertRowsIgnoringOrder(execute("SELECT pk, ck, v1 FROM " + table), expected.toArray(new Object[0][]));
+
+        verifyAndPrint(cfs, output);
+    }
+
+    /**
+     * The sstable carries no filter data: {@code FilterFactory}'s always-present singleton serializes
+     * to zero bytes, where any real bloom filter over a non-empty key set would not.
+     * <p>
+     * This is a precondition guard, and that is its whole job: it establishes that
+     * {@code bloom_filter_fp_chance = 1.0} really did take effect, so the compaction really does reach
+     * the {@code AlwaysPresent} branch the cursor index writer has to tolerate. Without it a later
+     * schema-default change could leave a real filter in place and the test would pass while
+     * exercising nothing. It is not a claim about the writer's own behaviour — the {@code IFilter}
+     * instance comes from {@code SortedTableWriter} and is shared by both compaction paths, so no
+     * cursor-path change could substitute a real filter here.
+     */
+    private static void assertFilterDisabled(SSTableReader sstable)
+    {
+        assertEquals("bloom_filter_fp_chance = 1.0 must leave no filter data in " + sstable.descriptor,
+                     0L, ((SSTableReaderWithFilter) sstable).getFilterSerializedSize());
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionLargeColumnSubsetTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionLargeColumnSubsetTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.simple;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.apache.cassandra.utils.TestHelper.verifyAndPrint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Compaction of rows whose column subset is written in the large-subset wire format, i.e. from a
+ * 64-column superset up ({@link org.apache.cassandra.db.Columns.Serializer#serializeSubset}). That
+ * format has two modes — a list of present indices or a list of missing ones — and both the mode
+ * rule and the present-index encoding are boundary-sensitive. Each test below fixes a superset size
+ * and a subset shape that sits on one of those boundaries, compacts, and asserts the output row
+ * decodes back to exactly the columns and values it was written with.
+ * <p>
+ * The scenarios are shaped so that a mis-encoded subset cannot pass: the deserializer takes its
+ * column count and its mode from the superset size and the delta, so an encoding that disagrees
+ * with it on either runs off the end of the index list and consumes row-body bytes as indices.
+ */
+public class CompactionLargeColumnSubsetTest extends SimpleCompactionTest
+{
+    /**
+     * 65 columns with 32 present: {@code presentCount == supersetCount / 2}, which the reference
+     * rule — {@code presentCount < supersetCount / 2}, tested identically by
+     * {@code Columns.Serializer.serializeLargeSubset} and {@code deserializeLargeSubset} — resolves
+     * to missing-index mode.
+     * <p>
+     * An odd superset size is what makes the boundary observable. The same shape stated in terms of
+     * the missing count is {@code missingCount == supersetCount / 2 + 1}, so a mode rule keyed off
+     * the missing count answers present-index mode here while the deserializer reads missing-index
+     * mode. For an even superset size the two formulations agree and the boundary is invisible.
+     */
+    @Test
+    public void testLargeSubsetModeSelectionAtOddSupersetBoundary() throws Throwable
+    {
+        int columnCount = 65;
+        // every even index below 64: 32 present, 33 missing (the 32 odd indices, plus index 64)
+        int[] present = new int[32];
+        for (int i = 0; i < present.length; i++)
+            present[i] = 2 * i;
+
+        int presentCount = present.length;
+        int missingCount = columnCount - presentCount;
+        assertTrue("the scenario must keep the two formulations of the mode rule in disagreement, " +
+                   "or it stops covering the boundary: superset=" + columnCount +
+                   " present=" + presentCount + " missing=" + missingCount,
+                   (presentCount < columnCount / 2) != (missingCount > columnCount / 2));
+
+        runLargeSubsetScenario(columnCount, present, false);
+    }
+
+    /**
+     * 70 columns with 10 present: {@code presentCount < supersetCount / 2}, so the subset is encoded
+     * as a list of present indices. The two highest columns of the superset are present and the
+     * highest missing one is index 67, so the run of present indices after the last missing index is
+     * non-empty — the part of the encoding that only exists when the subset holds the superset's
+     * largest indices, and that a walk bounded by the last missing index never reaches.
+     */
+    @Test
+    public void testLargeSubsetPresentIndexModeWithPresentTail() throws Throwable
+    {
+        int columnCount = 70;
+        int[] present = { 0, 1, 2, 3, 4, 5, 6, 7, 68, 69 };
+
+        assertEquals("the scenario must keep the superset's last column present, or there is no " +
+                     "tail after the last missing index",
+                     columnCount - 1, present[present.length - 1]);
+
+        runLargeSubsetScenario(columnCount, present, true);
+    }
+
+    /**
+     * Writes two rows into one partition — one holding every column of {@code columnCount}, one
+     * holding only {@code presentIndices} — compacts them, and asserts the subset row still decodes
+     * to exactly {@code presentIndices} with the values it was written with.
+     *
+     * @param presentIndexMode the mode the reference rule selects for this shape; asserted, so a
+     *                         change to the superset size or the subset cannot silently move the
+     *                         scenario onto the other mode
+     */
+    private void runLargeSubsetScenario(int columnCount, int[] presentIndices, boolean presentIndexMode) throws Throwable
+    {
+        int presentCount = presentIndices.length;
+        assertTrue("the large-subset format starts at a 64-column superset; got " + columnCount,
+                   columnCount >= 64);
+        assertTrue("an all-present or all-missing row takes a fast path instead of the subset " +
+                   "encoding; got " + presentCount + " of " + columnCount,
+                   presentCount > 0 && presentCount < columnCount);
+        assertEquals("the scenario no longer selects the large-subset mode it was written for",
+                     presentIndexMode, presentCount < columnCount / 2);
+
+        String[] names = columnNames(columnCount);
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : " +
+                                         "'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        StringBuilder create = new StringBuilder("CREATE TABLE %s ( pk bigint, ck bigint");
+        for (String name : names)
+            create.append(", ").append(name).append(" bigint");
+        create.append(", PRIMARY KEY(pk, ck))");
+        String table = createTable(keyspace, create.toString());
+        execute("use " + keyspace + ";");
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(ColumnFamilyStore::disableAutoCompaction));
+
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        // ck 0 carries every column, and that is what puts all of them in the superset the writer
+        // encodes against: a flushed sstable's serialization header lists the columns the memtable
+        // actually saw (Flushing.createFlushWriter), and compaction's header is the union of the
+        // input headers (SerializationHeader.make). Superset size selects both the wire format and
+        // the mode, so a scenario that only ever wrote the subset's columns would encode against a
+        // superset of presentCount and exercise nothing.
+        int[] all = new int[columnCount];
+        for (int i = 0; i < columnCount; i++)
+            all[i] = i;
+        insertRow(table, names, 0, all);
+        insertRow(table, names, 1, presentIndices);
+
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        assertEquals("the scenario needs its two rows in one input sstable, so that the input " +
+                     "header spans the whole superset", 1, cfs.getLiveSSTables().size());
+        SSTableReader flushed = cfs.getLiveSSTables().iterator().next();
+        assertSuperset(flushed, names);
+        assertCursorPathWillRun(cfs);
+
+        majorCompact(cfs);
+
+        assertEquals("expected a single compaction output", 1, cfs.getLiveSSTables().size());
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        // A major compaction that produced no task leaves the flushed sstable live, and every
+        // assertion below would then pass against bytes the flush path wrote — the cursor writer
+        // would never have run.
+        assertNotEquals("compaction did not rewrite the input, so nothing below exercises the " +
+                        "compaction writer", flushed.descriptor, sstable.descriptor);
+        assertSuperset(sstable, names);
+
+        try (ISSTableScanner scanner = sstable.getScanner())
+        {
+            assertTrue(scanner.hasNext());
+            UnfilteredRowIterator partition = scanner.next();
+            assertTrue(partition.partitionLevelDeletion().isLive());
+            assertTrue(partition.staticRow().isEmpty());
+            assertRowCells(partition, names, all);
+            assertRowCells(partition, names, presentIndices);
+            assertFalse(partition.hasNext());
+            assertFalse(scanner.hasNext());
+        }
+        verifyAndPrint(cfs, sstable);
+    }
+
+    /**
+     * Names for a {@code columnCount}-column superset, zero padded to a fixed width so that the name
+     * order the superset is sorted in matches the numbering — which is what lets the scenarios state
+     * their subsets as superset positions. {@link #assertSuperset} asserts that correspondence
+     * against the sstable rather than leaving it assumed.
+     */
+    private static String[] columnNames(int columnCount)
+    {
+        String format = "c%0" + Integer.toString(columnCount - 1).length() + 'd';
+        String[] names = new String[columnCount];
+        for (int i = 0; i < columnCount; i++)
+            names[i] = String.format(format, i);
+        return names;
+    }
+
+    /**
+     * Asserts the sstable's regular columns are exactly {@code names} in that order. This is the
+     * superset the writer encodes subsets against and indexes positionally
+     * ({@code SSTableCursorWriter} takes its column array from {@code header.columns(false)}), so it
+     * pins both the superset size the mode rule is applied to and the position each name holds.
+     */
+    private static void assertSuperset(SSTableReader sstable, String[] names)
+    {
+        List<String> actual = new ArrayList<>(names.length);
+        for (ColumnMetadata column : sstable.header.columns(false))
+            actual.add(column.name.toString());
+        assertEquals("the sstable's column superset is not the one the scenario states its subsets " +
+                     "in terms of", Arrays.asList(names), actual);
+    }
+
+    private void insertRow(String table, String[] names, long ck, int[] presentIndices) throws Throwable
+    {
+        StringBuilder insert = new StringBuilder("INSERT INTO ").append(table).append(" (pk, ck");
+        for (int i : presentIndices)
+            insert.append(", ").append(names[i]);
+        insert.append(") VALUES (?, ?");
+        for (int i = 0; i < presentIndices.length; i++)
+            insert.append(", ?");
+        insert.append(") USING TIMESTAMP 1");
+
+        Object[] values = new Object[2 + presentIndices.length];
+        values[0] = 0L;
+        values[1] = ck;
+        // each cell carries its own superset position as its value, so a subset that decodes to the
+        // wrong columns shows up as a name/value mismatch as well as a wrong column set
+        for (int i = 0; i < presentIndices.length; i++)
+            values[2 + i] = (long) presentIndices[i];
+        execute(insert.toString(), values);
+    }
+
+    private static void assertRowCells(UnfilteredRowIterator partition, String[] names, int[] expectedIndices)
+    {
+        assertTrue("expected a further row", partition.hasNext());
+        Unfiltered unfiltered = partition.next();
+        assertTrue(unfiltered.isRow());
+        Row row = (Row) unfiltered;
+        assertTrue(row.deletion().time().isLive());
+
+        List<String> expected = new ArrayList<>(expectedIndices.length);
+        for (int i : expectedIndices)
+            expected.add(names[i] + '=' + i);
+        List<String> actual = new ArrayList<>(expectedIndices.length);
+        for (Cell<?> cell : row.cells())
+            actual.add(cell.column().name.toString() + '=' + value(cell));
+
+        assertEquals("the row decoded to a different column subset than it was written with",
+                     expected, actual);
+    }
+
+    /**
+     * The cell's bigint value, or its width when it does not hold one — a subset that decodes to the
+     * wrong columns also carves the row body up at the wrong offsets, so rendering the width keeps
+     * the whole decoded subset in the comparison below instead of failing on the first bad cell.
+     */
+    private static String value(Cell<?> cell)
+    {
+        ByteBuffer buffer = cell.buffer();
+        return buffer.remaining() == Long.BYTES ? Long.toString(ByteBufferUtil.toLong(buffer))
+                                                : "<" + buffer.remaining() + " bytes>";
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionLargeColumnSubsetTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionLargeColumnSubsetTest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.simple;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.utils.TestHelper.verifyAndPrint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Compaction of rows whose column subset is written in the large-subset wire format, i.e. from a
+ * 64-column superset up ({@link org.apache.cassandra.db.Columns.Serializer#serializeSubset}). That
+ * format has two modes — a list of present indices or a list of missing ones — and both the mode
+ * rule and the present-index encoding are boundary-sensitive. Each test below fixes a superset size
+ * and a subset shape that sits on one of those boundaries, compacts, and asserts the output row
+ * decodes back to exactly the columns and values it was written with.
+ * <p>
+ * The scenarios are shaped so that a mis-encoded subset cannot pass: the deserializer takes its
+ * column count and its mode from the superset size and the delta, so an encoding that disagrees
+ * with it on either runs off the end of the index list and consumes row-body bytes as indices.
+ */
+public class CompactionLargeColumnSubsetTest extends SimpleCompactionTest
+{
+    /**
+     * 65 columns with 32 present: {@code presentCount == supersetCount / 2}, which the reference
+     * rule — {@code presentCount < supersetCount / 2}, tested identically by
+     * {@code Columns.Serializer.serializeLargeSubset} and {@code deserializeLargeSubset} — resolves
+     * to missing-index mode.
+     * <p>
+     * An odd superset size is what makes the boundary observable. The same shape stated in terms of
+     * the missing count is {@code missingCount == supersetCount / 2 + 1}, so a mode rule keyed off
+     * the missing count answers present-index mode here while the deserializer reads missing-index
+     * mode. For an even superset size the two formulations agree and the boundary is invisible.
+     */
+    @Test
+    public void testLargeSubsetModeSelectionAtOddSupersetBoundary() throws Throwable
+    {
+        int columnCount = 65;
+        // every even index below 64: 32 present, 33 missing (the 32 odd indices, plus index 64)
+        int[] present = new int[32];
+        for (int i = 0; i < present.length; i++)
+            present[i] = 2 * i;
+
+        int presentCount = present.length;
+        int missingCount = columnCount - presentCount;
+        assertTrue("the scenario must keep the two formulations of the mode rule in disagreement, " +
+                   "or it stops covering the boundary: superset=" + columnCount +
+                   " present=" + presentCount + " missing=" + missingCount,
+                   (presentCount < columnCount / 2) != (missingCount > columnCount / 2));
+
+        runLargeSubsetScenario(columnCount, present, false);
+    }
+
+    /**
+     * 70 columns with 10 present: {@code presentCount < supersetCount / 2}, so the subset is encoded
+     * as a list of present indices. The two highest columns of the superset are present and the
+     * highest missing one is index 67, so the run of present indices after the last missing index is
+     * non-empty — the part of the encoding that only exists when the subset holds the superset's
+     * largest indices, and that a walk bounded by the last missing index never reaches.
+     */
+    @Test
+    public void testLargeSubsetPresentIndexModeWithPresentTail() throws Throwable
+    {
+        int columnCount = 70;
+        int[] present = { 0, 1, 2, 3, 4, 5, 6, 7, 68, 69 };
+
+        assertEquals("the scenario must keep the superset's last column present, or there is no " +
+                     "tail after the last missing index",
+                     columnCount - 1, present[present.length - 1]);
+
+        runLargeSubsetScenario(columnCount, present, true);
+    }
+
+    /**
+     * Writes two rows into one partition — one holding every column of {@code columnCount}, one
+     * holding only {@code presentIndices} — compacts them, and asserts the subset row still decodes
+     * to exactly {@code presentIndices} with the values it was written with.
+     *
+     * @param presentIndexMode the mode the reference rule selects for this shape; asserted, so a
+     *                         change to the superset size or the subset cannot silently move the
+     *                         scenario onto the other mode
+     */
+    private void runLargeSubsetScenario(int columnCount, int[] presentIndices, boolean presentIndexMode) throws Throwable
+    {
+        int presentCount = presentIndices.length;
+        assertTrue("the large-subset format starts at a 64-column superset; got " + columnCount,
+                   columnCount >= 64);
+        assertTrue("an all-present or all-missing row takes a fast path instead of the subset " +
+                   "encoding; got " + presentCount + " of " + columnCount,
+                   presentCount > 0 && presentCount < columnCount);
+        assertEquals("the scenario no longer selects the large-subset mode it was written for",
+                     presentIndexMode, presentCount < columnCount / 2);
+
+        String[] names = columnNames(columnCount);
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : " +
+                                         "'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        StringBuilder create = new StringBuilder("CREATE TABLE %s ( pk bigint, ck bigint");
+        for (String name : names)
+            create.append(", ").append(name).append(" bigint");
+        create.append(", PRIMARY KEY(pk, ck))");
+        String table = createTable(keyspace, create.toString());
+        execute("use " + keyspace + ";");
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(ColumnFamilyStore::disableAutoCompaction));
+
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        // ck 0 carries every column, and that is what puts all of them in the superset the writer
+        // encodes against: a flushed sstable's serialization header lists the columns the memtable
+        // actually saw (Flushing.createFlushWriter), and compaction's header is the union of the
+        // input headers (SerializationHeader.make). Superset size selects both the wire format and
+        // the mode, so a scenario that only ever wrote the subset's columns would encode against a
+        // superset of presentCount and exercise nothing.
+        int[] all = new int[columnCount];
+        for (int i = 0; i < columnCount; i++)
+            all[i] = i;
+        insertRow(table, names, 0, all);
+        insertRow(table, names, 1, presentIndices);
+
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        assertEquals("the scenario needs its two rows in one input sstable, so that the input " +
+                     "header spans the whole superset", 1, cfs.getLiveSSTables().size());
+        SSTableReader flushed = cfs.getLiveSSTables().iterator().next();
+        assertSuperset(flushed, names);
+        assertCursorPathWillRun(cfs);
+
+        cfs.forceMajorCompaction();
+
+        assertEquals("expected a single compaction output", 1, cfs.getLiveSSTables().size());
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        // A major compaction that produced no task leaves the flushed sstable live, and every
+        // assertion below would then pass against bytes the flush path wrote — the cursor writer
+        // would never have run.
+        assertNotEquals("compaction did not rewrite the input, so nothing below exercises the " +
+                        "compaction writer", flushed.descriptor, sstable.descriptor);
+        assertSuperset(sstable, names);
+
+        try (ISSTableScanner scanner = sstable.getScanner())
+        {
+            assertTrue(scanner.hasNext());
+            UnfilteredRowIterator partition = scanner.next();
+            assertTrue(partition.partitionLevelDeletion().isLive());
+            assertTrue(partition.staticRow().isEmpty());
+            assertRowCells(partition, names, all);
+            assertRowCells(partition, names, presentIndices);
+            assertFalse(partition.hasNext());
+            assertFalse(scanner.hasNext());
+        }
+        verifyAndPrint(cfs, sstable);
+    }
+
+    /**
+     * Names for a {@code columnCount}-column superset, zero padded to a fixed width so that the name
+     * order the superset is sorted in matches the numbering — which is what lets the scenarios state
+     * their subsets as superset positions. {@link #assertSuperset} asserts that correspondence
+     * against the sstable rather than leaving it assumed.
+     */
+    private static String[] columnNames(int columnCount)
+    {
+        String format = "c%0" + Integer.toString(columnCount - 1).length() + 'd';
+        String[] names = new String[columnCount];
+        for (int i = 0; i < columnCount; i++)
+            names[i] = String.format(format, i);
+        return names;
+    }
+
+    /**
+     * Asserts the sstable's regular columns are exactly {@code names} in that order. This is the
+     * superset the writer encodes subsets against and indexes positionally
+     * ({@code SSTableCursorWriter} takes its column array from {@code header.columns(false)}), so it
+     * pins both the superset size the mode rule is applied to and the position each name holds.
+     */
+    private static void assertSuperset(SSTableReader sstable, String[] names)
+    {
+        List<String> actual = new ArrayList<>(names.length);
+        for (ColumnMetadata column : sstable.header.columns(false))
+            actual.add(column.name.toString());
+        assertEquals("the sstable's column superset is not the one the scenario states its subsets " +
+                     "in terms of", Arrays.asList(names), actual);
+    }
+
+    private void insertRow(String table, String[] names, long ck, int[] presentIndices) throws Throwable
+    {
+        StringBuilder insert = new StringBuilder("INSERT INTO ").append(table).append(" (pk, ck");
+        for (int i : presentIndices)
+            insert.append(", ").append(names[i]);
+        insert.append(") VALUES (?, ?");
+        for (int i = 0; i < presentIndices.length; i++)
+            insert.append(", ?");
+        insert.append(") USING TIMESTAMP 1");
+
+        Object[] values = new Object[2 + presentIndices.length];
+        values[0] = 0L;
+        values[1] = ck;
+        // each cell carries its own superset position as its value, so a subset that decodes to the
+        // wrong columns shows up as a name/value mismatch as well as a wrong column set
+        for (int i = 0; i < presentIndices.length; i++)
+            values[2 + i] = (long) presentIndices[i];
+        execute(insert.toString(), values);
+    }
+
+    private static void assertRowCells(UnfilteredRowIterator partition, String[] names, int[] expectedIndices)
+    {
+        assertTrue("expected a further row", partition.hasNext());
+        Unfiltered unfiltered = partition.next();
+        assertTrue(unfiltered.isRow());
+        Row row = (Row) unfiltered;
+        assertTrue(row.deletion().time().isLive());
+
+        List<String> expected = new ArrayList<>(expectedIndices.length);
+        for (int i : expectedIndices)
+            expected.add(names[i] + '=' + i);
+        List<String> actual = new ArrayList<>(expectedIndices.length);
+        for (Cell<?> cell : row.cells())
+            actual.add(cell.column().name.toString() + '=' + value(cell));
+
+        assertEquals("the row decoded to a different column subset than it was written with",
+                     expected, actual);
+    }
+
+    /**
+     * The cell's bigint value, or its width when it does not hold one — a subset that decodes to the
+     * wrong columns also carves the row body up at the wrong offsets, so rendering the width keeps
+     * the whole decoded subset in the comparison below instead of failing on the first bad cell.
+     */
+    private static String value(Cell<?> cell)
+    {
+        ByteBuffer buffer = cell.buffer();
+        return buffer.remaining() == Long.BYTES ? Long.toString(ByteBufferUtil.toLong(buffer))
+                                                : "<" + buffer.remaining() + " bytes>";
+    }
+
+    /**
+     * Guards the silent-fallback trap: with cursor compaction requested but unsupported for this
+     * table, the compaction below would run the iterator path and the scenario would assert nothing
+     * about the cursor writer's subset encoding.
+     */
+    private void assertCursorPathWillRun(ColumnFamilyStore cfs)
+    {
+        if (!cursorCompactionEnabled)
+            return;
+
+        // Cursor compaction only supports BIG output, so under a non-BIG selected format — which is
+        // what `ant test-latest` runs — the assertion below would fail for a reason that is not a
+        // defect. Skip, and keep the assertion for every other unsupported-ness reason.
+        Assume.assumeTrue("cursor compaction requires the BIG sstable format; selected=" +
+                          DatabaseDescriptor.getSelectedSSTableFormat().name(),
+                          BigFormat.isSelected());
+
+        Set<SSTableReader> inputs = new HashSet<>(cfs.getLiveSSTables());
+        try (CompactionController controller = new CompactionController(cfs, inputs, cfs.gcBefore(FBUtilities.nowInSeconds()));
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            assertTrue("cursor compaction is not supported for this scenario, so it would only " +
+                       "exercise the iterator path",
+                       CursorCompactor.isSupported(scanners, controller));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionMaxValueSizeTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionMaxValueSizeTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.simple;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.CompactionPipelineCounts;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * A cell value whose decoded length exceeds {@code max_value_size} must be refused by compaction,
+ * not copied. {@link org.apache.cassandra.db.marshal.AbstractType#read} applies two checks to a
+ * variable-length value's length — reject a negative one, reject one above the limit — and both
+ * compaction paths have to apply both: the iterator path reaches them through
+ * {@code Cell.Serializer.deserialize}, the cursor path mirrors them in
+ * {@code SSTableCursorReader.copyCellContents}.
+ * <p>
+ * The differential harness cannot cover this. It compares the outputs of two runs that both
+ * succeeded, and the correct behaviour here is that neither run produces an output at all. So the
+ * assertion has to be absolute, which is what this suite's {diskAccessMode, cursor} parameter rows
+ * give: the same refusal is required of both paths.
+ * <p>
+ * Two scenarios, because the cursor reaches its single check — in {@code copyCellContents} — from two
+ * different merge shapes: a value streamed from reader to writer, and a value copied into the
+ * compactor's temp buffer because a same-timestamp tie sent the merge into
+ * {@code resolveRegular}'s value comparison. Both refuse; the second is the one the memtable can
+ * silently take away.
+ * <p>
+ * The oversized length is produced by writing a value that is legal under the configured limit and
+ * then lowering the limit before compacting, rather than by corrupting a length vint — which is the
+ * shape real corruption takes, but is not something CQL can write. The check being exercised is the
+ * same one either way: it tests the decoded length against
+ * {@code DatabaseDescriptor.getMaxValueSize()} at read time.
+ */
+public class CompactionMaxValueSizeTest extends SimpleCompactionTest
+{
+    /** Twice LOWERED_LIMIT, and far under the 256MiB default the value is written under. */
+    private static final int VALUE_SIZE = 2 << 20;
+
+    /**
+     * Below VALUE_SIZE, and a whole number of mebibytes: {@link DatabaseDescriptor#setMaxValueSize}
+     * stores its argument as an {@code IntMebibytesBound}, so it divides by 1MiB and a sub-mebibyte
+     * limit truncates to a limit of ZERO — under which every non-empty variable-length value is
+     * refused and the scenario would no longer be about an oversized one. The limit is also global
+     * while it is lowered, so it has to stay large enough that ordinary reads elsewhere are
+     * unaffected. {@link #runRefusalScenario} asserts the effective limit after lowering rather than
+     * trusting this constant.
+     */
+    private static final int LOWERED_LIMIT = 1 << 20;
+
+    /** The explicit timestamp both halves of the comparison scenario are written at. */
+    private static final long TIE_TIMESTAMP = 5000L;
+
+    @Test
+    public void testOversizedCellValueIsRefusedWhenCopiedStraightThrough() throws Throwable
+    {
+        // Distinct partitions: nothing ties, so each value is streamed from the reader straight to
+        // the writer and copyCellContents is reached from SSTableCursorWriter.
+        runRefusalScenario((table, cfs) -> {
+            execute("INSERT INTO " + table + " (pk, ck, v) VALUES (?, ?, ?)", 0L, 0L, oversizedValue(1));
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+            execute("INSERT INTO " + table + " (pk, ck, v) VALUES (?, ?, ?)", 1L, 0L, oversizedValue(2));
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        }, 2, false);
+    }
+
+    @Test
+    public void testOversizedCellValueIsRefusedWhenBufferedForComparison() throws Throwable
+    {
+        // One partition, one clustering, two same-timestamp values in different sstables. The merge
+        // reaches the value comparison the shared decision defers to the compactor, which copies a
+        // value into one of the compactor's temp buffers rather than streaming it to the
+        // writer, so copyCellContents is reached from the compactor instead. Only reachable across
+        // sstables: within one flush the memtable reconciles the pair and the comparison never
+        // happens, which is what assertSameTimestampTie pins.
+        runRefusalScenario((table, cfs) -> {
+            execute("INSERT INTO " + table + " (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP " + TIE_TIMESTAMP,
+                    0L, 0L, oversizedValue(1));
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+            execute("INSERT INTO " + table + " (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP " + TIE_TIMESTAMP,
+                    0L, 0L, oversizedValue(2));
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        }, 1, true);
+    }
+
+    /** Writes the two input sstables for one scenario. */
+    private interface Writes
+    {
+        void write(String table, ColumnFamilyStore cfs) throws Throwable;
+    }
+
+    /**
+     * Builds the table, runs {@code writes}, lowers {@code max_value_size} below the value size,
+     * compacts, and asserts the refusal.
+     *
+     * @param expectedRows rows the inputs hold, asserted again after the refusal to show the
+     *                     sstables were not damaged
+     * @param sameTimestampTie whether this scenario's two inputs must collide at one clustering on
+     *                         one timestamp; asserted, so the scenario cannot stop reaching the
+     *                         value comparison and silently duplicate the straight-through one
+     */
+    private void runRefusalScenario(Writes writes, int expectedRows, boolean sameTimestampTie) throws Throwable
+    {
+        String keyspace = createKeyspace("CREATE KEYSPACE %s with replication = { 'class' : " +
+                                         "'SimpleStrategy', 'replication_factor' : 1 } and durable_writes = false");
+        // blob is variable-length, which is what puts a length vint on the wire ahead of the value;
+        // a fixed-length type carries no vint and its length is never decoded, so neither path has
+        // anything to check.
+        String table = createTable(keyspace, "CREATE TABLE %s ( pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck))");
+        execute("use " + keyspace + ";");
+        Keyspace.system().forEach(k -> k.getColumnFamilyStores().forEach(ColumnFamilyStore::disableAutoCompaction));
+
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        cfs.disableAutoCompaction();
+
+        writes.write(table, cfs);
+
+        Set<Descriptor> inputs = descriptors(cfs);
+        assertEquals("the scenario needs two input sstables so that compaction merges rather than " +
+                     "skipping", 2, inputs.size());
+        assertEquals("the scenario must hold the rows it claims before compacting",
+                     expectedRows, readValues(table));
+        if (sameTimestampTie)
+            assertSameTimestampTie(cfs, expectedRows);
+        assertCursorPathWillRun(cfs);
+
+        int originalLimit = DatabaseDescriptor.getMaxValueSize();
+        assertTrue("the value must be writable under the limit in force at write time: value=" +
+                   VALUE_SIZE + " limit=" + originalLimit, VALUE_SIZE <= originalLimit);
+
+        Throwable thrown;
+        DatabaseDescriptor.setMaxValueSize(LOWERED_LIMIT);
+        try
+        {
+            int effectiveLimit = DatabaseDescriptor.getMaxValueSize();
+            assertTrue("the lowered limit must be a real bound that this scenario's value exceeds, " +
+                       "not a truncated one: requested=" + LOWERED_LIMIT + " effective=" +
+                       effectiveLimit + " value=" + VALUE_SIZE,
+                       effectiveLimit > 0 && effectiveLimit < VALUE_SIZE);
+            // Bracketed here rather than inside compactExpectingRefusal, whose catch(Throwable)
+            // would swallow the assertion. The counter still moves on a refused compaction: the
+            // pipeline is selected in AbstractCompactionPipeline.create, and the value-size check
+            // that refuses runs afterwards, inside the pipeline.
+            CompactionPipelineCounts pipelines = CompactionPipelineCounts.mark();
+            thrown = compactExpectingRefusal(cfs);
+            CompactionPipelineCounts.assertPipelineRan(cursorCompactionEnabled && BigFormat.isSelected(), pipelines);
+        }
+        finally
+        {
+            DatabaseDescriptor.setMaxValueSize(originalLimit);
+        }
+
+        CorruptSSTableException refusal = findCorruptSSTableException(thrown);
+        assertNotNull("compaction must refuse an oversized value with a CorruptSSTableException, " +
+                      "but the failure was: " + describe(thrown), refusal);
+        // Both paths format the same message, by construction: the cursor's check was written to
+        // mirror AbstractType.read's wording. Asserting it separates this refusal from any other
+        // corruption the compaction might have reported instead.
+        assertTrue("the refusal must be the max_value_size check, but was: " + describe(thrown),
+                   describe(thrown).contains("max_value_size"));
+
+        // A refused value must leave no output behind: the inputs are still the live set, and no
+        // partially written sstable was committed alongside them.
+        assertEquals("a refused compaction must not commit an output sstable", inputs, descriptors(cfs));
+
+        // ...and the refusal must be a clean one rather than damage: with the limit restored every
+        // value decodes again at its full length. readValues projects v, so the values are really
+        // read rather than skipped.
+        assertEquals("the input sstables must still be readable after the refusal",
+                     expectedRows, readValues(table));
+    }
+
+    /**
+     * Reads every row's blob and returns the row count, failing if any value does not decode to its
+     * written length. Projecting {@code v} matters: a query that does not select it leaves the column
+     * fetched-but-not-queried, and {@code Cell.Serializer.deserialize} then skips the value instead of
+     * decoding it, so the read would say nothing about the payload.
+     */
+    private int readValues(String table) throws Throwable
+    {
+        int rows = 0;
+        for (UntypedResultSet.Row row : execute("SELECT pk, ck, v FROM " + table))
+        {
+            String at = " at pk=" + row.getLong("pk") + " ck=" + row.getLong("ck");
+            assertTrue("expected every row to carry a value" + at, row.has("v"));
+            assertEquals("a value did not decode to the length it was written with" + at,
+                         VALUE_SIZE, row.getBytes("v").remaining());
+            rows++;
+        }
+        return rows;
+    }
+
+    /**
+     * Every input carries exactly the tie timestamp, and the scenario resolves to the single row the
+     * two of them collide on, so the two oversized values really do meet at one clustering on one
+     * timestamp — which is what sends the merge into {@code resolveRegular}'s value comparison rather
+     * than letting it decide on the timestamp and skip the loser's value, where no length check runs.
+     * <p>
+     * Guards against a scenario drifting off its clustering or its timestamp, not against a
+     * deliberate rewrite: giving one of the two writes a TTL, for instance, moves the merge onto the
+     * expiring-beats-live rule while leaving every assertion here satisfied.
+     */
+    private static void assertSameTimestampTie(ColumnFamilyStore cfs, int expectedRows)
+    {
+        assertEquals("a same-timestamp tie resolves to the one row both writes target", 1, expectedRows);
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            StatsMetadata stats = sstable.getSSTableMetadata();
+            assertEquals("every input of the tie scenario must be written wholly at the tie " +
+                         "timestamp, or the merge resolves on timestamp instead of on value: " +
+                         sstable.descriptor, TIE_TIMESTAMP, stats.minTimestamp);
+            assertEquals("every input of the tie scenario must be written wholly at the tie " +
+                         "timestamp, or the merge resolves on timestamp instead of on value: " +
+                         sstable.descriptor, TIE_TIMESTAMP, stats.maxTimestamp);
+        }
+    }
+
+    /**
+     * Runs the major compaction that must fail and returns what it threw.
+     * <p>
+     * Deliberately catches Throwable: the exception crosses a compaction executor thread and
+     * {@code FBUtilities.waitOnFutures} may wrap it, so the type is asserted on the cause chain by
+     * the caller rather than here.
+     */
+    private Throwable compactExpectingRefusal(ColumnFamilyStore cfs)
+    {
+        try
+        {
+            cfs.forceMajorCompaction();
+        }
+        catch (Throwable t)
+        {
+            return t;
+        }
+        fail("compaction accepted a cell value of " + VALUE_SIZE + " bytes under a max_value_size " +
+             "of " + LOWERED_LIMIT);
+        throw new AssertionError("unreachable");
+    }
+
+    private static CorruptSSTableException findCorruptSSTableException(Throwable t)
+    {
+        for (Throwable cause = t; cause != null; cause = cause.getCause())
+        {
+            if (cause instanceof CorruptSSTableException)
+                return (CorruptSSTableException) cause;
+            if (cause.getCause() == cause)
+                break;
+        }
+        return null;
+    }
+
+    /** The whole cause chain's messages, so an assertion failure names the real reason. */
+    private static String describe(Throwable t)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable cause = t; cause != null; cause = cause.getCause())
+        {
+            sb.append(cause.getClass().getName()).append(": ").append(cause.getMessage()).append('\n');
+            if (cause.getCause() == cause)
+                break;
+        }
+        return sb.toString();
+    }
+
+    private static Set<Descriptor> descriptors(ColumnFamilyStore cfs)
+    {
+        Set<Descriptor> descriptors = new HashSet<>();
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            descriptors.add(sstable.descriptor);
+        return descriptors;
+    }
+
+    private static ByteBuffer oversizedValue(int salt)
+    {
+        byte[] bytes = new byte[VALUE_SIZE];
+        for (int i = 0; i < bytes.length; i++)
+            bytes[i] = (byte) (i + salt);
+        return ByteBuffer.wrap(bytes);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/simple/CompactionSimpleValueMergeTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/CompactionSimpleValueMergeTest.java
@@ -105,7 +105,7 @@ public class CompactionSimpleValueMergeTest extends SimpleCompactionTest
         }
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
         List<Object[]> rows = new ArrayList<>();
@@ -197,7 +197,7 @@ public class CompactionSimpleValueMergeTest extends SimpleCompactionTest
             cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
         }
 
-        cfs.forceMajorCompaction();
+        majorCompact(cfs);
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
         verifyAndPrint(cfs, sstable);
 

--- a/test/unit/org/apache/cassandra/db/compaction/simple/SimpleCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/simple/SimpleCompactionTest.java
@@ -19,12 +19,16 @@
 package org.apache.cassandra.db.compaction.simple;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
@@ -33,7 +37,17 @@ import org.junit.runners.Parameterized;
 import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CompactionPipelineCounts;
+import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.big.BigFormat;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TestHelper;
+
+import static org.junit.Assert.assertTrue;
 
 
 @Ignore
@@ -78,5 +92,54 @@ public abstract class SimpleCompactionTest extends CQLTester
     public static void teardown() throws IOException, InterruptedException, ExecutionException
     {
         TestHelper.teardown();
+    }
+
+    /**
+     * Fails before the compaction if cursor compaction is unsupported for this table, so the failure
+     * names the reason. {@link #majorCompact} catches the same case afterwards, as a pipeline-count
+     * mismatch with no explanation. Call this on the input sstables before compacting.
+     */
+    protected void assertCursorPathWillRun(ColumnFamilyStore cfs)
+    {
+        if (!cursorCompactionEnabled)
+            return;
+
+        // Cursor compaction only supports BIG output, so under a non-BIG selected format — which is
+        // what `ant test-latest` runs — the assertion below would fail for a reason that is not a
+        // defect. Skip, and keep the assertion for every other unsupported-ness reason.
+        Assume.assumeTrue("cursor compaction requires the BIG sstable format; selected=" +
+                          DatabaseDescriptor.getSelectedSSTableFormat().name(),
+                          BigFormat.isSelected());
+
+        Set<SSTableReader> inputs = new HashSet<>(cfs.getLiveSSTables());
+        try (CompactionController controller = new CompactionController(cfs, inputs, cfs.gcBefore(FBUtilities.nowInSeconds()));
+             AbstractCompactionStrategy.ScannerList scanners =
+                 cfs.getCompactionStrategyManager().getScanners(new ArrayList<>(inputs), null))
+        {
+            assertTrue("cursor compaction is not supported for this scenario, so it would only " +
+                       "exercise the iterator path",
+                       CursorCompactor.isSupported(scanners, controller));
+        }
+    }
+
+    /**
+     * Major-compacts and asserts the compaction really went through the pipeline this
+     * parameterization asked for. {@code cfs.forceMajorCompaction()} on its own cannot tell the two
+     * apart, and neither can a supportability precheck: pipeline selection also consults
+     * {@code cursorCompactionEnabled}, which {@code CursorCompactor.isSupported} never reads. A
+     * scenario that requested the cursor path and was served by the iterator one would assert
+     * nothing about the cursor reader or writer and still pass.
+     * <p>
+     * The expectation is derived from the parameterization and the selected format rather than from
+     * {@code isSupported}, so that it cannot become a tautology restating the predicate the pipeline
+     * itself consults. Under a non-BIG selected format — {@code ant test-latest} selects BTI — the
+     * cursor path is refused outright, so the iterator pipeline is the correct expectation there
+     * rather than a skip: asserting it is true, cheap, and still non-vacuous.
+     */
+    protected void majorCompact(ColumnFamilyStore cfs)
+    {
+        CompactionPipelineCounts before = CompactionPipelineCounts.mark();
+        cfs.forceMajorCompaction();
+        CompactionPipelineCounts.assertPipelineRan(cursorCompactionEnabled && BigFormat.isSelected(), before);
     }
 }

--- a/test/unit/org/apache/cassandra/db/rows/DeserializationHelperTest.java
+++ b/test/unit/org/apache/cassandra/db/rows/DeserializationHelperTest.java
@@ -23,17 +23,27 @@ import java.io.DataInput;
 
 import org.junit.Test;
 
+import org.apache.cassandra.db.LivenessInfo;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.io.util.TrackedDataInputPlus;
+import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
 
+import static org.apache.cassandra.db.rows.DeserializationHelper.NO_DROP_HORIZON;
+import static org.apache.cassandra.db.rows.DeserializationHelper.isDroppedAtHorizon;
 import static org.apache.cassandra.net.MessagingService.Version.VERSION_60;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class DeserializationHelperTest
 {
+    private static final long DROP_TIME = 20_000L;
+
     static TableMetadata metadata =
     TableMetadata.builder("DeserializationHelperTest", "Test")
                  .addPartitionKeyColumn("key", AsciiType.instance)
@@ -47,5 +57,56 @@ public class DeserializationHelperTest
         DeserializationHelper helper = new DeserializationHelper(metadata, VERSION_60.value, DeserializationHelper.Flag.LOCAL);
         TrackedDataInputPlus trackedDataInputPlus = helper.trackedDataInputPlus(mock(DataInput.class), 0);
         assertSame(trackedDataInputPlus, helper.trackedDataInputPlus(mock(DataInput.class), 1));
+    }
+
+    /**
+     * The horizon array the cursor reader precomputes must decide exactly what
+     * {@code isDropped(column, timestamp, false)} decides. The two forms part company on one input,
+     * and only because {@link DeserializationHelper#NO_DROP_HORIZON} is {@code Long.MIN_VALUE}: a
+     * bare {@code timestamp <= horizon} discards a cell timestamped {@link LivenessInfo#NO_TIMESTAMP}
+     * on a never-dropped column, which the iterator path keeps.
+     *
+     * This pins the RULE, in isolation. The end-to-end pin is
+     * {@code DroppedColumnDifferentialCompactionTest.noTimestampCellSurvivesBothSentinelCollisions}, which
+     * cannot reach the input through CQL: {@code cql3/RowUpdateBuilder}'s constructor rejects
+     * {@code Long.MIN_VALUE} for every modification statement, and {@code QueryOptions} rejects it again at
+     * the native protocol, both because the engine uses that value for "no timestamp". It writes through
+     * {@code PartitionUpdate.simpleBuilder}, which has no such guard. Nothing about the encoding stands in
+     * the way — a {@code Long.MIN_VALUE} cell timestamp round-trips through an sstable exactly, since
+     * {@code SerializationHeader} writes it as an unsigned vint delta from {@code minTimestamp} and reads it
+     * back by adding, inverses mod 2^64 for any base.
+     *
+     * That scenario walks three {@code Long.MIN_VALUE} collisions on one input, so it cannot say which of
+     * them a failure belongs to. That is what this test is for, and it is why the two are not redundant.
+     */
+    @Test
+    public void droppedHorizonAgreesWithTheMapLookup()
+    {
+        ColumnMetadata dropped = ColumnMetadata.regularColumn("DeserializationHelperTest", "Test", "gone",
+                                                             Int32Type.instance, ColumnMetadata.NO_UNIQUE_ID);
+        TableMetadata withDrop = TableMetadata.builder("DeserializationHelperTest", "Test")
+                                              .addPartitionKeyColumn("key", AsciiType.instance)
+                                              .addClusteringColumn("clustering", Int32Type.instance)
+                                              .addRegularColumn("data", Int32Type.instance)
+                                              .recordColumnDrop(dropped, DROP_TIME)
+                                              .build();
+        DeserializationHelper helper = new DeserializationHelper(withDrop, VERSION_60.value, DeserializationHelper.Flag.LOCAL);
+        ColumnMetadata live = withDrop.getColumn(ByteBufferUtil.bytes("data"));
+
+        // precondition: this helper is in the state the cursor reader's gate lets through at all
+        assertTrue(helper.hasDroppedColumns());
+        assertEquals(DROP_TIME, helper.droppedTimeOrMin(dropped));
+        assertEquals(NO_DROP_HORIZON, helper.droppedTimeOrMin(live));
+
+        // the one input the two forms disagree on unless the sentinel is tested first
+        assertFalse(isDroppedAtHorizon(LivenessInfo.NO_TIMESTAMP, helper.droppedTimeOrMin(live)));
+        assertFalse(helper.isDropped(live, LivenessInfo.NO_TIMESTAMP, false));
+
+        // and the rule itself, at and either side of the horizon
+        assertTrue(isDroppedAtHorizon(DROP_TIME, DROP_TIME));
+        assertTrue(isDroppedAtHorizon(DROP_TIME - 1, DROP_TIME));
+        assertFalse(isDroppedAtHorizon(DROP_TIME + 1, DROP_TIME));
+        assertEquals(helper.isDropped(dropped, DROP_TIME, false), isDroppedAtHorizon(DROP_TIME, DROP_TIME));
+        assertEquals(helper.isDropped(dropped, DROP_TIME + 1, false), isDroppedAtHorizon(DROP_TIME + 1, DROP_TIME));
     }
 }

--- a/test/unit/org/apache/cassandra/db/rows/ReusableCellLivenessInfoTest.java
+++ b/test/unit/org/apache/cassandra/db/rows/ReusableCellLivenessInfoTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.rows;
+
+import java.nio.ByteBuffer;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The cell half of what {@code ReusableLivenessInfo} used to answer for both roles.
+ *
+ * {@code isExpiring} and {@code isTombstone} are asserted against the reference, {@link AbstractCell}, which
+ * is an independent implementation of each. {@code isLive} is NOT: {@code Cell.isLive(long, long, int)}
+ * delegates to {@link CellLivenessInfo#isLive}, so the reference and this class now share one body and
+ * comparing them is a tautology. That also means the differential suite stopped being an oracle for the cell
+ * liveness rule — both paths would be wrong identically and the output bytes would still match. So the rule is
+ * pinned against expected literals here, and this class is the only thing in the tree that does so. Do not
+ * "simplify" those assertions back into a comparison against {@link AbstractCell}: that is what made them
+ * unable to fail.
+ */
+public class ReusableCellLivenessInfoTest
+{
+    private static final long TIMESTAMP = 1000L;
+    private static final long NOW_IN_SEC = 1_700_000_000L;
+
+    private static ColumnMetadata column;
+    private static ByteBuffer value;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        column = ColumnMetadata.regularColumn("ks", "tbl", "v", Int32Type.instance, 0);
+        value = Int32Type.instance.decompose(1);
+    }
+
+    /**
+     * {@code isExpiring()} is "has a TTL" and {@code isTombstone()} is "has a deletion time and no TTL",
+     * exactly as the cell reference defines them — a tombstone carries a deletion time without a TTL, which
+     * is why the two cannot share a predicate.
+     */
+    @Test
+    public void predicatesAgreeWithCellReference()
+    {
+        // (ttl, localDeletionTime): live, tombstone, expiring-and-not-yet-expired, expiring-and-EXPIRED, and
+        // the corrupt TTL with no deletion time. All five are representable by a Cell. The expired one is what
+        // exercises `nowInSec < localDeletionTime` as false with a TTL present; without it the expiry half of
+        // the rule is never evaluated.
+        int[] ttls = { Cell.NO_TTL, Cell.NO_TTL, 100, 100, 100 };
+        long[] ldts = { Cell.NO_DELETION_TIME, NOW_IN_SEC - 10, NOW_IN_SEC + 10, NOW_IN_SEC - 10, Cell.NO_DELETION_TIME };
+        boolean[] expectedLive = { true, false, true, false, true };
+        boolean[] expectedTombstone = { false, true, false, false, false };
+        boolean[] expectedExpiring = { false, false, true, true, true };
+
+        for (int i = 0; i < ttls.length; i++)
+        {
+            ReusableCellLivenessInfo liveness = new ReusableCellLivenessInfo();
+            liveness.reset(TIMESTAMP, ttls[i], ldts[i]);
+            Cell<?> reference = new BufferCell(column, TIMESTAMP, ttls[i], ldts[i], value, null);
+            String at = " at ttl=" + ttls[i] + " localDeletionTime=" + ldts[i];
+
+            assertEquals("timestamp must match" + at, reference.timestamp(), liveness.timestamp());
+            assertEquals("ttl must match" + at, reference.ttl(), liveness.ttl());
+            assertEquals("localDeletionTime must match" + at,
+                         reference.localDeletionTime(), liveness.localDeletionTime());
+            // against the reference, which implements these two independently
+            assertEquals("isExpiring must match AbstractCell.isExpiring()" + at,
+                         reference.isExpiring(), liveness.isExpiring());
+            assertEquals("isTombstone must match AbstractCell.isTombstone()" + at,
+                         reference.isTombstone(), liveness.isTombstone());
+
+            // against literals, because reference and holder share one isLive body
+            assertEquals("isExpiring" + at, expectedExpiring[i], liveness.isExpiring());
+            assertEquals("isTombstone" + at, expectedTombstone[i], liveness.isTombstone());
+            assertEquals("isLive" + at, expectedLive[i], liveness.isLive(NOW_IN_SEC));
+            assertEquals("the static must answer as the instance does" + at,
+                         expectedLive[i], CellLivenessInfo.isLive(NOW_IN_SEC, ldts[i], ttls[i]));
+            assertEquals("the reference shares that body, so it must agree too" + at,
+                         expectedLive[i], reference.isLive(NOW_IN_SEC));
+        }
+    }
+
+    /**
+     * Converting a lapsed TTL to a tombstone must produce what the reference produces:
+     * {@code AbstractCell.purge} builds {@code BufferCell.tombstone(column, timestamp(),
+     * localDeletionTime() - ttl(), path())}. Asserted against that cell rather than against a hand-computed
+     * {@code NOW_IN_SEC - 100}, so the mirror is structural — if the reference's arithmetic changes, this
+     * fails instead of silently encoding the old one.
+     */
+    @Test
+    public void ttlToTombstoneMatchesTheReferenceTombstone()
+    {
+        ReusableCellLivenessInfo liveness = new ReusableCellLivenessInfo();
+        liveness.reset(TIMESTAMP, 100, NOW_IN_SEC);
+        assertTrue(liveness.isExpiring());
+        assertFalse(liveness.isTombstone());
+
+        Cell<?> expiring = new BufferCell(column, TIMESTAMP, 100, NOW_IN_SEC, value, null);
+        Cell<?> reference = BufferCell.tombstone(column, expiring.timestamp(),
+                                                 expiring.localDeletionTime() - expiring.ttl(), expiring.path());
+
+        liveness.ttlToTombstone();
+
+        assertEquals("timestamp is unchanged", reference.timestamp(), liveness.timestamp());
+        assertEquals("the deletion time is the reference's", reference.localDeletionTime(), liveness.localDeletionTime());
+        assertEquals("the TTL is dropped, as the reference drops it", reference.ttl(), liveness.ttl());
+        assertEquals("isTombstone must match the reference tombstone",
+                     reference.isTombstone(), liveness.isTombstone());
+        assertEquals("isExpiring must match the reference tombstone",
+                     reference.isExpiring(), liveness.isExpiring());
+    }
+
+    /**
+     * A fresh instance carries no deletion time, so under the cell contract it is live. The row contract
+     * answers the opposite for its own fresh instance — see {@code ReusableLivenessInfoTest} — and that pair
+     * of assertions is the point of having split the two classes.
+     */
+    @Test
+    public void freshInstanceIsLiveAndNeitherExpiringNorTombstone()
+    {
+        ReusableCellLivenessInfo liveness = new ReusableCellLivenessInfo();
+        assertFalse(liveness.isExpiring());
+        assertFalse(liveness.isTombstone());
+        assertTrue("no deletion time means live under the cell contract", liveness.isLive(NOW_IN_SEC));
+    }
+
+    /**
+     * {@code isExpired(long)} is cell-only and drives the TTL-to-tombstone conversion in the merge, and was
+     * untested both here and in the class this was split out of.
+     */
+    @Test
+    public void isExpiredIsTheTtlLapseTest()
+    {
+        ReusableCellLivenessInfo liveness = new ReusableCellLivenessInfo();
+        liveness.reset(TIMESTAMP, 100, NOW_IN_SEC);
+        assertTrue("at the expiration second the TTL has lapsed", liveness.isExpired(NOW_IN_SEC));
+        assertTrue(liveness.isExpired(NOW_IN_SEC + 1));
+        assertFalse(liveness.isExpired(NOW_IN_SEC - 1));
+
+        // the merge guards this on the expiring flag, so combined they are AbstractCell.purge's condition.
+        // Asserted at BOTH polarities: at the expiration second the pair is false/true, and a second
+        // earlier it is true/false, so an implementation that returned a constant fails one of them.
+        assertEquals("guarded by isExpiring, isExpired is the negation of isLive",
+                     liveness.isLive(NOW_IN_SEC), !liveness.isExpired(NOW_IN_SEC));
+        assertEquals("and at the other polarity, a second before expiry",
+                     liveness.isLive(NOW_IN_SEC - 1), !liveness.isExpired(NOW_IN_SEC - 1));
+    }
+
+    /** The diagnostic that {@code UnfilteredValidation.handleInvalid} prints for a corrupt cell. */
+    @Test
+    public void toStringNamesTheFields()
+    {
+        ReusableCellLivenessInfo liveness = new ReusableCellLivenessInfo();
+        assertTrue("a fresh instance must render as empty, got " + liveness,
+                   liveness.toString().contains("NONE"));
+
+        liveness.reset(TIMESTAMP, 100, NOW_IN_SEC);
+        String rendered = liveness.toString();
+        assertTrue("must name the timestamp, got " + rendered, rendered.contains(String.valueOf(TIMESTAMP)));
+        assertTrue("must name the ttl, got " + rendered, rendered.contains("ttl=100"));
+        assertTrue("must name the deletion time, got " + rendered,
+                   rendered.contains("localDeletionTime=" + NOW_IN_SEC));
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CursorColumnsSubsetEncodingTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CursorColumnsSubsetEncodingTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.agrona.collections.IntArrayList;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Columns;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pins {@link SSTableCursorWriter#encodeColumnsSubset} byte-for-byte against the reference
+ * {@link Columns.Serializer#serializeSubset} for every encoding form and boundary:
+ *
+ *  - the < 64-column missing-bitmap form;
+ *  - the >= 64-column large-subset form in BOTH modes (present-index and missing-index),
+ *    including the exact mode boundary presentCount == supersetCount/2 at odd and even
+ *    superset sizes (a flipped mode selection at this boundary made the deserializer
+ *    read the wrong mode — silent corruption);
+ *  - subsets whose present columns sort AFTER the last missing column (a wrong tail-loop
+ *    bound silently dropped them from the encoding).
+ *
+ * The cursor writer cannot delegate to the upstream serializer — it requires a
+ * materialized Columns + iterator per call, a per-row allocation the garbage-free mandate
+ * forbids — so this sweep is what keeps the hand-mirror from drifting. Every encoding is
+ * also round-tripped through {@link Columns.Serializer#deserializeSubset} and compared to
+ * the expected present set.
+ */
+public class CursorColumnsSubsetEncodingTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    private static Columns superset(int size)
+    {
+        List<ColumnMetadata> cols = new ArrayList<>(size);
+        for (int i = 0; i < size; i++)
+            cols.add(ColumnMetadata.regularColumn("ks", "cf", String.format("c%04d", i), Int32Type.instance, i));
+        Columns columns = Columns.from(cols);
+        assertEquals(size, columns.size());
+        return columns;
+    }
+
+    private static void assertEncodingMatchesReference(Columns superset, boolean[] missing) throws Exception
+    {
+        int size = superset.size();
+        IntArrayList missingList = new IntArrayList();
+        List<ColumnMetadata> present = new ArrayList<>();
+        int i = 0;
+        for (ColumnMetadata c : superset)
+        {
+            if (missing[i])
+                missingList.addInt(i);
+            else
+                present.add(c);
+            i++;
+        }
+        // all-present and all-missing take dedicated fast paths in writeRowEnd, not this encoder
+        if (present.isEmpty() || missingList.isEmpty())
+            return;
+
+        DataOutputBuffer cursorBytes = new DataOutputBuffer();
+        SSTableCursorWriter.encodeColumnsSubset(missingList, size, cursorBytes);
+
+        DataOutputBuffer referenceBytes = new DataOutputBuffer();
+        Columns.serializer.serializeSubset(present, superset, referenceBytes);
+
+        assertArrayEquals(String.format("encoding diverges from Columns.Serializer at superset=%d missing=%d",
+                                        size, missingList.size()),
+                          referenceBytes.toByteArray(), cursorBytes.toByteArray());
+
+        // round-trip: the upstream deserializer must reconstruct exactly the present set
+        try (DataInputBuffer in = new DataInputBuffer(cursorBytes.toByteArray()))
+        {
+            Columns decoded = Columns.serializer.deserializeSubset(superset, in);
+            assertEquals(String.format("round-trip size mismatch at superset=%d missing=%d", size, missingList.size()),
+                         present.size(), decoded.size());
+            int j = 0;
+            for (ColumnMetadata c : decoded)
+                assertEquals(present.get(j++), c);
+        }
+    }
+
+    @Test
+    public void sweepSizesShapesAndBoundaries() throws Exception
+    {
+        Random random = new Random(20260611);
+        int[] sizes = { 2, 3, 10, 63, 64, 65, 70, 71, 127, 128, 130 };
+        for (int size : sizes)
+        {
+            Columns superset = superset(size);
+            for (int missingCount = 1; missingCount < size; missingCount++)
+            {
+                // structured shapes: leading block, trailing block (present columns sorting
+                // after the last missing index — the shape a wrong tail-loop bound used to
+                // silently drop), even spread
+                boolean[] leading = new boolean[size];
+                boolean[] trailing = new boolean[size];
+                boolean[] spread = new boolean[size];
+                for (int m = 0; m < missingCount; m++)
+                {
+                    leading[m] = true;
+                    trailing[size - 1 - m] = true;
+                    spread[(int) ((long) m * size / missingCount)] = true;
+                }
+                assertEncodingMatchesReference(superset, leading);
+                assertEncodingMatchesReference(superset, trailing);
+                assertEncodingMatchesReference(superset, spread);
+
+                // randomized shape, seeded
+                boolean[] randomShape = new boolean[size];
+                int placed = 0;
+                while (placed < missingCount)
+                {
+                    int idx = random.nextInt(size);
+                    if (!randomShape[idx])
+                    {
+                        randomShape[idx] = true;
+                        placed++;
+                    }
+                }
+                assertEncodingMatchesReference(superset, randomShape);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CursorIndexWriterOffsetWidthTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CursorIndexWriterOffsetWidthTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.DeletionTime;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pins {@link CursorIndexWriter#indexBlockStartOffset} at 64 bits wide.
+ *
+ * Why 64 bits is at the field's own declaration. What it feeds, and therefore what a narrowing
+ * would corrupt, is the index-block cut arithmetic ({@code BigCursorIndexWriter.java:100}) and the
+ * offset written into every promoted index entry ({@code :147}).
+ *
+ * The exercise is deliberately direct rather than a 2GiB partition: it drives
+ * {@link CursorIndexWriter#startPartition} and {@code notePosition} on a stub subclass, which
+ * is where the width lives, and needs no data file.
+ */
+public class CursorIndexWriterOffsetWidthTest
+{
+    /** Beyond Integer.MAX_VALUE, and beyond it by more than the block threshold. */
+    private static final long PAST_INT_MAX = 3_000_000_000L;
+    /** What PAST_INT_MAX becomes when truncated to 32 bits. */
+    private static final long TRUNCATED_TO_INT = -1_294_967_296L;
+
+    @Test
+    public void offsetPastIntMaxSurvivesFromPartitionStartZero()
+    {
+        StubIndexWriter writer = new StubIndexWriter();
+        writer.startPartition(0, 30);
+        assertEquals("partition header length", 30, writer.indexBlockStartOffset());
+
+        writer.notePosition(PAST_INT_MAX);
+        assertEquals("the index block offset must survive past Integer.MAX_VALUE; truncated to int " +
+                     "it would read " + TRUNCATED_TO_INT,
+                     PAST_INT_MAX, writer.indexBlockStartOffset());
+    }
+
+    @Test
+    public void offsetPastIntMaxSurvivesFromNonZeroPartitionStart()
+    {
+        StubIndexWriter writer = new StubIndexWriter();
+        long partitionStart = 1_000_000_000L;
+        writer.startPartition(partitionStart, partitionStart + 30);
+        writer.staticRowWritten(partitionStart + PAST_INT_MAX);
+        assertEquals("the index block offset must survive past Integer.MAX_VALUE; truncated to int " +
+                     "it would read " + TRUNCATED_TO_INT,
+                     PAST_INT_MAX, writer.indexBlockStartOffset());
+    }
+
+    /**
+     * The consequence of narrowing: a wrapped-negative block start makes the block size
+     * measured against it larger than the whole partition, cutting an index block per row.
+     */
+    @Test
+    public void blockSizeMeasuredPastIntMaxStaysSmall()
+    {
+        StubIndexWriter writer = new StubIndexWriter();
+        writer.startPartition(0, 30);
+        writer.notePosition(PAST_INT_MAX);
+
+        long rowEnd = PAST_INT_MAX + 100;
+        assertEquals("block size measured from a truncated start",
+                     100, writer.currentOffsetInPartition(rowEnd) - writer.indexBlockStartOffset());
+    }
+
+    private static class StubIndexWriter extends CursorIndexWriter
+    {
+        @Override
+        protected void reset()
+        {
+        }
+
+        @Override
+        public void rowWritten(UnfilteredDescriptor descriptor, long rowStart, long rowEnd, DeletionTime openMarker)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void endPartition(byte[] key, int keyLength, int headerLength,
+                                 DeletionTime partitionDeletionTime, long partitionEnd,
+                                 ClusteringDescriptor lastName)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterKeepOriginalsTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterKeepOriginalsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CompactionIterator;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.format.SSTableFormat;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.db.compaction.OperationType.COMPACTION;
+import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * keepOriginals=true must retain the original sstables even when early open is in play:
+ * moveStarts() used to obsolete fully-covered originals unconditionally (only the bulk
+ * obsoleteOriginals() call honored the flag), so a full-range rewrite with an online
+ * transaction deleted every original after the last reference was released.
+ *
+ * Isolated in its own class deliberately: a kept original intentionally leaves accounting
+ * residue in the column family (its bytes remain counted while no longer in the live set),
+ * which would poison the shared-fixture assertions of SSTableRewriterTest; per-class test
+ * JVMs make that residue harmless here.
+ */
+public class SSTableRewriterKeepOriginalsTest extends SSTableWriterTestBase
+{
+    @Test
+    public void keepOriginalsSurvivesEarlyOpen() throws Exception
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);
+        truncate(cfs);
+
+        for (int j = 0; j < 100; j++)
+        {
+            new RowUpdateBuilder(cfs.metadata(), j, String.valueOf(j))
+                .clustering("0")
+                .add("val", ByteBufferUtil.EMPTY_BYTE_BUFFER)
+                .build()
+                .apply();
+        }
+        Util.flush(cfs);
+        Set<SSTableReader> sstables = new HashSet<>(cfs.getLiveSSTables());
+        assertEquals(1, sstables.size());
+        SSTableReader original = sstables.iterator().next();
+        File originalData = original.descriptor.fileFor(SSTableFormat.Components.DATA);
+        long nowInSec = FBUtilities.nowInSeconds();
+        try (AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(sstables);
+             LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.UNKNOWN);
+             SSTableRewriter writer = SSTableRewriter.constructKeepingOriginals(txn, true, 1000);
+             CompactionController controller = new CompactionController(cfs, sstables, cfs.gcBefore(nowInSec));
+             CompactionIterator ci = new CompactionIterator(COMPACTION, scanners.scanners, controller, nowInSec, nextTimeUUID()))
+        {
+            writer.switchWriter(getWriter(cfs, original.descriptor.directory, txn));
+            while (ci.hasNext())
+                writer.append(ci.next());
+            writer.finish();
+        }
+        LifecycleTransaction.waitForDeletions();
+
+        assertTrue("keepOriginals=true must retain the original sstable through an online " +
+                   "early-open rewrite, but its data file was deleted",
+                   originalData.exists());
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/PreSortedBubbleInsertTest.java
+++ b/test/unit/org/apache/cassandra/utils/PreSortedBubbleInsertTest.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.apache.cassandra.db.compaction.CursorCompactor;
+import org.apache.cassandra.db.compaction.PreSortedBubbleInsert;
 
 public class PreSortedBubbleInsertTest
 {
@@ -124,8 +124,6 @@ public class PreSortedBubbleInsertTest
 
     private static <T> void bubbleSortFrom(T[] array, boolean[] equalsNext, Comparator<T> comparator, int perturbedLimit)
     {
-        for (; perturbedLimit > 0; perturbedLimit--) {
-            CursorCompactor.bubbleInsertElementToPreSorted(array, equalsNext, perturbedLimit, array.length, comparator);
-        }
+        new PreSortedBubbleInsert<>(comparator).sortPerturbed(array, equalsNext, perturbedLimit, array.length);
     }
 }


### PR DESCRIPTION
Adds multiple layers of testing around cursor compaction to ensure it generates the same exact outputs as the iterator path.


