### PR TITLE
CASSANDRA-21605 Improve algorithmic complexity for finding intersecting SSTables for LCS compaction candidates

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
@@ -99,7 +99,7 @@ class LeveledGenerations
     TreeSet<SSTableReader> getSortedLevel(int level)
     {
         if (level > levelCount() - 1 || level <= 0)
-            throw new ArrayIndexOutOfBoundsException("Invalid generation " + level + " - maximum is " + (levelCount() - 1));
+            throw new ArrayIndexOutOfBoundsException("Invalid sorted generation " + level + " - maximum is " + (levelCount() - 1) + " and minimum is 1");
         return levels[level - 1];
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
@@ -96,6 +96,13 @@ class LeveledGenerations
         return levels[level - 1];
     }
 
+    TreeSet<SSTableReader> getSortedLevel(int level)
+    {
+        if (level > levelCount() - 1 || level <= 0)
+            throw new ArrayIndexOutOfBoundsException("Invalid generation " + level + " - maximum is " + (levelCount() - 1));
+        return levels[level - 1];
+    }
+
     int levelCount()
     {
         return levels.length + 1;

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -596,6 +596,7 @@ public class LeveledManifest
         return Collections.emptyList();
     }
 
+    // Precondition: sstables in sstablesNextLevel must be disjoint
     @VisibleForTesting
     protected static Set<SSTableReader> getIntersectingSSTablesFromTreeSet(SSTableReader sstable, TreeSet<SSTableReader> sstablesNextLevel)
     {

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -450,7 +451,8 @@ public class LeveledManifest
         return overlapping(first, last, others);
     }
 
-    private static Set<SSTableReader> overlappingWithBounds(SSTableReader sstable, Map<SSTableReader, Bounds<Token>> others)
+    @VisibleForTesting
+    static Set<SSTableReader> overlappingWithBounds(SSTableReader sstable, Map<SSTableReader, Bounds<Token>> others)
     {
         return overlappingWithBounds(sstable.getFirst().getToken(), sstable.getLast().getToken(), others);
     }
@@ -573,14 +575,16 @@ public class LeveledManifest
                 return candidates;
         }
 
+        // We know that because we are in level L0+, this is a tree set with disjoint SSTables
+        TreeSet<SSTableReader> sstablesNextLevel = (TreeSet<SSTableReader>) generations.get(level + 1);
+
         // look for a non-suspect keyspace to compact with, starting with where we left off last time,
         // and wrapping back to the beginning of the generation if necessary
-        Map<SSTableReader, Bounds<Token>> sstablesNextLevel = genBounds(generations.get(level + 1));
         Iterator<SSTableReader> levelIterator = generations.wrappingIterator(level, lastCompactedSSTables[level]);
         while (levelIterator.hasNext())
         {
             SSTableReader sstable = levelIterator.next();
-            Set<SSTableReader> candidates = Sets.union(Collections.singleton(sstable), overlappingWithBounds(sstable, sstablesNextLevel));
+            Set<SSTableReader> candidates = getIntersectingSSTablesFromTreeSet(sstable, sstablesNextLevel);
 
             if (Iterables.any(candidates, SSTableReader::isMarkedSuspect))
                 continue;
@@ -590,6 +594,26 @@ public class LeveledManifest
 
         // all the sstables were suspect or overlapped with something suspect
         return Collections.emptyList();
+    }
+
+    public static Set<SSTableReader> getIntersectingSSTablesFromTreeSet(SSTableReader sstable, TreeSet<SSTableReader> sstablesNextLevel)
+    {
+        Set<SSTableReader> candidates = new HashSet<>();
+        candidates.add(sstable);
+
+        if (sstablesNextLevel.isEmpty())
+            return candidates;
+
+        SSTableReader start = sstablesNextLevel.floor(sstable);
+        Iterator<SSTableReader> it = sstablesNextLevel.tailSet(start != null ? start : sstablesNextLevel.first(), true).iterator();
+
+        while (it.hasNext()) {
+            SSTableReader s = it.next();
+            if (s.getFirst().compareTo(sstable.getLast()) > 0) break;
+            if (s.getLast().compareTo(sstable.getFirst()) >= 0) candidates.add(s);
+        }
+
+        return candidates;
     }
 
     private Set<SSTableReader> getCompactingL0()

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -451,8 +451,7 @@ public class LeveledManifest
         return overlapping(first, last, others);
     }
 
