### PR TITLE
CI: Prevent/kill Jenkins k8s agent orphans and unschedulable agent pods

### DIFF
--- a/.build/run-ci
+++ b/.build/run-ci
@@ -25,10 +25,10 @@ Python dependencies are found in .build/run-ci.d/requirements.txt
 Custom environment variables can be set in .build/.run-ci.env
 
 lint with:
- `pylint --disable=C0301,W0511,C0103,W0702,C0415,C0116,C0115,R0914,W0603,R0915,R0913,R0917,R0911,W0212,W0621 run-ci`
+ `pylint --disable=C0301,C0302,W0511,C0103,W0702,C0415,C0116,C0115,R0914,W0603,R0915,R0913,R0917,R0911,W0212,W0621 run-ci`
 
 test with:
- `python .build/run-ci.d/run-ci-test.py`
+ `python run-ci.d/run-ci-test.py`
 """
 
 import argparse
@@ -36,7 +36,9 @@ import fcntl
 import getpass
 import gzip
 import itertools
+import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -94,31 +96,39 @@ def get_current_branch() -> str:
     return subprocess.run(["git", "-C", str(CASSANDRA_DIR), "branch", "--show-current"],
                           capture_output=True, text=True, check=True).stdout.strip()
 
+def require_tracking_remote(branch: str):
+    """ Exits when the branch tracks no remote, since nothing can then be inferred about what to build. """
+    if 0 == subprocess.run(["git", "-C", str(CASSANDRA_DIR), "rev-parse", "--abbrev-ref", f"{branch}@{{u}}"],
+                           capture_output=True, text=True, check=False).returncode:
+        return
+    print(f"Branch {branch} tracks no remote, so the fork and branch to build cannot be detected.")
+    print("\nEither set the tracking up, which git will do on the first push of every new branch:")
+    print("    git config --global push.autoSetupRemote true")
+    print(f"  or for this branch alone: `git push --set-upstream <remote> {branch}`")
+    print("\nOr name what to build explicitly, with -r/--repository and -b/--branch.")
+    sys.exit(1)
+
 def is_local_git_dirty(args) -> bool:
     """Returns True if there are uncommitted/unpushed changes in the local git repository."""
     # use base_job_name to verify the remote branch exists
     base_job_name(args)
     # check if the working directory is clean
     clean = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "diff-index", "--quiet", "HEAD", "--"], check=False).returncode
-    # check if there are unpushed committed changes
-    unpushed_commits = bool(subprocess.run(["git", "-C", str(CASSANDRA_DIR), "log", "@{u}..HEAD", "--name-only"],
-                                           capture_output=True, text=True, check=False).stdout.strip())
-    return 0 != clean or unpushed_commits
+    # `@{u}` resolves to nothing without tracking, which would read as nothing unpushed.  Callers reach here
+    # only past require_tracking_remote, but report dirty on failure rather than depend on that invariant
+    unpushed = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "log", "@{u}..HEAD", "--name-only"],
+                              capture_output=True, text=True, check=False)
+    return 0 != clean or 0 != unpushed.returncode or bool(unpushed.stdout.strip())
 
-def get_tracking_remote_url() -> str:
-    """
-    Returns the tracking remote URL of the current branch, falling back to the 'origin' remote URL.
-    """
-    try:
-        # Get the tracking remote URL of the current branch
-        remote_name = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "config", "--get", f"branch.{DEFAULT_REPO_BRANCH}.remote"],
-                                     capture_output=True, text=True, check=True).stdout.strip()
+def get_tracking_remote_url() -> Optional[str]:
+    """ Returns the tracking remote URL of the current branch, or None when the branch tracks nothing. """
+    remote = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "config", "--get", f"branch.{DEFAULT_REPO_BRANCH}.remote"],
+                            capture_output=True, text=True, check=False)
 
-    except subprocess.CalledProcessError:
-        # Fallback to the 'origin' remote URL
-        remote_name = "origin"
+    if 0 != remote.returncode:
+        return None
 
-    repo_url = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "remote", "get-url", remote_name],
+    repo_url = subprocess.run(["git", "-C", str(CASSANDRA_DIR), "remote", "get-url", remote.stdout.strip()],
                                capture_output=True, text=True, check=True).stdout.strip()
     if repo_url.startswith("git@github.com:"):
         repo_url = repo_url.replace("git@github.com:", "https://github.com/")
@@ -206,7 +216,14 @@ def parse_arguments() -> argparse.Namespace:
     """
     args = argument_parser().parse_args()
 
