### PR TITLE
CASSANDRA-21595: docs: distinguish between reset_bootstrap_progress (true, false, unset)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.10
+ * Clarify the unset, true and false behaviours of cassandra.reset_bootstrap_progress in the abort message and docs (CASSANDRA-21595)
  * Avoid rebuilding per-SSTable SAI components unless missing or corrupted (CASSANDRA-21515)
  * Propagate trickle_fsync settings to compressed SSTable writers (CASSANDRA-21487)
  * Allow DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(0) to disable read-ahead buffer (CASSANDRA-21522)

--- a/doc/modules/cassandra/pages/managing/operating/topo_changes.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/topo_changes.adoc
@@ -50,9 +50,31 @@ unavailable replica, set the JVM flag
 On 2.2+, if the bootstrap process fails, it's possible to resume
 bootstrap from the previous saved state by calling
 `nodetool bootstrap resume`. If for some reason the bootstrap hangs or
-stalls, it may also be resumed by simply restarting the node. In order
-to cleanup bootstrap state and start fresh, you may set the JVM startup
-flag `-Dcassandra.reset_bootstrap_progress=true`.
+stalls, it may also be resumed by simply restarting the node.
+
+==== The `cassandra.reset_bootstrap_progress` JVM property
+
+When a bootstrap finds ranges that a previous, partially successful
+bootstrap already marked as available, the behaviour depends on the
+`cassandra.reset_bootstrap_progress` JVM startup property. Leaving it
+unset is *not* the same as setting it to `true` or to `false`.
+
+[cols=",",options="header",]
+|===
+|Value |Behaviour when previous bootstrap progress is found
+
+|unset (default) |Aborts the bootstrap with an error, so that no
+decision about the existing data is made on your behalf.
+
+|`true` |Discards the recorded progress and streams all ranges again.
+The files already streamed are *not* deleted, so remove them before
+retrying or you may resurrect or duplicate data. See
+https://issues.apache.org/jira/browse/CASSANDRA-17679[CASSANDRA-17679].
+
+|`false` |Keeps the recorded progress and streams only the ranges not
+already marked as available. Only safe if the data streamed by the
+previous attempt is still intact on disk.
+|===
 
 On lower versions, when the bootstrap proces fails it is recommended to
 wipe the node (remove all the data), and restart the bootstrap process

--- a/src/java/org/apache/cassandra/dht/RangeStreamer.java
+++ b/src/java/org/apache/cassandra/dht/RangeStreamer.java
@@ -736,14 +736,15 @@ public class RangeStreamer
                     if (remaining.size() < available.full.size() + available.trans.size())
                     {
                         // If the operator hasn't specified what to do when we discover a previous partially successful bootstrap,
-                        // we error out and tell them to manually reconcile it. See CASSANDRA-17679.
+                        // we error out and spell out the true/false choice. See CASSANDRA-17679.
                         if (!RESET_BOOTSTRAP_PROGRESS.isPresent())
                         {
                             List<FetchReplica> skipped = fetchReplicas.stream().filter(isAvailable).collect(Collectors.toList());
-                            String msg = String.format("Discovered existing bootstrap data and %s " +
-                                                       "is not configured; aborting bootstrap. Please clean up local files manually " +
-                                                       "and try again or set cassandra.reset_bootstrap_progress=true to ignore. " +
-                                                       "Found: %s. Fully available: %s. Transiently available: %s",
+                            String msg = String.format("Discovered existing bootstrap data from a previous, partially successful bootstrap " +
+                                                       "and %1$s is unset; aborting. Set -D%1$s=true to discard that progress and re-stream " +
+                                                       "all ranges, after deleting the data files the previous attempt streamed, or " +
+                                                       "-D%1$s=false to stream only the ranges still missing. " +
+                                                       "See CASSANDRA-17679. Found: %2$s. Fully available: %3$s. Transiently available: %4$s",
                                                        RESET_BOOTSTRAP_PROGRESS.getKey(), skipped, available.full, available.trans);
                             logger.error(msg);
                             throw new IllegalStateException(msg);


### PR DESCRIPTION
First contribution here. Please feel free to let me know if I am not doing this right :)

The only documenation available on `reset_bootstrap_progress` is the following:

> In order to cleanup bootstrap state and start fresh, you may set the JVM startup flag -Dcassandra.reset_bootstrap_progress=true.

This gives the impression that if I don't want to start fresh, I should not do anything. However, this is false. If I want my node to resume bootstraping with existing data, I need to set it to `false`, which is different than the default of `unset`.

I think this is impossible to infer from existing documentation. Only reading source code helped me understand.

Feel free to directly edit my wording here -- I documented this to the best of my understanding.

patch by Alexandre Viau; reviewed by TBD for CASSANDRA-21595