### PR TITLE
When decommission is attempted again, clear any existing transferred_ranges to force re-streaming and avoid consistency violation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@
  * Allow nodetool garbagecollect to take a user defined list of SSTables (CASSANDRA-16767)
  * Add a guardrail for misprepared statements (CASSANDRA-21139)
 Merged from 6.0:
+ * Ensure transferred_ranges reset on decommision re-attempt when pending ranges cannot be proven continous (CASSANDRA-16290)
  * Add blob type support to SAI (CASSANDRA-20012)
  * Fix deserialization of column masks in cluster metadata (CASSANDRA-21549)
  * Caffeine caches in CompressionDictionaryCache and ZstdDictionaryCompressor should specify an executor explicitly (CASSANDRA-21557)

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -1856,6 +1856,25 @@ public final class SystemKeyspace
         executeInternal(format(cql, SchemaConstants.SYSTEM_KEYSPACE_NAME, AVAILABLE_RANGES_V2), keyspace);
     }
 
+    /**
+     * Wipes the whole table rather than deleting per (operation, keyspace): keyspace_name is part of the
+     * partition key, so an operation-scoped delete would have to iterate keyspaces. Safe because the
+     * decommission path is the only reader - see getTransferredRanges. Revisit if another topology
+     * change starts consulting this table.
+     */
+    public static synchronized void resetTransferredRanges()
+    {
+        Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(TRANSFERRED_RANGES_V2).truncateBlockingWithoutSnapshot();
+        try
+        {
+            Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(LEGACY_TRANSFERRED_RANGES).truncateBlockingWithoutSnapshot();
+        }
+        catch (Throwable t)
+        {
+            logger.warn("failed to truncate system table {} but it should no longer be being consulted", LEGACY_TRANSFERRED_RANGES, t);
+        }
+    }
+
     public static synchronized void updateTransferredRanges(StreamOperation streamOperation,
                                                          InetAddressAndPort peer,
                                                          String keyspace,
@@ -1872,11 +1891,19 @@ public final class SystemKeyspace
         executeInternal(String.format(cql, TRANSFERRED_RANGES_V2), rangesToUpdate, streamOperation.getDescription(), peer.getAddress(), peer.getPort(), keyspace);
     }
 
