### PR TITLE
Enable trickle fsync by default

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -986,7 +986,11 @@ index_summary_resize_interval: 60m
 # buffers. Enable this to avoid sudden dirty buffer flushing from
 # impacting read latencies. Almost always a good idea on SSDs; not
 # necessarily on platters.
-trickle_fsync: false
+trickle_fsync: true
+# The interval bounds how much dirty data one fsync forces out, so it bounds the
+# size of a single writeback burst. Raising it trades read tail latency for write
+# throughput; raise it far enough and the kernel's own dirty page thresholds
+# start the writeback instead, which is the burst this setting exists to avoid.
 # The interval is counted in uncompressed bytes, so for compressed SSTables
 # (the default) an fsync fires after fewer bytes than this reach the disk.
 # Min unit: KiB

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -972,6 +972,12 @@ memtable_allocation_type: offheap_objects
 # impacting read latencies. Almost always a good idea on SSDs; not
 # necessarily on platters.
 trickle_fsync: true
+# The interval bounds how much dirty data one fsync forces out, so it bounds the
+# size of a single writeback burst. Raising it trades read tail latency for write
+# throughput; raise it far enough and the kernel's own dirty page thresholds
+# start the writeback instead, which is the burst this setting exists to avoid.
+# The interval is counted in uncompressed bytes, so for compressed SSTables
+# (the default) an fsync fires after fewer bytes than this reach the disk.
 # Min unit: KiB
 trickle_fsync_interval: 10240KiB
 

--- a/src/java/org/apache/cassandra/cache/AutoSavingCache.java
+++ b/src/java/org/apache/cassandra/cache/AutoSavingCache.java
@@ -110,7 +110,7 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
     {
         private final SequentialWriterOption writerOption = SequentialWriterOption.newBuilder()
                                                                     .trickleFsync(DatabaseDescriptor.getTrickleFsync())
-                                                                    .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInKiB() * 1024)
+                                                                    .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInBytes())
                                                                     .finishOnClose(true).build();
 
         public DataInputStreamPlus getInputStream(File dataPath, File crcPath) throws IOException

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -546,7 +546,7 @@ public class Config
     public volatile boolean use_creation_time_for_hint_ttl = true;
 
     public volatile boolean incremental_backups = false;
-    public boolean trickle_fsync = false;
+    public boolean trickle_fsync = true;
     @Replaces(oldName = "trickle_fsync_interval_in_kb", converter = Converters.KIBIBYTES_DATASTORAGE, deprecated = true)
     public DataStorageSpec.IntKibibytesBound trickle_fsync_interval = new DataStorageSpec.IntKibibytesBound("10240KiB");
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4496,9 +4496,9 @@ public class DatabaseDescriptor
         return conf.trickle_fsync;
     }
 
-    public static int getTrickleFsyncIntervalInKiB()
+    public static long getTrickleFsyncIntervalInBytes()
     {
-        return conf.trickle_fsync_interval.toKibibytes();
+        return conf.trickle_fsync_interval.toBytesInLong();
     }
 
     public static long getKeyCacheSizeInMiB()

--- a/src/java/org/apache/cassandra/hints/HintsWriter.java
+++ b/src/java/org/apache/cassandra/hints/HintsWriter.java
@@ -288,7 +288,7 @@ class HintsWriter implements AutoCloseable
 
         private void maybeFsync()
         {
-            if (position() >= lastSyncPosition + DatabaseDescriptor.getTrickleFsyncIntervalInKiB() * 1024L)
+            if (position() >= lastSyncPosition + DatabaseDescriptor.getTrickleFsyncIntervalInBytes())
                 fsync();
         }
 
@@ -298,7 +298,7 @@ class HintsWriter implements AutoCloseable
 
             // don't skip page cache for tiny files, on the assumption that if they are tiny, the target node is probably
             // alive, and if so, the file will be closed and dispatched shortly (within a minute), and the file will be dropped.