-    assert args.repository.startswith("https://github.com/") and args.repository.removesuffix(".git").endswith("cassandra"),\
+    # -r defaults to the branch's tracking remote, which is absent when the branch tracks nothing.  Only the
+    # flows that build, or that name artefacts after a build, need it: installing and tearing down do not,
+    # so an untracked branch can still deploy the cluster.
+    if not args.repository and not (args.only_setup or args.only_tear_down or args.only_node_cleaner):
+        require_tracking_remote(args.branch)
+
+    assert not args.repository or (args.repository.startswith("https://github.com/")
+                                   and args.repository.removesuffix(".git").endswith("cassandra")),\
         f"Only github apache/cassandra (forked) repository supported, got: {args.repository}"
     assert args.dtest_repository.startswith("https://github.com/") and args.dtest_repository.removesuffix(".git").endswith("cassandra-dtest"),\
         f"Only github apache/cassandra-dtest (forked) repository supported, got: {args.dtest_repository}"
@@ -267,6 +284,183 @@ def run_helm_command(kubeconfig: Optional[str], kubecontext: Optional[str], kube
     cmd += ["--namespace", kube_ns]
     cmd += command
     return subprocess.run(cmd, capture_output=capture_output, text=True, check=check)
+
+def check_agent_capacity(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str, values: dict):
+    """
+    Refuses to deploy podTemplates that ask for more agents than the cluster can ever schedule.
+
+    An instanceCap above the nodes its pool can hold does not merely idle: the podAntiAffinity in each
+    template puts one agent on a node, so the surplus pods can never be scheduled, they drive the
+    autoscaler to maxSize, expire after waitForPodSec and are requested again in a loop.  That churn is
+    what preceded the 2026-08-11 controller stall, both large node groups pinned at their maximum while
+    fifteen agents did the work.
+    Only what is established is enforced: a ceiling that could not be read is left unchecked, since
+    blocking a valid deploy on a check that cannot see the answer is worse than no check.
+    """
+
+    def agent_templates(values: dict) -> list:
+        """
+        The agent podTemplates as [{name, size, selector, instance_cap, instance_cap_str}].
+
+        The templates are opaque strings to the helm chart, parsed only by the kubernetes plugin, so they
+        are loaded here as the yaml they are.  `size` is the suffix of the `cassandra.jenkins.agent.<size>`
+        nodeSelector, which is what ties a template to a node pool.
+        """
+        templates = []
+        for name, raw in (values.get("agent", {}).get("podTemplates") or {}).items():
+            try:
+                template = yaml.safe_load(raw)[0]
+            except (yaml.YAMLError, IndexError, TypeError):
+                debug(f"Could not parse podTemplate {name}, skipping it")
+                continue
+            selector = dict(pair.split("=", 1) for pair in str(template.get("nodeSelector", "")).split(",")
+                            if "=" in pair)
+            size = next((key.rsplit(".", 1)[1] for key in selector if key.startswith("cassandra.jenkins.agent.")), None)
+            templates.append({"name": name, "size": size, "selector": selector,
+                              "instance_cap": template.get("instanceCap"),
+                              "instance_cap_str": template.get("instanceCapStr")})
+        return templates
+
+    def node_pool_sizes(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str) -> Tuple[dict, dict]:
+        """
+        What the live nodes reveal, as ({node pool name: size}, {label key: set of values seen}).
+
+        Live nodes are the authoritative way to tie a node pool to an agent size, and the only way to
+        confirm a nodeSelector is spelt the way the nodes actually are.  Pools scaled to zero contribute
+        nothing, which is the normal resting state, so neither result can be treated as exhaustive.
+        """
+        pool_label = ("eks.amazonaws.com/nodegroup", "cloud.google.com/gke-nodepool")
+        pools, seen = {}, {}
+        try:
+            nodes = json.loads(run_kubectl_command(kubeconfig, kubecontext, kube_ns, ["get", "nodes", "-o", "json"]))
+        except (subprocess.CalledProcessError, json.JSONDecodeError, TypeError) as e:
+            debug(f"Could not read nodes, agent sizes will not be attributed from them: {e}")
+            return pools, seen
+        for node in nodes.get("items", []):
+            labels = node.get("metadata", {}).get("labels", {})
+            for key, value in labels.items():
+                seen.setdefault(key, set()).add(value)
+            pool = next((labels[key] for key in pool_label if key in labels), None)
+            size = next((key.rsplit(".", 1)[1] for key, value in labels.items()
+                         if key.startswith("cassandra.jenkins.agent.") and value == "true"
+                         and key != "cassandra.jenkins.agent"), None)
+            if pool and size:
+                pools[pool] = size
+        return pools, seen
+
+    def pool_ceilings(kubeconfig: Optional[str], kubecontext: Optional[str], pools: dict, sizes: set) -> Tuple[dict, list]:
+        """
+        The most agents each size can ever run, as ({size: max nodes}, [(unattributed pool, maxSize)]).
+
+        kubectl cannot see a pool's maximum directly: a pool at zero nodes has no nodes to count, so the
+        only in-cluster record is the cluster-autoscaler's status configmap.  A managed autoscaler (GKE)
+        does not publish it, in which case nothing is established and the caller must not treat that as a
+        pass.  The autoscaler names a pool for its underlying group (`eks-<nodegroup>-<uuid>`), so a live
+        node's pool label is matched into it as a substring, falling back to the size word in the name for
+        pools that are scaled to zero.  Anything still unmatched is returned for reporting, never ignored.
+        """
+
+        def nodegroup_max_size(group: dict) -> Optional[int]:
+            """
+            A group's maximum, from its health condition where the autoscaler publishes it, or from the
+            group itself.
+            """
+            if not isinstance(group, dict):
+                return None
+            for value in ((group.get("health") or {}).get("maxSize"), group.get("maxSize")):
+                if isinstance(value, str) and value.strip().isdigit():
+                    return int(value)
+                if isinstance(value, int) and not isinstance(value, bool):
+                    return value
+            return None
+
+        try:
+            status = yaml.safe_load(run_kubectl_command(kubeconfig, kubecontext, "kube-system",
+                                                        ["get", "configmap", "cluster-autoscaler-status",
+                                                         "-o", "jsonpath={.data.status}"]))
+        except (subprocess.CalledProcessError, yaml.YAMLError) as e:
+            debug(f"Could not read the cluster-autoscaler status configmap: {e}")
+            return {}, []
+        ceilings, unattributed = {}, []
+        for group in (status or {}).get("nodeGroups", []) if isinstance(status, dict) else []:
+            maximum = nodegroup_max_size(group)
+            if maximum is None:
+                continue
+            name = group.get("name", "")
+            size = next((size for pool, size in pools.items() if pool and pool in name), None)
+            if not size:
+                words = [word for word in sizes if re.search(rf"(^|[-_]){re.escape(word)}([-_]|$)", name)]
+                size = words[0] if len(words) == 1 else None
+            if not size:
+                # the controller has its own pool, and runs no agents
+                if "jenkins-controller" not in name:
+                    unattributed.append((name, maximum))
+                continue
+            ceilings[size] = ceilings.get(size, 0) + maximum
+        return ceilings, unattributed
+
+    def check_template_capacity(template: dict, ceilings: dict, seen: dict) -> Tuple[list, list]:
+        """One podTemplate's (errors, warnings), errors being what could never be scheduled."""
+        name, size, cap = template["name"], template["size"], template["instance_cap"]
+        errors, warnings = [], []
+        # the plugin takes the cap from either key, so a disagreement resolves to whichever applies last
+        if str(template["instance_cap_str"]) != str(cap):
+            errors.append(f"{name}: instanceCap {cap} disagrees with instanceCapStr {template['instance_cap_str']}")
+        for key, value in template["selector"].items():
+            if key not in seen:
+                # the resting state is every pool at zero, so this is not worth a warning on each deploy
+                debug(f"{name}: nodeSelector {key}={value} unconfirmed, no node currently carries {key}")
+            elif value not in seen[key]:
+                errors.append(f"{name}: nodeSelector {key}={value} matches no node, though {key} is present with"
+                              f" {sorted(seen[key])}; agents would never be scheduled")
+        if size is None:
+            warnings.append(f"{name}: no cassandra.jenkins.agent.<size> nodeSelector, cap {cap} not checked")
+        elif size not in ceilings:
+            # a size unresolved while others resolved is a blind spot worth flagging.  Nothing resolving at all
+            # means the check could not run here, a fact about the cluster and not about these values
+            unchecked = f"{name}: instanceCap {cap} unchecked, no ceiling could be established for {size!r}"
+            if ceilings:
+                warnings.append(unchecked)
+            else:
+                debug(unchecked)
+        elif isinstance(cap, int) and cap > ceilings[size]:
+            errors.append(f"{name}: instanceCap {cap} exceeds the {ceilings[size]} nodes the {size} pool can hold,"
+                          f" so {cap - ceilings[size]} agents could never be scheduled")
+        else:
+            debug(f"{name}: instanceCap {cap} within the {size} pool's {ceilings[size]} nodes")
+        return errors, warnings
+
+    templates = agent_templates(values)
+    if not templates:
+        return
+    pools, seen = node_pool_sizes(kubeconfig, kubecontext, kube_ns)
+    ceilings, unattributed = pool_ceilings(kubeconfig, kubecontext, pools,
+                                           {template["size"] for template in templates if template["size"]})
+    errors, warnings = [], []
+    for template in templates:
+        template_errors, template_warnings = check_template_capacity(template, ceilings, seen)
+        errors += template_errors
+        warnings += template_warnings
+
+    container_cap = values.get("agent", {}).get("containerCap")
+    total = sum(template["instance_cap"] for template in templates if isinstance(template["instance_cap"], int))
+    if isinstance(container_cap, int) and total > container_cap:
+        # benign, and not a fault to warn about on every deploy: the cloud cap leaves builds queued rather
+        # than creating pods that cannot be scheduled, it only stops every pool reaching its cap at once
+        debug(f"instanceCaps sum to {total} against a containerCap of {container_cap}, so the cloud cap binds"
+              f" first and the pools cannot all reach their cap at once")
+    for name, maximum in unattributed:
+        warnings.append(f"node pool {name!r} (maxSize {maximum}) matched no agent size and was not counted")
+
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    if errors:
+        print("\nRefusing to deploy agent podTemplates that could never be scheduled:\n")
+        for error in errors:
+            print(f"  {error}")
+        print("\nFix the podTemplate in .jenkins/k8s/jenkins-deployment.yaml, or raise the node pool's maximum"
+              " first (see .jenkins/k8s/README.md).")
+        sys.exit(1)
 
 def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_ns: str,
                     values_override: Optional[str] = None):
