### PR TITLE
CASSANDRA-20705 Accord doesn't handle CL ALL correctly during migration

### DIFF
--- a/doc/modules/cassandra/pages/managing/operating/onboarding-to-accord.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/onboarding-to-accord.adoc
@@ -197,10 +197,10 @@ non-SERIAL operations will run using the usual eventually consistent
 path and `SERIAL` operations will execute on Paxos.
 
 During the duration between altering the table's `transactional++_++mode` to `off` and
-performing Accord repair, Cassandra may upgrade the consistency level of read requests to
-quorum if the supplied consistency level does not intersect with a quorum of nodes. This is done
-to prevent inconsistent reads when migrating off of Accord. Once Accord repair has finished,
-the supplied consistency level will then be used.
+performing Accord repair, Cassandra may upgrade the consistency level of single parition
+read requests to quorum if the supplied consistency level does not intersect with a quorum of nodes.
+This is done to prevent inconsistent reads when migrating off of Accord.
+Once Accord repair has finished, the supplied consistency level will then be used.
 
 == Migration commands
 

--- a/doc/modules/cassandra/pages/managing/operating/onboarding-to-accord.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/onboarding-to-accord.adoc
@@ -196,6 +196,12 @@ manually or via `nodetool finish-migration`, and once that completes
 non-SERIAL operations will run using the usual eventually consistent
 path and `SERIAL` operations will execute on Paxos.
 
+During the duration between altering the table's `transactional++_++mode` to `off` and
+performing Accord repair, Cassandra may upgrade the consistency level of read requests to
+quorum if the supplied consistency level does not intersect with a quorum of nodes. This is done
+to prevent inconsistent reads when migrating off of Accord. Once Accord repair has finished,
+the supplied consistency level will then be used.
+
 == Migration commands
 
 All the `nodetool` migration commands are based on new
@@ -234,8 +240,8 @@ specified keyspace and tables. If the entire range is marked migrating it is
 only necessary to invoke `begin-migration` on one node.
 
 This is only needed if
-`accord.default++_++transactional++_++mode=explicit` is set in
-`cassandra.yaml` otherwise all the ranges will already have been marked
+`accord.range++_++migration=explicit` is set,
+otherwise all the ranges will already have been marked
 migrating when the alter occurred.
 
 Ranges that are migrating will require at least an extra WAN roundtrip

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -226,6 +226,7 @@ import static org.apache.cassandra.service.consensus.migration.ConsensusMigratio
 import static org.apache.cassandra.service.consensus.migration.ConsensusMigrationMutationHelper.splitMutationsIntoAccordAndNormal;
 import static org.apache.cassandra.service.consensus.migration.ConsensusRequestRouter.getTableMetadata;
 import static org.apache.cassandra.service.consensus.migration.ConsensusRequestRouter.shouldReadEphemerally;
+import static org.apache.cassandra.service.consensus.migration.ConsensusRequestRouter.shouldUseQuorumConsistency;
 import static org.apache.cassandra.service.consensus.migration.ConsensusRequestRouter.splitReadsIntoAccordAndNormal;
 import static org.apache.cassandra.service.paxos.Ballot.Flag.GLOBAL;
 import static org.apache.cassandra.service.paxos.Ballot.Flag.LOCAL;
@@ -2460,6 +2461,10 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     if (normalReads != null)
                     {
+                        // We use Quorum consistency here to ensure that earlier writes that were done by Accord are still observed
+                        // See CASSANDRA-20705 for more details
+                        if (shouldUseQuorumConsistency(cm, group, consistencyLevel))
+                            consistencyLevel = ConsistencyLevel.QUORUM;
                         normalPartitions = readRegular(normalReads, consistencyLevel, coordinator, requestTime);
                         Tracing.trace("Successfully executed normal reads");
                     }

--- a/src/java/org/apache/cassandra/service/consensus/migration/ConsensusRequestRouter.java
+++ b/src/java/org/apache/cassandra/service/consensus/migration/ConsensusRequestRouter.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
 import org.apache.cassandra.db.ReadCommand;