-            if (position >= DatabaseDescriptor.getTrickleFsyncIntervalInKiB() * 1024L)
+            if (position >= DatabaseDescriptor.getTrickleFsyncIntervalInBytes())
                 NativeLibrary.trySkipCache(fd, 0, position - (position % PAGE_SIZE), file.path());
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/io/IndexFileUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/io/IndexFileUtils.java
@@ -42,7 +42,7 @@ public class IndexFileUtils
     @VisibleForTesting
     public static final SequentialWriterOption DEFAULT_WRITER_OPTION = SequentialWriterOption.newBuilder()
                                                                                              .trickleFsync(DatabaseDescriptor.getTrickleFsync())
-                                                                                             .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInKiB() * 1024)
+                                                                                             .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInBytes())
                                                                                              .bufferType(BufferType.OFF_HEAP)
                                                                                              .finishOnClose(true)
                                                                                              .build();

--- a/src/java/org/apache/cassandra/io/sstable/IOOptions.java
+++ b/src/java/org/apache/cassandra/io/sstable/IOOptions.java
@@ -33,7 +33,7 @@ public class IOOptions
                              DatabaseDescriptor.getDiskOptimizationEstimatePercentile(),
                              SequentialWriterOption.newBuilder()
                                                    .trickleFsync(DatabaseDescriptor.getTrickleFsync())
-                                                   .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInKiB() * 1024)
+                                                   .trickleFsyncByteInterval(DatabaseDescriptor.getTrickleFsyncIntervalInBytes())
                                                    .build(),
                              DatabaseDescriptor.getFlushCompression());
     }

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -62,7 +62,7 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
     // whether to do trickling fsync() to avoid sudden bursts of dirty buffer flushing by kernel causing read
     // latency spikes
     protected final SequentialWriterOption option;
-    private int bytesSinceTrickleFsync = 0;
+    private long bytesSinceTrickleFsync = 0;
 
     protected long lastFlushOffset;
 

--- a/src/java/org/apache/cassandra/io/util/SequentialWriterOption.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriterOption.java
@@ -45,13 +45,13 @@ public class SequentialWriterOption
     private final int bufferSize;
     private final BufferType bufferType;
     private final boolean trickleFsync;
-    private final int trickleFsyncByteInterval;
+    private final long trickleFsyncByteInterval;
     private final boolean finishOnClose;
 
     private SequentialWriterOption(int bufferSize,
                                    BufferType bufferType,
                                    boolean trickleFsync,
-                                   int trickleFsyncByteInterval,
+                                   long trickleFsyncByteInterval,
                                    boolean finishOnClose)
     {
         this.bufferSize = bufferSize;
@@ -81,7 +81,7 @@ public class SequentialWriterOption
         return trickleFsync;
     }
 
-    public int trickleFsyncByteInterval()
+    public long trickleFsyncByteInterval()
     {
         return trickleFsyncByteInterval;
     }
@@ -110,7 +110,7 @@ public class SequentialWriterOption
         /* default: no trickle fsync */
         private boolean trickleFsync = false;
         /* default tricle fsync byte interval: 10MiB */
-        private int trickleFsyncByteInterval = 10 * 1024 * 1024;
+        private long trickleFsyncByteInterval = 10 * 1024 * 1024;
         private boolean finishOnClose = false;
 
         /* construct throguh SequentialWriteOption.newBuilder */
@@ -140,7 +140,7 @@ public class SequentialWriterOption
             return this;
         }
 
-        public Builder trickleFsyncByteInterval(int trickleFsyncByteInterval)
+        public Builder trickleFsyncByteInterval(long trickleFsyncByteInterval)
         {
             this.trickleFsyncByteInterval = trickleFsyncByteInterval;
             return this;

--- a/test/conf/latest_diff.yaml
+++ b/test/conf/latest_diff.yaml
@@ -48,8 +48,6 @@ commitlog_disk_access_mode: auto
 
 background_write_disk_access_mode: direct
 
-trickle_fsync: true
-
 sstable:
   selected_format: bti
 


### PR DESCRIPTION
Replace getTrickleFsyncIntervalInKiB with getTrickleFsyncIntervalInBytes. The interval accepts up to Integer.MAX_VALUE KiB, so KiB * 1024 in int arithmetic overflowed above 2 GiB and could wrap negative, fsyncing every buffer. Widen the writer's counter and the option's interval to long for the same reason.

patch by Sam Lightfoot; reviewed by for [CASSANDRA-21572](https://issues.apache.org/jira/browse/CASSANDRA-21572)