### PR TITLE
CASSANDRA-21539: Remove hostname from ClientsTable and GossipInfoTable to avoid reverse-DNS lookups (6.0)

### DIFF
--- a/doc/modules/cassandra/pages/managing/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/virtualtables.adoc
@@ -175,7 +175,7 @@ We shall discuss some of the virtual tables in more detail next.
 
 The `clients` virtual table lists all active connections (connected
 clients) including their ip address, port, client_options, connection stage, driver
-name, driver version, hostname, protocol version, request count, ssl
+name, driver version, protocol version, request count, ssl
 enabled, ssl protocol and user name:
 
 [source, console]
@@ -190,7 +190,6 @@ cqlsh> SELECT * FROM system_views.clients;
  connection_stage | ready
  driver_name      | DataStax Python Driver
  driver_version   | 3.25.0
- hostname         | localhost
  protocol_version | 5
  request_count    | 16
  ssl_cipher_suite | null
@@ -206,7 +205,6 @@ cqlsh> SELECT * FROM system_views.clients;
  connection_stage | ready
  driver_name      | DataStax Python Driver
  driver_version   | 3.25.0
- hostname         | localhost
  protocol_version | 5
  request_count    | 4
  ssl_cipher_suite | null
@@ -222,7 +220,6 @@ cqlsh> SELECT * FROM system_views.clients;
  connection_stage | ready
  driver_name      | DataStax Java driver for Apache Cassandra(R)
  driver_version   | 4.13.0
- hostname         | localhost
  protocol_version | 5
  request_count    | 18
  ssl_cipher_suite | null
@@ -238,7 +235,6 @@ cqlsh> SELECT * FROM system_views.clients;
  connection_stage | ready
  driver_name      | DataStax Java driver for Apache Cassandra(R)
  driver_version   | 4.13.0
- hostname         | localhost
  protocol_version | 5
  request_count    | 7
  ssl_cipher_suite | null
