### PR TITLE
CASSANDRA-21549: Fix deserialization of column masks in cluster metadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha2
+ * Fix deserialization of column masks in cluster metadata (CASSANDRA-21549)
  * Apply performance optimizations for rows merging logic (CASSANDRA-21524)
  * Fix operationMode reporting DECOMMISSION_FAILED instead of LEAVING when resuming a failed decommission (CASSANDRA-21493)
  * Avoid megamorphic calls when serializing and deserializing fixed-length values (CASSANDRA-21536)

--- a/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
+++ b/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
@@ -315,14 +315,13 @@ public class ColumnMask
 
             int numArgs = in.readUnsignedVInt32();
             List<AbstractType<?>> argTypes = new ArrayList<>(numArgs + 1);
-            argTypes.set(0, columnType);
+            argTypes.add(columnType);
             ByteBuffer[] partialArgValues = new ByteBuffer[numArgs];
             for (int i = 0; i < numArgs; i++)
             {
-                AbstractType<?> argType = CQLTypeParser.parse(keyspace, in.readUTF(), types);
-                argTypes.set(i + 1,  argType);
+                argTypes.add(CQLTypeParser.parse(keyspace, in.readUTF(), types));
                 boolean valuePresent = in.readBoolean();
-                partialArgValues[i] = valuePresent ? null : ByteBufferUtil.readWithVIntLength(in);
+                partialArgValues[i] = valuePresent ? ByteBufferUtil.readWithVIntLength(in) : null;
             }
 
             Function function = FunctionResolver.get(keyspace, functionName, argTypes, null, null, null, functions);

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskMetadataSnapshotTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskMetadataSnapshotTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.IIsolatedExecutor.SerializableCallable;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.ClusterMetadataService;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that columns with an attached dynamic data mask survive a cluster metadata snapshot.
+ * <p>
+ * Ordinary schema changes are propagated as transformations that every node replays locally, so they never exercise
+ * {@link ColumnMask.Serializer}. The serializer is only reached once the schema is embedded in a serialized
+ * {@link ClusterMetadata}, which happens for cluster metadata snapshots. Those snapshots are read back when a node
+ * replays its persisted log at startup, and when a lagging peer catches up from the CMS.
+ */
+public class ColumnMaskMetadataSnapshotTest extends TestBaseImpl
+{
+    private static final String TABLE = "masked";
+
+    private static final String CREATE_TABLE =
+    "CREATE TABLE %s." + TABLE + " (" +
+    "k int PRIMARY KEY, " +
+    "no_args text MASKED WITH DEFAULT, " +           // masking function without partial arguments
+    "with_args text MASKED WITH mask_inner(2, 1), " + // masking function with partial arguments
+    "with_null text MASKED WITH mask_inner(null, 1))"; // masking function with a null partial argument
+
+    /**
+     * Tests that the masks of a table can be read back from a cluster metadata snapshot.
+     */
+    @Test
+    public void testMasksSurviveMetadataSnapshot() throws IOException
+    {
+        try (Cluster cluster = init(build(1)))
+        {
+            cluster.schemaChange(withKeyspace(CREATE_TABLE));
+
+            IInvokableInstance node = cluster.get(1);
+            node.nodetoolResult("cms", "snapshot").asserts().success();
+
+            assertTrue("the masks in the cluster metadata snapshot should match the in-memory schema",
+                       node.callOnInstance(snapshotMasksMatchCurrent(KEYSPACE)));
+        }
+    }
+
+    /**
+     * Tests that a node with masked columns can restart once its cluster metadata has been snapshotted, since startup
+     * replays the persisted log on top of the latest snapshot.
+     */
+    @Test
+    public void testRestartAfterMetadataSnapshot() throws Throwable
+    {
+        try (Cluster cluster = init(build(1)))
+        {
+            cluster.schemaChange(withKeyspace(CREATE_TABLE));
+
+            IInvokableInstance node = cluster.get(1);
+            node.nodetoolResult("cms", "snapshot").asserts().success();
+
+            node.shutdown().get();
+            node.startup();
+
+            // the masks should still be attached to the columns rebuilt from the snapshot
+            assertTrue("the masked columns should still carry their masks after a restart",
+                       node.callOnInstance(currentColumnsAreMasked(KEYSPACE)));
+        }
+    }
+
+    private static Cluster build(int nodeCount) throws IOException
+    {
+        return Cluster.build()
+                      .withNodes(nodeCount)
+                      .withConfig(conf -> conf.set("dynamic_data_masking_enabled", "true"))
+                      .start();
+    }
+
+    /**
+     * @return a task comparing the masks stored in the latest cluster metadata snapshot to the in-memory ones,
+     * returning {@code true} if every masked column has an identical mask in the snapshot
+     */
+    private static SerializableCallable<Boolean> snapshotMasksMatchCurrent(String keyspace)
+    {
+        String table = TABLE; // capture as a local, so the lambda doesn't read a static across the classloader boundary
+        return () -> {
+            ClusterMetadata snapshot = ClusterMetadataService.instance().snapshotManager().getLatestSnapshot();
+            if (snapshot == null)
+                return false;
+
+            TableMetadata fromSnapshot = snapshot.schema.getKeyspaceMetadata(keyspace).tables.getNullable(table);
+            TableMetadata current = ClusterMetadata.current().schema.getKeyspaceMetadata(keyspace).tables.getNullable(table);
+            if (fromSnapshot == null || current == null)
+                return false;
+
+            for (ColumnMetadata expected : current.columns())
+            {
+                ColumnMask expectedMask = expected.getMask();
+                if (expectedMask == null)
+                    continue;
+
+                ColumnMetadata actual = fromSnapshot.getColumn(expected.name.bytes);
+                if (actual == null || !expectedMask.equals(actual.getMask()))
+                    return false;
+            }
+            return true;
+        };
+    }
+
+    /**
+     * @return a task returning {@code true} if the in-memory schema still has a mask attached to every masked column
+     */
+    private static SerializableCallable<Boolean> currentColumnsAreMasked(String keyspace)
+    {
+        String tableName = TABLE; // capture as a local, see snapshotMasksMatchCurrent
+        return () -> {
+            TableMetadata table = ClusterMetadata.current().schema.getKeyspaceMetadata(keyspace).tables.getNullable(tableName);
+            if (table == null)
+                return false;
+
+            for (String column : new String[]{ "no_args", "with_args", "with_null" })
+            {
+                ColumnMetadata metadata = table.getColumn(ByteBufferUtil.bytes(column));
+                if (metadata == null || metadata.getMask() == null)
+                    return false;
+            }
+            return true;
+        };
+    }
+}