@@ -335,7 +529,7 @@ def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_
 
         lost = detect_lost_values(helm_values(), proposed)
         if not lost:
-            return
+            return proposed
 
         print(f"\nWARNING: {len(lost)} value(s) the deployed jenkins has are absent from what is about to be applied.")
         print("Each is either a customisation of this site, or a key removed from jenkins-deployment.yaml since"
@@ -352,8 +546,10 @@ def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_
         if input("\nDrop these values and continue? [y/N] ").strip().lower() not in ("y", "yes"):
             print("Aborted, nothing was deployed.")
             sys.exit(1)
+        return proposed
 
-    confirm_helm_updates()
+    # the values checked are the merged result, so a site override raising an instanceCap is checked too
+    check_agent_capacity(kubeconfig, kubecontext, kube_ns, confirm_helm_updates())
 
     print("Adding Helm repository for Jenkins Operator...")
     subprocess.run(["helm", "repo", "add", "jenkins", "https://charts.jenkins.io"], check=True)
@@ -361,8 +557,12 @@ def install_jenkins(kubeconfig: Optional[str], kubecontext: Optional[str], kube_
 
     # site customisations are applied last, helm merges each -f over the previous
     values_files = ["-f", DEPLOY_YAML] + (["-f", values_override] if values_override else [])
+    # --timeout is longer than helm's 5m default, which `--wait` would otherwise spend waiting for a pod
+    # whose controller.probes.startupProbe already permits a 300s boot, then fail a deploy that was
+    # succeeding.  Keep it clear of that budget plus the readinessProbe's, see jenkins-deployment.yaml
     result = run_helm_command(kubeconfig, kubecontext, kube_ns,
-                              ["upgrade", "--install"] + values_files + ["cassius", "jenkins/jenkins", "--wait"])
+                              ["upgrade", "--install"] + values_files
+                              + ["cassius", "jenkins/jenkins", "--wait", "--timeout", "10m"])
 
     run_kubectl_command(kubeconfig, kubecontext, kube_ns,
                         ["exec", DEFAULT_POD_NAME, "--",

--- a/.build/run-ci.d/run-ci-test.py
+++ b/.build/run-ci.d/run-ci-test.py
@@ -27,14 +27,17 @@
 
 import argparse
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
+import yaml
 
 
 # Import the functions from the script
 from run_ci import (
     DEPLOY_YAML,
+    check_agent_capacity,
     debug,
     install_jenkins,
     get_jenkins,
@@ -177,6 +180,87 @@ class TestCIPipeline(unittest.TestCase):
     def test_helm_installation_lock(self, mock_flock):
         with helm_installation_lock(Path("/tmp/.fake.lock")):
             mock_flock.assert_called()
+
+    LARGE_NODE = ('{"items":[{"metadata":{"labels":{"eks.amazonaws.com/nodegroup":"amd64-large-ondemand-2",'
+                  '"cassandra.jenkins.agent":"true","cassandra.jenkins.agent.large":"true"}}}]}')
+
+    @staticmethod
+    def ca_status(nested: bool = True) -> str:
+        """
+        The autoscaler's status configmap, holding the live cluster's node groups and maximums.
+
+        maxSize is the only in-cluster record of what a pool can hold, and a pool at zero nodes has no
+        nodes to count, so the check reads it from here.
+        """
+        groups = [(f"eks-amd64-{size}-ondemand-{n}-{n}cfd1c1", 0, maximum)
+                  for size, maximum in (("large", 80), ("medium", 65), ("small", 25)) for n in (2, 3)]
+
+        groups.append(("eks-jenkins-controller-0-2acd8787", 1, 1))
+        return yaml.safe_dump({"nodeGroups": [
+            {"name": name, **({"health": {"minSize": minimum, "maxSize": maximum}} if nested
+                              else {"minSize": minimum, "maxSize": maximum})}
+            for name, minimum, maximum in groups]})
+
+    def capacity_check(self, values: dict, nodes: str = '{"items":[]}', autoscaler: bool = True,
+                       nested: bool = True):
+        """
+        Runs check_agent_capacity against the autoscaler ceilings above, returning the exit code or 0.
+
+        `autoscaler=False` stands in for a cluster whose ceilings cannot be read at all, a managed
+        autoscaler that publishes no status configmap for instance, where kubectl exits non-zero.
+        """
+        def kubectl(_kubeconfig, _kubecontext, _ns, command):
+            if "nodes" in command:
+                return nodes
+            if not autoscaler:
+                raise subprocess.CalledProcessError(1, "kubectl", stderr="configmaps not found")
+            return self.ca_status(nested)
+        with patch('run_ci.run_kubectl_command', kubectl):
+            try:
+                check_agent_capacity(None, None, "default", values)
+                return 0
+            except SystemExit as e:
+                return e.code
+
+    def deployed_values(self, size: str = None, **overrides) -> dict:
+        """The committed values, optionally with one podTemplate's keys replaced."""
+        with open(DEPLOY_YAML, encoding="utf-8") as deploy_yaml:
+            values = yaml.safe_load(deploy_yaml)
+        if size:
+            template = yaml.safe_load(values["agent"]["podTemplates"][f"agent-dind-{size}"])
+            template[0].update(overrides)
+            values["agent"]["podTemplates"][f"agent-dind-{size}"] = yaml.safe_dump(template)
+        return values
+
+    def test_check_agent_capacity_allows_the_committed_values(self):
+        self.assertEqual(0, self.capacity_check(self.deployed_values()))
+        self.assertEqual(0, self.capacity_check(self.deployed_values(), nodes=self.LARGE_NODE))
+
+    def test_check_agent_capacity_blocks_a_cap_above_the_pool(self):
+        # 200 against the 160 nodes two large groups can hold: 40 agents could never be scheduled, which is
+        # not idle but a churn loop, and is what preceded the 2026-08-11 controller stall
+        over = self.deployed_values("large", instanceCap=200, instanceCapStr="200")
+        self.assertEqual(1, self.capacity_check(over))
+        # a cluster whose ceilings cannot be read leaves it unchecked rather than blocking a valid deploy
+        self.assertEqual(0, self.capacity_check(over, autoscaler=False))
+
+    def test_check_agent_capacity_reads_maxsize_wherever_it_is_published(self):
+        # the live cluster nests a group's maximum under its health condition, and the check also takes it
+        # from the group.  Reading the wrong key costs nothing visible: the ceilings come out empty and
+        # every cap passes unchecked, so the shapes are pinned here rather than in a deploy
+        over = self.deployed_values("large", instanceCap=200, instanceCapStr="200")
+        for nested in (True, False):
+            self.assertEqual(1, self.capacity_check(over, nested=nested))
+            self.assertEqual(0, self.capacity_check(self.deployed_values(), nested=nested))
+
+    def test_check_agent_capacity_blocks_contradictory_config(self):
+        # the plugin takes the cap from either key, so a disagreement resolves to whichever applies last
+        self.assertEqual(1, self.capacity_check(self.deployed_values("large", instanceCapStr="200")))
+        # a nodeSelector the live nodes contradict strands every agent of that size
+        typo = self.deployed_values("large", nodeSelector="cassandra.jenkins.agent.large=ture")
+        self.assertEqual(1, self.capacity_check(typo, nodes=self.LARGE_NODE))
+        # unconfirmable is not the same as contradicted: with that pool at zero there is nothing to check against
+        self.assertEqual(0, self.capacity_check(typo))
 
 if __name__ == '__main__':
     unittest.main()

--- a/.github/workflows/jenkins-check.yaml
+++ b/.github/workflows/jenkins-check.yaml
@@ -33,7 +33,7 @@ jobs:
           - name: Install dependencies
             run: pip install pylint -r .build/run-ci.d/requirements.txt
           - name: Lint run-ci
-            run: pylint --disable=C0301,W0511,C0103,W0702,C0415,C0116,C0115,R0914,W0603,R0915,R0913,R0917,R0911,W0212,W0621 .build/run-ci
+            run: pylint --disable=C0301,C0302,W0511,C0103,W0702,C0415,C0116,C0115,R0914,W0603,R0915,R0913,R0917,R0911,W0212,W0621 .build/run-ci
           - name: Run run-ci unit tests
             run: python .build/run-ci.d/run-ci-test.py
           - name: Check run-ci argument parsing
@@ -51,8 +51,11 @@ jobs:
               python-version: '3.x'
           - name: Install dependencies
             run: pip install pyyaml
+          # get-helm-3 defaults to the latest stable release (now helm 4), so pin the version explicitly.
           - name: Helm
-            uses: azure/setup-helm@v4
+            env:
+              DESIRED_VERSION: v3.21.3
+            run: curl -fsSL https://raw.githubusercontent.com/helm/helm/v3.21.3/scripts/get-helm-3 | bash
           # validate.sh runs groovy from docker when it is not on the PATH
           - name: Validate .jenkins/
             run: .jenkins/k8s/jenkins-test.sh

--- a/.jenkins/k8s/jenkins-deployment.yaml
+++ b/.jenkins/k8s/jenkins-deployment.yaml
@@ -47,7 +47,23 @@ controller:
     limits:
       cpu: 8
       memory: 20G
-  javaOpts: -server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=40 -Xms8G -Xmx8G
+  javaOpts: -server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=40 -Xms8G -Xmx8G -Xlog:gc*,safepoint:file=/var/jenkins_home/gc.log:time,uptime,level,tags:filecount=5,filesize=50M
+  # A stalling controller must not be killed mid-flight.  The restart abandons every running build and
+  #  strands their agent pods, which nothing then deletes: see agent.garbageCollection below.
+  # Liveness now tolerates ~100s of unresponsiveness before a kill.
+  # Readiness is loosened for a second reason: an unready controller is dropped from the cassius-jenkins-agent Service,
+  #  so agents cannot complete their JNLP handshake and then sit in "initialising" until waitForPodSec expires.
+  probes:
+    startupProbe:
+      # a 500Gi jenkins_home with this much build history can exceed the chart's default 120s budget
+      failureThreshold: 30
+      timeoutSeconds: 10
+    livenessProbe:
+      failureThreshold: 10
+      timeoutSeconds: 10
+    readinessProbe:
+      failureThreshold: 6
+      timeoutSeconds: 10
   installPlugins:
     - job-dsl
     - configuration-as-code
@@ -159,6 +175,13 @@ agent:
   node-selector:
     cassandra.jenkins.agent: true
   waitForPodSec: "180"
+  # Reap agent pods the controller no longer tracks.  A restart of the controller JVM clears its in-memory 
+  # agent registry, and because agent pods are bare pods with no ownerReference nothing else deletes them.
+  # Preferred over a pod activeDeadlineSeconds, which cannot distinguish an orphan from a long (6h) build.
+  garbageCollection:
+    enabled: true
+    # seconds
+    timeout: 900
   #
   # Each template below is an opaque string to the helm chart, parsed only by the kubernetes plugin,
   # so the chart (nor .jenkins/k8s/jenkins-test.sh) can validate it.
@@ -181,8 +204,10 @@ agent:
       - name: agent-dind-small
         label: agent-dind cassandra-small cassandra-amd64-small
         nodeSelector: 'cassandra.jenkins.agent.small=true'
+        # 0 = no pod lifetime cap: idleMinutes reuse means a pod's age is unrelated to any one build's timeout.  Orphans are reaped by agent.garbageCollection instead.
         activeDeadlineSeconds: '0'
         idleMinutes: 1
+        # should match the small pool's 50 nodes (README's --max-nodes), i.e. one agent per node. must not be higher than max nodes possible.
         instanceCap: 50
         instanceCapStr: "50"
         nodeUsageMode: "NORMAL"
@@ -209,8 +234,6 @@ agent:
               - envVar:
                   key: JENKINS_JAVA_OPTS
                   value: '-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.USE_BINARY_WRAPPER=true -Xlog:gc+heap+exit -XX:+HeapDumpOnOutOfMemoryError'
-            # there's a lot of docker pulls,
-            # TODO implement option for docker registry caches :: https://medium.com/@elementtech.dev/kubernetes-image-proxy-cache-from-minutes-to-milliseconds-fd14173e831f
             image: apache.jfrog.io/cassan-docker/apache/cassandra-jenkins-k8s
             livenessProbe:
               failureThreshold: '0'
@@ -289,8 +312,10 @@ agent:
       - name: agent-dind-medium
         label: agent-dind cassandra-medium cassandra-amd64-medium
         nodeSelector: 'cassandra.jenkins.agent.medium=true'
+        # 0 = no pod lifetime cap: idleMinutes reuse means a pod's age is unrelated to any one build's timeout.  Orphans are reaped by agent.garbageCollection instead.
         activeDeadlineSeconds: '0'
         idleMinutes: 1
+        # should match the medium pools 100 nodes (README's --max-nodes), i.e. one agent per node. must not be higher than max nodes possible.
         instanceCap: 100
         instanceCapStr: "100"
         nodeUsageMode: "NORMAL"
@@ -395,10 +420,14 @@ agent:
       - name: agent-dind-large
         label: agent-dind cassandra-large cassandra-amd64-large cassandra-amd64-large-dedicated
         nodeSelector: 'cassandra.jenkins.agent.large=true'
+        # 0 = no pod lifetime cap.  A microbench cell runs up to 6h (timeout_hours in the Jenkinsfile)
+        # and idleMinutes reuse extends a pod's age past any one build, so age cannot stand in for
+        # health here.  Orphans are reaped by agent.garbageCollection instead.
         activeDeadlineSeconds: '0'
         idleMinutes: 1
-        instanceCap: 200
-        instanceCapStr: "200"
+        # should match the large pools 160 nodes (README's --max-nodes), i.e. one agent per node. must not be higher than max nodes possible.
+        instanceCap: 160
+        instanceCapStr: "160"
         nodeUsageMode: "NORMAL"
         showRawYaml: 'true'
         slaveConnectTimeout: '30'


### PR DESCRIPTION
node pools can get stuck at max desired size, wasting a lot of resources and $$$
Either the instanceCap goes beyond the node group sizes, and it thrashes, or (for example) the controller fails its liveness probe, gets SIGKILLed, then orphans agent pods forever. Manually trying to scale down the node groups won't help the as the jenkins keeps trying to scale up again…

  jenkins-deployment.yaml:
   - enable agent.garbageCollection, so a controller restart no longer leaks agent pods; activeDeadlineSeconds cannot tell an orphan from a legitimate 6h microbench build
   - cap agent-dind-large at the 160 nodes its pool holds.  At 200 the surplus pods could never be scheduled, so they churned and drove both large node groups to maxSize
   - loosen the controller probes, so a stall no longer takes every running build with it
   - log gc and safepoints to the PVC, to make the next stall attributable

  run-ci:
   - refuse to deploy an instanceCap above what the node pools can schedule, read from the cluster-autoscaler status configmap
   - fail rather than fall back to origin when a branch tracks no remote, since origin carries no dev branches; suggest push.autoSetupRemote
   - helm --timeout 10m, as --wait's 5m default is now shorter than the startupProbe's boot budget

  jenkins-check.yaml
   - fix helm installation

  patch by Mick Semb Wever; reviewed by TODO for CASSANDRA-21576

Assisted-by: Claude Code:claude-opus-5
