### PR TITLE
Cassandra 21515 5.0 - Avoid Rebuilding Per-SSTable SAI components 

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -262,8 +262,6 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
     {
         IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
 
-        // if per-table files are incomplete or checksum fails. A single-index rebuild must NOT rewrite the
-        // shared per-SSTable components (CASSANDRA-21515).
         if (!indexDescriptor.isPerSSTableIndexBuildComplete()
             || !indexDescriptor.validatePerSSTableComponents(IndexValidation.CHECKSUM, true, false))
         {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -262,9 +262,9 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
     {
         IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
 
-        // if per-table files are incomplete, full rebuild is requested, or checksum fails
+        // if per-table files are incomplete or checksum fails. A single-index rebuild must NOT rewrite the
+        // shared per-SSTable components (CASSANDRA-21515).
         if (!indexDescriptor.isPerSSTableIndexBuildComplete()
-            || isFullRebuild
             || !indexDescriptor.validatePerSSTableComponents(IndexValidation.CHECKSUM, true, false))
         {
             CountDownLatch latch = CountDownLatch.newCountDownLatch(1);

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndexBuilder;
 import org.apache.cassandra.index.sai.analyzer.NonTokenizingOptions;
@@ -1001,6 +1002,41 @@ public class StorageAttachedIndexDDLTest extends SAITester
         assertEquals(rowCount, rows.all().size());
         rows = executeNet("SELECT id1 FROM %s WHERE v2='0'");
         assertEquals(rowCount, rows.all().size());
+    }
+
+    @Test
+    public void rebuildingOneIndexNotRewriteSharedPerSSTableComponents() throws Throwable
+    {
+        SSTableContext.class.getName();
+
+        Injections.Counter sharedContextBuilds = Injections.newCounter("SharedPerSSTableContextBuilds")
+                                                           .add(InvokePointBuilder.newInvokePoint().onClass(SSTableContext.class)
+                                                                                  .onMethod("create"))
+                                                           .build();
+
+        Injections.inject(sharedContextBuilds);
+
+        createTable(CREATE_TABLE_TEMPLATE);
+        String v1Index = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('0', 0, '100')");
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('1', 1, '101')");
+        flush();
+
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v1 = 0").size());
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v2 = '101'").size());
+
+        sharedContextBuilds.reset();
+
+        rebuildIndexes(v1Index);
+
+        // CASSANDRA-21515: rebuilding one index must NOT rewrite the shared per-SSTable components.
+        assertEquals("Rebuilding of a single SAI index must not rebuild the shared per-SSTable components",
+                     0, sharedContextBuilds.get());
+
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v2 = '101'").size());
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v1 = 0").size());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -1039,6 +1039,37 @@ public class StorageAttachedIndexDDLTest extends SAITester
     }
 
     @Test
+    public void rebuildRegeneratesCorruptSharedPerSSTableComponents() throws Throwable
+    {
+        Injections.Counter sharedContextBuilds = Injections.newCounter("SharedPerSSTableContextBuilds")
+                                                           .add(InvokePointBuilder.newInvokePoint().onClass(SSTableContext.class).onMethod("create"))
+                                                           .build();
+        Injections.inject(sharedContextBuilds);
+
+        createTable(CREATE_TABLE_TEMPLATE);
+        String v1Index = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        String v2Index = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('0', 0, '100')");
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('1', 1, '101')");
+        flush();
+
+        assertEquals(1, sharedContextBuilds.get());
+
+        corruptIndexComponent(IndexComponent.ROW_TO_PARTITION, CorruptionType.EMPTY_FILE);
+        sharedContextBuilds.reset();
+        assertEquals(0, sharedContextBuilds.get());
+
+        rebuildIndexes(v1Index, v2Index);
+
+        assertEquals("corrupt shared per-SSTable components must be regenerated on rebuild",
+                     1, sharedContextBuilds.get());
+
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v1 = 0").size());
+        assertEquals(1, execute("SELECT id1 FROM %s WHERE v2 = '101'").size());
+    }
+
+    @Test
     public void verifyCleanupFailedPerIndexFiles() throws Throwable
     {
         createTable(CREATE_TABLE_TEMPLATE);

--- a/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/StorageAttachedIndexDDLTest.java
@@ -1007,11 +1007,8 @@ public class StorageAttachedIndexDDLTest extends SAITester
     @Test
     public void rebuildingOneIndexNotRewriteSharedPerSSTableComponents() throws Throwable
     {
-        SSTableContext.class.getName();
-
         Injections.Counter sharedContextBuilds = Injections.newCounter("SharedPerSSTableContextBuilds")
-                                                           .add(InvokePointBuilder.newInvokePoint().onClass(SSTableContext.class)
-                                                                                  .onMethod("create"))
+                                                           .add(InvokePointBuilder.newInvokePoint().onClass(SSTableContext.class).onMethod("create"))
                                                            .build();
 
         Injections.inject(sharedContextBuilds);
@@ -1023,6 +1020,8 @@ public class StorageAttachedIndexDDLTest extends SAITester
         execute("INSERT INTO %s (id1, v1, v2) VALUES ('0', 0, '100')");
         execute("INSERT INTO %s (id1, v1, v2) VALUES ('1', 1, '101')");
         flush();
+
+        assertEquals(1, sharedContextBuilds.get());
 
         assertEquals(1, execute("SELECT id1 FROM %s WHERE v1 = 0").size());
         assertEquals(1, execute("SELECT id1 FROM %s WHERE v2 = '101'").size());

--- a/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
@@ -106,7 +106,8 @@ public class SnapshotTest extends SAITester
         verifyIndexFiles(indexTermType, indexIdentifier, 2);
         assertNotEquals(snapshotLastModified, indexFilesLastModified());
         assertNumRows(2, "SELECT * FROM %%s WHERE v1 >= 0");
-        assertValidationCount(2, 2); // compaction should not validate
+        // CASSANDRA-21515: a single-index rebuild no longer rewrites the shared per-SSTable components
+        assertValidationCount(4, 2);
 
         // index components are included after rebuild
         verifyIndexComponentsIncludedInSSTable();


### PR DESCRIPTION
Cassandra-21515

rebuild index on a single SAI index no longer rewrites the shared per-SSTable components.

patch by Sunil Ramchandra Pawar; reviewed by Caleb Rackliffe and David Capwell.