@@ -49,6 +50,7 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RetryOnDifferentSystemException;
+import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.ReplicaLayout;
 import org.apache.cassandra.schema.KeyspaceMetadata;
@@ -834,6 +836,37 @@ public class ConsensusRequestRouter
             this.accordReads = accordReads;
             this.normalReads = normalReads;
         }
+    }
+
+    public static boolean shouldUseQuorumConsistency(ClusterMetadata cm, SinglePartitionReadCommand.Group reads, ConsistencyLevel consistencyLevel)
+    {
+        TableMetadata tm = getTableMetadata(cm, reads.queries.get(0).metadata().id);
+        if (tm == null)
+            return false;
+
+        TableMigrationState tableMigrationState = cm.consensusMigrationState.tableStates.get(tm.id);
+
+        if (tableMigrationState == null)
+            return false;
+
+        NormalizedRanges<Token> migratingRanges = tableMigrationState.migratingRanges;
+        boolean containsTokenInMigratingRange = false;
+
+        for (SinglePartitionReadCommand command : reads.queries)
+        {
+            if (migratingRanges.intersects(command.partitionKey().getToken()))
+            {
+                containsTokenInMigratingRange = true;
+                break;
+            }
+        }
+
+        AbstractReplicationStrategy ars = Keyspace.open(tm.keyspace).getReplicationStrategy();
+
+        // If we intersect, this means that there exists a node from which we will get the latest value, so we will not need to contact a quorum
+        boolean willIntersectQuorum = (ConsistencyLevel.QUORUM.blockFor(ars) + consistencyLevel.blockFor(ars)) > ConsistencyLevel.ALL.blockFor(ars);
+
+        return tm.params.transactionalMigrationFrom.nonSerialWritesThroughAccord() && containsTokenInMigratingRange && !willIntersectQuorum;
     }
 
     public static SplitReads splitReadsIntoAccordAndNormal(ClusterMetadata cm, SinglePartitionReadCommand.Group reads, ReadCoordinator coordinator, Dispatcher.RequestTime requestTime)

--- a/src/java/org/apache/cassandra/service/consensus/migration/ConsensusRequestRouter.java
+++ b/src/java/org/apache/cassandra/service/consensus/migration/ConsensusRequestRouter.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
 import org.apache.cassandra.db.ReadCommand;
@@ -838,6 +837,7 @@ public class ConsensusRequestRouter
         }
     }
 
+    // TODO: Extend this method to partition range reads after CASSANDRA-20211 is done
     public static boolean shouldUseQuorumConsistency(ClusterMetadata cm, SinglePartitionReadCommand.Group reads, ConsistencyLevel consistencyLevel)
     {
         TableMetadata tm = getTableMetadata(cm, reads.queries.get(0).metadata().id);
@@ -861,7 +861,11 @@ public class ConsensusRequestRouter
             }
         }
 
