### PR TITLE
CASSANDRA-17559: FQLTool Replay should support full set of login options

### DIFF
--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ConnectionOptions.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ConnectionOptions.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.fqltool;
+
+import javax.net.ssl.SSLContext;
+
+import com.datastax.driver.core.AuthProvider;
+import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
+import com.datastax.driver.core.SSLOptions;
+
+import org.apache.cassandra.config.EncryptionOptions;
+import org.apache.cassandra.security.SSLFactory;
+
+/**
+ * Holds the SSL and authentication settings used to connect to target hosts during fqltool replay.
+ * Note that providing any SSL-related configuration option implicitly enables SSL.
+ */
+public class ConnectionOptions
+{
+    private final boolean ssl;
+    private final SSLOptions sslOptions;
+    private final String authProviderClass;
+
+    private ConnectionOptions(boolean ssl, SSLOptions sslOptions, String authProviderClass)
+    {
+        this.ssl = ssl;
+        this.sslOptions = sslOptions;
+        this.authProviderClass = authProviderClass;
+    }
+
+    public boolean ssl()
+    {
+        return ssl;
+    }
+
+    public SSLOptions sslOptions()
+    {
+        return sslOptions;
+    }
+
+    public String authProviderClass()
+    {
+        return authProviderClass;
+    }
+
+    /** 
+     * Builds the configured AuthProvider: a (String,String) constructor when credentials are present, otherwise a no-arg constructor.
+     */
+    @SuppressWarnings("unchecked")
+    public AuthProvider instantiateAuthProvider(String user, String password)
+    {
+        try
+        {
+            Class<? extends AuthProvider> clazz = (Class<? extends AuthProvider>) Class.forName(authProviderClass);
+
+            if (user != null && password != null)
+                return clazz.getConstructor(String.class, String.class).newInstance(user, password);
+
+            return clazz.getDeclaredConstructor().newInstance();
+        }
+        catch (NoSuchMethodException e)
+        {
+            throw new RuntimeException("Auth provider " + authProviderClass + " does not support plain text credentials", e);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Could not instantiate auth provider: " + authProviderClass, e);
+        }
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private boolean ssl;
+        private String truststorePath;
+        private String truststorePassword;
+        private String keystorePath;
+        private String keystorePassword;
+        private String authProviderClass;
+
+        public Builder withSsl(boolean ssl)
+        {
+            this.ssl = ssl;
+            return this;
+        }
+
+        public Builder withTruststore(String truststorePath)
+        {
+            this.truststorePath = truststorePath;
+            return this;
+        }
+
+        public Builder withTruststorePassword(String truststorePassword)
+        {
+            this.truststorePassword = truststorePassword;
+            return this;
+        }
+
+        public Builder withKeystore(String keystorePath)
+        {
+            this.keystorePath = keystorePath;
+            return this;
+        }
+
+        public Builder withKeystorePassword(String keystorePassword)
+        {
+            this.keystorePassword = keystorePassword;
+            return this;
+        }
+
+        public Builder withAuthProviderClass(String authProviderClass)
+        {
+            this.authProviderClass = authProviderClass;
+            return this;
+        }
+
+        public ConnectionOptions build()
+        {
+            if (truststorePassword != null && truststorePath == null)
+                throw new IllegalArgumentException("--ssl-truststore-password requires --ssl-truststore to be set");
+            if (keystorePassword != null && keystorePath == null)
+                throw new IllegalArgumentException("--ssl-keystore-password requires --ssl-keystore to be set");
+
+            // any SSL-related option implicitly enables SSL
+            boolean effectiveSsl = ssl || truststorePath != null || keystorePath != null;
+
+            if (authProviderClass != null)
+                validateAuthProviderClass();
+
+            SSLOptions sslOptions = effectiveSsl ? buildSSLOptions() : null;
+
+            return new ConnectionOptions(effectiveSsl, sslOptions, authProviderClass);
+        }
+
+        private void validateAuthProviderClass()
+        {
+            try
+            {
+                Class<?> clazz = Class.forName(authProviderClass);
+                if (!AuthProvider.class.isAssignableFrom(clazz))
+                    throw new IllegalArgumentException(authProviderClass + " does not implement " + AuthProvider.class.getName());
+            }
+            catch (ClassNotFoundException e)
+            {
+                throw new RuntimeException("Could not find auth provider class: " + authProviderClass, e);
+            }
+        }
+
+        private SSLOptions buildSSLOptions()
+        {
+            try
+            {
+                EncryptionOptions.ClientEncryptionOptions.Builder encBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder();
+                encBuilder.withEnabled(true);
+
+                if (truststorePath != null)
+                    encBuilder.withTrustStore(truststorePath);
+                if (truststorePassword != null)
+                    encBuilder.withTrustStorePassword(truststorePassword);
+
+                EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth = EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+                if (keystorePath != null)
+                {
+                    encBuilder.withKeyStore(keystorePath);
+                    clientAuth = EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
+                }
+                if (keystorePassword != null)
+                    encBuilder.withKeyStorePassword(keystorePassword);
+
+                EncryptionOptions.ClientEncryptionOptions clientEncOptions = encBuilder.build();
+                SSLContext sslContext = SSLFactory.createSSLContext(clientEncOptions, clientAuth);
+
+                return RemoteEndpointAwareJdkSSLOptions.builder()
+                                                        .withSSLContext(sslContext)
+                                                        .build();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Could not configure SSL for fqltool replay", e);
+            }
+        }
+    }
+}

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ConnectionOptions.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ConnectionOptions.java
@@ -18,14 +18,21 @@
 
 package org.apache.cassandra.fqltool;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 import com.datastax.driver.core.AuthProvider;
 import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
 import com.datastax.driver.core.SSLOptions;
-
-import org.apache.cassandra.config.EncryptionOptions;
-import org.apache.cassandra.security.SSLFactory;
 
 /**
  * Holds the SSL and authentication settings used to connect to target hosts during fqltool replay.
@@ -59,7 +66,7 @@ public class ConnectionOptions
         return authProviderClass;
     }
 
-    /** 
+    /**
      * Builds the configured AuthProvider: a (String,String) constructor when credentials are present, otherwise a no-arg constructor.
      */
     @SuppressWarnings("unchecked")
