### PR TITLE
CASSANDRA-21217: Stop decommission failing on a deleted hints file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 7.0
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
+ * Don't delete a hints file that a concurrent dispatch has already claimed (CASSANDRA-21217)
  * Support pluggable default role initialization (CASSANDRA-21546)
  * Add prepared statement cache stats to nodetool info (CASSANDRA-14366)
  * Don't increment client metrics on messaging service connection unpause (CASSANDRA-21491)

--- a/src/java/org/apache/cassandra/hints/HintsStore.java
+++ b/src/java/org/apache/cassandra/hints/HintsStore.java
@@ -20,12 +20,10 @@ package org.apache.cassandra.hints;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Deque;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -253,23 +251,27 @@ final class HintsStore
 
     private void deleteHints(Predicate<HintsDescriptor> predicate)
     {
-        Set<HintsDescriptor> removeSet = new HashSet<>();
-        try
+        for (HintsDescriptor descriptor : Iterables.concat(dispatchDequeue, corruptedFiles))
         {
-            for (HintsDescriptor descriptor : Iterables.concat(dispatchDequeue, corruptedFiles))
+            if (!predicate.test(descriptor))
+                continue;
+
+            // A dispatch running concurrently claims a descriptor by polling it off the dequeue, and then reads the
+            // file it points at. Take the descriptor out of the queues before touching the file, so that a dispatch
+            // either wins the claim and reads a file that is still there, or never sees the descriptor at all.
+            boolean claimed = dispatchDequeue.remove(descriptor);
+            claimed |= corruptedFiles.remove(descriptor);
+            if (!claimed)
             {
-                if (predicate.test(descriptor))
-                {
-                    cleanUp(descriptor);
-                    removeSet.add(descriptor);
-                    delete(descriptor);
-                }
+                // The predicate above may have just cached an expiration for a descriptor that somebody else owns
+                // now, so drop it rather than let it outlive the descriptor. The dispatch offset is left alone,
+                // the new owner may be part way through the file.
+                hintsExpirations.remove(descriptor);
+                continue;
             }
-        }
-        finally // remove the already deleted hints from internal queues in case of exception
-        {
-            dispatchDequeue.removeAll(removeSet);
-            corruptedFiles.removeAll(removeSet);
+
+            cleanUp(descriptor);
+            delete(descriptor);
         }
     }
 

