### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -13,7 +13,7 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v3
           - name: JDK 11
-            uses: actions/setup-java@v3
+            uses: actions/setup-java@v6
             with:
               java-version: '11'
               distribution: 'temurin'
@@ -27,7 +27,7 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v3
           - name: JDK 17
-            uses: actions/setup-java@v3
+            uses: actions/setup-java@v6
             with:
               java-version: '17'
               distribution: 'temurin'


### PR DESCRIPTION
Update both active `actions/setup-java@v3` references in `.github/workflows/code-check.yaml` to `actions/setup-java@v6`. This keeps Cassandra GitHub Actions checks on the current action major.

Validation: `git diff --check` passes and all active workflow files were checked for older setup-java references. No product tests were run because this is a workflow-only change.

The change is intentionally limited to GitHub Actions configuration and has no runtime impact.