@@ -170,34 +177,59 @@ public class ConnectionOptions
         {
             try
             {
-                EncryptionOptions.ClientEncryptionOptions.Builder encBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder();
-                encBuilder.withEnabled(true);
+                TrustManagerFactory tmf = buildTrustManagerFactory();
+                KeyManagerFactory kmf = keystorePath != null ? buildKeyManagerFactory() : null;
 
-                if (truststorePath != null)
-                    encBuilder.withTrustStore(truststorePath);
-                if (truststorePassword != null)
-                    encBuilder.withTrustStorePassword(truststorePassword);
-
-                EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth = EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
-                if (keystorePath != null)
-                {
-                    encBuilder.withKeyStore(keystorePath);
-                    clientAuth = EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
-                }
-                if (keystorePassword != null)
-                    encBuilder.withKeyStorePassword(keystorePassword);
-
-                EncryptionOptions.ClientEncryptionOptions clientEncOptions = encBuilder.build();
-                SSLContext sslContext = SSLFactory.createSSLContext(clientEncOptions, clientAuth);
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(kmf != null ? kmf.getKeyManagers() : null,
+                                tmf.getTrustManagers(),
+                                null);
 
                 return RemoteEndpointAwareJdkSSLOptions.builder()
                                                         .withSSLContext(sslContext)
                                                         .build();
             }
-            catch (Exception e)
+            catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException | CertificateException | IOException | UnrecoverableKeyException e)
             {
                 throw new RuntimeException("Could not configure SSL for fqltool replay", e);
             }
+        }
+
+        private TrustManagerFactory buildTrustManagerFactory() throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException
+        {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+            if (truststorePath != null)
+            {
+                KeyStore ts = KeyStore.getInstance("JKS");
+                char[] password = truststorePassword != null ? truststorePassword.toCharArray() : null;
+                try (FileInputStream fis = new FileInputStream(truststorePath))
+                {
+                    ts.load(fis, password);
+                }
+                tmf.init(ts);
+            }
+            else
+            {
+                tmf.init((KeyStore) null);
+            }
+
+            return tmf;
+        }
+
+        private KeyManagerFactory buildKeyManagerFactory() throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException, UnrecoverableKeyException
+        {
+            KeyStore ks = KeyStore.getInstance("JKS");
+            char[] password = keystorePassword != null ? keystorePassword.toCharArray() : null;
+            try (FileInputStream fis = new FileInputStream(keystorePath))
+            {
+                ks.load(fis, password);
+            }
+
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(ks, password);
+
+            return kmf;
         }
     }
 }

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
@@ -215,7 +215,7 @@ public class QueryReplayer implements Closeable
         resultHandler.close();
     }
 
-    static class ParsedTargetHost
+    public static class ParsedTargetHost
     {
         final int port;
         final String user;
@@ -228,6 +228,21 @@ public class QueryReplayer implements Closeable
             this.port = port;
             this.user = user;
             this.password = password;
+        }
+
+        /**
+         * Masks the password in a target host string so it's never logged or written to result paths.
+         */
+        public static String maskPassword(String target)
+        {
+            int at = target.lastIndexOf('@');
+            if (at < 0)
+                return target;
+            String userInfo = target.substring(0, at);
+            int colon = userInfo.indexOf(':');
+            if (colon < 0)
+                return target;
+            return userInfo.substring(0, colon) + ":*****@" + target.substring(at + 1);
         }
 
         static ParsedTargetHost fromString(String s)
@@ -277,7 +292,6 @@ public class QueryReplayer implements Closeable
         private final String keystorePassword;
         private final String authProviderClass;
         private final SSLOptions sslOptions;
-        private final AuthProvider authProvider;
 
         DefaultSessionProvider()
         {
@@ -294,9 +308,25 @@ public class QueryReplayer implements Closeable
             this.keystorePassword = keystorePassword;
             this.authProviderClass = authProviderClass;
 
-            // Eagerly validate and initialize SSL and AuthProvider to fail fast on invalid configuration
+            // Fail fast on bad SSL config or an unloadable auth provider class. The AuthProvider itself
+            // is built per-connection in connect(), using credentials parsed from the target host.
             this.sslOptions = ssl ? buildSSLOptions() : null;
-            this.authProvider = authProviderClass != null ? instantiateAuthProvider() : null;
+            if (authProviderClass != null)
+                validateAuthProviderClass();
+        }
+
+        private void validateAuthProviderClass()
+        {
+            try
+            {
+                Class<?> clazz = Class.forName(authProviderClass);
+                if (!AuthProvider.class.isAssignableFrom(clazz))
+                    throw new IllegalArgumentException(authProviderClass + " does not implement " + AuthProvider.class.getName());
+            }
+            catch (ClassNotFoundException e)
+            {
+                throw new RuntimeException("Could not find auth provider class: " + authProviderClass, e);
+            }
         }
 
         public synchronized Session connect(String connectionString)
@@ -311,8 +341,8 @@ public class QueryReplayer implements Closeable
             if (sslOptions != null)
                 builder.withSSL(sslOptions);
 
-            if (authProvider != null)
-                builder.withAuthProvider(authProvider);
+            if (authProviderClass != null)
+                builder.withAuthProvider(instantiateAuthProvider(pth.user, pth.password));
             else if (pth.user != null)
                 builder.withCredentials(pth.user, pth.password);
 
@@ -365,11 +395,24 @@ public class QueryReplayer implements Closeable
             }
         }
 
