### PR TITLE
Fixes for fully-expired SSTable index notification in compaction

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,7 @@ Merged from 5.0:
  * Fix ThreadLocalReadAheadBuffer#fill() to throw a CorruptBlockException if chunk metadata and file size are out of sync (CASSANDRA-21519)
  * Fix memtable on-heap accounting drift in BTree.update and BTreeRow.merge (CASSANDRA-21472)
 Merged from 4.0:
+ * Fixes for fully-expired SSTable index notification in compaction (CASSANDRA-21577)
  * During streaming Bounds.getNonOverlappingBounds produces incorrect bounds leading to row/counter cache not invalidate correctly (CASSANDRA-21594)
  * Validate authz before performing role check in LIST ROLES/PERMISSIONS (CASSANDRA-21560)
  * Add validation to uncompressed length during decompression (CASSANDRA-21567)

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -72,6 +72,7 @@ import org.apache.cassandra.service.snapshot.SnapshotManager;
 import org.apache.cassandra.service.snapshot.SnapshotOptions;
 import org.apache.cassandra.service.snapshot.SnapshotType;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Refs;
 
@@ -632,6 +633,10 @@ public class CompactionTask extends AbstractCompactionTask
 
         for (SSTableReader expiredSSTable : fullyExpiredSSTables)
         {
+            // Notifying indexers is best-effort: the SSTable is fully expired and is going to be obsoleted regardless.
+            // A read error (e.g. a corrupt-but-expired SSTable, which was previously dropped without ever being read) or
+            // a failure in a custom indexer must not silently leave the SSTable undropped, or every subsequent compaction
+            // would hit the same failure, leaving the expired SSTables permanently stuck.
             try (ISSTableScanner scanner = expiredSSTable.getScanner())
             {
                 while (scanner.hasNext())
@@ -658,21 +663,40 @@ public class CompactionTask extends AbstractCompactionTask
                             for (Index.Indexer indexer : indexers)
                                 indexer.begin();
 
-                            while (partition.hasNext())
+                            try
                             {
-                                Unfiltered unfiltered = partition.next();
-                                if (unfiltered instanceof Row)
+                                Row staticRow = partition.staticRow();
+                                if (!staticRow.isEmpty())
                                 {
                                     for (Index.Indexer indexer : indexers)
-                                        indexer.removeRow((Row) unfiltered);
+                                        indexer.removeRow(staticRow);
+                                }
+
+                                while (partition.hasNext())
+                                {
+                                    Unfiltered unfiltered = partition.next();
+                                    if (unfiltered instanceof Row)
+                                    {
+                                        for (Index.Indexer indexer : indexers)
+                                            indexer.removeRow((Row) unfiltered);
+                                    }
                                 }
                             }
-
-                            for (Index.Indexer indexer : indexers)
-                                indexer.finish();
+                            finally
+                            {
+                                for (Index.Indexer indexer : indexers)
+                                    indexer.finish();
+                            }
                         }
                     }
                 }
+            }
+            catch (Throwable t)
+            {
+                JVMStabilityInspector.inspectThrowable(t);
+                logger.warn("Failed to notify secondary indexes about rows in fully expired SSTable {} during compaction {}; " +
+                            "the SSTable will still be dropped, but index cleanup for it may be incomplete.",
+                            expiredSSTable, transaction.opIdString(), t);
             }
         }
     }

--- a/src/java/org/apache/cassandra/index/accord/NoOpIndex.java
+++ b/src/java/org/apache/cassandra/index/accord/NoOpIndex.java
@@ -119,6 +119,12 @@ public class NoOpIndex implements Index
     }
 
     @Override
+    public boolean notifyIndexerAboutRowsInFullyExpiredSSTables()
+    {
+        return false;
+    }
+
+    @Override
     public boolean supportsExpression(ColumnMetadata column, Operator operator)
     {
         return false;

--- a/src/java/org/apache/cassandra/index/accord/RouteJournalIndex.java
+++ b/src/java/org/apache/cassandra/index/accord/RouteJournalIndex.java
@@ -369,6 +369,12 @@ public class RouteJournalIndex implements Index, INotificationConsumer
     }
 
     @Override