-    @VisibleForTesting
-    static Set<SSTableReader> overlappingWithBounds(SSTableReader sstable, Map<SSTableReader, Bounds<Token>> others)
+    private static Set<SSTableReader> overlappingWithBounds(SSTableReader sstable, Map<SSTableReader, Bounds<Token>> others)
     {
         return overlappingWithBounds(sstable.getFirst().getToken(), sstable.getLast().getToken(), others);
     }

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -576,7 +576,7 @@ public class LeveledManifest
         }
 
         // We know that because we are in level L0+, this is a tree set with disjoint SSTables
-        TreeSet<SSTableReader> sstablesNextLevel = (TreeSet<SSTableReader>) generations.get(level + 1);
+        TreeSet<SSTableReader> sstablesNextLevel = generations.getSortedLevel(level + 1);
 
         // look for a non-suspect keyspace to compact with, starting with where we left off last time,
         // and wrapping back to the beginning of the generation if necessary
@@ -585,6 +585,7 @@ public class LeveledManifest
         {
             SSTableReader sstable = levelIterator.next();
             Set<SSTableReader> candidates = getIntersectingSSTablesFromTreeSet(sstable, sstablesNextLevel);
+            candidates.add(sstable);
 
             if (Iterables.any(candidates, SSTableReader::isMarkedSuspect))
                 continue;
@@ -596,10 +597,10 @@ public class LeveledManifest
         return Collections.emptyList();
     }
 
