### PR TITLE
CI: cache Docker Hub image pulls in-cluster for the k8s Jenkins agents

### DIFF
--- a/.build/run-ci
+++ b/.build/run-ci
@@ -288,6 +288,10 @@ def apply_docker_cache(kubeconfig: Optional[str], kubecontext: Optional[str], ku
         cmd += ["--context", kubecontext]
     cmd += ["--namespace", kube_ns, "apply", "-f", "-"]
     subprocess.run(cmd, input=yaml.safe_dump_all(docs), text=True, check=True)
+    # apply returning 0 only means the objects were accepted; wait for the pod to actually roll out
+    # (e.g. the PVC binds) so a stuck cache surfaces here rather than failing silently
+    run_kubectl_command(kubeconfig, kubecontext, kube_ns,
+                        ["rollout", "status", "deploy/docker-cache", "--timeout=120s"])
 
 def run_helm_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, command: list,
                      capture_output: bool = True, check: bool = True) -> subprocess.CompletedProcess:
@@ -928,9 +932,13 @@ def cleanup_and_maybe_teardown(kubeconfig: Optional[str], kubecontext: Optional[
     IS_RUNNING = False
     if tear_down:
         print("Cleaning up Jenkins and all resources.")
-        # the pull-through cache is disposable; its PVC is not annotated to keep, so this drops it too
-        run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["delete", "-f", DOCKER_CACHE_YAML, "--ignore-not-found"])
         run_helm_command(kubeconfig, kubecontext, kube_ns, ["uninstall", "cassius"], capture_output=False)
+        # the pull-through cache is disposable; its PVC is not annotated to keep, so this drops it too.
+        # done after the helm uninstall, and non-fatal, so a cache cleanup hiccup never leaves Jenkins up
+        try:
+            run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["delete", "-f", DOCKER_CACHE_YAML, "--ignore-not-found"])
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: failed to delete the docker-cache resources, remove them manually: {e}")
         # the pvc is annotated `helm.sh/resource-policy: keep`, see .jenkins/k8s/jenkins-deployment.yaml
         print(f"Jenkins uninstalled. The jenkins-home volume was kept, delete it with:\n"
               f"  kubectl --namespace {kube_ns} delete pvc cassius-jenkins")

--- a/.build/run-ci
+++ b/.build/run-ci
@@ -130,6 +130,7 @@ def get_tracking_remote_url() -> str:
 DEFAULT_KUBE_NS = "default"
 CASSANDRA_DIR = Path(__file__).resolve().parent.parent
 DEPLOY_YAML = str(CASSANDRA_DIR / ".jenkins/k8s/jenkins-deployment.yaml")
+DOCKER_CACHE_YAML = str(CASSANDRA_DIR / ".jenkins/k8s/docker-cache.yaml")
 DEFAULT_REPO_BRANCH = get_current_branch()
 DEFAULT_REPO_URL = get_tracking_remote_url()
 DEFAULT_DTEST_REPO_URL = "https://github.com/apache/cassandra-dtest.git"
@@ -256,6 +257,38 @@ def run_kubectl_command(kubeconfig: Optional[str], kubecontext: Optional[str], k
     cmd += command
     return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
 
+def resolve_storage_class(values_override: Optional[str]) -> Optional[str]:
+    """The persistence.storageClass a site set for Jenkins, reused for the cache PVC.
+    The override wins over jenkins-deployment.yaml (where it is normally commented out)."""
+    def storage_class(path: str) -> Optional[str]:
+        try:
+            with open(path, encoding="utf-8") as f:
+                return ((yaml.safe_load(f) or {}).get("persistence") or {}).get("storageClass")
+        except FileNotFoundError:
+            return None
+    return (storage_class(values_override) if values_override else None) or storage_class(DEPLOY_YAML)
+
+def apply_docker_cache(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str,
+                       values_override: Optional[str] = None):
+    """Applies .jenkins/k8s/docker-cache.yaml, injecting the PVC's storageClassName from the Jenkins
+    values so the cache binds on clusters (e.g. EKS) that mark no default StorageClass."""
+    with open(DOCKER_CACHE_YAML, encoding="utf-8") as f:
+        docs = [d for d in yaml.safe_load_all(f) if d]
+    storage_class = resolve_storage_class(values_override)
+    if storage_class:
+        for doc in docs:
+            if doc.get("kind") == "PersistentVolumeClaim":
+                doc.setdefault("spec", {})["storageClassName"] = storage_class
+    print(f"Applying the Docker Hub pull-through cache (docker-cache"
+          f"{f', storageClass={storage_class}' if storage_class else ''})...")
+    cmd = ["kubectl"]
+    if kubeconfig:
+        cmd += ["--kubeconfig", kubeconfig]
+    if kubecontext:
+        cmd += ["--context", kubecontext]
+    cmd += ["--namespace", kube_ns, "apply", "-f", "-"]
+    subprocess.run(cmd, input=yaml.safe_dump_all(docs), text=True, check=True)
+
 def run_helm_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, command: list,
                      capture_output: bool = True, check: bool = True) -> subprocess.CompletedProcess:
     """Runs a helm command with the specified kubeconfig, context and namespace."""
