### PR TITLE
CASSANDRA-21596: Remove the unused timeout pre-condition from the docker build scripts

### DIFF
--- a/.build/docker/_docker_run.sh
+++ b/.build/docker/_docker_run.sh
@@ -53,7 +53,6 @@ java_version=$3
 
 # pre-conditions
 command -v docker >/dev/null 2>&1 || { echo >&2 "docker needs to be installed"; exit 1; }
-command -v timeout >/dev/null 2>&1 || { echo >&2 "timeout needs to be installed"; exit 1; }
 (docker info >/dev/null 2>&1) || { echo >&2 "docker needs to running"; exit 1; }
 [ -f "${cassandra_dir}/build.xml" ] || { echo >&2 "${cassandra_dir}/build.xml must exist"; exit 1; }
 [ -f "${cassandra_dir}/.build/docker/${dockerfile}" ] || { echo >&2 "${cassandra_dir}/.build/docker/${dockerfile} must exist"; exit 1; }

--- a/.build/docker/run-tests.sh
+++ b/.build/docker/run-tests.sh
@@ -98,7 +98,6 @@ done
 # pre-conditions
 command -v docker >/dev/null 2>&1 || { error 1 "docker needs to be installed"; }
 command -v bc >/dev/null 2>&1 || { error 1 "bc needs to be installed"; }
-command -v timeout >/dev/null 2>&1 || { error 1 "timeout needs to be installed"; }
 (docker info >/dev/null 2>&1) || { error 1 "docker needs to running"; }
 [ -f "${cassandra_dir}/build.xml" ] || { error 1 "${cassandra_dir}/build.xml must exist"; }
 [ -f "${cassandra_dir}/.build/run-tests.sh" ] || { error 1 "${cassandra_dir}/.build/run-tests.sh must exist"; }


### PR DESCRIPTION
`.build/docker` scripts refuse to run without timeout, which they never invoke.

patch by Alexandre Viau; reviewed by TBD for CASSANDRA-21596