-    public static Set<SSTableReader> getIntersectingSSTablesFromTreeSet(SSTableReader sstable, TreeSet<SSTableReader> sstablesNextLevel)
+    @VisibleForTesting
+    protected static Set<SSTableReader> getIntersectingSSTablesFromTreeSet(SSTableReader sstable, TreeSet<SSTableReader> sstablesNextLevel)
     {
         Set<SSTableReader> candidates = new HashSet<>();
-        candidates.add(sstable);
 
         if (sstablesNextLevel.isEmpty())
             return candidates;
@@ -607,7 +608,8 @@ public class LeveledManifest
         SSTableReader start = sstablesNextLevel.floor(sstable);
         Iterator<SSTableReader> it = sstablesNextLevel.tailSet(start != null ? start : sstablesNextLevel.first(), true).iterator();
 
-        while (it.hasNext()) {
+        while (it.hasNext())
+        {
             SSTableReader s = it.next();
             if (s.getFirst().compareTo(sstable.getLast()) > 0) break;
             if (s.getLast().compareTo(sstable.getFirst()) >= 0) candidates.add(s);

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -596,7 +596,9 @@ public class LeveledManifest
         return Collections.emptyList();
     }
 
-    // Precondition: sstables in sstablesNextLevel must be disjoint
+    /**
+     * Precondition: SSTables in sstablesNextLevel must be disjoint
+    */
     @VisibleForTesting
     protected static Set<SSTableReader> getIntersectingSSTablesFromTreeSet(SSTableReader sstable, TreeSet<SSTableReader> sstablesNextLevel)
     {

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -75,6 +75,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.TimeUUID;
 
+import static accord.utils.Property.qt;
 import static java.util.Collections.singleton;
 import static org.apache.cassandra.db.compaction.LeveledManifest.getIntersectingSSTablesFromTreeSet;
 import static org.apache.cassandra.db.compaction.LeveledManifest.overlapping;
@@ -598,95 +599,95 @@ public class LeveledCompactionStrategyTest
     }
 
     @Test
-    public void testLinearScanTreeSetIntersectionEquivalence() throws IOException
+    public void testLinearScanTreeSetIntersectionEquivalence()
     {
-        ColumnFamilyStore cfs = MockSchema.newCFS();
-        List<SSTableReader> sstables = new ArrayList<>();
+        qt().withExamples(10).check(rs -> {
+            ColumnFamilyStore cfs = MockSchema.newCFS();
+            List<SSTableReader> sstables = new ArrayList<>();
 
-        long seed = System.currentTimeMillis();
-        Random r = new Random(seed);
+            // Generates disjoint sorted SSTables that match what we see in L1
+            int i = 0;
+            int lowerBound = 10;
+            while (i < 10000)
+            {
+                int start = lowerBound + 1 + rs.nextInt(15);
+                int end = start + rs.nextInt(15);
+                lowerBound = end;
+                sstables.add(MockSchema.sstableWithLevel(i++, start, end, 1, cfs));
+            }
 
-        // Generates disjoint sorted SSTables that match what we see in L1
-        int i = 0;
-        int lowerBound = 10;
-        while (i < 10000)
-        {
-            int start = lowerBound + 1 + r.nextInt(15);
-            int end = start + r.nextInt(15);
-            lowerBound = end;
-            SSTableReader l1sstable = MockSchema.sstableWithLevel(i, start, end, 1, cfs);
-            sstables.add(l1sstable);
-            i++;
-        }
+            LeveledGenerations generations = new LeveledGenerations();
+            generations.addAll(sstables);
 
-        LeveledGenerations generations = new LeveledGenerations();
-        generations.addAll(sstables);
+            // Every kind of overlap gets tested; randomness only selects the tokens
+            for (Overlap overlap : Overlap.values())
+            {
+                SSTableReader sstableinL1 = rs.pick(sstables);
+                Token newStart;
+                Token newEnd;
 
-        SSTableReader sstableinL1;
-        Token newStart;
-        Token newEnd;
+                switch (overlap)
+                {
+                    case NONE:
+                        newStart = sstableinL1.getLast().getToken().increaseSlightly();
+                        newEnd = newStart.getToken().increaseSlightly();
+                        break;
+                    case LEFT_END:
+                        newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
+                        newEnd = sstableinL1.getFirst().getToken().increaseSlightly();
+                        break;
+                    case RIGHT_END:
+                        newStart = sstableinL1.getLast().getToken().decreaseSlightly();
+                        newEnd = sstableinL1.getLast().getToken().increaseSlightly();
+                        break;
+                    case SUBSET:
+                        newStart = sstableinL1.getFirst().getToken().increaseSlightly();
+                        newEnd = sstableinL1.getLast().getToken().decreaseSlightly();
+                        break;
+                    case SUPERSET:
+                        newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
+                        newEnd = sstableinL1.getLast().getToken().increaseSlightly();
+                        break;
+                    case EXACT_MATCH:
+                        newStart = sstableinL1.getFirst().getToken();
+                        newEnd = sstableinL1.getLast().getToken();
+                        break;
+                    case WHOLE_LEVEL:
+                        newStart = sstables.get(0).getFirst().getToken();
+                        newEnd = sstables.get(sstables.size() - 1).getLast().getToken();
+                        break;
+                    case SINGLE_TOKEN:
+                        newStart = sstableinL1.getFirst().getToken();
+                        newEnd = sstableinL1.getFirst().getToken();
+                        break;
+                    default:
+                        throw new IllegalStateException("Unhandled overlap " + overlap);
+                }
 
-        int kind = r.nextInt(8);
+                SSTableReader sstable = MockSchema.sstableWithLevel(i++, newStart.getLongValue(), newEnd.getLongValue(), 0, cfs);
+                Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, generations.getSortedLevel(1));
+                Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.getSortedLevel(1));
 
-        switch (kind)
-        {
-            // No overlap
-            case 0:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getLast().getToken().increaseSlightly();
-                newEnd = newStart.getToken().increaseSlightly();
-                break;
-            // Overlaps on the left end
-            case 1:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
-                newEnd = sstableinL1.getFirst().getToken().increaseSlightly();
-                break;
-            // Overlaps on the right end
-            case 2:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getLast().getToken().decreaseSlightly();
-                newEnd = sstableinL1.getLast().getToken().increaseSlightly();
-                break;
-            // Subset of entire SSTable
-            case 3:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getFirst().getToken().increaseSlightly();
-                newEnd = sstableinL1.getLast().getToken().decreaseSlightly();
-                break;
-            // Superset of entire SSTable
-            case 4:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
-                newEnd = sstableinL1.getLast().getToken().increaseSlightly();
-                break;
-            // Exact SSTable match
-            case 5:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getFirst().getToken();
-                newEnd = sstableinL1.getLast().getToken();
-                break;
-            // Spans the whole L1
-            case 6:
-                newStart = sstables.get(0).getFirst().getToken();
-                newEnd = sstables.get(sstables.size() - 1).getLast().getToken();
-                break;
-            // Single token SSTables
-            case 7:
-                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
-                newStart = sstableinL1.getFirst().getToken();
-                newEnd = sstableinL1.getFirst().getToken();
-                break;
-            default:
-                throw new IllegalStateException("Unhandled kind " + kind);
-        }
+                // The results should be equivalent to doing a linear scan
+                assertTrue("treeSet and linear scan produce different results for overlap " + overlap,
+                           treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
+            }
+        });
+    }
 
-        SSTableReader sstable = MockSchema.sstableWithLevel(i, newStart.getLongValue(), newEnd.getLongValue(), 0, cfs);
-        Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, generations.getSortedLevel(1));
-        Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.getSortedLevel(1));
-
-        // The results should be equivalent to doing a linear scan
-        assertTrue("[seed = " + seed + " treeSet and linear scan produce different results]", treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
+    /**
+     * The ways a new L0 SSTable can overlap the SSTables in L1.
+     */
+    private enum Overlap
+    {
+        NONE,
+        LEFT_END,
+        RIGHT_END,
+        SUBSET,
+        SUPERSET,
+        EXACT_MATCH,
+        WHOLE_LEVEL,
+        SINGLE_TOKEN
     }
 
     private int getTaskLevel(ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -609,12 +609,12 @@ public class LeveledCompactionStrategyTest
 
         // Generates disjoint sorted SSTables that match what we see in L1
         int i = 0;
-        int lower_bound = 10;
+        int lowerBound = 10;
         while (i < 10000)
         {
-            int start = lower_bound + 1 + r.nextInt(30);
+            int start = lowerBound + 1 + r.nextInt(30);
             int end = start + 10 + r.nextInt(30);
-            lower_bound = end;
+            lowerBound = end;
             SSTableReader l1sstable = MockSchema.sstableWithLevel(i, start, end, 1, cfs);
             sstables.add(l1sstable);
             i++;
@@ -679,10 +679,9 @@ public class LeveledCompactionStrategyTest
         SSTableReader sstable = MockSchema.sstableWithLevel(i, newStart.getLongValue(), newEnd.getLongValue(), 0, cfs);
         Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, (TreeSet<SSTableReader>) generations.get(1));
         Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.get(1));
-        linearScanIntersectionSSTables.add(sstable);
 
         // The results should be equivalent to doing a linear scan
-        assertTrue(treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
+        assertTrue("[seed = " + seed + " tree set and linear scan produce different results]", treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
     }
 
     private int getTaskLevel(ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -683,11 +682,11 @@ public class LeveledCompactionStrategyTest
         }
 
         SSTableReader sstable = MockSchema.sstableWithLevel(i, newStart.getLongValue(), newEnd.getLongValue(), 0, cfs);
-        Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, (TreeSet<SSTableReader>) generations.get(1));
-        Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.get(1));
+        Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, generations.getSortedLevel(1));
+        Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.getSortedLevel(1));
 
         // The results should be equivalent to doing a linear scan
