### PR TITLE
CASSANDRA-21478: Add a guardrail for the number of SSTables touched per read

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
  * Add prepared statement cache stats to nodetool info (CASSANDRA-14366)
  * Don't increment client metrics on messaging service connection unpause (CASSANDRA-21491)
  * Add nodetool getreplicas (CASSANDRA-17665)
+ * Add a guardrail for the number of SSTables touched per read (CASSANDRA-21478)
  * Implementation of CEP-49: Hardware-accelerated compression (CASSANDRA-20975)
  * Avoid using ObjectUtils.getFirstNonNull in Schema (CASSANDRA-21394)
  * Allow nodetool garbagecollect to take a user defined list of SSTables (CASSANDRA-16767)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -90,14 +90,34 @@ New features
       deployments that authenticate over mutual TLS. PasswordDefaultRoleInitializer
       remains the default and produces the historical behaviour. See CASSANDRA-21546
       for more information.
+    - A new read threshold, sstables_per_read_warn_threshold / sstables_per_read_fail_threshold,
+      bounds the number of SSTables touched by a single local read on a replica. Like the existing
+      read-size thresholds, it is surfaced through the read-warnings framework (read_thresholds_enabled):
+      a client read that touches more than the warn threshold emits a client warning, and one that
+      exceeds the fail threshold is aborted before opening the remaining SSTables, protecting the node
+      from an exorbitantly expensive local read. See CASSANDRA-21478.
 
 Upgrading
 ---------
 
     - trickle_fsync is by default set to "true" instead of "false" in cassandra.yaml (see CASSANDRA-21572)
+    - sstables_per_read_log_threshold and its StorageServiceMBean JMX methods
+      (get/setSSTablesPerReadLogThreshold) are deprecated in favor of the new sstables_per_read
+      guardrail but keep working - the yaml key now maps to sstables_per_read_warn_threshold
+      (default 100), and the "The following query ... has read N SSTables" diagnostic log is retained
+      for all reads. Rename the key to sstables_per_read_warn_threshold to silence the startup
+      deprecation warning. See CASSANDRA-21478.
 
 Deprecation
 -----------
+
+    - sstables_per_read_log_threshold is deprecated in favor of the sstables_per_read guardrail
+      (sstables_per_read_warn_threshold / sstables_per_read_fail_threshold). See CASSANDRA-21478.
+    - In the JMX MBean `org.apache.cassandra.db:type=StorageService`: deprecate getter method
+      `getSSTablesPerReadLogThreshold` and setter method `setSSTablesPerReadLogThreshold` in favor of
+      the sstables_per_read guardrail on the JMX MBean `org.apache.cassandra.db:type=Guardrails`
+      (`getSSTablesPerReadWarnThreshold`, `getSSTablesPerReadFailThreshold`, `setSSTablesPerReadThreshold`).
+      See CASSANDRA-21478.
 
 
 6.0

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2069,9 +2069,15 @@ transparent_data_encryption_options:
 # SAFETY THRESHOLDS #
 #####################
 
-# Log the query if it reads more than
-# sstables_per_read_log_threshold SSTables
-sstables_per_read_log_threshold: 100
+# Guardrail on the number of SSTables touched by a single local read (per replica).
+# A read that touches more than sstables_per_read_warn_threshold SSTables logs a diagnostic
+# warning (for all reads) and, for client reads, warns the client; a client read that touches
+# more than sstables_per_read_fail_threshold SSTables is aborted before opening the remaining
+# SSTables, protecting the node from an exorbitantly expensive local read. A value <= 0 disables
+# the corresponding threshold. Internal (system/repair) reads are never warned or aborted.
+# sstables_per_read_warn_threshold replaces the deprecated sstables_per_read_log_threshold.
+sstables_per_read_warn_threshold: 100
+sstables_per_read_fail_threshold: -1
 
 # When executing a scan, within or across a partition, we need to keep the
 # tombstones seen in memory so we can return them to the coordinator, which

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -632,7 +632,9 @@ public class Config
     public volatile DataStorageSpec.LongBytesBound row_index_read_size_warn_threshold = null;
     public volatile DataStorageSpec.LongBytesBound row_index_read_size_fail_threshold = null;
 
-    public volatile int sstables_per_read_log_threshold = 100;
+    @Replaces(oldName = "sstables_per_read_log_threshold", converter = Converters.IDENTITY, deprecated = true)
+    public volatile int sstables_per_read_warn_threshold = 100;
+    public volatile int sstables_per_read_fail_threshold = -1;
     public volatile int tombstone_warn_threshold = 1000;
     public volatile int tombstone_failure_threshold = 100000;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -3370,14 +3370,18 @@ public class DatabaseDescriptor
         return conf.max_mutation_size.toBytes();
     }
 
+    /** @deprecated See CASSANDRA-21478 */
+    @Deprecated(since = "7.0")
     public static int getSSTablesPerReadLogThreshold()
     {
-        return conf.sstables_per_read_log_threshold;
+        return conf.sstables_per_read_warn_threshold;
     }
 
+    /** @deprecated See CASSANDRA-21478 */
+    @Deprecated(since = "7.0")
     public static void setSSTablesPerReadLogThreshold(int threshold)
     {
-        conf.sstables_per_read_log_threshold = threshold;
+        conf.sstables_per_read_warn_threshold = threshold;
     }
 
     public static int getTombstoneWarnThreshold()

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -116,6 +116,7 @@ public class GuardrailsOptions implements GuardrailsConfig
                                  config.sai_sstable_indexes_per_query_fail_threshold,
                                  "sai_sstable_indexes_per_query",
                                  false);
+        validateMaxIntThreshold(config.sstables_per_read_warn_threshold, config.sstables_per_read_fail_threshold, "sstables_per_read");
         validatePasswordPolicy(config.password_policy);
         validateRoleNamePolicy(config.role_name_policy);
         validateAndSanitizeClientDriverVersions(config.minimum_client_driver_versions_warned, "minimum_client_driver_versions_warned");
@@ -1230,6 +1231,33 @@ public class GuardrailsOptions implements GuardrailsConfig
                                   fail,
                                   () -> config.sai_sstable_indexes_per_query_fail_threshold,
                                   x -> config.sai_sstable_indexes_per_query_fail_threshold = x);
