### PR TITLE
CASSANDRA-21540 Fix startup fails when TDE is enabled

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -395,6 +395,8 @@ public class DatabaseDescriptor
 
         applyCompressorProviders();
 
+        applyEncryptionContext();
+
         applySimpleConfig();
 
         applyPartitioner();
@@ -402,8 +404,6 @@ public class DatabaseDescriptor
         applySnitch();
 
         applyFailureDetector();
-
-        applyEncryptionContext();
     }
 
     /**
@@ -577,6 +577,8 @@ public class DatabaseDescriptor
 
         applyCryptoProvider();
 
+        applyEncryptionContext();
+
         applySimpleConfig();
 
         applyPartitioner();
@@ -590,8 +592,6 @@ public class DatabaseDescriptor
         applyTokensConfig();
 
         applySeedProvider();
-
-        applyEncryptionContext();
 
         applySslContext();
 


### PR DESCRIPTION
Reorder methods call in DatabaseDescriptor for correct determ commitlog_disk_access_mode with enabled TDE:
   applyEncryptionContext() before applySimpleConfig().

https://issues.apache.org/jira/browse/CASSANDRA-21540
patch by Valery Baranov [klammrock@gmail.com](mailto:klammrock@gmail.com)

