### PR TITLE
CASSANDRA-21575: Keep message ids unsigned so they do not inflate every message header

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Keep message ids unsigned so they do not inflate every message header once the id counter wraps (CASSANDRA-21575)
  * Add prepared statement cache stats to nodetool info (CASSANDRA-14366)
  * Don't increment client metrics on messaging service connection unpause (CASSANDRA-21491)
  * Add nodetool getreplicas (CASSANDRA-17665)

--- a/src/java/org/apache/cassandra/net/ForwardingInfo.java
+++ b/src/java/org/apache/cassandra/net/ForwardingInfo.java
@@ -108,7 +108,7 @@ public final class ForwardingInfo implements Serializable
             for (int i = 0; i < count; i++)
             {
                 targets.add(inetAddressAndPortSerializer.deserialize(in, version));
-                ids[i] = in.readUnsignedVInt32();
+                ids[i] = in.readUnsignedVInt();
             }
 
             return new ForwardingInfo(targets, ids);

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -483,11 +483,25 @@ public class Message<T> implements ResponseContext
         long id;
         do
         {
-            id = nextId.incrementAndGet();
+            id = toUnsignedId(nextId.incrementAndGet());
         }
         while (id == NO_ID);
 
         return id;
+    }
+
+    /**
+     * Widens the id counter as unsigned.
+     * <p>
+     * The counter is an {@code int} and wraps to {@link Integer#MIN_VALUE} once it passes
+     * {@link Integer#MAX_VALUE}. Widening it directly would sign-extend, and {@link Serializer} writes the id as an
+     * unsigned vint, so every negative id occupies the maximum width of 9 bytes instead of at most 5. Masking keeps
+     * ids in {@code [0, 2^32)}, which covers the same number of distinct values while staying cheap to encode.
+     */
+    @VisibleForTesting
+    static long toUnsignedId(int counter)
+    {
+        return counter & 0xFFFFFFFFL;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/net/ForwardingInfoTest.java
+++ b/test/unit/org/apache/cassandra/net/ForwardingInfoTest.java
@@ -44,6 +44,42 @@ public class ForwardingInfoTest
             testVersion(version.value);
     }
 