--- a/test/unit/org/apache/cassandra/hints/HintsStoreCleanupRaceTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsStoreCleanupRaceTest.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.hints;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+
+import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
+import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Expired-hints cleanup and hint dispatch run on different threads and both end up deleting hints files.
+ * The dispatch side claims a file by polling its descriptor off the store; the cleanup side has to respect
+ * that claim, otherwise it unlinks a file that a dispatcher is about to read (CASSANDRA-21217).
+ */
+@RunWith(BMUnitRunner.class)
+public class HintsStoreCleanupRaceTest
+{
+    private static final String KEYSPACE = "hints_store_cleanup_race_test";
+    private static final String TABLE = "table";
+
+    private static final long AWAIT_MINUTES = 1;
+
+    // Rendezvous between the cleanup thread, parked inside HintsStore, and the thread racing it.
+    static volatile CountDownLatch cleanupReachedUnlink;
+    static volatile CountDownLatch dispatchPolled;
+    static volatile CountDownLatch cleanupFinishedUnlink;
+    static volatile CountDownLatch losingCleanupCachedExpiry;
+    static volatile CountDownLatch winningCleanupDone;
+
+    static volatile AtomicBoolean firstPollRecorded;
+    static volatile AtomicBoolean losingCleanupParked;
+    static volatile AtomicReference<HintsDescriptor> claimedByDispatch;
+
+    static volatile Thread cleanupThread;
+    static volatile Thread losingCleanupThread;
+    static volatile boolean armed;
+
+    private File directory;
+    private UUID hostId;
+
+    @BeforeClass
+    public static void defineSchema()
+    {
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE, KeyspaceParams.simple(1), SchemaLoader.standardCFMD(KEYSPACE, TABLE));
+    }
+
+    @Before
+    public void setUp() throws IOException
+    {
+        directory = new File(Files.createTempDirectory(null));
+        directory.deleteOnExit();
+        hostId = UUID.randomUUID();
+
+        cleanupReachedUnlink = new CountDownLatch(1);
+        dispatchPolled = new CountDownLatch(1);
+        cleanupFinishedUnlink = new CountDownLatch(1);
+        losingCleanupCachedExpiry = new CountDownLatch(1);
+        winningCleanupDone = new CountDownLatch(1);
+        firstPollRecorded = new AtomicBoolean();
+        losingCleanupParked = new AtomicBoolean();
+        claimedByDispatch = new AtomicReference<>();
+        cleanupThread = null;
+        losingCleanupThread = null;
+        armed = false;
+    }
+
+    public static void pauseCleanupBeforeUnlink()
+    {
+        if (!armed || Thread.currentThread() != cleanupThread)
+            return;
+
+        cleanupReachedUnlink.countDown();
+        await(dispatchPolled);
+    }
+
+    public static void releaseDispatchAfterUnlink()
+    {
+        if (!armed || Thread.currentThread() != cleanupThread)
+            return;
+
+        cleanupFinishedUnlink.countDown();
+    }
+
+    public static void recordDispatchPoll(Object descriptor)
+    {
+        if (!armed || Thread.currentThread() == cleanupThread)
+            return;
+
+        if (!firstPollRecorded.compareAndSet(false, true))
+            return;
+
+        claimedByDispatch.set((HintsDescriptor) descriptor);
+        dispatchPolled.countDown();
+
+        // Hold the dispatcher until the cleanup has finished unlinking, so that the outcome does not depend on
+        // which of the two threads happens to reach the file first.
+        if (descriptor != null)
+            await(cleanupFinishedUnlink);
+    }
+
+    public static void pauseLosingCleanupBeforeCachingExpiry()
+    {
+        if (!armed || Thread.currentThread() != losingCleanupThread)
+            return;
+
+        if (!losingCleanupParked.compareAndSet(false, true))
+            return;
+
+        losingCleanupCachedExpiry.countDown();
+        await(winningCleanupDone);
+    }
+
+    private static void await(CountDownLatch latch)
+    {
+        try
+        {
+            if (!latch.await(AWAIT_MINUTES, TimeUnit.MINUTES))
+                throw new AssertionError("Timed out waiting for the other thread to reach the rendezvous");
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Parks the cleanup thread at the point where it has decided a hints file is expired and is about to unlink it,
+     * then lets a real transfer run against the same store. If the descriptor is still claimable at that point the
+     * transfer picks it up and reads a file that the cleanup thread then deletes underneath it.
+     */
+    @Test(timeout = 300000)
+    @BMRules(rules = {
+        @BMRule(name = "park the cleanup thread just before it unlinks a hints file",
+                targetClass = "org.apache.cassandra.hints.HintsStore",
+                targetMethod = "delete",
+                targetLocation = "AT ENTRY",
+                action = "org.apache.cassandra.hints.HintsStoreCleanupRaceTest.pauseCleanupBeforeUnlink()"),
+        @BMRule(name = "release the dispatch thread once the hints file is unlinked",
+                targetClass = "org.apache.cassandra.hints.HintsStore",
+                targetMethod = "delete",
+                targetLocation = "AT EXIT",
+                action = "org.apache.cassandra.hints.HintsStoreCleanupRaceTest.releaseDispatchAfterUnlink()"),
+        @BMRule(name = "record the descriptor the dispatch thread claims",
+                targetClass = "org.apache.cassandra.hints.HintsStore",
+                targetMethod = "poll",
+                targetLocation = "AT EXIT",
+                action = "org.apache.cassandra.hints.HintsStoreCleanupRaceTest.recordDispatchPoll($!)")
+    })
+    public void expiredHintsCleanupMustNotUnlinkAClaimedFile() throws Exception
+    {
+        long now = currentTimeMillis();
+        HintsDescriptor descriptor = new HintsDescriptor(hostId, now);
+        writeHints(descriptor, 100, now);
+
+        HintsCatalog catalog = HintsCatalog.load(directory, ImmutableMap.of());
+        HintsStore store = catalog.get(hostId);
+        assertEquals(1, store.getDispatchQueueSize());
+
+        HintsDispatchExecutor dispatchExecutor =
+            new HintsDispatchExecutor(directory, 1, new AtomicBoolean(false), address -> true);
+
+        long afterExpiry = now + TimeUnit.SECONDS.toMillis(Hint.maxHintTTL) + 10;
+        Thread cleanup = new Thread(() -> store.deleteExpiredHints(afterExpiry), "hints-expired-cleanup");
+        cleanupThread = cleanup;
+        armed = true;
+        cleanup.start();
+
+        // The cleanup thread has now committed to unlinking this file.
+        await(cleanupReachedUnlink);
+
+        // Start dispatching only now, so the cleanup thread always reaches the unlink first.
+        Future<?> transfer = dispatchExecutor.transfer(catalog, () -> UUID.randomUUID());
+
+        await(dispatchPolled);
+        cleanup.join(TimeUnit.MINUTES.toMillis(AWAIT_MINUTES));
+
+        Throwable dispatchFailure = null;
+        try
+        {
+            transfer.get(AWAIT_MINUTES, TimeUnit.MINUTES);
+        }
+        catch (ExecutionException e)
+        {
+            dispatchFailure = e.getCause();
+        }
+        finally
+        {
+            armed = false;
+            dispatchExecutor.shutdownBlocking();
+        }
+
+        assertNull("Expired-hints cleanup unlinked " + descriptor.fileName() + " while a concurrent dispatch had " +
+                   "already claimed it. The dispatch then failed with: " + dispatchFailure,
+                   claimedByDispatch.get());
+        assertFalse("The expired hints file should have been dropped from the store", store.hasFiles());
+        assertFalse("The expired hints file should have been deleted", descriptor.file(directory).exists());
+    }
+
+    /**
+     * Two cleanup passes over the same descriptor. The losing one has already read the file and is about to cache
+     * the expiration it computed, so it caches an entry for a descriptor the winner has since taken and deleted.
+     * Losing the claim must not leave that entry behind.
+     */
+    @Test(timeout = 300000)
+    @BMRule(name = "park a cleanup thread just before it caches a computed expiration",
+            targetClass = "org.apache.cassandra.hints.HintsStore",
+            targetMethod = "hasExpired",
+            targetLocation = "AT INVOKE largestGcgs",
+            action = "org.apache.cassandra.hints.HintsStoreCleanupRaceTest.pauseLosingCleanupBeforeCachingExpiry()")
+    public void aCleanupThatLosesTheClaimMustNotStrandItsCachedExpiry() throws Exception
+    {
+        long now = currentTimeMillis();
+        HintsDescriptor descriptor = new HintsDescriptor(hostId, now);
+        writeHints(descriptor, 100, now);
+
+        HintsStore store = HintsCatalog.load(directory, ImmutableMap.of()).get(hostId);
+        assertEquals(1, store.getDispatchQueueSize());
+        assertEquals(0, store.getHintsExpirationsMapSize());
+
+        long afterExpiry = now + TimeUnit.SECONDS.toMillis(Hint.maxHintTTL) + 10;
+
+        Thread losing = new Thread(() -> store.deleteExpiredHints(afterExpiry), "hints-expired-cleanup-loser");
+        losingCleanupThread = losing;
+        armed = true;
+        losing.start();
+
+        // The losing thread has read the file and is one statement away from caching its expiration.
+        await(losingCleanupCachedExpiry);
+
+        // A second pass claims the descriptor and runs to completion, clearing the cache on its way out.
+        store.deleteExpiredHints(afterExpiry);
+        assertFalse("The winning cleanup should have deleted the hints file", store.hasFiles());
+
+        winningCleanupDone.countDown();
+        losing.join(TimeUnit.MINUTES.toMillis(AWAIT_MINUTES));
+        armed = false;
+
+        assertEquals("A cleanup that lost the claim left its cached expiration behind",
+                     0, store.getHintsExpirationsMapSize());
+    }
+
+    private void writeHints(HintsDescriptor descriptor, int hintsCount, long hintCreationTime) throws IOException
+    {
+        try (HintsWriter writer = HintsWriter.create(directory, descriptor))
+        {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(256 * 1024);
+            try (HintsWriter.Session session = writer.newSession(buffer))
+            {
+                for (int i = 0; i < hintsCount; i++)
+                    session.append(createHint(i, hintCreationTime));
+            }
+            MemoryUtil.clean(buffer);
+        }
+    }
+
+    private Hint createHint(int idx, long creationTime)
+    {
+        TableMetadata table = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        Mutation mutation = new RowUpdateBuilder(table, creationTime, bytes(idx))
+                            .clustering(bytes(idx))
+                            .add("val", bytes(idx))
+                            .build();
+
+        return Hint.create(mutation, creationTime, 1);
+    }
+}

--- a/test/unit/org/apache/cassandra/hints/HintsStoreTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsStoreTest.java
@@ -142,6 +142,8 @@ public class HintsStoreTest
         }
         assertTrue(es.awaitTermination(2, TimeUnit.SECONDS));
         assertFalse("All hints files should be deleted", store.hasFiles());