-        AbstractReplicationStrategy ars = Keyspace.open(tm.keyspace).getReplicationStrategy();
+        Optional<KeyspaceMetadata> ksm = cm.schema.maybeGetKeyspaceMetadata(tm.keyspace);
+
+        if (ksm.isEmpty())
+            return false;
+        AbstractReplicationStrategy ars = ksm.get().replicationStrategy;
 
         // If we intersect, this means that there exists a node from which we will get the latest value, so we will not need to contact a quorum
         boolean willIntersectQuorum = (ConsistencyLevel.QUORUM.blockFor(ars) + consistencyLevel.blockFor(ars)) > ConsistencyLevel.ALL.blockFor(ars);

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/MigrationFromAccordNonSerialReadConsistencyTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/MigrationFromAccordNonSerialReadConsistencyTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.distributed.test.accord;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.Config.PaxosVariant;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.impl.Instance;
+import org.apache.cassandra.distributed.shared.AssertUtils;
+import org.apache.cassandra.locator.EndpointsForToken;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.locator.ReplicaPlans;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.service.consensus.TransactionalMode;
+import org.apache.cassandra.service.consensus.migration.TransactionalMigrationFromMode;
+import org.apache.cassandra.service.reads.ReadCoordinator;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MigrationFromAccordNonSerialReadConsistencyTest extends AccordTestBase
+{
+    private static final Logger logger = LoggerFactory.getLogger(MigrationFromAccordNonSerialReadConsistencyTest.class);
+
+    private static final int STALE_NODE = 3;
+
+    @Override
+    protected Logger logger()
+    {
+        return logger;
+    }
+
+    @BeforeClass
+    public static void setupClass() throws IOException
+    {
+        ServerTestUtils.daemonInitialization();
+        AccordTestBase.setupCluster(builder -> builder.appendConfig(config -> config
+                                    .with(Feature.NETWORK)
+                                    // We turn dynamic_snitch off to not interfere with the routing of the read to STALE_NODE
+                                    .set("dynamic_snitch", false)
+                                    .set("paxos_variant", PaxosVariant.v2.name())), 3);
+    }
+
+    @Test
+    public void migratingReadAtConsistencyLevelOneIsUpgradedToQuorum() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH read_repair = 'NONE' AND speculative_retry = 'NONE' AND " + transactionalMode.asCqlParam(), cluster -> {
+            // Prevent STALE_NODE from applying write
+            cluster.filters()
+                   .inbound()
+                   .to(STALE_NODE)
+                   .verbs(Verb.ACCORD_APPLY_REQ.id,
+                          Verb.ACCORD_APPLY_AND_WAIT_REQ.id,
+                          Verb.ACCORD_INTEROP_APPLY_REQ.id,
+                          Verb.ACCORD_FETCH_DATA_RSP.id,
+                          Verb.ACCORD_CHECK_STATUS_RSP.id)
+                   .drop();
+
+            cluster.coordinator(1).execute(format("INSERT INTO %s (k, v) VALUES (1, 1)", qualifiedAccordTableName), ALL);
+
+            // Ensure that write to key 1 is only applied on nodes 1 & nodes 2
+            Util.spinUntilTrue(() -> cluster.get(1).executeInternal(selectCQL(1)).length == 1, 30);
+            Util.spinUntilTrue(() -> cluster.get(2).executeInternal(selectCQL(1)).length == 1, 30);
+            assertEquals(0, cluster.get(STALE_NODE).executeInternal(selectCQL(1)).length);
+
+            alterTableTransactionalMode(TransactionalMode.off, TransactionalMigrationFromMode.full);
+            nodetool(cluster.coordinator(1), "consensus_admin", "begin-migration", KEYSPACE, accordTableName);
+
+            assertTrue(readPlanOnlyIncludesSelfForConsistencyLevelOne(cluster.get(STALE_NODE), accordTableName));
+            assertEquals(0, cluster.get(STALE_NODE).executeInternal(selectCQL(1)).length);
+            Object[][] row = cluster.coordinator(STALE_NODE).execute(selectCQL(1), ONE);
+            AssertUtils.assertRows(row, AssertUtils.row(1, 1));
+        });
+    }
+
+    @Test
+    public void testMigratedRangesAreRoutedUsingConsistencyLevelOne() throws Throwable
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH read_repair = 'NONE' AND speculative_retry = 'NONE' AND " + transactionalMode.asCqlParam(), cluster -> {
+            String table = accordTableName;
+
+            // Prevent STALE_NODE from applying write
+            cluster.filters()
+                   .inbound()
+                   .to(STALE_NODE)
+                   .verbs(Verb.ACCORD_APPLY_REQ.id,
+                          Verb.ACCORD_APPLY_AND_WAIT_REQ.id,
+                          Verb.ACCORD_INTEROP_APPLY_REQ.id,
+                          Verb.ACCORD_FETCH_DATA_RSP.id,
+                          Verb.ACCORD_CHECK_STATUS_RSP.id)
+                   .drop();
+
+            cluster.coordinator(1).execute("INSERT INTO " + qualifiedAccordTableName + " (k, v) VALUES (1, 1)", ALL);
+
+            // Ensure that write to key 1 is only applied on nodes 1 & nodes 2
+            Util.spinUntilTrue(() -> cluster.get(1).executeInternal(selectCQL(1)).length == 1, 30);
+            Util.spinUntilTrue(() -> cluster.get(2).executeInternal(selectCQL(1)).length == 1, 30);
+            assertEquals(0, cluster.get(STALE_NODE).executeInternal(selectCQL(1)).length);
+
+            alterTableTransactionalMode(TransactionalMode.off, TransactionalMigrationFromMode.full);
+
+            long tokenOfMigratedKey = cluster.get(1).callOnInstance(() ->
+                Schema.instance.getTableMetadata(KEYSPACE, table)
+                               .partitioner.getToken(Int32Type.instance.decompose(1)).getLongValue());
+
+            // We reset the filter so that Accord repair can finish
+            cluster.filters().reset();
+
+            // We perform repair for key 1
+            cluster.get(1).nodetoolResult("consensus_admin", "finish-migration",
+                                          "-st", Long.toString(tokenOfMigratedKey - 1),
+                                          "-et", Long.toString(tokenOfMigratedKey),
+                                          KEYSPACE, accordTableName)
+                   .asserts().success();
+
+
+            // Node 3, now has key 1
+            assertEquals(1, cluster.get(STALE_NODE).executeInternal(selectCQL(1)).length);
+
+            AtomicInteger readRequestsFromStaleNode = new AtomicInteger();
+            cluster.filters()
+                   .outbound()
+                   .from(STALE_NODE)
+                   .verbs(Verb.READ_REQ.id)
+                   .messagesMatching((from, to, message) -> cluster.get(to).callsOnInstance(() -> {
+                       ReadCommand readCommand = (ReadCommand) Instance.deserializeMessage(message).payload;
+                       if (readCommand.metadata().keyspace.equals(KEYSPACE))
+                           readRequestsFromStaleNode.incrementAndGet();
+                       return false;
+                   }).call())
+                   .drop();
+
+            readRequestsFromStaleNode.set(0);
+
+            assertTrue(readPlanOnlyIncludesSelfForConsistencyLevelOne(cluster.get(STALE_NODE), accordTableName));
+            AssertUtils.assertRows(cluster.coordinator(STALE_NODE).execute(selectCQL(1), ONE), AssertUtils.row(1, 1));
+
+            // Since the key 1 is migrated, the read should be served at CL.ONE instead of CL.QUORUM
+            assertEquals(0, readRequestsFromStaleNode.get());
+        });
+    }
+
+    private static boolean readPlanOnlyIncludesSelfForConsistencyLevelOne(IInvokableInstance instance, String table)
+    {
+        return instance.callOnInstance(() -> {
+            Keyspace keyspace = Keyspace.open(KEYSPACE);
+            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(table);
+            Token token = cfs.decorateKey(Int32Type.instance.decompose(1)).getToken();
+
+            ReplicaPlan.ForTokenRead replicaPlan = ReplicaPlans.forRead(ClusterMetadata.current(),
+                                                                        keyspace,
+                                                                        cfs.getTableId(),
+                                                                        token,
+                                                                        null,
+                                                                        org.apache.cassandra.db.ConsistencyLevel.ONE,
+                                                                        cfs.metadata().params.speculativeRetry,
+                                                                        ReadCoordinator.DEFAULT);
+            EndpointsForToken contactedReplicas = replicaPlan.contacts();
+            InetAddressAndPort self = FBUtilities.getBroadcastAddressAndPort();
+
+            return contactedReplicas.size() == 1 && contactedReplicas.get(0).endpoint().equals(self);
+        });
+    }
+
+    private String selectCQL(int key)
+    {
+        return format("SELECT k, v FROM %s WHERE k = %d", qualifiedAccordTableName, key);
+    }
+}


### PR DESCRIPTION
We upgrade the consistency level for single partition read commands, when migrating off of Accord and the supplied consistency level does not intersect a quorum in order to maintain consistency. 

patch by Alan Wang;

reviewed by for [CASSANDRA-20705](https://issues.apache.org/jira/browse/CASSANDRA-20705)

Co-authored-by: Name1
Co-authored-by: Name2