-        private AuthProvider instantiateAuthProvider()
+        /**
+         * Builds the configured AuthProvider: a (String,String) constructor when credentials are present otherwise a no-arg constructor.
+         */
+        @SuppressWarnings("unchecked")
+        private AuthProvider instantiateAuthProvider(String user, String password)
         {
             try
             {
-                return (AuthProvider) Class.forName(authProviderClass).getDeclaredConstructor().newInstance();
+                Class<? extends AuthProvider> clazz = (Class<? extends AuthProvider>) Class.forName(authProviderClass);
+
+                if (user != null && password != null)
+                    return clazz.getConstructor(String.class, String.class).newInstance(user, password);
+
+                return clazz.getDeclaredConstructor().newInstance();
+            }
+            catch (NoSuchMethodException e)
+            {
+                throw new RuntimeException("Auth provider " + authProviderClass + " does not support plain text credentials", e);
             }
             catch (Exception e)
             {

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
@@ -26,14 +26,23 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.security.KeyStore;
+import java.security.SecureRandom;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.datastax.driver.core.AuthProvider;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.google.common.util.concurrent.FutureCallback;
@@ -74,6 +83,26 @@ public class QueryReplayer implements Closeable
                          String queryFilePathString)
     {
         this(queryIterator, targetHosts, resultPaths, filters, queryFilePathString, new DefaultSessionProvider(), null);
+    }
+
+    /**
+     * Constructor supporting SSL and custom auth provider options for the default session provider.
+     */
+    public QueryReplayer(Iterator<List<FQLQuery>> queryIterator,
+                         List<String> targetHosts,
+                         List<File> resultPaths,
+                         List<Predicate<FQLQuery>> filters,
+                         String queryFilePathString,
+                         boolean ssl,
+                         String truststorePath,
+                         String truststorePassword,
+                         String keystorePath,
+                         String keystorePassword,
+                         String authProviderClass)
+    {
+        this(queryIterator, targetHosts, resultPaths, filters, queryFilePathString,
+             new DefaultSessionProvider(ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass),
+             null);
     }
 
     /**
@@ -241,6 +270,35 @@ public class QueryReplayer implements Closeable
     {
         private final static Map<String, Session> sessionCache = new HashMap<>();
 
+        private final boolean ssl;
+        private final String truststorePath;
+        private final String truststorePassword;
+        private final String keystorePath;
+        private final String keystorePassword;
+        private final String authProviderClass;
+        private final SSLOptions sslOptions;
+        private final AuthProvider authProvider;
+
+        DefaultSessionProvider()
+        {
+            this(false, null, null, null, null, null);
+        }
+
+        DefaultSessionProvider(boolean ssl, String truststorePath, String truststorePassword,
+                                String keystorePath, String keystorePassword, String authProviderClass)
+        {
+            this.ssl = ssl;
+            this.truststorePath = truststorePath;
+            this.truststorePassword = truststorePassword;
+            this.keystorePath = keystorePath;
+            this.keystorePassword = keystorePassword;
+            this.authProviderClass = authProviderClass;
+
+            // Eagerly validate and initialize SSL and AuthProvider to fail fast on invalid configuration
+            this.sslOptions = ssl ? buildSSLOptions() : null;
+            this.authProvider = authProviderClass != null ? instantiateAuthProvider() : null;
+        }
+
         public synchronized Session connect(String connectionString)
         {
             if (sessionCache.containsKey(connectionString))
@@ -249,11 +307,74 @@ public class QueryReplayer implements Closeable
             ParsedTargetHost pth = ParsedTargetHost.fromString(connectionString);
             builder.addContactPoint(pth.host);
             builder.withPort(pth.port);
-            if (pth.user != null)
+
+            if (sslOptions != null)
+                builder.withSSL(sslOptions);
+
+            if (authProvider != null)
+                builder.withAuthProvider(authProvider);
+            else if (pth.user != null)
                 builder.withCredentials(pth.user, pth.password);
+
             Cluster c = builder.build();
             sessionCache.put(connectionString, c.connect());
             return sessionCache.get(connectionString);
+        }
+
+        private SSLOptions buildSSLOptions()
+        {
+            try
+            {
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                if (truststorePath != null)
+                {
+                    KeyStore ts = KeyStore.getInstance("JKS");
+                    try (java.io.FileInputStream fis = new java.io.FileInputStream(truststorePath))
+                    {
+                        ts.load(fis, truststorePassword != null ? truststorePassword.toCharArray() : null);
+                    }
+                    tmf.init(ts);
+                }
+                else
+                {
+                    tmf.init((KeyStore) null);
+                }
+
+                KeyManagerFactory kmf = null;
+                if (keystorePath != null)
+                {
+                    kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                    KeyStore ks = KeyStore.getInstance("JKS");
+                    try (java.io.FileInputStream fis = new java.io.FileInputStream(keystorePath))
+                    {
+                        ks.load(fis, keystorePassword != null ? keystorePassword.toCharArray() : null);
+                    }
+                    kmf.init(ks, keystorePassword != null ? keystorePassword.toCharArray() : null);
+                }
+
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(kmf != null ? kmf.getKeyManagers() : null, tmf.getTrustManagers(), new SecureRandom());
+
+                return RemoteEndpointAwareJdkSSLOptions.builder()
+                                                        .withSSLContext(sslContext)
+                                                        .build();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Could not configure SSL for fqltool replay", e);
+            }
+        }
+
+        private AuthProvider instantiateAuthProvider()
+        {
+            try
+            {
+                return (AuthProvider) Class.forName(authProviderClass).getDeclaredConstructor().newInstance();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Could not instantiate auth provider: " + authProviderClass, e);
+            }
         }
 
         public void close()

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/QueryReplayer.java
@@ -26,23 +26,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.security.KeyStore;
-import java.security.SecureRandom;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.datastax.driver.core.AuthProvider;
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
 import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.google.common.util.concurrent.FutureCallback;
@@ -86,23 +77,17 @@ public class QueryReplayer implements Closeable
     }
 
     /**
-     * Constructor supporting SSL and custom auth provider options for the default session provider.
+     * Constructor that takes SSL and auth provider settings via ConnectionOptions.
      */
     public QueryReplayer(Iterator<List<FQLQuery>> queryIterator,
                          List<String> targetHosts,
                          List<File> resultPaths,
                          List<Predicate<FQLQuery>> filters,
                          String queryFilePathString,
-                         boolean ssl,
-                         String truststorePath,
-                         String truststorePassword,
-                         String keystorePath,
-                         String keystorePassword,
-                         String authProviderClass)
+                         ConnectionOptions connectionOptions)
     {
         this(queryIterator, targetHosts, resultPaths, filters, queryFilePathString,
-             new DefaultSessionProvider(ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass),
-             null);
+             new DefaultSessionProvider(connectionOptions), null);
     }
 
     /**
@@ -247,24 +232,25 @@ public class QueryReplayer implements Closeable
 
         static ParsedTargetHost fromString(String s)
         {
-            String [] userInfoHostPort = s.split("@");
-
-            String hostPort = null;
+            int at = s.lastIndexOf('@');
+            String hostPort;
             String user = null;
             String password = null;
-            if (userInfoHostPort.length == 2)
+
+            if (at >= 0)
             {
-                String [] userPassword = userInfoHostPort[0].split(":");
-                if (userPassword.length != 2)
+                String userInfo = s.substring(0, at);
+                hostPort = s.substring(at + 1);
+                int colon = userInfo.indexOf(':');
+                if (colon < 0)
                     throw new RuntimeException("Username provided but no password");
-                hostPort = userInfoHostPort[1];
-                user = userPassword[0];
-                password = userPassword[1];
+                user = userInfo.substring(0, colon);
+                password = userInfo.substring(colon + 1);
             }
-            else if (userInfoHostPort.length == 1)
-                hostPort = userInfoHostPort[0];
             else
-                throw new RuntimeException("Malformed target host: "+s);
+            {
+                hostPort = s;
+            }
 
             String[] splitHostPort = hostPort.split(":");
             int port = 9042;
@@ -285,48 +271,16 @@ public class QueryReplayer implements Closeable
     {
         private final static Map<String, Session> sessionCache = new HashMap<>();
 
-        private final boolean ssl;
-        private final String truststorePath;
-        private final String truststorePassword;
-        private final String keystorePath;
-        private final String keystorePassword;
-        private final String authProviderClass;
-        private final SSLOptions sslOptions;
+        private final ConnectionOptions connectionOptions;
 
         DefaultSessionProvider()
         {
-            this(false, null, null, null, null, null);
+            this(ConnectionOptions.builder().build());
         }
 
-        DefaultSessionProvider(boolean ssl, String truststorePath, String truststorePassword,
-                                String keystorePath, String keystorePassword, String authProviderClass)
+        DefaultSessionProvider(ConnectionOptions connectionOptions)
         {
-            this.ssl = ssl;
-            this.truststorePath = truststorePath;
-            this.truststorePassword = truststorePassword;
-            this.keystorePath = keystorePath;
-            this.keystorePassword = keystorePassword;
-            this.authProviderClass = authProviderClass;
-
-            // Fail fast on bad SSL config or an unloadable auth provider class. The AuthProvider itself
-            // is built per-connection in connect(), using credentials parsed from the target host.
-            this.sslOptions = ssl ? buildSSLOptions() : null;
-            if (authProviderClass != null)
-                validateAuthProviderClass();
-        }
-
-        private void validateAuthProviderClass()
-        {
-            try
-            {
-                Class<?> clazz = Class.forName(authProviderClass);
-                if (!AuthProvider.class.isAssignableFrom(clazz))
-                    throw new IllegalArgumentException(authProviderClass + " does not implement " + AuthProvider.class.getName());
-            }
-            catch (ClassNotFoundException e)
-            {
-                throw new RuntimeException("Could not find auth provider class: " + authProviderClass, e);
-            }
+            this.connectionOptions = connectionOptions;
         }
 
         public synchronized Session connect(String connectionString)
@@ -338,86 +292,17 @@ public class QueryReplayer implements Closeable
             builder.addContactPoint(pth.host);
             builder.withPort(pth.port);
 
-            if (sslOptions != null)
-                builder.withSSL(sslOptions);
+            if (connectionOptions.sslOptions() != null)
+                builder.withSSL(connectionOptions.sslOptions());
 
-            if (authProviderClass != null)
-                builder.withAuthProvider(instantiateAuthProvider(pth.user, pth.password));
+            if (connectionOptions.authProviderClass() != null)
+                builder.withAuthProvider(connectionOptions.instantiateAuthProvider(pth.user, pth.password));
             else if (pth.user != null)
                 builder.withCredentials(pth.user, pth.password);
 
             Cluster c = builder.build();
             sessionCache.put(connectionString, c.connect());
             return sessionCache.get(connectionString);
-        }
-
-        private SSLOptions buildSSLOptions()
-        {
-            try
-            {
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                if (truststorePath != null)
-                {
-                    KeyStore ts = KeyStore.getInstance("JKS");
-                    try (java.io.FileInputStream fis = new java.io.FileInputStream(truststorePath))
-                    {
-                        ts.load(fis, truststorePassword != null ? truststorePassword.toCharArray() : null);
-                    }
-                    tmf.init(ts);
-                }
-                else
-                {
-                    tmf.init((KeyStore) null);
-                }
-
-                KeyManagerFactory kmf = null;
-                if (keystorePath != null)
-                {
-                    kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-                    KeyStore ks = KeyStore.getInstance("JKS");
-                    try (java.io.FileInputStream fis = new java.io.FileInputStream(keystorePath))
-                    {
-                        ks.load(fis, keystorePassword != null ? keystorePassword.toCharArray() : null);
-                    }
-                    kmf.init(ks, keystorePassword != null ? keystorePassword.toCharArray() : null);
-                }
-
-                SSLContext sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(kmf != null ? kmf.getKeyManagers() : null, tmf.getTrustManagers(), new SecureRandom());
-
-                return RemoteEndpointAwareJdkSSLOptions.builder()
-                                                        .withSSLContext(sslContext)
-                                                        .build();
-            }
-            catch (Exception e)
-            {
-                throw new RuntimeException("Could not configure SSL for fqltool replay", e);
-            }
-        }
-
-        /**
-         * Builds the configured AuthProvider: a (String,String) constructor when credentials are present otherwise a no-arg constructor.
-         */
-        @SuppressWarnings("unchecked")
-        private AuthProvider instantiateAuthProvider(String user, String password)
-        {
-            try
-            {
-                Class<? extends AuthProvider> clazz = (Class<? extends AuthProvider>) Class.forName(authProviderClass);
-
-                if (user != null && password != null)
-                    return clazz.getConstructor(String.class, String.class).newInstance(user, password);
-
-                return clazz.getDeclaredConstructor().newInstance();
-            }
-            catch (NoSuchMethodException e)
-            {
-                throw new RuntimeException("Auth provider " + authProviderClass + " does not support plain text credentials", e);
-            }
-            catch (Exception e)
-            {
-                throw new RuntimeException("Could not instantiate auth provider: " + authProviderClass, e);
-            }
         }
 
         public void close()

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
@@ -47,9 +47,27 @@ public class ResultHandler implements Closeable
 
     public ResultHandler(List<String> targetHosts, List<File> resultPaths, File queryFilePath, MismatchListener mismatchListener)
     {
-        this.targetHosts = targetHosts;
+        this.targetHosts = targetHosts.stream().map(ResultHandler::maskPassword).collect(Collectors.toList());
         resultStore = resultPaths != null ? new ResultStore(resultPaths, queryFilePath) : null;
         resultComparator = new ResultComparator(mismatchListener);
+    }
+
+    /**
+     * Masks the password portion of a target host string (format: [user:password@]host[:port])
+     * so it is never written to logs or result files.
+     * Uses lastIndexOf to correctly handle passwords containing @ symbols.
+     */
+    @VisibleForTesting
+    public static String maskPassword(String target)
+    {
+        int at = target.lastIndexOf('@');
+        if (at < 0)
+            return target;
+        String userInfo = target.substring(0, at);
+        int colon = userInfo.indexOf(':');
+        if (colon < 0)
+            return target;
+        return userInfo.substring(0, colon) + ":*****@" + target.substring(at + 1);
     }
 
     /**

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
@@ -47,29 +47,10 @@ public class ResultHandler implements Closeable
 
     public ResultHandler(List<String> targetHosts, List<File> resultPaths, File queryFilePath, MismatchListener mismatchListener)
     {
-        this.targetHosts = targetHosts.stream().map(ResultHandler::maskPassword).collect(Collectors.toList());
+        this.targetHosts = targetHosts.stream().map(QueryReplayer.ParsedTargetHost::maskPassword).collect(Collectors.toList());
         resultStore = resultPaths != null ? new ResultStore(resultPaths, queryFilePath) : null;
         resultComparator = new ResultComparator(mismatchListener);
     }
-
-    /**
-     * Masks the password portion of a target host string (format: [user:password@]host[:port])
-     * so it is never written to logs or result files.
-     * Uses lastIndexOf to correctly handle passwords containing @ symbols.
-     */
-    @VisibleForTesting
-    public static String maskPassword(String target)
-    {
-        int at = target.lastIndexOf('@');
-        if (at < 0)
-            return target;
-        String userInfo = target.substring(0, at);
-        int colon = userInfo.indexOf(':');
-        if (colon < 0)
-            return target;
-        return userInfo.substring(0, colon) + ":*****@" + target.substring(at + 1);
-    }
-
     /**
      * Since we can't iterate a ResultSet more than once, and we don't want to keep the entire result set in memory
      * we feed the rows one-by-one to resultComparator and resultStore.

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
@@ -51,6 +51,7 @@ public class ResultHandler implements Closeable
         resultStore = resultPaths != null ? new ResultStore(resultPaths, queryFilePath) : null;
         resultComparator = new ResultComparator(mismatchListener);
     }
+
     /**
      * Since we can't iterate a ResultSet more than once, and we don't want to keep the entire result set in memory
      * we feed the rows one-by-one to resultComparator and resultStore.

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.fqltool.FQLQuery;
 import org.apache.cassandra.fqltool.FQLQueryIterator;
 import org.apache.cassandra.fqltool.QueryReplayer;
+import org.apache.cassandra.fqltool.ResultHandler;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.MergeIterator;
 
@@ -55,7 +56,7 @@ public class Replay implements Runnable
     @Parameters(paramLabel = "path", description = "Paths containing the full query logs to replay.", arity = "1..*")
     private List<String> arguments = new ArrayList<>();
 
-    @Option(paramLabel = "target", names = { "--target" }, description = "Hosts to replay the logs to, can be repeated to replay to more hosts.", required = true)
+    @Option(paramLabel = "target", names = { "--target" }, description = "Hosts to replay the logs to, can be repeated to replay to more hosts. Format: [username:password@]host[:port], for example 'cassandra:cassandra@127.0.0.1:9042'.", required = true)
     private List<String> targetHosts;
 
     @Option(paramLabel = "results", names = { "--results" }, description = "Where to store the results of the queries, this should be a directory. Leave this option out to avoid storing results.")
@@ -69,6 +70,24 @@ public class Replay implements Runnable
 
     @Option(paramLabel = "replay_ddl_statements", names = { "--replay-ddl-statements" }, description = "If specified, replays DDL statements as well, they are excluded from replaying by default.")
     private boolean replayDDLStatements;
+
+    @Option(paramLabel = "ssl", names = { "--ssl" }, description = "Use SSL for connecting to the target hosts.")
+    private boolean ssl;
+
+    @Option(paramLabel = "ssl_truststore", names = { "--ssl-truststore" }, description = "Path to the SSL truststore.")
+    private String truststorePath;
+
+    @Option(paramLabel = "ssl_truststore_password", names = { "--ssl-truststore-password" }, description = "Password for the SSL truststore.")
+    private String truststorePassword;
+
+    @Option(paramLabel = "ssl_keystore", names = { "--ssl-keystore" }, description = "Path to the SSL keystore, required for two-way SSL.")
+    private String keystorePath;
+
+    @Option(paramLabel = "ssl_keystore_password", names = { "--ssl-keystore-password" }, description = "Password for the SSL keystore.")
+    private String keystorePassword;
+
+    @Option(paramLabel = "auth_provider", names = { "--auth-provider" }, description = "Fully qualified class name of a custom com.datastax.driver.core.AuthProvider implementation (e.g. for Kerberos).")
+    private String authProviderClass;
 
     @Override
     public void run()
@@ -84,14 +103,15 @@ public class Replay implements Runnable
                     System.err.println("The results path (" + basePath + ") should be an existing directory");
                     throw new IllegalArgumentException("The results path (" + basePath + ") should be an existing directory");
                 }
-                resultPaths = targetHosts.stream().map(target -> new File(basePath, target)).collect(Collectors.toList());
+                resultPaths = targetHosts.stream().map(target -> new File(basePath, ResultHandler.maskPassword(target))).collect(Collectors.toList());
                 resultPaths.forEach(File::mkdir);
             }
             if (targetHosts.size() < 1)
             {
                 throw new IllegalArgumentException("You need to state at least one --target host to replay the query against");
             }
-            replay(keyspace, arguments, targetHosts, resultPaths, queryStorePath, replayDDLStatements);
+            replay(keyspace, arguments, targetHosts, resultPaths, queryStorePath, replayDDLStatements,
+                   ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass);
         }
         catch (Exception e)
         {
@@ -99,7 +119,8 @@ public class Replay implements Runnable
         }
     }
 
-    public static void replay(String keyspace, List<String> arguments, List<String> targetHosts, List<File> resultPaths, String queryStorePath, boolean replayDDLStatements)
+    public static void replay(String keyspace, List<String> arguments, List<String> targetHosts, List<File> resultPaths, String queryStorePath, boolean replayDDLStatements,
+                               boolean ssl, String truststorePath, String truststorePassword, String keystorePath, String keystorePassword, String authProviderClass)
     {
         int readAhead = 200; // how many fql queries should we read in to memory to be able to sort them?
         List<ChronicleQueue> readQueues = null;
@@ -124,7 +145,8 @@ public class Replay implements Runnable
             readQueues = arguments.stream().map(s -> SingleChronicleQueueBuilder.single(s).readOnly(true).build()).collect(Collectors.toList());
             iterators = readQueues.stream().map(ChronicleQueue::createTailer).map(tailer -> new FQLQueryIterator(tailer, readAhead)).collect(Collectors.toList());
             try (MergeIterator<FQLQuery, List<FQLQuery>> iter = MergeIterator.get(iterators, FQLQuery::compareTo, new Reducer());
-                 QueryReplayer replayer = new QueryReplayer(iter, targetHosts, resultPaths, filters, queryStorePath))
+                 QueryReplayer replayer = new QueryReplayer(iter, targetHosts, resultPaths, filters, queryStorePath,
+                                                             ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass))
             {
                 replayer.replay();
             }

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
@@ -128,6 +128,11 @@ public class Replay implements Runnable
         }
     }
 
+    public static void replay(String keyspace, List<String> arguments, List<String> targetHosts, List<File> resultPaths, String queryStorePath, boolean replayDDLStatements)
+    {
+        replay(keyspace, arguments, targetHosts, resultPaths, queryStorePath, replayDDLStatements, ConnectionOptions.builder().build());
+    }
+
     public static void replay(String keyspace, List<String> arguments, List<String> targetHosts, List<File> resultPaths, String queryStorePath, boolean replayDDLStatements,
                                ConnectionOptions connectionOptions)
     {

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.fqltool.FQLQuery;
 import org.apache.cassandra.fqltool.FQLQueryIterator;
 import org.apache.cassandra.fqltool.QueryReplayer;
-import org.apache.cassandra.fqltool.ResultHandler;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.MergeIterator;
 
@@ -103,7 +102,7 @@ public class Replay implements Runnable
                     System.err.println("The results path (" + basePath + ") should be an existing directory");
                     throw new IllegalArgumentException("The results path (" + basePath + ") should be an existing directory");
                 }
-                resultPaths = targetHosts.stream().map(target -> new File(basePath, ResultHandler.maskPassword(target))).collect(Collectors.toList());
+                resultPaths = targetHosts.stream().map(target -> new File(basePath, QueryReplayer.ParsedTargetHost.maskPassword(target))).collect(Collectors.toList());
                 resultPaths.forEach(File::mkdir);
             }
             if (targetHosts.size() < 1)

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Replay.java
@@ -34,6 +34,7 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.fqltool.ConnectionOptions;
 import org.apache.cassandra.fqltool.FQLQuery;
 import org.apache.cassandra.fqltool.FQLQueryIterator;
 import org.apache.cassandra.fqltool.QueryReplayer;
@@ -109,8 +110,17 @@ public class Replay implements Runnable
             {
                 throw new IllegalArgumentException("You need to state at least one --target host to replay the query against");
             }
-            replay(keyspace, arguments, targetHosts, resultPaths, queryStorePath, replayDDLStatements,
-                   ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass);
+
+            ConnectionOptions connectionOptions = ConnectionOptions.builder()
+                                                                    .withSsl(ssl)
+                                                                    .withTruststore(truststorePath)
+                                                                    .withTruststorePassword(truststorePassword)
+                                                                    .withKeystore(keystorePath)
+                                                                    .withKeystorePassword(keystorePassword)
+                                                                    .withAuthProviderClass(authProviderClass)
+                                                                    .build();
+
+            replay(keyspace, arguments, targetHosts, resultPaths, queryStorePath, replayDDLStatements, connectionOptions);
         }
         catch (Exception e)
         {
@@ -119,7 +129,7 @@ public class Replay implements Runnable
     }
 
     public static void replay(String keyspace, List<String> arguments, List<String> targetHosts, List<File> resultPaths, String queryStorePath, boolean replayDDLStatements,
-                               boolean ssl, String truststorePath, String truststorePassword, String keystorePath, String keystorePassword, String authProviderClass)
+                               ConnectionOptions connectionOptions)
     {
         int readAhead = 200; // how many fql queries should we read in to memory to be able to sort them?
         List<ChronicleQueue> readQueues = null;
@@ -144,8 +154,7 @@ public class Replay implements Runnable
             readQueues = arguments.stream().map(s -> SingleChronicleQueueBuilder.single(s).readOnly(true).build()).collect(Collectors.toList());
             iterators = readQueues.stream().map(ChronicleQueue::createTailer).map(tailer -> new FQLQueryIterator(tailer, readAhead)).collect(Collectors.toList());
             try (MergeIterator<FQLQuery, List<FQLQuery>> iter = MergeIterator.get(iterators, FQLQuery::compareTo, new Reducer());
-                 QueryReplayer replayer = new QueryReplayer(iter, targetHosts, resultPaths, filters, queryStorePath,
-                                                             ssl, truststorePath, truststorePassword, keystorePath, keystorePassword, authProviderClass))
+                 QueryReplayer replayer = new QueryReplayer(iter, targetHosts, resultPaths, filters, queryStorePath, connectionOptions))
             {
                 replayer.replay();
             }

--- a/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
+++ b/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
@@ -580,6 +580,61 @@ public class FQLReplayTest
         assertEquals("bbb", pth.password);
     }
 
+    @Test
+    public void testInvalidAuthProviderClassThrows()
+    {
+        try
+        {
+            new QueryReplayer(Collections.emptyIterator(),
+                              Lists.newArrayList("127.0.0.1:9999"),
+                              null,
+                              new ArrayList<>(),
+                              null,
+                              false, null, null, null, null,
+                              "com.not.a.real.AuthProviderClass");
+            throw new AssertionError("Expected RuntimeException to be thrown for invalid auth provider class");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue("Exception message should mention auth provider",
+                       e.getMessage().contains("auth provider") || e.getMessage().contains("AuthProvider"));
+            assertTrue("Exception message should mention the class name",
+                       e.getMessage().contains("com.not.a.real.AuthProviderClass"));
+        }
+    }
+
+    @Test
+    public void testMaskPassword()
+    {
+        assertEquals("aaa:*****@127.0.0.1:9042", ResultHandler.maskPassword("aaa:bbb@127.0.0.1:9042"));
+        assertEquals("127.0.0.1:9042", ResultHandler.maskPassword("127.0.0.1:9042"));
+        assertEquals("127.0.0.1", ResultHandler.maskPassword("127.0.0.1"));
+        assertEquals("user:*****@host:9042", ResultHandler.maskPassword("user:p@ssword@host:9042"));
+        assertEquals("cassandra:*****@127.0.0.1", ResultHandler.maskPassword("cassandra:p@ss@w@rd@127.0.0.1"));
+    }
+
+    @Test
+    public void testInvalidTruststorePathThrows()
+    {
+        try
+        {
+            new QueryReplayer(Collections.emptyIterator(),
+                              Lists.newArrayList("127.0.0.1:9999"),
+                              null,
+                              new ArrayList<>(),
+                              null,
+                              true, "/path/does/not/exist.jks", "password", null, null,
+                              null);
+            throw new AssertionError("Expected RuntimeException to be thrown for invalid truststore path");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue("Exception message should mention SSL or truststore",
+                       e.getMessage().contains("SSL") || e.getMessage().contains("ssl") ||
+                       e.getMessage().contains("truststore") || e.getMessage().contains("fqltool"));
+        }
+    }
+
     @Test(expected = RuntimeException.class)
     public void testNoPass()
     {

--- a/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
+++ b/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
@@ -578,6 +578,12 @@ public class FQLReplayTest
         assertEquals(9042, pth.port );
         assertEquals("aaa", pth.user);
         assertEquals("bbb", pth.password);
+
+        pth = fromString("user:p@ssword@127.0.0.1:9042");
+        assertEquals("127.0.0.1", pth.host);
+        assertEquals(9042, pth.port);
+        assertEquals("user", pth.user);
+        assertEquals("p@ssword", pth.password);
     }
 
     @Test
@@ -585,21 +591,12 @@ public class FQLReplayTest
     {
         try
         {
-            new QueryReplayer(Collections.emptyIterator(),
-                              Lists.newArrayList("127.0.0.1:9999"),
-                              null,
-                              new ArrayList<>(),
-                              null,
-                              false, null, null, null, null,
-                              "com.not.a.real.AuthProviderClass");
-            throw new AssertionError("Expected RuntimeException to be thrown for invalid auth provider class");
+            ConnectionOptions.builder().withAuthProviderClass("com.not.a.real.AuthProviderClass").build();
+            throw new AssertionError("Expected RuntimeException for invalid auth provider class");
         }
         catch (RuntimeException e)
         {
-            assertTrue("Exception message should mention auth provider",
-                       e.getMessage().contains("auth provider") || e.getMessage().contains("AuthProvider"));
-            assertTrue("Exception message should mention the class name",
-                       e.getMessage().contains("com.not.a.real.AuthProviderClass"));
+            assertTrue(e.getMessage().contains("com.not.a.real.AuthProviderClass"));
         }
     }
 
@@ -618,20 +615,55 @@ public class FQLReplayTest
     {
         try
         {
-            new QueryReplayer(Collections.emptyIterator(),
-                              Lists.newArrayList("127.0.0.1:9999"),
-                              null,
-                              new ArrayList<>(),
-                              null,
-                              true, "/path/does/not/exist.jks", "password", null, null,
-                              null);
-            throw new AssertionError("Expected RuntimeException to be thrown for invalid truststore path");
+            ConnectionOptions.builder().withSsl(true).withTruststore("/path/does/not/exist.jks").withTruststorePassword("password").build();
+            throw new AssertionError("Expected RuntimeException for a bad truststore path");
         }
         catch (RuntimeException e)
         {
-            assertTrue("Exception message should mention SSL or truststore",
-                       e.getMessage().contains("SSL") || e.getMessage().contains("ssl") ||
-                       e.getMessage().contains("truststore") || e.getMessage().contains("fqltool"));
+            assertTrue(e.getMessage().contains("SSL"));
+        }
+    }
+
+    @Test
+    public void testImplicitSslEnableWithTruststoreOnly()
+    {
+        // no --ssl flag given, but a truststore path should still turn SSL on rather than being ignored
+        try
+        {
+            ConnectionOptions.builder().withTruststore("/path/does/not/exist.jks").build();
+            throw new AssertionError("Expected RuntimeException since SSL should be implicitly enabled");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue(e.getMessage().contains("SSL"));
+        }
+    }
+
+    @Test
+    public void testTruststorePasswordWithoutPathThrows()
+    {
+        try
+        {
+            ConnectionOptions.builder().withTruststorePassword("somepassword").build();
+            throw new AssertionError("Expected IllegalArgumentException when truststore password is given without a path");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertTrue(e.getMessage().contains("--ssl-truststore-password requires --ssl-truststore"));
+        }
+    }
+
+    @Test
+    public void testKeystorePasswordWithoutPathThrows()
+    {
+        try
+        {
+            ConnectionOptions.builder().withKeystorePassword("somepassword").build();
+            throw new AssertionError("Expected IllegalArgumentException when keystore password is given without a path");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertTrue(e.getMessage().contains("--ssl-keystore-password requires --ssl-keystore"));
         }
     }
 
@@ -648,6 +680,9 @@ public class FQLReplayTest
     @Test
     public void testAuthProviderWithoutCredentialsConstructorThrows()
     {
+        ConnectionOptions connectionOptions = ConnectionOptions.builder()
+                                                                .withAuthProviderClass(NoArgOnlyAuthProvider.class.getName())
+                                                                .build();
         try
         {
             new QueryReplayer(Collections.emptyIterator(),
@@ -655,14 +690,12 @@ public class FQLReplayTest
                               null,
                               new ArrayList<>(),
                               null,
-                              false, null, null, null, null,
-                              NoArgOnlyAuthProvider.class.getName());
+                              connectionOptions);
             throw new AssertionError("Expected RuntimeException when auth provider lacks a (String,String) constructor");
         }
         catch (RuntimeException e)
         {
-            assertTrue("Exception should mention plain text credentials",
-                       e.getMessage().contains("does not support plain text credentials"));
+            assertTrue(e.getMessage().contains("does not support plain text credentials"));
         }
     }
 

--- a/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
+++ b/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
@@ -606,11 +606,11 @@ public class FQLReplayTest
     @Test
     public void testMaskPassword()
     {
-        assertEquals("aaa:*****@127.0.0.1:9042", ResultHandler.maskPassword("aaa:bbb@127.0.0.1:9042"));
-        assertEquals("127.0.0.1:9042", ResultHandler.maskPassword("127.0.0.1:9042"));
-        assertEquals("127.0.0.1", ResultHandler.maskPassword("127.0.0.1"));
-        assertEquals("user:*****@host:9042", ResultHandler.maskPassword("user:p@ssword@host:9042"));
-        assertEquals("cassandra:*****@127.0.0.1", ResultHandler.maskPassword("cassandra:p@ss@w@rd@127.0.0.1"));
+        assertEquals("aaa:*****@127.0.0.1:9042", QueryReplayer.ParsedTargetHost.maskPassword("aaa:bbb@127.0.0.1:9042"));
+        assertEquals("127.0.0.1:9042", QueryReplayer.ParsedTargetHost.maskPassword("127.0.0.1:9042"));
+        assertEquals("127.0.0.1", QueryReplayer.ParsedTargetHost.maskPassword("127.0.0.1"));
+        assertEquals("user:*****@host:9042", QueryReplayer.ParsedTargetHost.maskPassword("user:p@ssword@host:9042"));
+        assertEquals("cassandra:*****@127.0.0.1", QueryReplayer.ParsedTargetHost.maskPassword("cassandra:p@ss@w@rd@127.0.0.1"));
     }
 
     @Test
@@ -632,6 +632,37 @@ public class FQLReplayTest
             assertTrue("Exception message should mention SSL or truststore",
                        e.getMessage().contains("SSL") || e.getMessage().contains("ssl") ||
                        e.getMessage().contains("truststore") || e.getMessage().contains("fqltool"));
+        }
+    }
+
+    public static class NoArgOnlyAuthProvider implements com.datastax.driver.core.AuthProvider
+    {
+        public NoArgOnlyAuthProvider() { }
+
+        public com.datastax.driver.core.Authenticator newAuthenticator(java.net.InetSocketAddress host, String authenticator)
+        {
+            throw new UnsupportedOperationException("not needed for this test");
+        }
+    }
+
+    @Test
+    public void testAuthProviderWithoutCredentialsConstructorThrows()
+    {
+        try
+        {
+            new QueryReplayer(Collections.emptyIterator(),
+                              Lists.newArrayList("aaa:bbb@127.0.0.1:9999"),
+                              null,
+                              new ArrayList<>(),
+                              null,
+                              false, null, null, null, null,
+                              NoArgOnlyAuthProvider.class.getName());
+            throw new AssertionError("Expected RuntimeException when auth provider lacks a (String,String) constructor");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue("Exception should mention plain text credentials",
+                       e.getMessage().contains("does not support plain text credentials"));
         }
     }
 

--- a/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
+++ b/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
@@ -699,6 +699,30 @@ public class FQLReplayTest
         }
     }
 
+    @Test
+    public void testOneWayTLSSucceeds()
+    {
+        ConnectionOptions connectionOptions = ConnectionOptions.builder()
+                                                                .withTruststore("test/conf/cassandra_ssl_test.truststore")
+                                                                .withTruststorePassword("cassandra")
+                                                                .build();
+        assertTrue(connectionOptions.ssl());
+        assertNotNull(connectionOptions.sslOptions());
+    }
+
+    @Test
+    public void testTwoWayTLSSucceeds()
+    {
+        ConnectionOptions connectionOptions = ConnectionOptions.builder()
+                                                                .withTruststore("test/conf/cassandra_ssl_test.truststore")
+                                                                .withTruststorePassword("cassandra")
+                                                                .withKeystore("test/conf/cassandra_ssl_test.keystore")
+                                                                .withKeystorePassword("cassandra")
+                                                                .build();
+        assertTrue(connectionOptions.ssl());
+        assertNotNull(connectionOptions.sslOptions());
+    }
+
     @Test(expected = RuntimeException.class)
     public void testNoPass()
     {


### PR DESCRIPTION
### What this PR does
This PR implements the missing connection options for `fqltool replay`. Previously, the tool lacked support for SSL and custom authentication providers, which prevented it from connecting to secured Cassandra clusters. It also fixes a security issue where passwords in the connection string were exposed in plain text.

### Changes Included
* **SSL Support:** Added command-line arguments to support SSL connections (`--ssl`, keystore, and truststore options).
* **Auth Providers:** Added the `--auth-provider` flag to allow custom authentication via the DataStax Driver.
* **Password Masking:** Ensured passwords provided in the connection string (`user:password@host`) are safely masked and never written to logs or result directories.
* **Fail-Fast Validation:** The tool now validates SSL paths and Auth classes immediately on startup, failing fast if the configuration is invalid.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-17559

