### PR TITLE
CASSANDRA-21602 Fix bug with NormalizedRanges.Intersects

### DIFF
--- a/src/java/org/apache/cassandra/dht/NormalizedRanges.java
+++ b/src/java/org/apache/cassandra/dht/NormalizedRanges.java
@@ -48,12 +48,12 @@ public class NormalizedRanges<T extends RingPosition<T>> extends AbstractList<Ra
         boolean rangeRightIsMin = range.right.isMinimum();
         boolean keyIsMinimum = key.isMinimum();
 
-        if (keyIsMinimum & rangeRightIsMin)
-            return 0;
+        if (keyIsMinimum)
+            return rangeRightIsMin ? 0 : -1;
 
         int lc = key.compareTo(range.left);
         int rc = key.compareTo(range.right);
-        if ((lc < 0 & !keyIsMinimum) | lc == 0) return 1;
+        if (lc <= 0) return 1;
         if (rc > 0 & !rangeRightIsMin) return -1;
         return 0;
     };

--- a/test/unit/org/apache/cassandra/dht/RangeTest.java
+++ b/test/unit/org/apache/cassandra/dht/RangeTest.java
@@ -861,6 +861,25 @@ public class RangeTest extends CassandraTestBase
     }
 
     @Test
+    @UseMurmur3Partitioner
+    public void testNormalizedRangesWithMinToken()
+    {
+        Token min = t(Long.MIN_VALUE);
+
+        for (NormalizedRanges<Token> ranges : ImmutableList.of(
+            normalizedRanges(ImmutableList.of(r(Long.MIN_VALUE, Long.MIN_VALUE))),
+            normalizedRanges(ImmutableList.of(r(Long.MIN_VALUE, 100))),
+            normalizedRanges(ImmutableList.of(r(100, Long.MIN_VALUE))),
+            normalizedRanges(ImmutableList.of(r(-500, -100), r(100, 500))),
+            normalizedRanges(ImmutableList.of(r(Long.MIN_VALUE, -100), r(100, 500))),
+            normalizedRanges(ImmutableList.of(r(Long.MIN_VALUE, -100), r(100, Long.MIN_VALUE))),
+            normalizedRanges(ImmutableList.of(r(100, 500)))))
+        {
+            assertEquals(Range.isInRanges(min, ranges), ranges.intersects(min));
+        }
+    }
+
+    @Test
     public void testExpensiveChecksBurn()
     {
         long seed = System.nanoTime();


### PR DESCRIPTION
NormalizedRanges.Intersects incorrectly handles min token key. For cases where a range does not intersect a min token key, it returns true. The test case `assertFalse(normalizedRanges(ImmutableList.of(r(100, 500))).intersects(min));` fails.

patch by Alan Wang;

reviewed by for [CASSANDRA-21602](https://issues.apache.org/jira/browse/CASSANDRA-21602)

Co-authored-by: Name1
Co-authored-by: Name2