-        assertTrue("[seed = " + seed + " tree set and linear scan produce different results]", treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
+        assertTrue("[seed = " + seed + " treeSet and linear scan produce different results]", treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
     }
 
     private int getTaskLevel(ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -76,6 +77,8 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.TimeUUID;
 
 import static java.util.Collections.singleton;
+import static org.apache.cassandra.db.compaction.LeveledManifest.getIntersectingSSTablesFromTreeSet;
+import static org.apache.cassandra.db.compaction.LeveledManifest.overlapping;
 import static org.apache.cassandra.schema.MockSchema.readerBounds;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -593,6 +596,93 @@ public class LeveledCompactionStrategyTest
         {
             CompactionManager.instance.setDisableSTCSInL0(false);
         }
+    }
+
+    @Test
+    public void testLinearScanTreeSetIntersectionEquivalence() throws IOException
+    {
+        ColumnFamilyStore cfs = MockSchema.newCFS();
+        List<SSTableReader> sstables = new ArrayList<>();
+
+        long seed = System.currentTimeMillis();
+        Random r = new Random(seed);
+
+        // Generates disjoint sorted SSTables that match what we see in L1
+        int i = 0;
+        int lower_bound = 10;
+        while (i < 10000)
+        {
+            int start = lower_bound + 1 + r.nextInt(30);
+            int end = start + 10 + r.nextInt(30);
+            lower_bound = end;
+            SSTableReader l1sstable = MockSchema.sstableWithLevel(i, start, end, 1, cfs);
+            sstables.add(l1sstable);
+            i++;
+        }
+
+        LeveledGenerations generations = new LeveledGenerations();
+        generations.addAll(sstables);
+
+        SSTableReader sstableinL1;
+        Token newStart;
+        Token newEnd;
+
+        int kind = r.nextInt(7);
+
+        switch (kind)
+        {
+            // No overlap
+            case 0:
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
+                newStart = sstableinL1.getLast().getToken().increaseSlightly();
+                newEnd = newStart.getToken().increaseSlightly();
+                break;
+            // Overlaps on the left end
+            case 1:
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
+                newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
+                newEnd = sstableinL1.getFirst().getToken().increaseSlightly();
+                break;
+            // Overlaps on the right end
+            case 2:
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
+                newStart = sstableinL1.getLast().getToken().decreaseSlightly();
+                newEnd = sstableinL1.getLast().getToken().increaseSlightly();
+                break;
+            // Subset of entire SSTable
+            case 3:
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
+                newStart = sstableinL1.getFirst().getToken().increaseSlightly();
+                newEnd = sstableinL1.getLast().getToken().decreaseSlightly();
+                break;
+            // Superset of entire SSTable
+            case 4:
+                sstableinL1 = sstables.get(0);
+                newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
+                newEnd = sstableinL1.getLast().getToken().increaseSlightly();
+                break;
+            // Exact SSTable match
+            case 5:
+                sstableinL1 = sstables.get(0);
+                newStart = sstableinL1.getFirst().getToken();
+                newEnd = sstableinL1.getLast().getToken();
+                break;
+            // Spans the whole L1
+            case 6:
+                newStart = sstables.get(0).getFirst().getToken();
+                newEnd = sstables.get(sstables.size() - 1).getLast().getToken();
+                break;
+            default:
+                throw new IllegalStateException("Unhandled kind " + kind);
+        }
+
+        SSTableReader sstable = MockSchema.sstableWithLevel(i, newStart.getLongValue(), newEnd.getLongValue(), 0, cfs);
+        Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, (TreeSet<SSTableReader>) generations.get(1));
+        Collection<SSTableReader> linearScanIntersectionSSTables = overlapping(sstable.getFirst().getToken(), sstable.getLast().getToken(), generations.get(1));
+        linearScanIntersectionSSTables.add(sstable);
+
+        // The results should be equivalent to doing a linear scan
+        assertTrue(treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
     }
 
     private int getTaskLevel(ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -607,12 +607,17 @@ public class LeveledCompactionStrategyTest
 
             // Generates disjoint sorted SSTables that match what we see in L1
             int i = 0;
-            int lowerBound = 10;
-            while (i < 10000)
+            int start;
+            int end = 10;
+            while (i < 1000)
             {
-                int start = lowerBound + 1 + rs.nextInt(15);
-                int end = start + rs.nextInt(15);
-                lowerBound = end;
+                // Start with at least offset 1 to ensure that SSTables are disjoint
+                start = end + rs.nextInt(1, 15);
+
+                // Include space in between SSTables, so we don't hit the case where when
+                // going through Overlap.SUBSET we generate a SSTable that has start > end
+                end = start + rs.nextInt(5, 20);
+
                 sstables.add(MockSchema.sstableWithLevel(i++, start, end, 1, cfs));
             }
 
@@ -673,6 +678,19 @@ public class LeveledCompactionStrategyTest
                            treeSetIntersectingSSTables.containsAll(linearScanIntersectionSSTables) && linearScanIntersectionSSTables.containsAll(treeSetIntersectingSSTables));
             }
         });
