### PR TITLE
CASSANDRA-21548: cqlsh prompt does not reset to default after dropping the current keyspace

### DIFF
--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -911,11 +911,25 @@ class Shell(cmd.Cmd):
         result = None
         try:
             result = future.result()
-            qs = getattr(statement, 'query_string', str(statement)).strip().lower()
-            if qs.startswith('drop keyspace'):
-                dropped_ks = qs.replace(';', '').split()[-1].strip('"\'')
-                if self.current_keyspace and self.current_keyspace.lower() == dropped_ks:
-                    self.current_keyspace = None
+            # If we just dropped the keyspace we are currently in, clear current_keyspace so the
+            # prompt falls back to the default 'cqlsh>' (CASSANDRA-21548). Only DROP statements are
+            # candidates, so cheaply skip parsing everything else. For a candidate we parse with the
+            # cqlsh grammar (handles whitespace, IF EXISTS and quoting), require it to actually be
+            # DROP KEYSPACE (DROP TABLE also binds ksname), and normalise the dropped name via
+            # cql_unprotect_name so it matches how do_use stores current_keyspace (quoted identifiers
+            # stay case-sensitive, unquoted ones fold to lower case).
+            qs = getattr(statement, 'query_string', str(statement))
+            if qs.lstrip().lower().startswith('drop'):
+                try:
+                    parsed = ruleset.cql_parse(qs)[1]
+                except IndexError:
+                    parsed = None
+                if (parsed is not None and len(parsed.matched) >= 2
+                        and parsed.matched[0][1].upper() == 'DROP'
+                        and parsed.matched[1][1].upper() == 'KEYSPACE'):
+                    dropped_ks = self.cql_unprotect_name(parsed.get_binding('ksname', None))
+                    if self.current_keyspace is not None and self.current_keyspace == dropped_ks:
+                        self.current_keyspace = None
         except CQL_ERRORS as err:
             err_msg = err.message if hasattr(err, 'message') else str(err)
             self.printerr(str(err.__class__.__name__) + ": " + err_msg)

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -911,6 +911,11 @@ class Shell(cmd.Cmd):
         result = None
         try:
             result = future.result()
+            qs = getattr(statement, 'query_string', str(statement)).strip().lower()
+            if qs.startswith('drop keyspace'):
+                dropped_ks = qs.replace(';', '').split()[-1].strip('"\'')
+                if self.current_keyspace and self.current_keyspace.lower() == dropped_ks:
+                    self.current_keyspace = None
         except CQL_ERRORS as err:
             err_msg = err.message if hasattr(err, 'message') else str(err)
             self.printerr(str(err.__class__.__name__) + ": " + err_msg)

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -645,6 +645,38 @@ class TestCqlshOutput(BaseTestCase):
                     if do_drop:
                         curs.execute('drop keyspace {}'.format(new_ks_name))
 