@@ -372,6 +405,9 @@ def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_
     if result.returncode != 0:
         print("Failed to install Jenkins Operator using Helm. Check the configuration and/or `kubectl logs cassius-jenkins-0`.")
         sys.exit(1)
+
+    # in-cluster Docker Hub pull-through cache for the agents' dind --registry-mirror, see .jenkins/k8s/docker-cache.yaml
+    apply_docker_cache(kubeconfig, kubecontext, kube_ns, values_override)
 
 
 def wait_for_jenkins_http(ip: str):
@@ -892,6 +928,8 @@ def cleanup_and_maybe_teardown(kubeconfig: Optional[str], kubecontext: Optional[
     IS_RUNNING = False
     if tear_down:
         print("Cleaning up Jenkins and all resources.")
+        # the pull-through cache is disposable; its PVC is not annotated to keep, so this drops it too
+        run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["delete", "-f", DOCKER_CACHE_YAML, "--ignore-not-found"])
         run_helm_command(kubeconfig, kubecontext, kube_ns, ["uninstall", "cassius"], capture_output=False)
         # the pvc is annotated `helm.sh/resource-policy: keep`, see .jenkins/k8s/jenkins-deployment.yaml
         print(f"Jenkins uninstalled. The jenkins-home volume was kept, delete it with:\n"

--- a/.build/run-ci
+++ b/.build/run-ci
@@ -243,7 +243,8 @@ def init_k8s_namespace(k8s_client, namespace: str):
         else:
             raise
 
-def run_kubectl_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, command: list) -> str:
+def run_kubectl_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, command: list,
+                        stdin_input: Optional[str] = None) -> str:
     """
     Runs a kubectl command with the specified kubeconfig and context.
     Used when functionality is not available in k8s_client.
@@ -255,43 +256,7 @@ def run_kubectl_command(kubeconfig: Optional[str], kubecontext: Optional[str], k
         cmd += ["--context", kubecontext]
     cmd += ["--namespace", kube_ns]
     cmd += command
-    return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
-
-def resolve_storage_class(values_override: Optional[str]) -> Optional[str]:
-    """The persistence.storageClass a site set for Jenkins, reused for the cache PVC.
-    The override wins over jenkins-deployment.yaml (where it is normally commented out)."""
-    def storage_class(path: str) -> Optional[str]:
-        try:
-            with open(path, encoding="utf-8") as f:
-                return ((yaml.safe_load(f) or {}).get("persistence") or {}).get("storageClass")
-        except FileNotFoundError:
-            return None
-    return (storage_class(values_override) if values_override else None) or storage_class(DEPLOY_YAML)
-
-def apply_docker_cache(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str,
-                       values_override: Optional[str] = None):
-    """Applies .jenkins/k8s/docker-cache.yaml, injecting the PVC's storageClassName from the Jenkins
-    values so the cache binds on clusters (e.g. EKS) that mark no default StorageClass."""
-    with open(DOCKER_CACHE_YAML, encoding="utf-8") as f:
-        docs = [d for d in yaml.safe_load_all(f) if d]
-    storage_class = resolve_storage_class(values_override)
-    if storage_class:
-        for doc in docs:
-            if doc.get("kind") == "PersistentVolumeClaim":
-                doc.setdefault("spec", {})["storageClassName"] = storage_class
-    print(f"Applying the Docker Hub pull-through cache (docker-cache"
-          f"{f', storageClass={storage_class}' if storage_class else ''})...")
-    cmd = ["kubectl"]
-    if kubeconfig:
-        cmd += ["--kubeconfig", kubeconfig]
-    if kubecontext:
-        cmd += ["--context", kubecontext]
-    cmd += ["--namespace", kube_ns, "apply", "-f", "-"]
-    subprocess.run(cmd, input=yaml.safe_dump_all(docs), text=True, check=True)
-    # apply returning 0 only means the objects were accepted; wait for the pod to actually roll out
-    # (e.g. the PVC binds) so a stuck cache surfaces here rather than failing silently
-    run_kubectl_command(kubeconfig, kubecontext, kube_ns,
-                        ["rollout", "status", "deploy/docker-cache", "--timeout=120s"])
+    return subprocess.run(cmd, input=stdin_input, capture_output=True, text=True, check=True).stdout.strip()
 
 def run_helm_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, command: list,
                      capture_output: bool = True, check: bool = True) -> subprocess.CompletedProcess:
@@ -308,6 +273,28 @@ def run_helm_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube
 def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str,
                     values_override: Optional[str] = None):
     """Installs Jenkins Operator using Helm in the specified K8s namespace."""
+
+    def apply_docker_cache(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str,
+                           values_override: Optional[str] = None):
+        """Applies .jenkins/k8s/docker-cache.yaml, injecting the PVC's storageClassName from the Jenkins
+        values (persistence.storageClass, an override winning over jenkins-deployment.yaml where it is
+        normally commented out) so the cache binds on clusters, e.g. EKS, marking no default StorageClass.
+        Waits for the rollout, so a stuck cache (e.g. an unbound PVC) surfaces here rather than silently."""
+        def storage_class(path: Optional[str]) -> Optional[str]:
+            try:
+                with open(path, encoding="utf-8") as f:
+                    return ((yaml.safe_load(f) or {}).get("persistence") or {}).get("storageClass")
+            except (FileNotFoundError, TypeError):
+                return None
+        with open(DOCKER_CACHE_YAML, encoding="utf-8") as f:
+            docs = [d for d in yaml.safe_load_all(f) if d]
+        sc = storage_class(values_override) or storage_class(DEPLOY_YAML)
+        for doc in (docs if sc else []):
+            if doc.get("kind") == "PersistentVolumeClaim":
+                doc.setdefault("spec", {})["storageClassName"] = sc
+        print(f"Applying the Docker Hub pull-through cache (docker-cache{f', storageClass={sc}' if sc else ''})...")
+        run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["apply", "-f", "-"], stdin_input=yaml.safe_dump_all(docs))
+        run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["rollout", "status", "deploy/docker-cache", "--timeout=120s"])
 
     def confirm_helm_updates():
         """Prompts before an upgrade drops any values the deployed jenkins currently has."""
@@ -777,30 +764,14 @@ def delete_remote_junit_files(k8s_client, pod_name: str, kube_ns: str, base_job_
 
 def download_results_and_print_summary(k8s_client, pod_name: str, kube_ns: str, build_number: int, ip: str, args):
 
-    def download_console_log(pod_name: str, container_name: str,  kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, console_log_path: str, local_console_log: Path):
-        max_retries = 5
-        for attempt in range(max_retries):
-            try:
-                run_kubectl_command(kubeconfig, kubecontext, kube_ns,
-                                    ["cp", "-c", container_name, f"{kube_ns}/{pod_name}:{console_log_path}", str(local_console_log)])
-
-                print(f"Console log saved to {local_console_log}.gz\n")
-                break
-            except subprocess.CalledProcessError as e:
-                if attempt < max_retries:
-                    debug(f" Failed to download {pod_name}:{console_log_path}: {e}. Retrying ({attempt + 1}/{max_retries})...")
-                    time.sleep(5)  # Wait before retrying
-                else:
-                    raise
-
-    def download_archive_tarball(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, pod_name: str, container_name: str, remote_path: str, local_path, max_retries=5):
+    def kubectl_cp(kubeconfig, kubecontext, container_name, remote_path, local_path, on_success, max_retries=5):
+        # copies pod_name:remote_path to local_path via `kubectl cp`, retrying, then calls on_success
         for attempt in range(max_retries):
             try:
                 run_kubectl_command(kubeconfig, kubecontext, kube_ns,
                                     ["cp", "-c", container_name, f"{kube_ns}/{pod_name}:{remote_path}", str(local_path)])
-
-                debug(f"Build Artifacts saved in {local_path}")
-                break
+                on_success()
+                return
             except subprocess.CalledProcessError as e:
                 if attempt < max_retries:
                     debug(f" Failed to download {pod_name}:{remote_path}: {e}. Retrying ({attempt + 1}/{max_retries})...")
@@ -823,21 +794,18 @@ def download_results_and_print_summary(k8s_client, pod_name: str, kube_ns: str, 
         print(f"Logs in {local_results_dir / 'archive/stage-logs/'} and {local_results_dir / 'archive/test/logs/'}")
 
     def print_results_summary_console(local_console_log):
-        if local_console_log.exists():
-            with open(local_console_log, 'r', encoding="utf-8") as log_file:
-                log_content = log_file.read()
-                if "BUILD FAILED" in log_content:
-                    print("---")
-                    failed_index = log_content.index("BUILD FAILED")
-                    # Print the 200 characters after "BUILD FAILED"
-                    print(log_content[failed_index:failed_index + 200])
-            with open(local_console_log, 'r', encoding="utf-8") as log_file:
-                for line in log_file:
-                    if "Finished: " in line:
-                        print(line.strip())
-                        break
-        else:
+        if not local_console_log.exists():
             print("Missing console log.")
+            return
+        log_content = local_console_log.read_text(encoding="utf-8")
+        if "BUILD FAILED" in log_content:
+            print("---")
+            failed_index = log_content.index("BUILD FAILED")
+            print(log_content[failed_index:failed_index + 200])  # the 200 chars after "BUILD FAILED"
+        for line in log_content.splitlines():
+            if "Finished: " in line:
+                print(line.strip())
+                break
 
     def print_results_summary_ci_summary(ci_summary_file):
         if ci_summary_file.exists():
@@ -901,8 +869,9 @@ def download_results_and_print_summary(k8s_client, pod_name: str, kube_ns: str, 
         remote_archive_dir = f"{remote_build_dir}/archive"
 
         print("Downloading build results and logs...")
-        console_log_thread = threading.Thread(target=download_console_log,
-                                              args=(pod_name, DEFAULT_CONTAINER_NAME, kubeconfig, kubecontext, kube_ns, remote_console_log_path, local_console_log))
+        console_log_thread = threading.Thread(target=kubectl_cp, args=(
+            kubeconfig, kubecontext, DEFAULT_CONTAINER_NAME, remote_console_log_path, local_console_log,
+            lambda: print(f"Console log saved to {local_console_log}.gz\n")))
         console_log_thread.start()
 
         # Compress and download the archive directory if it exists
@@ -913,8 +882,8 @@ def download_results_and_print_summary(k8s_client, pod_name: str, kube_ns: str, 
             stream.stream(k8s_client.connect_get_namespaced_pod_exec, pod_name, kube_ns, container=DEFAULT_CONTAINER_NAME,
                         command=compress_command, stderr=True, stdin=False, stdout=True, tty=False)
 
-            local_archive_tar = local_results_dir / "archive.tar.gz"
-            download_archive_tarball(kubeconfig, kubecontext, kube_ns, pod_name, DEFAULT_CONTAINER_NAME, archive_path_in_pod, local_archive_tar)
+            kubectl_cp(kubeconfig, kubecontext, DEFAULT_CONTAINER_NAME, archive_path_in_pod, local_archive_tar,
+                       lambda: debug(f"Build Artifacts saved in {local_archive_tar}"))
             # delete
             stream.stream(k8s_client.connect_get_namespaced_pod_exec, pod_name, kube_ns, container=DEFAULT_CONTAINER_NAME,
                         command=['rm', archive_path_in_pod], stderr=True, stdin=False, stdout=True, tty=False)
@@ -933,8 +902,7 @@ def cleanup_and_maybe_teardown(kubeconfig: Optional[str], kubecontext: Optional[
     if tear_down:
         print("Cleaning up Jenkins and all resources.")
         run_helm_command(kubeconfig, kubecontext, kube_ns, ["uninstall", "cassius"], capture_output=False)
-        # the pull-through cache is disposable; its PVC is not annotated to keep, so this drops it too.
-        # done after the helm uninstall, and non-fatal, so a cache cleanup hiccup never leaves Jenkins up
+        # the disposable pull-through cache (its PVC is not kept); after the uninstall and non-fatal, so a hiccup here never leaves Jenkins up
         try:
             run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["delete", "-f", DOCKER_CACHE_YAML, "--ignore-not-found"])
         except subprocess.CalledProcessError as e:

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -502,18 +502,22 @@ def buildJVMDTestJars(cell, script_vars, logfile) {
 }
 
 def fetchDockerImages(dockerfiles) {
-  // prefetch, from apache jfrog, reduces risking dockerhub pull rate limits
-  // also prefetch alpine:latest as its used as a utility in the scripts
+  // prefetch the build/test images so they are warm before the build needs them, and prefetch
+  // alpine:3.19.1 as the scripts use it as a utility.  Pull the Docker Hub names the build scripts
+  // actually consume (`docker pull apache/cassandra-<image>:<md5>` in .build/docker/run-tests.sh and
+  // _docker_run.sh); these route through the in-cluster Docker Hub pull-through cache configured on
+  // dind's --registry-mirror (.jenkins/k8s/docker-cache.yaml), so each image is fetched from Docker
+  // Hub once per cache rather than once per agent, sidestepping Docker Hub's pull-rate limits.
   def dockerfilesVar = dockerfiles.join(' ')
   sh label: "fetching docker images...", script: """#!/bin/bash
       for dockerfile in ${dockerfilesVar} ; do
         image_tag="\$(md5sum .build/docker/\${dockerfile}.docker | cut -d' ' -f1)"
         image_name="apache/cassandra-\${dockerfile}:\${image_tag}"
         if ! ( [[ "" != "\$(docker images -q \${image_name} 2>/dev/null)" ]] ) ; then