+    public boolean notifyIndexerAboutRowsInFullyExpiredSSTables()
+    {
+        return false;
+    }
+
+    @Override
     public boolean supportsExpression(ColumnMetadata column, Operator operator)
     {
         // disallow all queries, in order to interact with this index you must bypass CQL

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedIndex.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedIndex.java
@@ -254,6 +254,12 @@ public class PaxosUncommittedIndex implements Index, PaxosUncommittedTracker.Upd
         return indexer;
     }
 
+    @Override
+    public boolean notifyIndexerAboutRowsInFullyExpiredSSTables()
+    {
+        return false;
+    }
+
     public Searcher searcherFor(ReadCommand command)
     {
         throw new UnsupportedOperationException();

--- a/test/unit/org/apache/cassandra/index/CustomIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/CustomIndexTest.java
@@ -43,7 +43,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Uninterruptibles;
 
 import org.junit.Assert;
 import org.junit.Assume;
@@ -85,6 +84,7 @@ import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTableFlushObserver;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.Indexes;
@@ -723,17 +723,16 @@ public class CustomIndexTest extends CQLTester
         StubIndex index1  = (StubIndex1)cfs.indexManager.getIndexByName("row_ttl_test_index_1");
         StubIndex index2  = (StubIndex2)cfs.indexManager.getIndexByName("row_ttl_test_index_2");
 
-        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 20", 0, 0);
-        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 20", 1, 1);
-        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 20", 2, 2);
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 0, 0);
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 1, 1);
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 2, 2);
 
-        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 20", 0, 0);
-        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 20", 1, 1);
-        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 20", 2, 2);
+        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 2", 0, 0);
+        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 2", 1, 1);
+        execute("INSERT INTO %s (id, col2) VALUES (?, ?) USING TTL 2", 2, 2);
 
         flush();
-
-        Uninterruptibles.sleepUninterruptibly(60, TimeUnit.SECONDS);
+        awaitFullyExpired(cfs);
 
         compact();
 
@@ -742,6 +741,69 @@ public class CustomIndexTest extends CQLTester
 
         Assert.assertFalse(index2.rowsDeleted.isEmpty());
         Assert.assertEquals(3, index2.rowsDeleted.size());
+    }
+
+    @Test
+    public void indexerFailureDoesNotBlockDroppingFullyExpiredSSTables()
+    {
+        createTable("CREATE TABLE %s (id int primary key, col1 int) " +
+                    "WITH compaction = {'class': 'TimeWindowCompactionStrategy', " +
+                    "                   'compaction_window_size': 1," +
+                    "                   'compaction_window_unit': 'MINUTES'," +
+                    "                   'expired_sstable_check_frequency_seconds': 10} " +
+                    "AND gc_grace_seconds = 0");
+
+        createIndex(String.format("CREATE CUSTOM INDEX throwing_expired_index ON %%s(col1) USING '%s'", ThrowingStubIndex.class.getName()));
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 0, 0);
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 1, 1);
+        execute("INSERT INTO %s (id, col1) VALUES (?, ?) USING TTL 2", 2, 2);
+
+        flush();
+        Assert.assertFalse(cfs.getLiveSSTables().isEmpty());
+        awaitFullyExpired(cfs);
+
+        // The indexer throws while being notified, but compaction must complete and still drop the expired SSTables.
+        compact();
+
+        Assert.assertTrue("Fully expired SSTables should have been dropped despite the indexer throwing",
+                          cfs.getLiveSSTables().isEmpty());
+    }
+
+    @Test
+    public void notifyIndexesOfStaticRowsInFullyExpiredSSTablesDuringCompaction()
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, s int static, v int, PRIMARY KEY (pk, ck)) " +
+                    "WITH compaction = {'class': 'TimeWindowCompactionStrategy', " +
+                    "                   'compaction_window_size': 1," +
+                    "                   'compaction_window_unit': 'MINUTES'," +
+                    "                   'expired_sstable_check_frequency_seconds': 10} " +
+                    "AND gc_grace_seconds = 0");
+
+        createIndex(String.format("CREATE CUSTOM INDEX static_expired_index ON %%s(s) USING '%s'", StubIndex.class.getName()));
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        StubIndex index = (StubIndex) cfs.indexManager.getIndexByName("static_expired_index");
+        Assert.assertNotNull(index);
+
+        // Static-only writes: each partition gets a static row and no clustering rows, so removeRow would never be
+        // invoked for these partitions unless the static row is handled explicitly.
+        execute("INSERT INTO %s (pk, s) VALUES (?, ?) USING TTL 2", 0, 100);
+        execute("INSERT INTO %s (pk, s) VALUES (?, ?) USING TTL 2", 1, 200);
+
+        flush();
+        Assert.assertFalse(cfs.getLiveSSTables().isEmpty());
+        awaitFullyExpired(cfs);
+
+        // Ignore anything recorded during index build/flush; only care about the compaction-time notifications.
+        index.reset();
+        compact();
+
+        Assert.assertEquals("Static rows in fully-expired SSTables should be forwarded to the indexer",
+                            2, index.rowsDeleted.size());
+        Assert.assertTrue(cfs.getLiveSSTables().isEmpty());
     }
 
     @Test