+        assertEquals("Cleanups that lost the claim should not leave cached expirations behind",
+                     0, store.getHintsExpirationsMapSize());
     }
 
     @Test


### PR DESCRIPTION
Decommission fails when hint transfer and expired-hints cleanup pick up the same file. The transfer opens a hints file cleanup has just unlinked, the failure propagates out of the decommission, and the node never leaves the ring. The reporter hit this three times and had to disable `transfer_hints_on_decommission`. After this patch the decommission completes with its hints transferred.

```
java.nio.file.NoSuchFileException: .../hints/5da9d583-...-1744041563101-2.hints
	at org.apache.cassandra.hints.HintsDispatchExecutor$DispatchHintsTask.deliver(HintsDispatchExecutor.java:290)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
```

`HintsStore.poll()` is how a dispatch claims a descriptor. The removal is atomic, so one thread owns the file it points at, and the bulk delete path relies on that. `deleteExpiredHints` did not: it deleted each expired file in place and removed the descriptors afterwards, so between the expiry check and the unlink a dispatch could claim a descriptor whose file was already gone. The decommission transfer is the exposed caller, since it runs its dispatch tasks inline and never registers them for interruption.

The fix removes the descriptor from the queues before touching the file. A loser also drops the expiration it may have just cached, but leaves the dispatch offset alone since the new owner may be using it.

Warning and continuing on a missing file, as the ticket suggests, would hide data loss: a dispatch cannot tell a deleted expired file from a genuinely lost one.

## Testing

`HintsStoreCleanupRaceTest` uses Byteman to fix the interleaving rather than sleeps.

```
$ git checkout f8e3018 -- src/java/org/apache/cassandra/hints/HintsStore.java
$ ant test -Dtest.name=HintsStoreCleanupRaceTest -Dtest.timeout=480000
expiredHintsCleanupMustNotUnlinkAClaimedFile FAILED
Expired-hints cleanup unlinked cff39475-...-4.hints while a concurrent dispatch
had already claimed it.
tests="2" errors="0" failures="1"

$ git checkout HEAD -- src/java/org/apache/cassandra/hints/HintsStore.java
$ ant test -Dtest.name=HintsStoreCleanupRaceTest -Dtest.timeout=480000
tests="2" errors="0" failures="0"
```

The second test goes red only when the expiration cleanup is dropped, guarding a regression this patch would otherwise introduce.

The red run died on an unrelated initializer error in the unit JVM rather than the production `NoSuchFileException`, so the test asserts the ownership violation itself.