+    }
+
+    @Override
+    public int getSSTablesPerReadWarnThreshold()
+    {
+        return config.sstables_per_read_warn_threshold;
+    }
+
+    @Override
+    public int getSSTablesPerReadFailThreshold()
+    {
+        return config.sstables_per_read_fail_threshold;
+    }
+
+    @Override
+    public void setSSTablesPerReadThreshold(int warn, int fail)
+    {
+        validateMaxIntThreshold(warn, fail, "sstables_per_read");
+        updatePropertyWithLogging("sstables_per_read_warn_threshold",
+                                  warn,
+                                  () -> config.sstables_per_read_warn_threshold,
+                                  x -> config.sstables_per_read_warn_threshold = x);
+
+        updatePropertyWithLogging("sstables_per_read_fail_threshold",
+                                  fail,
+                                  () -> config.sstables_per_read_fail_threshold,
+                                  x -> config.sstables_per_read_fail_threshold = x);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -415,6 +415,7 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
                 inputCollector.addMemtableIterator(RTBoundValidator.validate(iter, RTBoundValidator.Stage.MEMTABLE, false));
             }
 
+            SSTablesPerReadGuardrail sstablesPerReadGuardrail = sstablesPerReadGuardrail();
             int selectedSSTablesCnt = 0;
             for (SSTableReader sstable : view.sstables)
             {
@@ -425,19 +426,24 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
                 if (!intersects && !hasPartitionLevelDeletions && !hasRequiredStatics)
                     continue;
 
+                // abort (client reads only) before opening this SSTable's scanner, so a pathological
+                // fan-out is stopped before opening the remaining SSTables
+                selectedSSTablesCnt++;
+                sstablesPerReadGuardrail.failIf(selectedSSTablesCnt);
+
                 UnfilteredPartitionIterator iter = sstable.partitionIterator(columnFilter(), dataRange(), readCountUpdater);
                 inputCollector.addSSTableIterator(sstable, RTBoundValidator.validate(iter, RTBoundValidator.Stage.SSTABLE, false));
 
                 if (!sstable.isRepaired())
                     controller.updateMinOldestUnrepairedTombstone(sstable.getMinLocalDeletionTime());
-
-                selectedSSTablesCnt++;
             }
 
             final int finalSelectedSSTables = selectedSSTablesCnt;
 
             if (finalSelectedSSTables > DatabaseDescriptor.getSSTablesPerReadLogThreshold())
                 noSpamLogger.info("The following query '{}' has read {} SSTables.", this.toCQLString(), finalSelectedSSTables);
+
+            sstablesPerReadGuardrail.warnIf(finalSelectedSSTables);
 
             // iterators can be empty for offline tools
             if (inputCollector.isEmpty())

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -54,6 +54,8 @@ import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.LocalReadSizeTooLargeException;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.db.filter.TooManySSTablesReadException;
+import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.partitions.PurgeFunction;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -759,6 +761,53 @@ public abstract class ReadCommand extends AbstractReadQuery
         return trackWarnings
                && !SchemaConstants.isSystemKeyspace(metadata().keyspace)
                && !(warnThresholdBytes == null && abortThresholdBytes == null);
+    }
+
+    protected SSTablesPerReadGuardrail sstablesPerReadGuardrail()
+    {
+        return new SSTablesPerReadGuardrail();
+    }
+
+    /**
+     * Per-read snapshot of the {@code sstables_per_read} guardrail. The warn/fail thresholds and the
+     * client-read gate are captured once, so a threshold change during the read is ignored until the
+     * next read (matching {@code local_read_size}). Limited to client reads on user tables, like
+     * {@link #shouldTrackSize}.
+     */
+    protected final class SSTablesPerReadGuardrail
+    {
+        private final boolean applies = trackWarnings && !SchemaConstants.isSystemKeyspace(metadata().keyspace);
+        private final int warnThreshold = Guardrails.CONFIG_PROVIDER.getOrCreate(null).getSSTablesPerReadWarnThreshold();
+        private final int failThreshold = Guardrails.CONFIG_PROVIDER.getOrCreate(null).getSSTablesPerReadFailThreshold();
+
+        boolean fails(int sstables)
+        {
+            return applies && failThreshold > 0 && sstables > failThreshold;
+        }
+
+        /**
+         * Aborts the local read on the replica when a client read exceeds the fail threshold, reporting
+         * the abort to the coordinator via {@link MessageParams}.
+         */
+        void failIf(int sstables)
+        {
+            if (fails(sstables))
+            {
+                String msg = String.format("Query %s attempted to read from %d SSTables in a single local read, " +
+                                           "but max allowed is %s; query aborted (see sstables_per_read_fail_threshold)",
+                                           toCQLString(), sstables, failThreshold);
+                Tracing.trace(msg);
+                MessageParams.remove(ParamType.TOO_MANY_SSTABLES_WARN);
+                MessageParams.add(ParamType.TOO_MANY_SSTABLES_FAIL, sstables);
+                throw new TooManySSTablesReadException(msg);
+            }
+        }
+
+        void warnIf(int sstables)
+        {
+            if (applies && warnThreshold > 0 && sstables > warnThreshold && !fails(sstables))
+                MessageParams.add(ParamType.TOO_MANY_SSTABLES_WARN, sstables);
+        }
     }
 
     private UnfilteredPartitionIterator withQuerySizeTracking(UnfilteredPartitionIterator iterator)

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -907,12 +907,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
 
             List<UnfilteredRowIterator> iterators = inputCollector.finalizeIterators(cfs, nowInSec(), controller.oldestUnrepairedTombstone());
 
-            UnfilteredRowIterator result = withSSTablesIterated(iterators, cfs.metric, metricsCollector);
-
-            if (metricsCollector.getMergedSSTables() > DatabaseDescriptor.getSSTablesPerReadLogThreshold())
-                noSpamLogger.info("The following query '{}' has read {} SSTables.", this.toCQLString(), metricsCollector.getMergedSSTables());
-
-            return result;
+            return withSSTablesIterated(iterators, cfs.metric, metricsCollector);
         }
         catch (RuntimeException | Error e)
         {
@@ -999,6 +994,8 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
                int mergedSSTablesIterated = metricsCollector.getMergedSSTables();
                metrics.updateSSTableIterated(mergedSSTablesIterated);
                Tracing.trace("Merged data from memtables and {} sstables", mergedSSTablesIterated);
+               metricsCollector.maybeLogSSTablesRead();
+               metricsCollector.guardrail.warnIf(mergedSSTablesIterated);
            }
         }
         return Transformation.apply(merged, new UpdateSstablesIterated());