+    /**
+     * Message ids are drawn from an unsigned 32-bit counter, so they span the whole [1, 2^32) range. They are written
+     * as 64-bit unsigned vints, and the reader has to use the matching width: reading them back as a 32-bit vint
+     * throws {@link org.apache.cassandra.utils.vint.VIntOutOfRangeException} for any id above Integer.MAX_VALUE.
+     */
+    @Test
+    public void testLargeMessageIdsRoundTrip() throws Exception
+    {
+        InetAddressAndPort.initializeDefaultPort(65532);
+        List<InetAddressAndPort> addresses = ImmutableList.of(InetAddressAndPort.getByName("127.0.0.1:7000"),
+                                                              InetAddressAndPort.getByName("127.0.0.2:7000"),
+                                                              InetAddressAndPort.getByName("127.0.0.3:7000"),
+                                                              InetAddressAndPort.getByName("127.0.0.4:7000"));
+
+        long[] ids = { 1L, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L, 0xFFFFFFFFL };
+        ForwardingInfo forwardingInfo = new ForwardingInfo(addresses, ids);
+
+        for (MessagingService.Version version : MessagingService.Version.supportedVersions())
+        {
+            ByteBuffer buffer;
+            try (DataOutputBuffer dob = new DataOutputBuffer())
+            {
+                ForwardingInfo.serializer.serialize(forwardingInfo, dob, version.value);
+                buffer = dob.buffer();
+            }
+
+            assertEquals(buffer.remaining(), ForwardingInfo.serializer.serializedSize(forwardingInfo, version.value));
+
+            try (DataInputBuffer dib = new DataInputBuffer(buffer, false))
+            {
+                ForwardingInfo deserialized = ForwardingInfo.serializer.deserialize(dib, version.value);
+                assertTrue(Arrays.equals(ids, deserialized.messageIds));
+            }
+        }
+    }
+
     private void testVersion(int version) throws Exception
     {
         InetAddressAndPort.initializeDefaultPort(65532);

--- a/test/unit/org/apache/cassandra/net/MessageTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageTest.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.FreeRunningClock;
 import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.vint.VIntCoding;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static org.apache.cassandra.exceptions.RemoteExceptionTest.normalizeThrowable;
@@ -367,5 +368,56 @@ public class MessageTest
 
         long localTimeNanos = localClock.now();
         assertTrue( Message.Serializer.calculateCreationTimeNanos(remoteCreatedAt, localClock.translate(), localTimeNanos) > 0);
+    }
+
+    /**
+     * The id counter is an int, so it wraps to Integer.MIN_VALUE after Integer.MAX_VALUE. Ids must stay within
+     * [0, 2^32) across that wrap: the serializer writes them as unsigned vints, so a sign-extended negative id would
+     * occupy the maximum width of 9 bytes rather than at most 5.
+     */
+    @Test
+    public void testIdsRemainUnsignedAcrossCounterWrap()
+    {
+        for (int counter : new int[]{ 1, Integer.MAX_VALUE - 1, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE + 1, -1 })
+        {
+            long id = Message.toUnsignedId(counter);
+            assertTrue("id must not be negative, got " + id + " for counter " + counter, id >= 0);
+            assertTrue("id must fit in 32 unsigned bits, got " + id, id <= 0xFFFFFFFFL);
+            assertTrue("id must encode within 5 bytes, got " + VIntCoding.computeUnsignedVIntSize(id),
+                       VIntCoding.computeUnsignedVIntSize(id) <= 5);
+        }
+
+        // the mapping stays injective, so ids remain as distinct as the counter itself
+        assertEquals(Integer.MAX_VALUE + 1L, Message.toUnsignedId(Integer.MIN_VALUE));
+        assertEquals(0xFFFFFFFFL, Message.toUnsignedId(-1));
+    }
+
+    /**
+     * Ids now span the whole unsigned 32-bit range, so the message header must round-trip the upper half too.
+     */
+    @Test
+    public void testLargeIdRoundTrips() throws IOException
+    {
+        for (Version version : Version.supportedVersions())
+        {
+            for (long id : new long[]{ 1L, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L, 0xFFFFFFFFL })
+            {
+                Message<NoPayload> msg = Message.builder(Verb._TEST_1, noPayload)
+                                                .withId(id)
+                                                .from(FBUtilities.getBroadcastAddressAndPort())
+                                                .build();
+
+                try (DataOutputBuffer out = new DataOutputBuffer())
+                {
+                    serializer.serialize(msg, out, version.value);
+                    assertEquals(msg.serializedSize(version.value), out.getLength());
+
+                    try (DataInputBuffer in = new DataInputBuffer(out.buffer(), false))
+                    {
+                        assertEquals(id, serializer.deserialize(in, msg.from(), version.value).id());
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
[CASSANDRA-21575](https://issues.apache.org/jira/browse/CASSANDRA-21575)

## Problem

`Message.nextId()` draws from a shared `AtomicInteger` and widens the result to a `long`:

```java
private static final AtomicInteger nextId = new AtomicInteger(0);

private static long nextId()
{
    long id;
    do
    {
        id = nextId.incrementAndGet();
    }
    while (id == NO_ID);

    return id;
}
```

Once the counter passes `Integer.MAX_VALUE` it wraps to `Integer.MIN_VALUE`, and the negative `int`
sign-extends into a negative `long`. `Message.Serializer` writes the id as an unsigned vint, and a
negative long has all its high bits set, so it always encodes at the maximum width:

| id | wire bytes |
|---|---|
| `1` | 1 |
| `2147483647` | 5 |
| `-2147483648` (first wrap) | **9** |
| `-1` | **9** |

That is an extra 4 bytes on the header of **every** internode message, sustained for the 2³¹ messages
until the counter cycles back through positive, and again on every subsequent wrap. A node sending
50k messages/sec reaches the first wrap in about 12 hours, so this is steady state for any
long-running cluster, not an edge case.

## Fix

Mask the counter so ids stay in `[0, 2^32)`. Same number of distinct values, always non-negative,
encoding bounded at 5 bytes. Ids are opaque correlation keys — used only for matching responses to
callbacks in `RequestCallbacks` — so nothing depends on their sign, and the wire format itself is
unchanged.

## Why `ForwardingInfo` is in the same commit

`ForwardingInfo` is the `FORWARD_TO` parameter used for inter-DC write forwarding. It writes ids with
the 64-bit form and sizes them the same way, but reads them back with the 32-bit form:

```java
out.writeUnsignedVInt(ids[i]);              // serialize
size += computeUnsignedVIntSize(ids[i]);    // serializedSize
ids[i] = in.readUnsignedVInt32();           // deserialize  <- mismatch
```

This is the only 32-bit read of a message id in the tree; everything else uses
`readUnsignedVInt`/`getUnsignedVInt`. It is harmless today only by accident — ids always fit in `int`
because they come from an `int` counter, so the `checkedCast` inside `readUnsignedVInt32` succeeds
even for sign-extended negative values.

It is therefore a blocker for the fix, not a separate cleanup. Once ids span the full unsigned 32-bit
range this read throws and inter-DC forwarding breaks:

```
id=2147483648   ForwardingInfo.deserialize: VIntOutOfRangeException
id=4294967295   ForwardingInfo.deserialize: VIntOutOfRangeException
```

## Tests

The existing `ForwardingInfoTest` only ever used ids `44..49`, which is why the width mismatch was
never exercised.

- `ForwardingInfoTest.testLargeMessageIdsRoundTrip` — round-trips ids across the whole unsigned
  32-bit range including `Integer.MAX_VALUE + 1` and `0xFFFFFFFF`, for every supported messaging
  version, asserting `serializedSize` matches the bytes written. Verified to fail without the
  `ForwardingInfo` change: `VIntOutOfRangeException: 2147483648 is out of range for a 32-bit integer`.
- `MessageTest.testIdsRemainUnsignedAcrossCounterWrap` — ids stay non-negative, stay within 32
  unsigned bits, and encode within 5 bytes across the wrap boundary.
- `MessageTest.testLargeIdRoundTrips` — message headers carrying ids from the upper half of the
  range round-trip for every supported messaging version.

Green locally: `ant jar`, `ant checkstyle checkstyle-test` (2907 files), and `MessageTest` (11),
`ForwardingInfoTest` (2), `MessageSerializationPropertyTest` (2), `MessageDeliveryTest` (4).

## Branches

Both defects are present from 4.0 onwards — on 4.0/4.1 the narrowing is spelled
`Ints.checkedCast(in.readUnsignedVInt())`. This PR targets trunk; happy to prepare backports for
whichever branches you want it on.

Prepared with AI assistance (Claude Opus 5); the commit carries an `Assisted-by:` trailer.