+    }
+
+    @Test
+    public void testTreeSetIntersectionForEmptyNextLevelIsEmpty()
+    {
+        ColumnFamilyStore cfs = MockSchema.newCFS();
+        LeveledGenerations generations = new LeveledGenerations();
+
+        SSTableReader sstable = MockSchema.sstableWithLevel(0, 1, 10, 0, cfs);
+        Collection<SSTableReader> treeSetIntersectingSSTables = getIntersectingSSTablesFromTreeSet(sstable, generations.getSortedLevel(1));
+
+        assertTrue("treeSet and linear scan produce different results",
+                   treeSetIntersectingSSTables.isEmpty());
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -612,8 +612,8 @@ public class LeveledCompactionStrategyTest
         int lowerBound = 10;
         while (i < 10000)
         {
-            int start = lowerBound + 1 + r.nextInt(30);
-            int end = start + 10 + r.nextInt(30);
+            int start = lowerBound + 1 + r.nextInt(15);
+            int end = start + r.nextInt(15);
             lowerBound = end;
             SSTableReader l1sstable = MockSchema.sstableWithLevel(i, start, end, 1, cfs);
             sstables.add(l1sstable);
@@ -627,7 +627,7 @@ public class LeveledCompactionStrategyTest
         Token newStart;
         Token newEnd;
 
-        int kind = r.nextInt(7);
+        int kind = r.nextInt(8);
 
         switch (kind)
         {
@@ -657,13 +657,13 @@ public class LeveledCompactionStrategyTest
                 break;
             // Superset of entire SSTable
             case 4:
-                sstableinL1 = sstables.get(0);
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
                 newStart = sstableinL1.getFirst().getToken().decreaseSlightly();
                 newEnd = sstableinL1.getLast().getToken().increaseSlightly();
                 break;
             // Exact SSTable match
             case 5:
-                sstableinL1 = sstables.get(0);
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
                 newStart = sstableinL1.getFirst().getToken();
                 newEnd = sstableinL1.getLast().getToken();
                 break;
@@ -671,6 +671,12 @@ public class LeveledCompactionStrategyTest
             case 6:
                 newStart = sstables.get(0).getFirst().getToken();
                 newEnd = sstables.get(sstables.size() - 1).getLast().getToken();
+                break;
+            // Single token SSTables
+            case 7:
+                sstableinL1 = sstables.get(r.nextInt(sstables.size()));
+                newStart = sstableinL1.getFirst().getToken();
+                newEnd = sstableinL1.getFirst().getToken();
                 break;
             default:
                 throw new IllegalStateException("Unhandled kind " + kind);


### PR DESCRIPTION
For LCS, SSTables in levels 1 through level 8 are already stored in a tree set and are disjoint. However when we look for compaction candidates we do a linear scan of the entire set to find intersecting SSTables. We can instead just take the floor of the tree set and iterate forwards until we no longer find any intersections. 

patch by Alan Wang;

reviewed by for [CASSANDRA-21605](https://issues.apache.org/jira/browse/CASSANDRA-21605)

Co-authored-by: Name1
Co-authored-by: Name2