@@ -1123,8 +1120,8 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
 
         cfs.metric.updateSSTableIterated(metricsCollector.getMergedSSTables());
 
-        if (metricsCollector.getMergedSSTables() > DatabaseDescriptor.getSSTablesPerReadLogThreshold())
-            noSpamLogger.info("The following query '{}' has read {} SSTables.", this.toCQLString(), metricsCollector.getMergedSSTables());
+        metricsCollector.maybeLogSSTablesRead();
+        metricsCollector.guardrail.warnIf(metricsCollector.getMergedSSTables());
 
         if (result == null || result.isEmpty())
             return EmptyIterators.unfilteredRow(metadata(), partitionKey(), false);
@@ -1514,7 +1511,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     /**
      * {@code SSTableReaderListener} used to collect metrics about SSTable read access.
      */
-    private static final class SSTableReadMetricsCollector implements SSTableReadsListener
+    private final class SSTableReadMetricsCollector implements SSTableReadsListener
     {
         /**
          * The number of SSTables that need to be merged. This counter is only updated for single partition queries
@@ -1522,11 +1519,23 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
          */
         private int mergedSSTables;
 
+        /** Ensures the diagnostic "has read N SSTables" log is emitted at most once per local read. */
+        private boolean logged;
+
+        private final SSTablesPerReadGuardrail guardrail = sstablesPerReadGuardrail();
+
         @Override
         public void onSSTableSelected(SSTableReader sstable, SelectionReason reason)
         {
             sstable.incrementReadCount();
             mergedSSTables++;
+
+            // log once before aborting, so a failing read still records how many SSTables it touched
+            if (guardrail.fails(mergedSSTables))
+            {
+                maybeLogSSTablesRead();
+                guardrail.failIf(mergedSSTables);
+            }
         }
 
         /**
@@ -1536,6 +1545,19 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         public int getMergedSSTables()
         {
             return mergedSSTables;
+        }
+
+        /**
+         * Emits the diagnostic {@code sstables_per_read} log at most once per local read.
+         */
+        void maybeLogSSTablesRead()
+        {
+            if (!logged && mergedSSTables > DatabaseDescriptor.getSSTablesPerReadLogThreshold())
+            {
+                logged = true;
+                noSpamLogger.info("The following query '{}' has read {} SSTables.",
+                                  SinglePartitionReadCommand.this.toCQLString(), mergedSSTables);
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/db/filter/TooManySSTablesReadException.java
+++ b/src/java/org/apache/cassandra/db/filter/TooManySSTablesReadException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.filter;
+
+import org.apache.cassandra.db.RejectException;
+
+public class TooManySSTablesReadException extends RejectException
+{
+    public TooManySSTablesReadException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
@@ -655,6 +655,18 @@ public final class Guardrails implements GuardrailsMBean
                              what, isWarning ? "warning" : "failure", threshold, value)));
 
     /**
+     * Guardrail on the number of SSTables touched by a single local read.
+     */
+    public static final MaxThreshold sstablesPerRead =
+    new MaxThreshold("sstables_per_read",
+                     "A single local read touching too many SSTables can consume excessive resources on the replica",
+                     state -> CONFIG_PROVIDER.getOrCreate(state).getSSTablesPerReadWarnThreshold(),
+                     state -> CONFIG_PROVIDER.getOrCreate(state).getSSTablesPerReadFailThreshold(),
+                     ((isWarning, what, value, threshold) ->
+                      format("Query %s attempted to read from %s SSTables in a single local read, which violated the %s threshold of %s",
+                             what, value, isWarning ? "warning" : "failure", threshold)));
+
+    /**
      * Guardrail on the size of a string term written to SAI index.
      */
     public static final MaxThreshold saiStringTermSize =
@@ -1758,6 +1770,24 @@ public final class Guardrails implements GuardrailsMBean
     public void setSaiSSTableIndexesPerQueryThreshold(int warn, int fail)
     {
         DEFAULT_CONFIG.setSaiSSTableIndexesPerQueryThreshold(warn, fail);
+    }
+
+    @Override
+    public int getSSTablesPerReadWarnThreshold()
+    {
+        return DEFAULT_CONFIG.getSSTablesPerReadWarnThreshold();
+    }
+
+    @Override
+    public int getSSTablesPerReadFailThreshold()
+    {
+        return DEFAULT_CONFIG.getSSTablesPerReadFailThreshold();
+    }
+
+    @Override
+    public void setSSTablesPerReadThreshold(int warn, int fail)
+    {
+        DEFAULT_CONFIG.setSSTablesPerReadThreshold(warn, fail);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
@@ -588,6 +588,24 @@ public interface GuardrailsConfig
     void setSaiSSTableIndexesPerQueryThreshold(int warn, int fail);
 
     /**
+     * @return the warning threshold for the number of SSTables touched by a single local read
+     */
+    int getSSTablesPerReadWarnThreshold();
+
+    /**
+     * @return the failure threshold for the number of SSTables touched by a single local read
+     */
+    int getSSTablesPerReadFailThreshold();
+
+    /**
+     * Sets warning and failure thresholds for the number of SSTables touched by a single local read
+     *
+     * @param warn value to set for warn threshold
+     * @param fail value to set for fail threshold
+     */
+    void setSSTablesPerReadThreshold(int warn, int fail);
+
+    /**
      * @return the warning threshold for the size of string terms written to an SAI index
      */
     DataStorageSpec.LongBytesBound getSaiStringTermSizeWarnThreshold();

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
@@ -1034,6 +1034,24 @@ public interface GuardrailsMBean
     void setSaiSSTableIndexesPerQueryThreshold(int warn, int fail);
 
     /**
+     * @return the warning threshold for the number of SSTables touched by a single local read
+     */
+    int getSSTablesPerReadWarnThreshold();
+
+    /**
+     * @return the failure threshold for the number of SSTables touched by a single local read
+     */
+    int getSSTablesPerReadFailThreshold();
+
+    /**
+     * Sets warning and failure thresholds for the number of SSTables touched by a single local read
+     *
+     * @param warn value to set for warn threshold
+     * @param fail value to set for fail threshold
+     */
+    void setSSTablesPerReadThreshold(int warn, int fail);
+
+    /**
      * @return The warning threshold for string terms written to an SAI index, as a human-readable string.
      *         (ex. {@code 10GiB}, {@code 20MiB}, {@code 30KiB} or {@code 40B}) A {@code null} value means disabled.
      */

--- a/src/java/org/apache/cassandra/exceptions/RequestFailure.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailure.java
@@ -54,6 +54,7 @@ public class RequestFailure
     public static final RequestFailure INDEX_NOT_AVAILABLE = new RequestFailure(RequestFailureReason.INDEX_NOT_AVAILABLE);
     public static final RequestFailure COORDINATOR_BEHIND = new RequestFailure(RequestFailureReason.COORDINATOR_BEHIND);
     public static final RequestFailure READ_TOO_MANY_INDEXES = new RequestFailure(RequestFailureReason.READ_TOO_MANY_INDEXES);
+    public static final RequestFailure READ_TOO_MANY_SSTABLES = new RequestFailure(RequestFailureReason.READ_TOO_MANY_SSTABLES);
     public static final RequestFailure RETRY_ON_DIFFERENT_TRANSACTION_SYSTEM = new RequestFailure(RequestFailureReason.RETRY_ON_DIFFERENT_TRANSACTION_SYSTEM);
     public static final RequestFailure INDEX_BUILD_IN_PROGRESS = new RequestFailure(RequestFailureReason.INDEX_BUILD_IN_PROGRESS);
     public static final RequestFailure TRUNCATE_FAILED = new RequestFailure(RequestFailureReason.TRUNCATE_FAILED);
@@ -149,6 +150,7 @@ public class RequestFailure
             case INDEX_NOT_AVAILABLE: return INDEX_NOT_AVAILABLE;
             case COORDINATOR_BEHIND: return COORDINATOR_BEHIND;
             case READ_TOO_MANY_INDEXES: return READ_TOO_MANY_INDEXES;
+            case READ_TOO_MANY_SSTABLES: return READ_TOO_MANY_SSTABLES;
             case INDEX_BUILD_IN_PROGRESS: return INDEX_BUILD_IN_PROGRESS;
             case RETRY_ON_DIFFERENT_TRANSACTION_SYSTEM: return RETRY_ON_DIFFERENT_TRANSACTION_SYSTEM;
             case TRUNCATE_FAILED: return TRUNCATE_FAILED;

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -52,6 +52,8 @@ public enum RequestFailureReason
     COORDINATOR_BEHIND                      (10),
     RETRY_ON_DIFFERENT_TRANSACTION_SYSTEM   (11),
     TRUNCATE_FAILED                         (12),
+    // below reason does not have an associated exception
+    READ_TOO_MANY_SSTABLES                  (13),
     // The following codes have been ported from an external fork, where they were offset explicitly to avoid conflicts.
     INDEX_BUILD_IN_PROGRESS                 (503),
     ;
@@ -76,7 +78,7 @@ public enum RequestFailureReason
 
     static
     {
-        EnumSet<RequestFailureReason> withoutExceptions = EnumSet.of(UNKNOWN, NODE_DOWN, READ_TOO_MANY_INDEXES);
+        EnumSet<RequestFailureReason> withoutExceptions = EnumSet.of(UNKNOWN, NODE_DOWN, READ_TOO_MANY_INDEXES, READ_TOO_MANY_SSTABLES);
         Sets.SetView<RequestFailureReason> withExceptions =  Sets.difference(EnumSet.allOf(RequestFailureReason.class), withoutExceptions);
         RequestFailureReason[] reasons = values();
 

--- a/src/java/org/apache/cassandra/exceptions/TooManySSTablesReadAbortException.java
+++ b/src/java/org/apache/cassandra/exceptions/TooManySSTablesReadAbortException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+import java.util.Map;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.locator.InetAddressAndPort;
+
+public class TooManySSTablesReadAbortException extends ReadAbortException
+{
+    public final int nodes;
+    public final long maxValue;
+
+    public TooManySSTablesReadAbortException(String msg, int nodes, long maxValue, boolean dataPresent, ConsistencyLevel consistency, int received, int blockFor, Map<InetAddressAndPort, RequestFailureReason> failureReasonByEndpoint)
+    {
+        super(msg, consistency, received, blockFor, dataPresent, failureReasonByEndpoint);
+        this.nodes = nodes;
+        this.maxValue = maxValue;
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -193,6 +193,8 @@ public class KeyspaceMetrics
 
     public final Meter tooManySSTableIndexesReadWarnings;
     public final Meter tooManySSTableIndexesReadAborts;
+    public final Meter sstablesPerReadWarnings;
+    public final Meter sstablesPerReadAborts;
 
     public final Meter writeSizeWarnings;
     public final Meter writeTombstoneWarnings;
@@ -315,6 +317,8 @@ public class KeyspaceMetrics
 
         tooManySSTableIndexesReadWarnings = createKeyspaceMeter("TooManySSTableIndexesReadWarnings");
         tooManySSTableIndexesReadAborts = createKeyspaceMeter("TooManySSTableIndexesReadAborts");
+        sstablesPerReadWarnings = createKeyspaceMeter("SSTablesPerReadWarnings");
+        sstablesPerReadAborts = createKeyspaceMeter("SSTablesPerReadAborts");
 
         writeSizeWarnings = createKeyspaceMeter("WriteSizeWarnings");
         writeTombstoneWarnings = createKeyspaceMeter("WriteTombstoneWarnings");

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -313,6 +313,9 @@ public class TableMetrics
     public final TableMeter tooManySSTableIndexesReadWarnings;
     public final TableMeter tooManySSTableIndexesReadAborts;
 
+    public final TableMeter sstablesPerReadWarnings;
+    public final TableMeter sstablesPerReadAborts;
+
     public final TableMeter writeSizeWarnings;
     public final TableMeter writeTombstoneWarnings;
 
@@ -918,6 +921,9 @@ public class TableMetrics
 
         tooManySSTableIndexesReadWarnings = createTableMeter("TooManySSTableIndexesReadWarnings", cfs.keyspace.metric.tooManySSTableIndexesReadWarnings);
         tooManySSTableIndexesReadAborts = createTableMeter("TooManySSTableIndexesReadAborts", cfs.keyspace.metric.tooManySSTableIndexesReadAborts);
+
+        sstablesPerReadWarnings = createTableMeter("SSTablesPerReadWarnings", cfs.keyspace.metric.sstablesPerReadWarnings);
+        sstablesPerReadAborts = createTableMeter("SSTablesPerReadAborts", cfs.keyspace.metric.sstablesPerReadAborts);
 
         writeSizeWarnings = createTableMeter("WriteSizeWarnings", cfs.keyspace.metric.writeSizeWarnings);
         writeTombstoneWarnings = createTableMeter("WriteTombstoneWarnings", cfs.keyspace.metric.writeTombstoneWarnings);

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -60,6 +60,8 @@ public enum ParamType
     WRITE_SIZE_WARN                  (18, WriteThresholdMapSerializer.serializer),
     WRITE_TOMBSTONE_WARN             (19, WriteThresholdMapSerializer.serializer),
     ACCORD_TRACING                   (20, AccordRemoteTracing.tracingSerializer),
+    TOO_MANY_SSTABLES_WARN           (21, Int32Serializer.serializer),
+    TOO_MANY_SSTABLES_FAIL           (22, Int32Serializer.serializer),
     ;
 
     final int id;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4802,11 +4802,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         DatabaseDescriptor.setInvalidateKeycacheOnSSTableDeletion(invalidate);
     }
 
+    @Deprecated(since = "7.0")
     public int getSSTablesPerReadLogThreshold()
     {
         return DatabaseDescriptor.getSSTablesPerReadLogThreshold();
     }
 
+    @Deprecated(since = "7.0")
     public void setSSTablesPerReadLogThreshold(int threshold)
     {
         DatabaseDescriptor.setSSTablesPerReadLogThreshold(threshold);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1059,9 +1059,13 @@ public interface StorageServiceMBean extends NotificationEmitter
     /** Returns the cluster partitioner */
     public String getPartitionerName();
 
-    /** Returns the threshold for logging queries that read more than threshold amount of SSTables */
+    /** Returns the threshold for logging queries that read more than threshold amount of SSTables
+     * @deprecated See CASSANDRA-21478; superseded by the {@code sstables_per_read} guardrail. */
+    @Deprecated(since = "7.0")
     public int getSSTablesPerReadLogThreshold();
-    /** Sets the threshold for logging queries that read more than threshold amount of SSTables */
+    /** Sets the threshold for logging queries that read more than threshold amount of SSTables
+     * @deprecated See CASSANDRA-21478; superseded by the {@code sstables_per_read} guardrail. */
+    @Deprecated(since = "7.0")
     public void setSSTablesPerReadLogThreshold(int threshold);
 
     /** Returns the threshold for warning of queries with many tombstones */

--- a/src/java/org/apache/cassandra/service/reads/thresholds/CoordinatorWarnings.java
+++ b/src/java/org/apache/cassandra/service/reads/thresholds/CoordinatorWarnings.java
@@ -112,6 +112,9 @@ public class CoordinatorWarnings
 
             recordAborts(merged.indexReadSSTablesCount, cql, loggableTokens, cfs.metric.tooManySSTableIndexesReadAborts, WarningsSnapshot::tooManyIndexesReadAbortMessage);
             recordWarnings(merged.indexReadSSTablesCount, cql, loggableTokens, cfs.metric.tooManySSTableIndexesReadWarnings, WarningsSnapshot::tooManyIndexesReadWarnMessage);
+
+            recordAborts(merged.sstablesPerRead, cql, loggableTokens, cfs.metric.sstablesPerReadAborts, WarningsSnapshot::tooManySSTablesReadAbortMessage);
+            recordWarnings(merged.sstablesPerRead, cql, loggableTokens, cfs.metric.sstablesPerReadWarnings, WarningsSnapshot::tooManySSTablesReadWarnMessage);
         });
     }
 

--- a/src/java/org/apache/cassandra/service/reads/thresholds/WarningContext.java
+++ b/src/java/org/apache/cassandra/service/reads/thresholds/WarningContext.java
@@ -31,12 +31,14 @@ public class WarningContext
     private static final EnumSet<ParamType> SUPPORTED = EnumSet.of(ParamType.TOMBSTONE_WARNING, ParamType.TOMBSTONE_FAIL,
                                                              ParamType.LOCAL_READ_SIZE_WARN, ParamType.LOCAL_READ_SIZE_FAIL,
                                                              ParamType.ROW_INDEX_READ_SIZE_WARN, ParamType.ROW_INDEX_READ_SIZE_FAIL,
-                                                             ParamType.TOO_MANY_REFERENCED_INDEXES_WARN, ParamType.TOO_MANY_REFERENCED_INDEXES_FAIL);
+                                                             ParamType.TOO_MANY_REFERENCED_INDEXES_WARN, ParamType.TOO_MANY_REFERENCED_INDEXES_FAIL,
+                                                             ParamType.TOO_MANY_SSTABLES_WARN, ParamType.TOO_MANY_SSTABLES_FAIL);
 
     final WarnAbortCounter tombstones = new WarnAbortCounter();
     final WarnAbortCounter localReadSize = new WarnAbortCounter();
     final WarnAbortCounter rowIndexReadSize = new WarnAbortCounter();
     final WarnAbortCounter indexReadSSTablesCount = new WarnAbortCounter();
+    final WarnAbortCounter sstablesPerRead = new WarnAbortCounter();
 
     public static boolean isSupported(Set<ParamType> keys)
     {
@@ -71,6 +73,11 @@ public class WarningContext
                 case TOO_MANY_REFERENCED_INDEXES_WARN:
                     counter = indexReadSSTablesCount;
                     break;
+                case TOO_MANY_SSTABLES_FAIL:
+                    reason = RequestFailure.READ_TOO_MANY_SSTABLES;
+                case TOO_MANY_SSTABLES_WARN:
+                    counter = sstablesPerRead;
+                    break;
             }
             if (reason != null)
             {
@@ -85,6 +92,7 @@ public class WarningContext
 
     public WarningsSnapshot snapshot()
     {
-        return WarningsSnapshot.create(tombstones.snapshot(), localReadSize.snapshot(), rowIndexReadSize.snapshot(), indexReadSSTablesCount.snapshot());
+        return WarningsSnapshot.create(tombstones.snapshot(), localReadSize.snapshot(),
+                                       rowIndexReadSize.snapshot(), indexReadSSTablesCount.snapshot(), sstablesPerRead.snapshot());
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/thresholds/WarningsSnapshot.java
+++ b/src/java/org/apache/cassandra/service/reads/thresholds/WarningsSnapshot.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.exceptions.QueryReferencesTooManyIndexesAbortExcepti
 import org.apache.cassandra.exceptions.ReadSizeAbortException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.TombstoneAbortException;
+import org.apache.cassandra.exceptions.TooManySSTablesReadAbortException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 
 public class WarningsSnapshot
@@ -38,19 +39,22 @@ public class WarningsSnapshot
     private static final WarningsSnapshot EMPTY = new WarningsSnapshot(Warnings.EMPTY,
                                                                        Warnings.EMPTY,
                                                                        Warnings.EMPTY,
+                                                                       Warnings.EMPTY,
                                                                        Warnings.EMPTY);
 
-    public final Warnings tombstones, localReadSize, rowIndexReadSize, indexReadSSTablesCount;
+    public final Warnings tombstones, localReadSize, rowIndexReadSize, indexReadSSTablesCount, sstablesPerRead;
 
     private WarningsSnapshot(Warnings tombstones,
                              Warnings localReadSize,
                              Warnings rowIndexReadSize,
-                             Warnings indexReadSSTablesCount)
+                             Warnings indexReadSSTablesCount,
+                             Warnings sstablesPerRead)
     {
         this.tombstones = tombstones;
         this.localReadSize = localReadSize;
         this.rowIndexReadSize = rowIndexReadSize;
         this.indexReadSSTablesCount = indexReadSSTablesCount;
+        this.sstablesPerRead = sstablesPerRead;
     }
 
     public static WarningsSnapshot empty()
@@ -61,15 +65,17 @@ public class WarningsSnapshot
     public static WarningsSnapshot create(Warnings tombstones,
                                           Warnings localReadSize,
                                           Warnings rowIndexTooLarge,
-                                          Warnings indexReadSSTablesCount)
+                                          Warnings indexReadSSTablesCount,
+                                          Warnings sstablesPerRead)
     {
         if (tombstones == localReadSize
             && tombstones == rowIndexTooLarge
             && tombstones == indexReadSSTablesCount
+            && tombstones == sstablesPerRead
             && tombstones == Warnings.EMPTY)
             return EMPTY;
 
-        return new WarningsSnapshot(tombstones, localReadSize, rowIndexTooLarge, indexReadSSTablesCount);
+        return new WarningsSnapshot(tombstones, localReadSize, rowIndexTooLarge, indexReadSSTablesCount, sstablesPerRead);
     }
 
     public static WarningsSnapshot merge(WarningsSnapshot... values)
@@ -101,7 +107,8 @@ public class WarningsSnapshot
         return WarningsSnapshot.create(tombstones.merge(other.tombstones),
                                        localReadSize.merge(other.localReadSize),
                                        rowIndexReadSize.merge(other.rowIndexReadSize),
-                                       indexReadSSTablesCount.merge(other.indexReadSSTablesCount));
+                                       indexReadSSTablesCount.merge(other.indexReadSSTablesCount),
+                                       sstablesPerRead.merge(other.sstablesPerRead));
     }
 
     public void maybeAbort(ReadCommand command, ConsistencyLevel cl, int received, int blockFor, boolean isDataPresent, Map<InetAddressAndPort, RequestFailureReason> failureReasonByEndpoint)
