### PR TITLE
CASSANDRA-21600 Fix bug with IntegerInterval covers

### DIFF
--- a/src/java/org/apache/cassandra/utils/IntegerInterval.java
+++ b/src/java/org/apache/cassandra/utils/IntegerInterval.java
@@ -201,9 +201,9 @@ public class IntegerInterval
 
             int covered = upper(ranges[rpos]);
 
-            // We need to walk through ranges as [0, 1] [2, 3] are non overlapping,
-            // however we still cover [0, 3]. Without this loop, covered
-            // would be equal to 1
+            // We need to walk through the ranges. Take for example, when we have intervals
+            // [0, 1] [2, 3], we cover [0, 3]. However without this loop, we would return false
+            // as we only look at 1 of the intervals.
             for (int i = rpos + 1; i < ranges.length; i++)
             {
                 if (covered >= end)

--- a/src/java/org/apache/cassandra/utils/IntegerInterval.java
+++ b/src/java/org/apache/cassandra/utils/IntegerInterval.java
@@ -198,7 +198,21 @@ public class IntegerInterval
                 rpos = (-1 - rpos) - 1;
             if (rpos == -1)
                 return false;
-            return upper(ranges[rpos]) >= end;
+
+            int covered = upper(ranges[rpos]);
+
+            // We need to walk through ranges as [0, 1] [2, 3] are non overlapping,
+            // however we still cover [0, 3]. Without this loop, covered
+            // would be equal to 1
+            for (int i = rpos + 1; i < ranges.length; i++)
+            {
+                if (covered >= end)
+                    break;
+                if (lower(ranges[i]) == covered + 1)
+                    covered = upper(ranges[i]);
+            }
+
+            return covered >= end;
         }
 
         /**

--- a/test/unit/org/apache/cassandra/utils/IntegerIntervalsTest.java
+++ b/test/unit/org/apache/cassandra/utils/IntegerIntervalsTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.utils.IntegerInterval.Set;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class IntegerIntervalsTest
@@ -342,5 +343,15 @@ public class IntegerIntervalsTest
 
         testSetCovers(4, 5, false);
         testSetCovers(4, Integer.MAX_VALUE, false);
+    }
+
+    @Test
+    public void testSetCoversRegression()
+    {
+        Set s = new Set();
+        s.add(0, 1);
+        s.add(2, 3);
+
+        assertTrue(s.covers(new IntegerInterval(0, 3)));
     }
 }


### PR DESCRIPTION
IntegerInterval covers returns that [0, 3] does not cover the following intervals [0,1] [2,3]. 

patch by Alan Wang;

reviewed by for [CASSANDRA-21600](https://issues.apache.org/jira/browse/CASSANDRA-21600)

Co-authored-by: Name1
Co-authored-by: Name2