--- a/test/unit/org/apache/cassandra/schema/SchemaMetadataSerializationTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaMetadataSerializationTest.java
@@ -18,8 +18,11 @@
 package org.apache.cassandra.schema;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -27,6 +30,12 @@ import org.junit.Test;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.FieldIdentifier;
+import org.apache.cassandra.cql3.functions.Function;
+import org.apache.cassandra.cql3.functions.FunctionName;
+import org.apache.cassandra.cql3.functions.FunctionResolver;
+import org.apache.cassandra.cql3.functions.ScalarFunction;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.UserType;
@@ -94,6 +103,58 @@ public class SchemaMetadataSerializationTest
         assertNotNull("Email column should exist", emailColumn);
         assertEquals("User email", emailColumn.comment);
         assertEquals("PII-EMAIL", emailColumn.securityLabel);
+    }
+
+    /**
+     * Round-trips a column masked with a function that takes no partial arguments, e.g. {@code MASKED WITH DEFAULT}.
+     */
+    @Test
+    public void testMaskedColumnMetadataSerializationWithoutPartialArguments() throws IOException
+    {
+        ColumnMask mask = mask("mask_default", UTF8Type.instance);
+        ColumnMetadata original = maskedColumn(mask);
+
+        ColumnMetadata deserialized = serializeAndDeserializeColumn(original);
+
+        assertEquals("Mask should survive serialization", mask, deserialized.getMask());
+    }
+
+    /**
+     * Round-trips a column masked with a function that takes partial arguments, e.g.
+     * {@code MASKED WITH mask_inner(2, 1)}. Both the arguments and the fields serialized after the mask need to
+     * survive, since losing the arguments would also leave the input stream misaligned.
+     */
+    @Test
+    public void testMaskedColumnMetadataSerializationWithPartialArguments() throws IOException
+    {
+        ColumnMask mask = mask("mask_inner",
+                               UTF8Type.instance, Int32Type.instance, Int32Type.instance,
+                               Int32Type.instance.decompose(2), Int32Type.instance.decompose(1));
+        ColumnMetadata original = maskedColumn(mask);
+
+        ColumnMetadata deserialized = serializeAndDeserializeColumn(original);
+
+        assertEquals("Mask should survive serialization", mask, deserialized.getMask());
+        assertEquals("Masked column comment should survive serialization", "User email", deserialized.comment);
+        assertEquals("Masked column security label should survive serialization", "PII-EMAIL", deserialized.securityLabel);
+    }
+
+    /**
+     * Round-trips a column masked with a function that takes a null partial argument, e.g.
+     * {@code MASKED WITH mask_inner(null, 1)}.
+     */
+    @Test
+    public void testMaskedColumnMetadataSerializationWithNullPartialArgument() throws IOException
+    {
+        ColumnMask mask = mask("mask_inner",
+                               UTF8Type.instance, Int32Type.instance, Int32Type.instance,
+                               null, Int32Type.instance.decompose(1));
+        ColumnMetadata original = maskedColumn(mask);
+
+        ColumnMetadata deserialized = serializeAndDeserializeColumn(original);
+
+        assertEquals("Mask should survive serialization", mask, deserialized.getMask());
+        assertEquals("Masked column comment should survive serialization", "User email", deserialized.comment);
     }
 
     @Test