@@ -124,6 +131,13 @@ public class WarningsSnapshot
                                                                   indexReadSSTablesCount.aborts.maxValue,
                                                                   isDataPresent,
                                                                   cl, received, blockFor, failureReasonByEndpoint);
+
+        if (!sstablesPerRead.aborts.instances.isEmpty())
+            throw new TooManySSTablesReadAbortException(tooManySSTablesReadAbortMessage(sstablesPerRead.aborts.instances.size(), sstablesPerRead.aborts.maxValue, command.toCQLString()),
+                                                        sstablesPerRead.aborts.instances.size(),
+                                                        sstablesPerRead.aborts.maxValue,
+                                                        isDataPresent,
+                                                        cl, received, blockFor, failureReasonByEndpoint);
     }
 
     @VisibleForTesting
@@ -174,6 +188,20 @@ public class WarningsSnapshot
     {
         return String.format("%s nodes referenced %s SSTable indexes for a query without restrictions on partition key " +
                              "and aborted the query %s (see sai_sstable_indexes_per_query_fail_threshold)", nodes, value, cql);
+    }
+
+    @VisibleForTesting
+    public static String tooManySSTablesReadWarnMessage(int nodes, long value, String cql)
+    {
+        return String.format("%s nodes read from up to %s SSTables in a single local read " +
+                             "and issued warnings for query %s (see sstables_per_read_warn_threshold)", nodes, value, cql);
+    }
+
+    @VisibleForTesting
+    public static String tooManySSTablesReadAbortMessage(int nodes, long value, String cql)
+    {
+        return String.format("%s nodes read from over %s SSTables in a single local read " +
+                             "and aborted the query %s (see sstables_per_read_fail_threshold)", nodes, value, cql);
     }
 
     @Override
