### PR TITLE
fix(cassandra): use counted() not rowsCounted() for GROUP BY ShortReadProtection

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -720,7 +720,7 @@ public abstract class DataLimits
 
         public DataLimits forShortReadRetry(int toFetch)
         {
-            return new CQLLimits(toFetch);
+            return new CQLGroupByLimits(toFetch, groupPerPartitionLimit, rowLimit, groupBySpec, state);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
@@ -150,7 +150,7 @@ public class ShortReadPartitionsProtection extends Transformation<UnfilteredRowI
          * then future ShortReadRowsProtection.moreContents() calls will fetch the missing ones.
          */
         int toQuery = command.limits().count() != DataLimits.NO_LIMIT
-                      ? command.limits().count() - mergedResultCounter.rowsCounted()
+                      ? Math.max(0, command.limits().count() - mergedResultCounter.counted())
                       : command.limits().perPartitionCount();
 
         ColumnFamilyStore.metricsFor(command.metadata().id).shortReadProtectionRequests.mark();


### PR DESCRIPTION
Short read protection computes the wrong retry count under `GROUP BY`, and drops the grouping spec when it retries.

## The bug

`ShortReadPartitionsProtection.moreContents()` sizes the retry query with:

```java
int toQuery = command.limits().count() != DataLimits.NO_LIMIT
              ? command.limits().count() - mergedResultCounter.rowsCounted()
              : command.limits().perPartitionCount();
```

Under `GROUP BY`, `command.limits().count()` is a limit on groups, while `rowsCounted()` returns rows. The two are not the same unit, so the subtraction mixes them. With 8 groups already counted against a limit expressed over 25 rows, `toQuery` comes out as -15.

The second problem is in `DataLimits.CQLGroupByLimits.forShortReadRetry()`, which returned `new CQLLimits(toFetch)`. That discards `groupBySpec` and `state`, so the retry runs without the grouping it was created for.

## The fix

`moreContents()` now uses `mergedResultCounter.counted()`, which returns groups when the query groups, so both sides of the subtraction are in the same unit. The result is clamped with `Math.max(0, ...)`.

`CQLGroupByLimits.forShortReadRetry()` now returns `new CQLGroupByLimits(toFetch, groupPerPartitionLimit, rowLimit, groupBySpec, state)`, preserving the grouping spec and state across the retry.

Two files, one line changed in each.

## Verification

Verified red to green against the bug condition.