@@ -241,6 +302,50 @@ public class SchemaMetadataSerializationTest
                             .build();
     }
 
+    /**
+     * @param functionName the name of a native masking function
+     * @param argTypes the types of the arguments of the function, including the type of the masked column
+     * @param partialArgumentValues the values of the arguments of the function, excluding the masked column
+     */
+    private static ColumnMask mask(String functionName, List<AbstractType<?>> argTypes, ByteBuffer... partialArgumentValues)
+    {
+        Function function = FunctionResolver.get(KEYSPACE,
+                                                 FunctionName.nativeFunction(functionName),
+                                                 argTypes,
+                                                 KEYSPACE,
+                                                 "users",
+                                                 argTypes.get(0),
+                                                 UserFunctions.none());
+        assertNotNull("Masking function should be resolvable", function);
+        return new ColumnMask((ScalarFunction) function, partialArgumentValues);
+    }
+
+    private static ColumnMask mask(String functionName, AbstractType<?> columnType)
+    {
+        return mask(functionName, Collections.singletonList(columnType));
+    }
+
+    private static ColumnMask mask(String functionName,
+                                   AbstractType<?> columnType,
+                                   AbstractType<?> firstArgType,
+                                   AbstractType<?> secondArgType,
+                                   ByteBuffer firstArgValue,
+                                   ByteBuffer secondArgValue)
+    {
+        return mask(functionName,
+                    Arrays.asList(columnType, firstArgType, secondArgType),
+                    firstArgValue,
+                    secondArgValue);
+    }
+
+    private static ColumnMetadata maskedColumn(ColumnMask mask)
+    {
+        return ColumnMetadata.regularColumn(KEYSPACE, "users", "email", UTF8Type.instance, ColumnMetadata.NO_UNIQUE_ID)
+                             .withNewMask(mask)
+                             .withNewComment("User email")
+                             .withNewSecurityLabel("PII-EMAIL");
+    }
+
     private UserType createUserType(String name, String comment, String securityLabel)
     {
         FieldIdentifier field = FieldIdentifier.forUnquoted("field1");
@@ -262,6 +367,15 @@ public class SchemaMetadataSerializationTest
 
         DataInputBuffer in = new DataInputBuffer(out.toByteArray());
         return KeyspaceMetadata.serializer.deserialize(in, Version.V8);
+    }
+
+    private ColumnMetadata serializeAndDeserializeColumn(ColumnMetadata original) throws IOException
+    {
+        DataOutputBuffer out = new DataOutputBuffer();
+        ColumnMetadata.serializer.serialize(original, out, Version.V8);
+
+        DataInputBuffer in = new DataInputBuffer(out.toByteArray());
+        return ColumnMetadata.serializer.deserialize(in, Types.none(), UserFunctions.none(), Version.V8);
     }
 
     private TableMetadata serializeAndDeserializeTable(TableMetadata original) throws IOException