@@ -332,7 +360,7 @@ public class WarningsSnapshot
         public Builder tombstonesWarning(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(new Warnings(counter, Counter.EMPTY), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(new Warnings(counter, Counter.EMPTY), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
@@ -344,7 +372,7 @@ public class WarningsSnapshot
         public Builder tombstonesAbort(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(new Warnings(Counter.EMPTY, counter), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(new Warnings(Counter.EMPTY, counter), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
@@ -356,7 +384,7 @@ public class WarningsSnapshot
         public Builder localReadSizeWarning(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, new Warnings(counter, Counter.EMPTY), Warnings.EMPTY, Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, new Warnings(counter, Counter.EMPTY), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
@@ -368,35 +396,49 @@ public class WarningsSnapshot
         public Builder localReadSizeAbort(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), Warnings.EMPTY, Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
         public Builder rowIndexSizeWarning(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(counter, Counter.EMPTY), Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(counter, Counter.EMPTY), Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
         public Builder rowIndexSizeAbort(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), Warnings.EMPTY));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), Warnings.EMPTY, Warnings.EMPTY));
             return this;
         }
 
         public Builder indexReadSSTablesWarning(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), new Warnings(counter, Counter.EMPTY)));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), new Warnings(counter, Counter.EMPTY), Warnings.EMPTY));
             return this;
         }
 
         public Builder indexReadSSTablesAbort(Counter counter)
         {
             Objects.requireNonNull(counter);
-            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter)));
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter), Warnings.EMPTY));
+            return this;
+        }
+
+        public Builder sstablesPerReadWarning(Counter counter)
+        {
+            Objects.requireNonNull(counter);
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, new Warnings(counter, Counter.EMPTY)));
+            return this;
+        }
+
+        public Builder sstablesPerReadAbort(Counter counter)
+        {
+            Objects.requireNonNull(counter);
+            snapshot = snapshot.merge(new WarningsSnapshot(Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, Warnings.EMPTY, new Warnings(Counter.EMPTY, counter)));
             return this;
         }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailSSTablesPerReadTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailSSTablesPerReadTest.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.guardrails;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IIsolatedExecutor;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.exceptions.TooManySSTablesReadAbortException;
