### PR TITLE
CASSANDRA-21594 Fix incorrectly calculated getNonOverlappingBounds

### DIFF
--- a/src/java/org/apache/cassandra/dht/Bounds.java
+++ b/src/java/org/apache/cassandra/dht/Bounds.java
@@ -155,7 +155,7 @@ public class Bounds<T extends RingPosition<T>> extends AbstractBounds<T>
      * [   ] [   ]    [   ]   [  ]
      * [   ]         [       ]
      * This method will return the following bounds:
-     * [         ]    [          ]
+     * [         ]   [          ]
      *
      * @param bounds unsorted bounds to find overlaps
      * @return the non-overlapping bounds
@@ -176,11 +176,16 @@ public class Bounds<T extends RingPosition<T>> extends AbstractBounds<T>
         PeekingIterator<Bounds<T>> it = Iterators.peekingIterator(sortedBounds.iterator());
         while (it.hasNext())
         {
-            Bounds<T> beginBound = it.next();
-            Bounds<T> endBound = beginBound;
-            while (it.hasNext() && endBound.right.compareTo(it.peek().left) >= 0)
-                endBound = it.next();
-            nonOverlappingBounds.add(new Bounds<>(beginBound.left, endBound.right));
+            Bounds<T> startBound = it.next();
+            T end = startBound.right;
+            while (it.hasNext() && end.compareTo(it.peek().left) >= 0)
+            {
+                Bounds<T> bound = it.next();
+                if (end.compareTo(bound.right) < 0)
+                    end = bound.right;
+            }
+
+            nonOverlappingBounds.add(new Bounds<>(startBound.left, end));
         }
 
         return nonOverlappingBounds;

--- a/src/java/org/apache/cassandra/dht/Bounds.java
+++ b/src/java/org/apache/cassandra/dht/Bounds.java
@@ -17,14 +17,13 @@
  */
 package org.apache.cassandra.dht;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
 
@@ -162,15 +161,7 @@ public class Bounds<T extends RingPosition<T>> extends AbstractBounds<T>
      */
     public static <T extends RingPosition<T>> Set<Bounds<T>> getNonOverlappingBounds(Iterable<Bounds<T>> bounds)
     {
-        ArrayList<Bounds<T>> sortedBounds = Lists.newArrayList(bounds);
-        Collections.sort(sortedBounds, new Comparator<Bounds<T>>()
-        {
-            public int compare(Bounds<T> o1, Bounds<T> o2)
-            {
-                return o1.left.compareTo(o2.left);
-            }
-        });
-
+        List<Bounds<T>> sortedBounds = ImmutableList.sortedCopyOf(Comparator.comparing(o -> o.left), bounds);
         Set<Bounds<T>> nonOverlappingBounds = Sets.newHashSet();
 
         PeekingIterator<Bounds<T>> it = Iterators.peekingIterator(sortedBounds.iterator());

--- a/test/unit/org/apache/cassandra/dht/BoundsTest.java
+++ b/test/unit/org/apache/cassandra/dht/BoundsTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.cassandra.dht;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -29,21 +29,20 @@ import static org.junit.Assert.assertTrue;
 
 public class BoundsTest
 {
-
     private Bounds<Token> bounds(long left, long right)
     {
         return new Bounds<Token>(new Murmur3Partitioner.LongToken(left), new Murmur3Partitioner.LongToken(right));
     }
 
-    @Test
     /**
      * [0,1],[0,5],[1,8],[4,10] = [0, 10]
      * [15,19][19,20] = [15,20]
      * [21, 22] = [21,22]
      */
+    @Test
     public void testGetNonOverlappingBounds()
     {
-        List<Bounds<Token>> bounds = new LinkedList<>();
+        List<Bounds<Token>> bounds = new ArrayList<>();
         bounds.add(bounds(19, 20));
         bounds.add(bounds(0, 1));
         bounds.add(bounds(4, 10));
@@ -57,5 +56,65 @@ public class BoundsTest
         assertTrue(nonOverlappingBounds.contains(bounds(0, 10)));
         assertTrue(nonOverlappingBounds.contains(bounds(15,20)));
         assertTrue(nonOverlappingBounds.contains(bounds(21,22)));
+    }
+
+    /**
+     * [1, 100] [2, 5] = [1, 100]
+     */
+    @Test
+    public void testGetNonOverlappingBounds2()
+    {
+        List<Bounds<Token>> bounds = new ArrayList<>();
+        bounds.add(bounds(1, 100));
+        bounds.add(bounds(2, 5));
+
+        Set<Bounds<Token>> nonOverlappingBounds = Bounds.getNonOverlappingBounds(bounds);
+        assertEquals(1, nonOverlappingBounds.size());
+        assertTrue(nonOverlappingBounds.contains(bounds(1, 100)));
+    }
+
+    /**
+     * [1, 100] [99, 101] = [1, 101]
+     */
+    @Test
+    public void testGetNonOverlappingBounds3()
+    {
+        List<Bounds<Token>> bounds = new ArrayList<>();
+        bounds.add(bounds(1, 100));
+        bounds.add(bounds(99, 101));
+
+        Set<Bounds<Token>> nonOverlappingBounds = Bounds.getNonOverlappingBounds(bounds);
+        assertEquals(1, nonOverlappingBounds.size());
+        assertTrue(nonOverlappingBounds.contains(bounds(1, 101)));
+    }
+
+    /**
+     * [0, 2] [1, 100] = [0, 100]
+     */
+    @Test
+    public void testGetNonOverlappingBounds4()
+    {
+        List<Bounds<Token>> bounds = new ArrayList<>();
+        bounds.add(bounds(0, 2));
+        bounds.add(bounds(1, 100));
+
+        Set<Bounds<Token>> nonOverlappingBounds = Bounds.getNonOverlappingBounds(bounds);
+        assertEquals(1, nonOverlappingBounds.size());
+        assertTrue(nonOverlappingBounds.contains(bounds(0, 100)));
+    }
+
+    /**
+     * [0, 0] [0, 100] = [0, 100]
+     */
+    @Test
+    public void testGetNonOverlappingBounds5()
+    {
+        List<Bounds<Token>> bounds = new ArrayList<>();
+        bounds.add(bounds(0, 0));
+        bounds.add(bounds(0, 100));
+
+        Set<Bounds<Token>> nonOverlappingBounds = Bounds.getNonOverlappingBounds(bounds);
+        assertEquals(1, nonOverlappingBounds.size());
+        assertTrue(nonOverlappingBounds.contains(bounds(0, 100)));
     }
 }


### PR DESCRIPTION
Bounds.getNonOverlappingBounds is not calculated correctly which can cause us to not invalidate the correct ranges for the row cache and the counter cache when performing SSTable streaming. 

Bounds.getNonOverlappingBounds incorrectly computes [1, 100] [2, 5] as [1, 5]. 

patch by Alan Wang;

reviewed by for [CASSANDRA-21594](https://issues.apache.org/jira/browse/CASSANDRA-21594)

Co-authored-by: Name1
Co-authored-by: Name2