### PR TITLE
CASSANDRA-21539: Remove hostname from ClientsTable and GossipInfoTable to avoid reverse-DNS lookups (4.0)

### DIFF
--- a/doc/modules/cassandra/pages/new/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/new/virtualtables.adoc
@@ -107,15 +107,15 @@ We shall discuss some of the virtual tables in more detail next.
 
 The `clients` virtual table lists all active connections (connected
 clients) including their ip address, port, connection stage, driver
-name, driver version, hostname, protocol version, request count, ssl
+name, driver version, protocol version, request count, ssl
 enabled, ssl protocol and user name:
 
 ....
 cqlsh:system_views> select * from system_views.clients;
- address   | port  | connection_stage | driver_name | driver_version | hostname  | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
------------+-------+------------------+-------------+----------------+-----------+------------------+---------------+------------------+-------------+--------------+-----------
- 127.0.0.1 | 50628 |            ready |        null |           null | localhost |                4 |            55 |             null |       False |         null | anonymous
- 127.0.0.1 | 50630 |            ready |        null |           null | localhost |                4 |            70 |             null |       False |         null | anonymous
+ address   | port  | connection_stage | driver_name | driver_version | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
+-----------+-------+------------------+-------------+----------------+------------------+---------------+------------------+-------------+--------------+-----------
+ 127.0.0.1 | 50628 |            ready |        null |           null |                4 |            55 |             null |       False |         null | anonymous
+ 127.0.0.1 | 50630 |            ready |        null |           null |                4 |            70 |             null |       False |         null | anonymous
 
 (2 rows)
 ....
@@ -139,7 +139,6 @@ CREATE TABLE system_views.clients (
   connection_stage text,
   driver_name text,
   driver_version text,
-  hostname text,
   port int,
   protocol_version int,
   request_count bigint,
@@ -401,10 +400,10 @@ cqlsh> SELECT * FROM clients LIMIT 2;
 
 [source, cql]
 ----
- address   | port  | connection_stage | driver_name            | driver_version | hostname  | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
------------+-------+------------------+------------------------+----------------+-----------+------------------+---------------+------------------+-------------+--------------+-----------
- 127.0.0.1 | 37308 |            ready | DataStax Python Driver |   3.21.0.post0 | localhost |                4 |            17 |             null |       False |         null | anonymous
- 127.0.0.1 | 37310 |            ready | DataStax Python Driver |   3.21.0.post0 | localhost |                4 |             8 |             null |       False |         null | anonymous
+ address   | port  | connection_stage | driver_name            | driver_version | protocol_version | request_count | ssl_cipher_suite | ssl_enabled | ssl_protocol | username
+-----------+-------+------------------+------------------------+----------------+------------------+---------------+------------------+-------------+--------------+-----------
+ 127.0.0.1 | 37308 |            ready | DataStax Python Driver |   3.21.0.post0 |                4 |            17 |             null |       False |         null | anonymous
+ 127.0.0.1 | 37310 |            ready | DataStax Python Driver |   3.21.0.post0 |                4 |             8 |             null |       False |         null | anonymous
 
 (2 rows)
 ----

--- a/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
@@ -29,7 +29,6 @@ final class ClientsTable extends AbstractVirtualTable
 {
     private static final String ADDRESS = "address";
     private static final String PORT = "port";
-    private static final String HOSTNAME = "hostname";
     private static final String USERNAME = "username";
     private static final String CONNECTION_STAGE = "connection_stage";
     private static final String PROTOCOL_VERSION = "protocol_version";
@@ -48,7 +47,6 @@ final class ClientsTable extends AbstractVirtualTable
                            .partitioner(new LocalPartitioner(InetAddressType.instance))
                            .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
                            .addClusteringColumn(PORT, Int32Type.instance)
-                           .addRegularColumn(HOSTNAME, UTF8Type.instance)
                            .addRegularColumn(USERNAME, UTF8Type.instance)
                            .addRegularColumn(CONNECTION_STAGE, UTF8Type.instance)
                            .addRegularColumn(PROTOCOL_VERSION, Int32Type.instance)
@@ -71,7 +69,6 @@ final class ClientsTable extends AbstractVirtualTable
             InetSocketAddress remoteAddress = client.remoteAddress();
 
             result.row(remoteAddress.getAddress(), remoteAddress.getPort())
-                  .column(HOSTNAME, remoteAddress.getHostName())
                   .column(USERNAME, client.username().orElse(null))
                   .column(CONNECTION_STAGE, client.stage().toString().toLowerCase())
                   .column(PROTOCOL_VERSION, client.protocolVersion())


### PR DESCRIPTION
The current code uses getHostName(), which has the known effect: This method may trigger a name service reverse lookup if the address was created with a literal IP address. This field in both ClientsTable and GossipInfoTable was constructed with addresses to begin with, not names, so getHostName() was always doing a blocking reverse-DNS lookup on row reads for the first call.

This is a potentially slow blocking call, and we want to avoid doing any DNS lookups here because repeatedly querying this table could potentially overwhelm DNS, especially with frequently-changing client connections.

We could instead use getHostName, but the primary key of both ClientsTable and GossipInfoTable is (address, port), where address is type inet. Thus, this field is redundant.

To the best of my searching, no in-repo consumer depends on this column having a resolved name (and instead use an address-only path), and nodetool clientstats already doesn't display the hostname column.

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21539)