-          docker pull -q apache.jfrog.io/cassan-docker/\${image_name} &
+          docker pull -q \${image_name} &
         fi
       done
-      docker pull -q apache.jfrog.io/cassan-docker/alpine:3.19.1 &
+      docker pull -q alpine:3.19.1 &
       wait
       # debug how much space the images have taken.  df reports the node's filesystem: an emptyDir has no
       # size of its own, so this sees node pressure coming, never the docker-storage sizeLimit

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -502,22 +502,24 @@ def buildJVMDTestJars(cell, script_vars, logfile) {
 }
 
 def fetchDockerImages(dockerfiles) {
-  // prefetch the build/test images so they are warm before the build needs them, and prefetch
-  // alpine:3.19.1 as the scripts use it as a utility.  Pull the Docker Hub names the build scripts
-  // actually consume (`docker pull apache/cassandra-<image>:<md5>` in .build/docker/run-tests.sh and
-  // _docker_run.sh); these route through the in-cluster Docker Hub pull-through cache configured on
-  // dind's --registry-mirror (.jenkins/k8s/docker-cache.yaml), so each image is fetched from Docker
-  // Hub once per cache rather than once per agent, sidestepping Docker Hub's pull-rate limits.
+  // prefetch the build|test image so they are warm before the build needs them, and the base alpine:3.19.1
+  // where dind advertises a registry mirror (see use of .jenkins/k8s/docker-cache.yaml), use it, otherwise use apache.jfrog.io
   def dockerfilesVar = dockerfiles.join(' ')
   sh label: "fetching docker images...", script: """#!/bin/bash
+      # empty prefix when a registry mirror is present (pulls route through it), else use apache.jfrog.io
+      registry_prefix=""
+      if ! docker info --format '{{.RegistryConfig.Mirrors}}' 2>/dev/null | grep -q '://' ; then
+        # xxx – a custom registry for behind firewalls can be also defined here
+        registry_prefix="apache.jfrog.io/cassan-docker/"
+      fi
       for dockerfile in ${dockerfilesVar} ; do
         image_tag="\$(md5sum .build/docker/\${dockerfile}.docker | cut -d' ' -f1)"
         image_name="apache/cassandra-\${dockerfile}:\${image_tag}"
         if ! ( [[ "" != "\$(docker images -q \${image_name} 2>/dev/null)" ]] ) ; then
-          docker pull -q \${image_name} &
+          docker pull -q \${registry_prefix}\${image_name} &
         fi
       done
-      docker pull -q alpine:3.19.1 &
+      docker pull -q \${registry_prefix}alpine:3.19.1 &
       wait
       # debug how much space the images have taken.  df reports the node's filesystem: an emptyDir has no
       # size of its own, so this sees node pressure coming, never the docker-storage sizeLimit

--- a/.jenkins/k8s/docker-cache.yaml
+++ b/.jenkins/k8s/docker-cache.yaml
@@ -50,7 +50,7 @@ spec:
   resources:
     requests:
       # holds several multi-arch build/test images; the largest (ubuntu-test) is ~35Gi.
-      # registry:2 proxy also purges cached content past REGISTRY_PROXY_TTL (default 168h).
+      # the registry proxy also evicts content untouched past REGISTRY_PROXY_TTL (336h below).
       storage: 200Gi
   # .build/run-ci injects storageClassName here from the Jenkins values' persistence.storageClass
   # (see install_jenkins), so a site declares its storage class once.  Applying this manifest by
@@ -81,7 +81,7 @@ spec:
         cassandra.jenkins.controller: "true"
       containers:
         - name: registry
-          image: registry:2
+          image: registry:3.1.1
           ports:
             - containerPort: 5000
           env:
@@ -107,6 +107,11 @@ spec:
               value: ":5000"
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: /var/lib/registry
+            # evict cached content untouched for the TTL, bounding the PVC over time
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+            - name: REGISTRY_PROXY_TTL
+              value: "336h"
           volumeMounts:
             - name: storage
               mountPath: /var/lib/registry
@@ -117,18 +122,24 @@ spec:
             limits:
               cpu: "2"
               memory: 4Gi
+          # generous timeout/failureThreshold: when many agents start at once the cache serves a
+          # burst of pulls and can be slow to answer the probe
           readinessProbe:
             httpGet:
               path: /v2/
               port: 5000
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /v2/
               port: 5000
             initialDelaySeconds: 15
             periodSeconds: 30
+            timeoutSeconds: 20
+            failureThreshold: 5
       volumes:
         - name: storage
           persistentVolumeClaim:

--- a/.jenkins/k8s/docker-cache.yaml
+++ b/.jenkins/k8s/docker-cache.yaml
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# In-cluster Docker Hub pull-through cache, applied by `.build/run-ci --only-setup`
+# (see install_jenkins) into the same namespace as the Jenkins release.
+#
+# Why: every agent runs its own docker-in-docker daemon on an emptyDir, so nothing
+# is shared between agents.  Each therefore pulls the same build/test images (the
+# ~35Gi cassandra-ubuntu-test among them) afresh.  At hundreds of concurrent agents
+# that is slow, wasteful, and trips Docker Hub's pull-rate limits.  This registry:2
+# proxy fetches each image from Docker Hub once, then serves it to every agent over
+# the cluster LAN.
+#
+# Why Docker Hub and not apache.jfrog.io: the build scripts consume the images by
+# their Docker Hub names -- `docker pull apache/cassandra-<image>:<md5>` in
+# .build/docker/run-tests.sh and _docker_run.sh, plus `alpine:3.19.1`.  Docker's
+# --registry-mirror (set on the agents' dind in jenkins-deployment.yaml) can only
+# mirror Docker Hub; a transparent pull-through cache for an arbitrary registry such
+# as apache.jfrog.io is not possible via --registry-mirror.  If the mirror is
+# unreachable dind falls back to Docker Hub directly, so agents keep working.
+#
+# Runs on the always-on controller node; the agent node pools autoscale to zero.
+#
+# Assumes agent pods launch in the Jenkins release's namespace (the kubernetes-plugin
+# default), so `docker-cache` resolves for them.  Validate the cache is serving with:
+#   kubectl -n <ns> exec deploy/docker-cache -- wget -qO- http://localhost:5000/v2/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: docker-cache
+  labels:
+    app: docker-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # holds several multi-arch build/test images; the largest (ubuntu-test) is ~35Gi.
+      # registry:2 proxy also purges cached content past REGISTRY_PROXY_TTL (default 168h).
+      storage: 200Gi
+  # .build/run-ci injects storageClassName here from the Jenkins values' persistence.storageClass
+  # (see install_jenkins), so a site declares its storage class once.  Applying this manifest by
+  # hand on a cluster with no default StorageClass needs it set, e.g. `storageClassName: gp2` on EKS.
+  #storageClassName: gp2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-cache
+  labels:
+    app: docker-cache
+spec:
+  replicas: 1
+  # a pull-through cache's local store is the whole point; never run two pods over one RWO PVC
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: docker-cache
+  template:
+    metadata:
+      labels:
+        app: docker-cache
+    spec:
+      # pin to the always-on controller node; agent pools autoscale to zero
+      nodeSelector:
+        cassandra.jenkins.controller: "true"
+      containers:
+        - name: registry
+          image: registry:2
+          ports:
+            - containerPort: 5000
+          env:
+            - name: REGISTRY_PROXY_REMOTEURL
+              value: "https://registry-1.docker.io"
+            # Optional Docker Hub credentials lift the anonymous pull-rate limit that
+            # the whole cluster would otherwise share through this one cache.  Create with:
+            #   kubectl -n <ns> create secret generic docker-cache-dockerhub \
+            #     --from-literal=username=<user> --from-literal=password=<access-token>
+            - name: REGISTRY_PROXY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: docker-cache-dockerhub
+                  key: username
+                  optional: true
+            - name: REGISTRY_PROXY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: docker-cache-dockerhub
+                  key: password
+                  optional: true
+            - name: REGISTRY_HTTP_ADDR
+              value: ":5000"
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: /var/lib/registry
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/registry
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: docker-cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-cache
+  labels:
+    app: docker-cache
+spec:
+  selector:
+    app: docker-cache
+  ports:
+    - port: 5000
+      targetPort: 5000

--- a/.jenkins/k8s/jenkins-deployment.yaml
+++ b/.jenkins/k8s/jenkins-deployment.yaml
@@ -209,8 +209,6 @@ agent:
               - envVar:
                   key: JENKINS_JAVA_OPTS
                   value: '-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.USE_BINARY_WRAPPER=true -Xlog:gc+heap+exit -XX:+HeapDumpOnOutOfMemoryError'
-            # there's a lot of docker pulls,
-            # TODO implement option for docker registry caches :: https://medium.com/@elementtech.dev/kubernetes-image-proxy-cache-from-minutes-to-milliseconds-fd14173e831f
             image: apache.jfrog.io/cassan-docker/apache/cassandra-jenkins-k8s
             livenessProbe:
               failureThreshold: '0'
@@ -238,7 +236,12 @@ agent:
                 key: "DOCKER_IPTABLES_LEGACY"
                 value: "1"
             image: docker:dind
-            args: "--default-address-pool base=192.168.96.0/20,size=24"  # overwrite docker subnet in case of overlapping
+            # default-address-pool: overwrite docker subnet in case of overlapping.
+            # registry-mirror: route Docker Hub pulls through the in-cluster pull-through cache
+            #   (.jenkins/k8s/docker-cache.yaml) so each image is fetched once, not once per agent;
+            #   dind falls back to Docker Hub directly if the cache is unreachable.
+            # insecure-registry: the cache is served over plain HTTP inside the cluster.
+            args: "--default-address-pool base=192.168.96.0/20,size=24 --registry-mirror=http://docker-cache:5000 --insecure-registry=docker-cache:5000"
             livenessProbe:
               failureThreshold: '0'
               initialDelaySeconds: '0'
@@ -344,7 +347,12 @@ agent:
                 key: "DOCKER_IPTABLES_LEGACY"
                 value: "1"
             image: docker:dind
-            args: "--default-address-pool base=192.168.96.0/20,size=24"  # overwrite docker subnet in case of overlapping
+            # default-address-pool: overwrite docker subnet in case of overlapping.
+            # registry-mirror: route Docker Hub pulls through the in-cluster pull-through cache
+            #   (.jenkins/k8s/docker-cache.yaml) so each image is fetched once, not once per agent;
+            #   dind falls back to Docker Hub directly if the cache is unreachable.
+            # insecure-registry: the cache is served over plain HTTP inside the cluster.
+            args: "--default-address-pool base=192.168.96.0/20,size=24 --registry-mirror=http://docker-cache:5000 --insecure-registry=docker-cache:5000"
             livenessProbe:
               failureThreshold: '0'
               initialDelaySeconds: '0'
@@ -450,7 +458,12 @@ agent:
                 key: "DOCKER_IPTABLES_LEGACY"
                 value: "1"
             image: docker:dind
-            args: "--default-address-pool base=192.168.96.0/20,size=24"  # overwrite docker subnet in case of overlapping
+            # default-address-pool: overwrite docker subnet in case of overlapping.
+            # registry-mirror: route Docker Hub pulls through the in-cluster pull-through cache
+            #   (.jenkins/k8s/docker-cache.yaml) so each image is fetched once, not once per agent;
+            #   dind falls back to Docker Hub directly if the cache is unreachable.
+            # insecure-registry: the cache is served over plain HTTP inside the cluster.
+            args: "--default-address-pool base=192.168.96.0/20,size=24 --registry-mirror=http://docker-cache:5000 --insecure-registry=docker-cache:5000"
             livenessProbe:
               failureThreshold: '0'
               initialDelaySeconds: '0'

--- a/.jenkins/k8s/jenkins-test.sh
+++ b/.jenkins/k8s/jenkins-test.sh
@@ -76,39 +76,44 @@ k8s_dir = Path(sys.argv[1])
 errors = 0
 
 for path in sorted(k8s_dir.glob("*.yaml")):
+    # plain k8s manifests (e.g. docker-cache.yaml) hold several `---`-separated documents;
+    # helm values files (jenkins-deployment.yaml) hold one.  safe_load_all handles both.
     try:
-        values = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        documents = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
     except yaml.YAMLError as error:
         print(f"  INVALID {path.name}: {error}")
         errors += 1
         continue
     print(f"  {path.name} parses")
 
-    # the values in these two maps are themselves yaml documents, and a chart never validates them —
-    # a misindented pod template reaches the kubernetes plugin and silently loses its agents
-    for keys in (("agent", "podTemplates"), ("controller", "JCasC", "configScripts")):
-        embedded = values
-        for key in keys:
-            embedded = embedded.get(key, {}) if isinstance(embedded, dict) else {}
-        for name, document in (embedded or {}).items():
-            location = f"{path.name} {'.'.join(keys)}.{name}"
-            try:
-                parsed = yaml.safe_load(document)
-            except yaml.YAMLError as error:
-                print(f"  INVALID {location}: {error}")
-                errors += 1
-                continue
-            print(f"  {location} parses")
-            # each pod template may carry a raw kubernetes pod spec in a nested `yaml` key
-            for template in parsed if isinstance(parsed, list) else []:
-                if isinstance(template, dict) and "yaml" in template:
-                    try:
-                        yaml.safe_load(template["yaml"])
-                    except yaml.YAMLError as error:
-                        print(f"  INVALID {location}.yaml: {error}")
-                        errors += 1
-                    else:
-                        print(f"  {location}.yaml parses")
+    for values in documents:
+        if not isinstance(values, dict):
+            continue
+        # the values in these two maps are themselves yaml documents, and a chart never validates them —
+        # a misindented pod template reaches the kubernetes plugin and silently loses its agents
+        for keys in (("agent", "podTemplates"), ("controller", "JCasC", "configScripts")):
+            embedded = values
+            for key in keys:
+                embedded = embedded.get(key, {}) if isinstance(embedded, dict) else {}
+            for name, document in (embedded or {}).items():
+                location = f"{path.name} {'.'.join(keys)}.{name}"
+                try:
+                    parsed = yaml.safe_load(document)
+                except yaml.YAMLError as error:
+                    print(f"  INVALID {location}: {error}")
+                    errors += 1
+                    continue
+                print(f"  {location} parses")
+                # each pod template may carry a raw kubernetes pod spec in a nested `yaml` key
+                for template in parsed if isinstance(parsed, list) else []:
+                    if isinstance(template, dict) and "yaml" in template:
+                        try:
+                            yaml.safe_load(template["yaml"])
+                        except yaml.YAMLError as error:
+                            print(f"  INVALID {location}.yaml: {error}")
+                            errors += 1
+                        else:
+                            print(f"  {location}.yaml parses")
 
 sys.exit(1 if errors else 0)
 EOF


### PR DESCRIPTION
  In a Helm deployed CI, each CI agent runs its own docker-in-docker daemon on an emptyDir, blank to begin with.  Every agent therefore pulls the same build and test images afresh; the largest, `cassandra-ubuntu-test`, is ~35Gi.  At hundreds of concurrent agents this is slow, wastes  bandwidth, and trips pull-rate limits.

  Add an in-cluster Docker Hub pull-through cache (a registry:2 proxy) and point the agents' `dind` at it via `--registry-mirror`.  Each image is then fetched from Docker Hub once and served to every agent over the cluster LAN; `dind` falls back to Docker Hub directly if the cache is unreachable.

  Docker's `--registry-mirror` can only mirror Docker Hub, not an arbitrary registry such as apache.jfrog.io.   So the prefetch in the Jenkinsfile is repointed from the  apache.jfrog.io names to those same Docker Hub names.

  Patch changes:
  - `.jenkins/k8s/docker-cache.yaml`: the pull-through cache (Deployment, Service, PVC), pinned to the always-on controller node.
  - `.jenkins/k8s/jenkins-deployment.yaml`: `dind` `--registry-mirror` in all three agent templates.
  - `.build/run-ci`: `--setup/--only-setup` applies the cache; teardown removes it.
  - `.jenkins/Jenkinsfile`: prefetch the Docker Hub image names.

  The cache runs a single replica for now.  It converts repeated WAN pulls into one origin fetch plus LAN reads; if the pod's egress becomes the bottleneck this can be scaled with replicas or an object-storage backend.