### PR DESCRIPTION
[CASSANDRA-21549](https://issues.apache.org/jira/browse/CASSANDRA-21549)

### Problem

`ColumnMask.Serializer.deserialize` has two independent defects:

1. `new ArrayList<>(numArgs + 1)` sets the *capacity*, not the size, so the list is empty and
   `argTypes.set(0, columnType)` throws `IndexOutOfBoundsException`. This fires for every masked
   column, including `MASKED WITH DEFAULT`.
2. The ternary reading each partial argument value is inverted
   (`valuePresent ? null : read(..)`). Besides losing the value, this desynchronises the input
   stream and corrupts every field deserialized afterwards.

### Impact

`ColumnMask.serializer` is reached through
`ColumnMetadata → TableMetadata → Tables → KeyspaceMetadata → DistributedSchema → ClusterMetadata`.
Ordinary DDL never hits it, because schema changes propagate as transformations that each node
replays locally. It is reached once the schema is embedded in a serialized `ClusterMetadata`, i.e.
for cluster metadata snapshots, which are read back on startup and when a lagging peer catches up
from the CMS.

Restarting a node that has a masked column and a stored snapshot fails during startup:

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/java.util.ArrayList.set(ArrayList.java:470)
	at org.apache.cassandra.cql3.functions.masking.ColumnMask$Serializer.deserialize(ColumnMask.java:318)
	at org.apache.cassandra.schema.ColumnMetadata$Serializer.deserialize(ColumnMetadata.java:819)
	...
	at org.apache.cassandra.tcm.MetadataSnapshots$SystemKeyspaceMetadataSnapshots.getLatestSnapshot(MetadataSnapshots.java:131)
	at org.apache.cassandra.tcm.log.SystemKeyspaceStorage.getPersistedLogState(SystemKeyspaceStorage.java:133)
	at org.apache.cassandra.tcm.log.LocalLog.replayPersisted(LocalLog.java:584)
	at org.apache.cassandra.tcm.Startup.initializeAsNonCmsNode(Startup.java:185)
	at org.apache.cassandra.tcm.Startup.initialize(Startup.java:120)
```

Note that `MetadataSnapshots.getSnapshot` only catches `IOException`, so this unchecked exception
propagates rather than degrading to a null snapshot.

### Reproduction

```
CREATE TABLE ks.t (k int PRIMARY KEY, v text MASKED WITH mask_inner(2, 1));
nodetool cms snapshot
# restart the node -> startup fails with the stack above
```

### Tests

Existing DDM tests miss this because none of them force a metadata snapshot.

- `SchemaMetadataSerializationTest` — three round-trip cases: a masking function with no partial
  arguments, with partial arguments, and with a null partial argument.
- `ColumnMaskMetadataSnapshotTest` (new dtest) — snapshot read-back, and node restart after a
  snapshot.

Verified on `cassandra-6.0`, unpatched vs patched:

| Suite | Patched | Unpatched |
|---|---|---|
| `SchemaMetadataSerializationTest` | 11/11 pass | 3 errors |
| `ColumnMaskMetadataSnapshotTest` | 2/2 pass | 2 errors |
| `ColumnMaskTest` (unit) | 17/17 pass | — |
| `ColumnMaskTest` (distributed) | 2/2 pass | — |
| `ClusterMetadataSerializerTest` | 2/2 pass | — |

Isolating defect 1 alone makes the same tests fail with
`EOFException: EOF after 43 bytes out of 1024`, confirming defect 2 independently.

`ant jar`, `ant checkstyle` and `ant checkstyle-test` are clean.

### Branch

Based on `cassandra-6.0`. Not applicable to `cassandra-5.0`, which has no `ColumnMask.Serializer` —
dynamic data masking shipped in 5.0, but the schema is only serialized into cluster metadata from
6.0 onwards. Needs merging forward to `trunk`.

---

Prepared with AI assistance (Claude Opus 5); the commit carries an `Assisted-by:` trailer.