+    def test_drop_keyspace_prompt_behavior(self):
+        with cqlsh_testrun() as c:
+            c.send("CREATE KEYSPACE test_normal WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+            c.send("CREATE KEYSPACE test_other WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+            c.send("CREATE KEYSPACE \"Test_Quoted\" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+
+            c.send("USE test_normal;\n")
+            c.read_to_next_prompt()
+
+            c.send("DROP KEYSPACE test_other;\n")
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_other = c.read_to_next_prompt()
+            self.assertIn('test_normal', out_other.lower())
+
+            c.send("DROP KEYSPACE test_normal;\n")
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_normal = c.read_to_next_prompt()
+            self.assertNotIn('test_normal', out_normal.lower())
+
+            c.send("USE \"Test_Quoted\";\n")
+            c.read_to_next_prompt()
+            c.send("DROP KEYSPACE IF EXISTS \"Test_Quoted\";\n")
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_quoted = c.read_to_next_prompt()
+            self.assertNotIn('test_quoted', out_quoted.lower())
+
     def check_describe_keyspace_output(self, output, qksname):
         expected_bits = [r'(?im)^CREATE KEYSPACE %s WITH\b' % re.escape(qksname),
                          r';\s*$',

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -677,6 +677,40 @@ class TestCqlshOutput(BaseTestCase):
             out_quoted = c.read_to_next_prompt()
             self.assertNotIn('test_quoted', out_quoted.lower())
 
+            # Arbitrary whitespace between DROP and KEYSPACE (and around the name) must still reset
+            # the prompt (CASSANDRA-21548: the original startswith('drop keyspace') missed these).
+            c.send("CREATE KEYSPACE test_spaces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+            c.send("USE test_spaces;\n")
+            c.read_to_next_prompt()
+            c.send("DROP   KEYSPACE   test_spaces ;\n")
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_spaces = c.read_to_next_prompt()
+            self.assertNotIn('test_spaces', out_spaces.lower())
+
+            # Case-sensitivity: quoted "ABC" and unquoted abc are DIFFERENT keyspaces. While in "ABC",
+            # dropping the other (lower-case) keyspace must NOT reset the prompt (CASSANDRA-21548: the
+            # original case-insensitive comparison reset it by mistake); dropping "ABC" itself must.
+            c.send("CREATE KEYSPACE \"ABC\" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+            c.send("CREATE KEYSPACE abc WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\n")
+            c.read_to_next_prompt()
+            c.send("USE \"ABC\";\n")
+            c.read_to_next_prompt()
+
+            c.send("DROP KEYSPACE abc;\n")          # drops the other, lower-case keyspace, not "ABC"
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_false_positive = c.read_to_next_prompt()
+            self.assertIn(':ABC>', out_false_positive)   # still in "ABC" -> prompt must be unchanged
+
+            c.send("DROP KEYSPACE \"ABC\";\n")       # now drop the actual current keyspace
+            c.read_to_next_prompt()
+            c.send("\n")
+            out_abc = c.read_to_next_prompt()
+            self.assertNotIn(':ABC>', out_abc)      # current keyspace dropped -> prompt reset to default
+
     def check_describe_keyspace_output(self, output, qksname):
         expected_bits = [r'(?im)^CREATE KEYSPACE %s WITH\b' % re.escape(qksname),
                          r';\s*$',


### PR DESCRIPTION
### Summary
This PR fixes an issue where the `cqlsh` shell prompt remains stuck displaying a keyspace name even after that keyspace has been successfully dropped.

### Problem
When a user is currently inside a keyspace in `cqlsh` (e.g., `cqlsh:test_ks>`) and executes `DROP KEYSPACE test_ks;`, the server deletes the keyspace, but the client-side `cqlsh` prompt does not reset to the default `cqlsh>` prompt. Executing subsequent queries inside the dropped keyspace context throws a `Keyspace does not exist` error.

### Solution
- Updated `perform_simple_statement` in `pylib/cqlshlib/cqlshmain.py` to check if an executed statement is a `DROP KEYSPACE` statement.
- If the dropped keyspace matches `self.current_keyspace`, `self.current_keyspace` is reset to `None`, which automatically updates the shell prompt back to `cqlsh>`.
- Included safe string manipulation and `.lower()` normalization to handle edge cases like quoted keyspace names (`"Test_KS"`) and `IF EXISTS` clauses.

### Testing
- Added automated unit tests in `pylib/cqlshlib/test/test_cqlsh_output.py` covering:
  1. Standard keyspace drop resetting the prompt.
  2. Dropping a non-active keyspace without altering the current prompt.
  3. Case-sensitive quoted keyspace names and `DROP KEYSPACE IF EXISTS` syntax.
- Verified test execution using pytest (`python3 -m pytest pylib/cqlshlib/test/test_cqlsh_output.py -k "test_drop_keyspace_prompt_behavior"`).

---

patch by Arvind Kandpal; reviewed by TBA for CASSANDRA-21548