-    public static synchronized Map<InetAddressAndPort, Set<Range<Token>>> getTransferredRanges(String description, String keyspace, IPartitioner partitioner)
+    // Only consulted on the decommission path, where the leaving node is the only streamer and its
+    // local transferred_ranges_v2 is therefore a complete record of what has already moved.
+    //
+    // Being node-local rules out the other topology changes. Under removenode the surviving replicas
+    // stream, and the node running it need not be one of them, so its local table may record nothing;
+    // even when it is a replica it can only account for its own streams. Move could use it for the
+    // ranges the moving node gives up, but the move path registers no listener so nothing is recorded,
+    // and it would still miss the ranges moving the other way.
+    public static synchronized Map<InetAddressAndPort, Set<Range<Token>>> getTransferredRanges(StreamOperation streamOperation, String keyspace, IPartitioner partitioner)
     {
         Map<InetAddressAndPort, Set<Range<Token>>> result = new HashMap<>();
         String query = "SELECT * FROM system.%s WHERE operation = ? AND keyspace_name = ?";
-        UntypedResultSet rs = executeInternal(String.format(query, TRANSFERRED_RANGES_V2), description, keyspace);
+        UntypedResultSet rs = executeInternal(String.format(query, TRANSFERRED_RANGES_V2), streamOperation.getDescription(), keyspace);
         for (UntypedResultSet.Row row : rs)
         {
             InetAddress peerAddress = row.getInetAddress("peer");

--- a/src/java/org/apache/cassandra/tcm/sequences/RemoveNodeStreams.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/RemoveNodeStreams.java
@@ -45,7 +45,7 @@ import static org.apache.cassandra.streaming.StreamOperation.RESTORE_REPLICA_COU
 
 public class RemoveNodeStreams implements LeaveStreams
 {
-    private static final Logger logger = LoggerFactory.getLogger(UnbootstrapStreams.class);
+    private static final Logger logger = LoggerFactory.getLogger(RemoveNodeStreams.class);
     private final AtomicBoolean finished = new AtomicBoolean();
     private final AtomicBoolean failed = new AtomicBoolean();
     private DataMovements.ResponseTracker responseTracker;

--- a/src/java/org/apache/cassandra/tcm/sequences/SingleNodeSequences.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/SingleNodeSequences.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -82,6 +83,10 @@ public interface SingleNodeSequences
         if (inProgress == null)
         {
             logger.info("starting decommission with {} {}", metadata.epoch, self);
+            // We reset transferred ranges upon starting a decommission so that we fully stream
+            // anything written since a previous attempt which may not have been persisted to a pending endpoint
+            SystemKeyspace.resetTransferredRanges();
+            logger.info("done resetting transferred ranges {} {}", metadata.epoch, self);
             ClusterMetadataService.instance().commit(new PrepareLeave(self,
                                                                       force,
                                                                       ClusterMetadataService.instance().placementProvider(),

--- a/src/java/org/apache/cassandra/tcm/sequences/UnbootstrapStreams.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/UnbootstrapStreams.java
@@ -184,8 +184,7 @@ public class UnbootstrapStreams implements LeaveStreams
             if (rangesWithEndpoints.isEmpty())
                 continue;
 
-            //Description is always Unbootstrap? Is that right?
-            Map<InetAddressAndPort, Set<Range<Token>>> transferredRangePerKeyspace = SystemKeyspace.getTransferredRanges("Unbootstrap",
+            Map<InetAddressAndPort, Set<Range<Token>>> transferredRangePerKeyspace = SystemKeyspace.getTransferredRanges(StreamOperation.DECOMMISSION,
                                                                                                                          keyspace,
                                                                                                                          ClusterMetadata.current().tokenMap.partitioner());
             RangesByEndpoint.Builder replicasPerEndpoint = new RangesByEndpoint.Builder();
@@ -196,7 +195,7 @@ public class UnbootstrapStreams implements LeaveStreams
                 Set<Range<Token>> transferredRanges = transferredRangePerKeyspace.get(remote.endpoint());
                 if (transferredRanges != null && transferredRanges.contains(local.range()))
                 {
-                    logger.debug("Skipping transferred range {} of keyspace {}, endpoint {}", local, keyspace, remote);
+                    logger.info("Skipping transferred range {} of keyspace {}, endpoint {}", local, keyspace, remote);
                     continue;
                 }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
@@ -257,8 +257,13 @@ public class BootstrapTest extends TestBaseImpl
 
     public static void populate(ICluster cluster, int from, int to, int coord, int rf, ConsistencyLevel cl)
     {
+        populate(cluster, from, to, coord, rf, cl, "pk int, ck int, v int");
+    }
+
+    public static void populate(ICluster cluster, int from, int to, int coord, int rf, ConsistencyLevel cl, String columnDefinitions)
+    {
         cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': " + rf + "};");
-        cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (" + columnDefinitions + ", PRIMARY KEY (pk, ck))");
         populateExistingTable(cluster, from, to, coord, cl);
         for (int i = from; i < to; i++)
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/DecommissionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/DecommissionTest.java
@@ -19,12 +19,16 @@
 package org.apache.cassandra.distributed.test.ring;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +43,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.Constants;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
@@ -60,8 +65,11 @@ import org.apache.cassandra.tcm.transformations.PrepareLeave;
 import org.apache.cassandra.tcm.transformations.Startup;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.db.SystemKeyspace.TRANSFERRED_RANGES_V2;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.distributed.shared.ClusterUtils.pauseBeforeCommit;
@@ -105,7 +113,7 @@ public class DecommissionTest extends TestBaseImpl
             IInvokableInstance cmsNode = cluster.get(1);
             IInvokableInstance leavingNode = cluster.get(2);
 
-            // --force required: cie_internal keyspace has RF=3, decommission would fail replication check otherwise
+            // --force required: system_distributed keyspace has RF=3, decommission would fail replication check otherwise
             leavingNode.nodetoolResult("decommission", "--force").asserts().failure();
             leavingNode.runOnInstance(() -> assertEquals(StorageService.Mode.DECOMMISSION_FAILED, StorageService.instance.operationMode()));
 
@@ -166,8 +174,72 @@ public class DecommissionTest extends TestBaseImpl
         }
     }
 
+    @Test
+    public void testAbortingDecommissionRestreams() throws Exception
+    {
+        // https://issues.apache.org/jira/browse/CASSANDRA-16290
+        // We demonstrate here that decommissioning and then aborting decommission is unsafe
+        // if we've persisted transferred ranges and then skip them for something which was delivered after we aborted the decommission but before we resumed
+        try (Cluster cluster = builder().withNodes(4)
+                                        .withConfig(config -> config.with(NETWORK, GOSSIP)
+                                                                    // disable hints to simplify test
+                                                                    .set("hinted_handoff_enabled", false)
+                                        )
+                                        .withInstanceInitializer(BB::streamHintsInstall)
+                                        .start())
+        {
+            // We need blob columns here so later we can do Murmur3Partitioner.LongToken.keyForToken(token);
+            populate(cluster, 0, 100, 1, 2, ConsistencyLevel.QUORUM, "pk blob, ck blob, v blob");
+
+            IInvokableInstance leavingNode = cluster.get(2);
+
+            leavingNode.nodetoolResult("decommission").asserts().failure();
+            leavingNode.runOnInstance(() -> assertEquals(StorageService.Mode.DECOMMISSION_FAILED, StorageService.instance.operationMode()));
+
+            // abort the decommission
+            leavingNode.nodetoolResult("abortdecommission").asserts().success();
+
+            // Stop the non leaving nodes so we can write at ONE and fail to stream that datum
+            ClusterUtils.stopUnchecked(cluster.get(1));
+            ClusterUtils.stopUnchecked(cluster.get(3));
+            ClusterUtils.stopUnchecked(cluster.get(4));
+
+            List<Murmur3Partitioner.LongToken> tokens = ClusterUtils.getLocalTokens(leavingNode).stream().map(t -> new Murmur3Partitioner.LongToken(Long.parseLong(t))).collect(Collectors.toList());
+            for (Murmur3Partitioner.LongToken token : tokens)
+            {
+                ByteBuffer key = Murmur3Partitioner.LongToken.keyForToken(token);
+                leavingNode.coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)", ConsistencyLevel.ONE, key, key, key);
+            }
+
+            ClusterUtils.start(cluster.get(1), props -> {});
+            ClusterUtils.start(cluster.get(3), props -> {});
+            ClusterUtils.start(cluster.get(4), props -> {});
+
+            ClusterUtils.awaitRingHealthy(leavingNode);
+            ClusterUtils.waitForCMSToQuiesce(cluster, cluster.get(1));
+
+            Object[][] ranges = leavingNode.executeInternal("SELECT keyspace_name from system." + TRANSFERRED_RANGES_V2);
+
+            assertTrue("transferred ranges missing entirely", ranges.length > 0);
+            assertTrue("transferred ranges present for keyspace", Arrays.stream(ranges).anyMatch(x -> x[0].equals(KEYSPACE)));
+
+            // Resume decomm
+            leavingNode.nodetoolResult("decommission").asserts().success();
+
+            // Try and read data we wrote at ONE at ALL
+            for (Murmur3Partitioner.LongToken token : tokens)
+            {
+                ByteBuffer key = Murmur3Partitioner.LongToken.keyForToken(token);
+                Object[][] resp = cluster.get(1).coordinator().execute("SELECT pk from " + KEYSPACE + ".tbl where pk=?", ConsistencyLevel.ALL, key);
+                assertTrue("We should get a response for this key we wrote it at ONE", resp.length > 0);
+                assertEquals(key, resp[0][0]);
+            }
+        }
+    }
+
     public static class BB
     {
+
         static void install(ClassLoader cl, int nodeNumber)
         {
             if (nodeNumber != 2)
@@ -178,7 +250,29 @@ public class DecommissionTest extends TestBaseImpl
                            .make()
                            .load(cl, ClassLoadingStrategy.Default.INJECTION);
         }
+
+        static void streamHintsInstall(ClassLoader cl, int nodeNumber)
+        {
+            if (nodeNumber != 2)
+                return;
+            new ByteBuddy().rebase(StorageService.class)
+                           .method(named("streamHints"))
+                           .intercept(MethodDelegation.to(BB.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
         static AtomicBoolean first = new AtomicBoolean();
+
+        public static Future<?> streamHints(@SuperCall Callable<Future<?>> zuper) throws Exception
+        {
+            if (!first.get())
+            {
+                first.set(true);
+                return ImmediateFuture.failure(new IOException("failing hints so that decomm fails at last moment possible" ));
+            }
+            return zuper.call();
+        }
 
         public static void startStreamingFiles(@Nullable StreamSession.PrepareDirection prepareDirection, @SuperCall Callable<Void> zuper) throws Exception
         {
@@ -286,7 +380,7 @@ public class DecommissionTest extends TestBaseImpl
                                         .start())
         {
             populate(cluster, 0, 100, 1, 2, ConsistencyLevel.QUORUM);
-            cluster.get(3).nodetoolResult("decommission", "--force").asserts().success();
+            cluster.get(3).nodetoolResult("decommission").asserts().success();
 
             int[] remainingNodes = {1, 2, 4};
             Set<String> expectedPeers = new HashSet<>();


### PR DESCRIPTION
Patch by Matt Byrd; reviewed by Caleb Rackliffe and Sam Tunnicliffe for CASSANDRA-16290

CI will be attached to JIRA
