### PR TITLE
CASSANDRA-21583: Node can report DECOMMISSION_FAILED while actively leaving after a rejected decommission attempt

### DIFF
--- a/src/java/org/apache/cassandra/tcm/sequences/SingleNodeSequences.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/SingleNodeSequences.java
@@ -97,13 +97,13 @@ public interface SingleNodeSequences
         else if (InProgressSequences.isLeave(inProgress))
         {
             logger.info("Resuming decommission @ {} (current epoch = {}): {}", inProgress.latestModification, metadata.epoch, inProgress.status());
-            StorageService.instance.clearTransientMode();
         }
         else
         {
             throw new IllegalArgumentException("Can not decommission a node that has an in-progress sequence");
         }
 
+        StorageService.instance.clearTransientMode();
         InProgressSequences.finishInProgressSequences(self);
         Gossiper.instance.unsafeBroadcastLeftStatus(FBUtilities.getBroadcastAddressAndPort(),
                                                     tokens,

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/DecommissionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/DecommissionTest.java
@@ -134,6 +134,38 @@ public class DecommissionTest extends TestBaseImpl
     }
 
     @Test
+    public void testOperationModeOnFreshDecomAfterRejectedAttempt() throws Exception
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withConfig(config -> config.with(NETWORK, GOSSIP))
+                                        .start())
+        {
+            populate(cluster, 0, 100, 1, 2, ConsistencyLevel.QUORUM);
+
+            IInvokableInstance cmsNode = cluster.get(1);
+            IInvokableInstance leavingNode = cluster.get(2);
+
+            leavingNode.nodetoolResult("decommission").asserts().failure();
+            leavingNode.runOnInstance(() -> assertEquals(StorageService.Mode.DECOMMISSION_FAILED,
+                                                         StorageService.instance.operationMode()));
+
+            Callable<Epoch> midLeavePaused = pauseBeforeCommit(cmsNode, e -> e instanceof PrepareLeave.MidLeave);
+
+            Thread decomThread = new Thread(() -> leavingNode.nodetoolResult("decommission", "--force").asserts().success());
+            decomThread.start();
+            midLeavePaused.call();
+
+            leavingNode.runOnInstance(() ->
+                assertEquals("operationMode during re-decommission after rejected attempt should be LEAVING, not DECOMMISSION_FAILED",
+                             StorageService.Mode.LEAVING,
+                             StorageService.instance.operationMode()));
+
+            unpauseCommits(cmsNode);
+            decomThread.join(TimeUnit.MINUTES.toMillis(2));
+        }
+    }
+
+    @Test
     public void testAddressReuseAfterDecommission() throws IOException, ExecutionException, InterruptedException
     {
         // Initially, all nodes should be in dc1/rack1. Node 3 will be decommissioned and a new node added re-using


### PR DESCRIPTION
When a decommission attempt is rejected due to replication constraints, the node is left in DECOMMISSION_FAILED with no in-progress sequence. A subsequent forced decommission succeeds but does not clear the stale failed state, leaving the node reporting DECOMMISSION_FAILED throughout an otherwise successful leave. This patch ensures the stale mode is always cleared once the node is confirmed to be actively leaving, regardless of which path got it there.

patch by @minal-kyada ; reviewed by @frankgh @maedhroz for CASSANDRA-21583

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