@@ -965,6 +1027,19 @@ public class CustomIndexTest extends CQLTester
         assertEquals(index.rangeTombstones, index2.rangeTombstones);
     }
 
+    /**
+     * wait until all sstables are fully expired for the given {@code cfs}
+     */
+    private static void awaitFullyExpired(ColumnFamilyStore cfs)
+    {
+        long maxLocalDeletionTime = cfs.getLiveSSTables().stream()
+                                       .mapToLong(SSTableReader::getMaxLocalDeletionTime)
+                                       .max()
+                                       .orElseThrow(AssertionError::new);
+
+        Util.spinUntilTrue(() -> FBUtilities.nowInSeconds() > maxLocalDeletionTime, 30, TimeUnit.SECONDS);
+    }
+
 
     // Used for index creation above
     @SuppressWarnings("unused")
@@ -1018,6 +1093,39 @@ public class CustomIndexTest extends CQLTester
     private static IndexTarget indexTarget(String name, IndexTarget.Type type)
     {
         return new IndexTarget(ColumnIdentifier.getInterned(name, true), type);
+    }
+
+    // A stub index whose Indexer throws while removing rows, to simulate a misbehaving custom index (or a read error)
+    // while being notified about rows in a fully-expired SSTable during compaction.
+    public static class ThrowingStubIndex extends StubIndex
+    {
+        public ThrowingStubIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+        }
+
+        @Override
+        public Indexer indexerFor(DecoratedKey key,
+                                  RegularAndStaticColumns columns,
+                                  long nowInSec,
+                                  WriteContext ctx,
+                                  IndexTransaction.Type transactionType,
+                                  Memtable memtable)
+        {
+            return new Indexer()
+            {
+                public void begin() { }
+                public void partitionDelete(DeletionTime deletionTime) { }
+                public void rangeTombstone(RangeTombstone tombstone) { }
+                public void insertRow(Row row) { }
+                public void updateRow(Row oldRowData, Row newRowData) { }
+                public void removeRow(Row row)
+                {
+                    throw new RuntimeException("simulated indexer failure during fully-expired SSTable notification");
+                }
+                public void finish() { }
+            };
+        }
     }
 
     public static final class CountMetadataReloadsIndex extends StubIndex


### PR DESCRIPTION
The 2i notification path added to CompactionTask (CASSANDRA-20829) had three issues, all reachable on upgrade for existing clusters:

- A read error or a throwing custom indexer aborted the whole compaction. Expired SSTables were never obsoleted and every retry hit the same failure.
- The static row was never passed to removeRow, so static-column indexes missed expired-data notifications.
- NoOpIndex, PaxosUncommittedIndex and RouteJournalIndex inherited the default (true) and did no useful work on this path, forcing needless full scans of expired SSTables on system.paxos / accord tables. Opt them out matching SAI/SASI.

patch by Francisco Guerrero; reviewed by TBD for CASSANDRA-21577