+import org.apache.cassandra.service.ClientWarn;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.db.ConsistencyLevel.ALL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Distributed test for the {@code sstables_per_read} guardrail (CASSANDRA-21478): a single local read
+ * that touches more than the warn/fail number of SSTables warns the client (warn) or aborts the read
+ * on the replica and rejects it to the client (fail). Internal reads are never aborted.
+ *
+ * The keyspace is recreated before each test so the per-keyspace warn/abort metrics are isolated.
+ */
+public class GuardrailSSTablesPerReadTest extends TestBaseImpl
+{
+    private static final String TABLE = "tbl";
+
+    private static Cluster cluster;
+
+    @BeforeClass
+    public static void setupCluster() throws IOException
+    {
+        cluster = Cluster.build(2)
+                         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NATIVE_PROTOCOL)
+                                           .set("read_thresholds_enabled", "true"))
+                         .start();
+    }
+
+    @AfterClass
+    public static void teardownCluster()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @Before
+    public void beforeEachTest()
+    {
+        cluster.schemaChange("DROP KEYSPACE IF EXISTS " + KEYSPACE);
+        init(cluster);
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, PRIMARY KEY (k, c))", KEYSPACE, TABLE));
+        cluster.forEach(i -> i.acceptsOnInstance((IIsolatedExecutor.SerializableBiConsumer<String, String>) (ks, tb) ->
+            Keyspace.open(ks).getColumnFamilyStore(tb).disableAutoCompaction()).accept(KEYSPACE, TABLE));
+    }
+
+    @Test
+    public void testSinglePartitionWarnThreshold()
+    {
+        setThresholds(5, -1);
+
+        // 3 SSTables for partition 0 -> below warn (5)
+        flushPartition(0, 3);
+        assertNull(clientReadWarnings(format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE)));
+        assertWarnAborts(0, 0);
+
+        // 3 more SSTables for partition 0 -> 6 > warn (5)
+        flushPartition(0, 3);
+        List<String> warnings = clientReadWarnings(format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE));
+        assertNotNull(warnings);
+        assertThat(warnings.toString()).contains("2 nodes")
+                                       .contains("SSTables in a single local read")
+                                       .contains("sstables_per_read_warn_threshold");
+        assertWarnAborts(1, 0);
+    }
+
+    @Test
+    public void testSinglePartitionFailThreshold()
+    {
+        setThresholds(2, 5);
+
+        // 6 SSTables for partition 0 -> above fail (5)
+        flushPartition(0, 6);
+        String abortMessage = clientReadAbortMessage(format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE));
+        assertNotNull("expected the read to be aborted", abortMessage);
+        assertThat(abortMessage).contains("SSTables in a single local read")
+                                .contains("aborted")
+                                .contains("sstables_per_read_fail_threshold");
+        // a failing read must not also emit a warning
+        assertWarnAborts(0, 1);
+    }
+
+    @Test
+    public void testRangeReadWarnThreshold()
+    {
+        setThresholds(5, -1);
+
+        // 6 distinct partitions, each in its own SSTable -> a full range scan touches 6 > warn (5)
+        for (int i = 0; i < 6; i++)
+            flushPartition(i, 1);
+
+        List<String> warnings = clientReadWarnings(format("SELECT * FROM %s.%s", KEYSPACE, TABLE));
+        assertNotNull(warnings);
+        assertThat(warnings.toString()).contains("2 nodes")
+                                       .contains("SSTables in a single local read")
+                                       .contains("sstables_per_read_warn_threshold");
+        assertWarnAborts(1, 0);
+    }
+
+    @Test
+    public void testRangeReadFailThreshold()
+    {
+        setThresholds(2, 5);
+
+        // 6 distinct partitions, each in its own SSTable -> a full range scan touches 6 > fail (5)
+        for (int i = 0; i < 6; i++)
+            flushPartition(i, 1);
+
+        String abortMessage = clientReadAbortMessage(format("SELECT * FROM %s.%s", KEYSPACE, TABLE));
+        assertNotNull("expected the range read to be aborted", abortMessage);
+        assertThat(abortMessage).contains("SSTables in a single local read")
+                                .contains("aborted")
+                                .contains("sstables_per_read_fail_threshold");
+        // a failing read must not also emit a warning
+        assertWarnAborts(0, 1);
+    }
+
+    @Test
+    public void testRuntimeThresholdChange()
+    {
+        setThresholds(2, -1);
+        flushPartition(0, 6); // 6 SSTables for partition 0 -> above warn (2)
+
+        String query = format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE);
+
+        assertNotNull(clientReadWarnings(query));
+        assertWarnAborts(1, 0);
+
+        // raise the warn threshold above the count at runtime -> the guardrail stops firing
+        setThresholds(100, -1);
+        assertNull(clientReadWarnings(query));
+        assertWarnAborts(1, 0);
+
+        // lower it again -> it fires once more
+        setThresholds(2, -1);
+        assertNotNull(clientReadWarnings(query));
+        assertWarnAborts(2, 0);
+    }
+
+    @Test
+    public void testCompactionClearsCondition()
+    {
+        setThresholds(5, -1);
+        flushPartition(0, 6); // 6 SSTables for partition 0 -> above warn (5)
+
+        String query = format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE);
+
+        assertNotNull(clientReadWarnings(query));
+        assertWarnAborts(1, 0);
+
+        // compacting merges the 6 SSTables into 1, dropping below the threshold -> no more warnings
+        compactAll();
+        assertNull(clientReadWarnings(query));
+        assertWarnAborts(1, 0);
+    }
+
+    @Test
+    public void testInternalReadNotAborted()
+    {
+        setThresholds(2, 5);
+
+        // 6 SSTables for partition 0 -> above fail (5)
+        flushPartition(0, 6);
+
+        // An internal read (no warning tracking) must never be aborted, regardless of the fail threshold.
+        Object[][] result = cluster.get(1).executeInternal(format("SELECT * FROM %s.%s WHERE k = 0", KEYSPACE, TABLE));
+        assertNotNull(result);
+        // internal reads never warn or abort through the guardrail
+        assertWarnAborts(0, 0);
+    }
+
+    /** Inserts {@code count} rows into {@code partition}, flushing after each so each becomes its own SSTable. */
+    private void flushPartition(int partition, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            cluster.coordinator(1).execute(format("INSERT INTO %s.%s (k, c, v) VALUES (?, ?, ?)", KEYSPACE, TABLE),
+                                           ConsistencyLevel.ALL, partition, i, i);
+            cluster.forEach(instance -> instance.flush(KEYSPACE));
+        }
+    }
+
+    /** Force-major-compacts the table on every node, merging the per-partition SSTables. */
+    private void compactAll()
+    {
+        cluster.forEach(i -> i.acceptsOnInstance((IIsolatedExecutor.SerializableBiConsumer<String, String>) (ks, tb) ->
+            Keyspace.open(ks).getColumnFamilyStore(tb).forceMajorCompaction()).accept(KEYSPACE, TABLE));
+    }
+
+    private void setThresholds(int warn, int fail)
+    {
+        cluster.stream().forEach(instance ->
+            instance.acceptsOnInstance((IIsolatedExecutor.SerializableBiConsumer<Integer, Integer>)
+                                       (w, f) -> Guardrails.instance.setSSTablesPerReadThreshold(w, f)).accept(warn, fail));
+    }
+
+    private void assertWarnAborts(int warns, int aborts)
+    {
+        assertEquals(warns, totalWarnings());
+        assertEquals(aborts, totalAborts());
+    }
+
+    private long totalWarnings()
+    {
+        return cluster.stream().mapToLong(i -> i.metrics().getCounter("org.apache.cassandra.metrics.keyspace.SSTablesPerReadWarnings." + KEYSPACE)).sum();
+    }
+
+    private long totalAborts()
+    {
+        return cluster.stream().mapToLong(i -> i.metrics().getCounter("org.apache.cassandra.metrics.keyspace.SSTablesPerReadAborts." + KEYSPACE)).sum();
+    }
+
+    /** Runs a client read (with warning tracking) on node 1; returns the client warnings, or null if none. */
+    private List<String> clientReadWarnings(String query)
+    {
+        return cluster.get(1).callsOnInstance((IIsolatedExecutor.SerializableCallable<List<String>>) () -> {
+            ClientWarn.instance.captureWarnings();
+            CoordinatorWarnings.init();
+            try
+            {
+                QueryProcessor.execute(query, ALL, QueryState.forInternalCalls());
+            }
+            finally
+            {
+                CoordinatorWarnings.done();
+                CoordinatorWarnings.reset();
+            }
+            return ClientWarn.instance.getWarnings();
+        }).call();
+    }
+
+    /** Runs a client read expected to abort; returns the abort message, or null if it did not abort.
+     *  The exception is caught inside the instance to avoid crossing the classloader boundary. */
+    private String clientReadAbortMessage(String query)
+    {
+        return cluster.get(1).callsOnInstance((IIsolatedExecutor.SerializableCallable<String>) () -> {
+            ClientWarn.instance.captureWarnings();
+            CoordinatorWarnings.init();
+            try
+            {
+                QueryProcessor.execute(query, ALL, QueryState.forInternalCalls());
+                return null;
+            }
+            catch (TooManySSTablesReadAbortException e)
+            {
+                return e.getMessage();
+            }
+            finally
+            {
+                CoordinatorWarnings.done();
+                CoordinatorWarnings.reset();
+            }
+        }).call();
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
@@ -252,6 +252,7 @@ public class GuardrailsConfigCommandsTest extends CQLTester
     "sai_string_term_size_threshold               [8KiB, 1KiB]  \n" +
     "sai_vector_term_size_threshold               [32KiB, 16KiB]\n" +
     "secondary_indexes_per_table_threshold        [-1, -1]      \n" +
+    "sstables_per_read_threshold                  [-1, 100]     \n" +
     "tables_threshold                             [-1, -1]      \n" +
     "vector_dimensions_threshold                  [-1, -1]      \n";
 
@@ -314,6 +315,8 @@ public class GuardrailsConfigCommandsTest extends CQLTester
     "sai_vector_term_size_warn_threshold               16KiB\n" +
     "secondary_indexes_per_table_fail_threshold        -1   \n" +
     "secondary_indexes_per_table_warn_threshold        -1   \n" +
+    "sstables_per_read_fail_threshold                  -1   \n" +
+    "sstables_per_read_warn_threshold                  100  \n" +
     "tables_fail_threshold                             -1   \n" +
     "tables_warn_threshold                             -1   \n" +
     "vector_dimensions_fail_threshold                  -1   \n" +


### PR DESCRIPTION
Add a guardrail for the number of SSTables touched per read

Adds an operator-configurable warn/fail guardrail, evaluated per local read on
the replica, that bounds how many SSTables a single read may touch (modeled on
local_read_size). A client read over the warn threshold warns the client; one
over the fail threshold is aborted before opening the remaining SSTables. Both
the single-partition and range paths are covered; internal reads are never
aborted. The old sstables_per_read_log_threshold config and its StorageService
JMX methods are deprecated and folded into sstables_per_read_warn_threshold.

The pre-existing "has read N SSTables" diagnostic log is retained (so internal
reads keep their visibility) but, on the single-partition path, now fires from
the final SSTable count so the logged number matches the new client warning.

patch by Shlomit; reviewed by TBD for CASSANDRA-21478
