### PR TITLE
[CASSANDRA-21587] Megamorphic call in ClusteringPrefix.Deserializer.deserializeOne slows down readseserializeOne slows down reads

### DIFF
--- a/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
@@ -20,8 +20,9 @@ package org.apache.cassandra.serializers;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -54,10 +55,10 @@ public class AbstractTypeSerializer
     public List<AbstractType<?>> deserializeList(DataInputPlus in) throws IOException
     {
         int size = (int) in.readUnsignedVInt();
-        List<AbstractType<?>> types = new ArrayList<>(size);
+        ImmutableList.Builder<AbstractType<?>> types = ImmutableList.builderWithExpectedSize(size);
         for (int i = 0; i < size; i++)
             types.add(deserialize(in));
-        return types;
+        return types.build();
     }
 
     public long serializedSize(AbstractType<?> type)

--- a/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
@@ -25,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 
 import org.junit.Assert;
@@ -52,6 +53,8 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -65,6 +68,26 @@ public class SerializationHeaderTest
     static
     {
         DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test
+    public void testDeserializedClusteringTypesAreImmutable() throws Exception
+    {
+        TableMetadata schema = TableMetadata.builder(KEYSPACE, "testDeserializedClusteringTypesAreImmutable")
+                                              .addPartitionKeyColumn("k", Int32Type.instance)
+                                              .addClusteringColumn("c", Int32Type.instance)
+                                              .build();
+        SerializationHeader.Component component = SerializationHeader.makeWithoutStats(schema).toComponent();
+        SSTableFormat<?, ?> format = DatabaseDescriptor.getSelectedSSTableFormat();
+
+        try (DataOutputBuffer out = new DataOutputBuffer())
+        {
+            SerializationHeader.serializer.serialize(format.getLatestVersion(), component, out);
+            SerializationHeader.Component deserialized = SerializationHeader.serializer.deserialize(format.getLatestVersion(),
+                                                                                                      new DataInputBuffer(out.buffer(), true));
+
+            Assert.assertTrue(deserialized.getClusteringTypes() instanceof ImmutableList);
+        }
     }
 
     /**


### PR DESCRIPTION
#### Description
`ClusteringPrefix.Deserializer.deserializeOne()` reads clustering components in a hot partition-scan loop:

```java
  serializationHeader.clusteringTypes()
                     .get(i)
                     .readArray(in, DatabaseDescriptor.getMaxValueSize());
```

`clusteringTypes()` is declared as List, but its runtime implementation differs by header source:

 - SSTable Stats component read from disk: ArrayList
  - Flush or compaction with one clustering column: SingletonImmutableList
  - Flush or compaction with multiple clustering columns: RegularImmutableList

This makes the List.get() call megamorphic. HotSpot can optimize one or two receiver types, but the third ArrayList receiver forces a slower interface-table dispatch.

#### Fix
Change `AbstractTypeSerializer.deserializeList()` to return an `ImmutableList` built with `ImmutableList.builderWithExpectedSize(size)`.

This removes the SSTable-only ArrayList receiver. The call site remains bimorphic:
  - One clustering column: SingletonImmutableList
  - Multiple clustering columns: RegularImmutableList

#### Numbers

Production node, async-profiler, 120 seconds, 97,036 CPU samples:
  - deserializeOne inclusive: 4,869 samples, 5.0% of total CPU
  - Interface-table stub from clusteringTypes().get(i): 608 samples, 0.63% of total CPU
  - Approximately one eighth of deserializeOne CPU time is dispatch overhead rather than deserialization work.

JMH benchmark with controlled receiver count:
  - 3 receiver classes: 1129.1 ± 17.1 ns/op
  - 2 receiver classes: 981.4 ± 34.8 ns/op
  - 1 receiver class: 934.7 ± 27.4 ns/op
 
 patch by koo.taejin; reviewed by <reviewer> for CASSANDRA-21587

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21587)  