@@ -275,7 +271,6 @@ VIRTUAL TABLE system_views.clients (
   connection_stage text,
   driver_name text,
   driver_version text,
-  hostname text,
   protocol_version int,
   request_count bigint,
   ssl_cipher_suite text,
@@ -673,10 +668,10 @@ results in:
 +
 [source, cql]
 ----
- address   | port  | connection_stage | driver_name            | driver_version | hostname  | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
------------+-------+------------------+------------------------+----------------+-----------|||+------------------+---------------+------------------+-------------+--------------+-----------
- 127.0.0.1 | 37308 |            ready | DataStax Python Driver |   3.21.0.post0 | localhost |                4 |            17 |             null |       False |         null | anonymous
- 127.0.0.1 | 37310 |            ready | DataStax Python Driver |   3.21.0.post0 | localhost |                4 |             8 |             null |       False |         null | anonymous
+ address   | port  | connection_stage | driver_name            | driver_version | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
+-----------+-------+------------------+------------------------+----------------+------------------+---------------+------------------+-------------+--------------+-----------
+ 127.0.0.1 | 37308 |            ready | DataStax Python Driver |   3.21.0.post0 |                4 |            17 |             null |       False |         null | anonymous
+ 127.0.0.1 | 37310 |            ready | DataStax Python Driver |   3.21.0.post0 |                4 |             8 |             null |       False |         null | anonymous
 
 (2 rows)
 ----

--- a/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
@@ -38,7 +38,6 @@ final class ClientsTable extends AbstractVirtualTable
 {
     private static final String ADDRESS = "address";
     private static final String PORT = "port";
-    private static final String HOSTNAME = "hostname";
     private static final String USERNAME = "username";
     private static final String CONNECTION_STAGE = "connection_stage";
     private static final String PROTOCOL_VERSION = "protocol_version";
@@ -61,7 +60,6 @@ final class ClientsTable extends AbstractVirtualTable
                            .partitioner(new LocalPartitioner(InetAddressType.instance))
                            .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
                            .addClusteringColumn(PORT, Int32Type.instance)
-                           .addRegularColumn(HOSTNAME, UTF8Type.instance)
                            .addRegularColumn(USERNAME, UTF8Type.instance)
                            .addRegularColumn(CONNECTION_STAGE, UTF8Type.instance)
                            .addRegularColumn(PROTOCOL_VERSION, Int32Type.instance)
@@ -88,7 +86,6 @@ final class ClientsTable extends AbstractVirtualTable
             InetSocketAddress remoteAddress = client.remoteAddress();
 
             result.row(remoteAddress.getAddress(), remoteAddress.getPort())
-                  .column(HOSTNAME, remoteAddress.getHostName())
                   .column(USERNAME, client.username().orElse(null))
                   .column(CONNECTION_STAGE, toLowerCaseLocalized(client.stage().toString()))
                   .column(PROTOCOL_VERSION, client.protocolVersion())

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -48,7 +48,6 @@ final class GossipInfoTable extends AbstractVirtualTable
 
     static final String ADDRESS = "address";
     static final String PORT = "port";
-    static final String HOSTNAME = "hostname";
     static final String GENERATION = "generation";
     static final String HEARTBEAT = "heartbeat";
 
@@ -98,7 +97,6 @@ final class GossipInfoTable extends AbstractVirtualTable
             EndpointState localState = new EndpointState(entry.getValue());
 
             SimpleDataSet dataSet = result.row(endpoint.getAddress(), endpoint.getPort())
-                                          .column(HOSTNAME, endpoint.getHostName())
                                           .column(GENERATION, getGeneration(localState))
                                           .column(HEARTBEAT, getHeartBeat(localState));
 
@@ -175,7 +173,6 @@ final class GossipInfoTable extends AbstractVirtualTable
                                                      .partitioner(new LocalPartitioner(InetAddressType.instance))
                                                      .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
                                                      .addClusteringColumn(PORT, Int32Type.instance)
-                                                     .addRegularColumn(HOSTNAME, UTF8Type.instance)
                                                      .addRegularColumn(GENERATION, Int32Type.instance)
                                                      .addRegularColumn(HEARTBEAT, Int32Type.instance);
 

--- a/test/unit/org/apache/cassandra/db/virtual/ClientsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/ClientsTableTest.java
@@ -70,6 +70,7 @@ public class ClientsTableTest extends CQLTester
         shouldUseEncryption(true);
         shouldUseClientCertificate(true);
         ResultSet result = executeNet("SELECT * FROM vts.clients");
+        assertThat(result.getColumnDefinitions().size()).isEqualTo(15);
         for (Row r : result)
         {
             Assert.assertEquals(InetAddress.getLoopbackAddress(), r.getInet("address"));
@@ -78,7 +79,6 @@ public class ClientsTableTest extends CQLTester
             Assert.assertNotNull(r.getMap("client_options", String.class, String.class));
             Assert.assertTrue(r.getLong("request_count") > 0 );
             // the following are questionable if they belong here
-            Assert.assertEquals("localhost", r.getString("hostname"));
             Assertions.assertThat(r.getMap("client_options", String.class, String.class))
                       .hasEntrySatisfying("DRIVER_VERSION", value -> assertThat(value.contains(r.getString("driver_name"))))
                       .hasEntrySatisfying("DRIVER_VERSION", value -> assertThat(value.contains(r.getString("driver_version"))));

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -70,13 +70,12 @@ public class GossipInfoTableTest extends CQLTester
 
             assertThat(resultSet.size()).isEqualTo(1);
             UntypedResultSet.Row row = resultSet.one();
-            assertThat(row.getColumns().size()).isEqualTo(66);
+            assertThat(row.getColumns().size()).isEqualTo(65);
 
             assertThat(endpoint).isNotNull();
             assertThat(localState).isNotNull();
             assertThat(row.getInetAddress("address")).isEqualTo(endpoint.getAddress());
             assertThat(row.getInt("port")).isEqualTo(endpoint.getPort());
-            assertThat(row.getString("hostname")).isEqualTo(endpoint.getHostName());
             assertThat(row.getInt("generation")).isEqualTo(localState.getHeartBeatState().getGeneration());
             assertThat(row.getInt("heartbeat")).isNotNull();
 


### PR DESCRIPTION
The current code uses getHostName(), which has the known effect: This method may trigger a name service reverse lookup if the address was created with a literal IP address. This field in both ClientsTable and GossipInfoTable was constructed with addresses to begin with, not names, so getHostName() was always doing a blocking reverse-DNS lookup on row reads for the first call.

This is a potentially slow blocking call, and we want to avoid doing any DNS lookups here because repeatedly querying this table could potentially overwhelm DNS, especially with frequently-changing client connections.

We could instead use getHostName, but the primary key of both ClientsTable and GossipInfoTable is (address, port), where address is type inet. Thus, this field is redundant.

To the best of my searching, no in-repo consumer depends on this column having a resolved name (and instead use an address-only path), and nodetool clientstats already doesn't display the hostname column.

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21539)