### PR TITLE
Override option for default consistency levels in cqlsh

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.10
+ * Add cqlsh options to override the default consistency levels (CASSANDRA-20626)
  * Avoid rebuilding per-SSTable SAI components unless missing or corrupted (CASSANDRA-21515)
  * Propagate trickle_fsync settings to compressed SSTable writers (CASSANDRA-21487)
  * Allow DatabaseDescriptor.setCompressedReadAheadBufferSizeInKb(0) to disable read-ahead buffer (CASSANDRA-21522)

--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -78,6 +78,14 @@
 ;; A version of CQL to use (this should almost never be set)
 ; version = 3.2.1
 
+;; The consistency level to start cqlsh with - ONE by default.
+;; This setting can be overridden with the --consistency-level command line option.
+; consistency_level = LOCAL_QUORUM
+
+;; The serial consistency level to start cqlsh with - SERIAL by default.
+;; This setting can be overridden with the --serial-consistency-level command line option.
+; serial_consistency_level = LOCAL_SERIAL
+
 
 
 [connection]

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -116,6 +116,12 @@ Options:
 `--request-timeout=REQUEST_TIMEOUT`::
   Specify the default request timeout in seconds
   (default: 10 seconds).
+`--consistency-level=CONSISTENCY_LEVEL`::
+  Specify the initial consistency level (default: ONE).
+  A serial consistency level is not valid here.
+`--serial-consistency-level=SERIAL_CONSISTENCY_LEVEL`::
+  Specify the initial serial consistency level
+  (default: SERIAL). Only SERIAL and LOCAL_SERIAL are valid here.
 `-t, --tty`::
   Force tty mode (command prompt).
 `-v` `--v`::

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -148,6 +148,10 @@ parser.add_argument("--connect-timeout", default=DEFAULT_CONNECT_TIMEOUT_SECONDS
                     help='Specify the connection timeout in seconds (default: %(default)s seconds).')
 parser.add_argument("--request-timeout", default=DEFAULT_REQUEST_TIMEOUT_SECONDS, dest='request_timeout',
                     help='Specify the default request timeout in seconds (default: %(default)s seconds).')
+parser.add_argument("--consistency-level", dest='consistency_level',
+                    help='Specify the initial consistency level.')
+parser.add_argument("--serial-consistency-level", dest='serial_consistency_level',
+                    help='Specify the initial serial consistency level.')
 parser.add_argument("-t", "--tty", action='store_true', dest='tty',
                     help='Force tty mode (command prompt).')
 parser.add_argument('--disable-history', default=False, action='store_true',
@@ -360,11 +364,14 @@ class Shell(cmd.Cmd):
     use_paging = True
 
     default_page_size = 100
+    consistency_level = None
+    serial_consistency_level = None
 
     def __init__(self, hostname, port, color=False,
                  username=None, encoding=None, stdin=None, tty=True,
                  completekey=DEFAULT_COMPLETEKEY, browser=None, use_conn=None,
                  cqlver=None, keyspace=None,
+                 consistency_level=None, serial_consistency_level=None,
                  tracing_enabled=False, expand_enabled=False,
                  display_nanotime_format=DEFAULT_NANOTIME_FORMAT,
                  display_timestamp_format=DEFAULT_TIMESTAMP_FORMAT,
@@ -399,6 +406,14 @@ class Shell(cmd.Cmd):
         self.tracing_enabled = tracing_enabled
         self.page_size = self.default_page_size
         self.expand_enabled = expand_enabled
+
+        if not consistency_level:
+            raise Exception('Argument consistency_level must not be None')
+        if not serial_consistency_level:
+            raise Exception('Argument serial_consistency_level must not be None')
+        self.consistency_level = consistency_level
+        self.serial_consistency_level = serial_consistency_level
+
         if use_conn:
             self.conn = use_conn
         else:
@@ -474,8 +489,6 @@ class Shell(cmd.Cmd):
             self.show_line_nums = True
         self.stdin = stdin
         self.query_out = sys.stdout
-        self.consistency_level = cassandra.ConsistencyLevel.ONE
-        self.serial_consistency_level = cassandra.ConsistencyLevel.SERIAL
 
         self.empty_lines = 0
         self.statement_error = False
@@ -1574,6 +1587,8 @@ class Shell(cmd.Cmd):
                          username=self.username,
                          encoding=self.encoding, stdin=f, tty=False, use_conn=self.conn,
                          cqlver=self.cql_version, keyspace=self.current_keyspace,
+                         consistency_level=self.consistency_level,
+                         serial_consistency_level=self.serial_consistency_level,
                          tracing_enabled=self.tracing_enabled,
                          display_nanotime_format=self.display_nanotime_format,
                          display_timestamp_format=self.display_timestamp_format,
@@ -2108,6 +2123,9 @@ def read_options(cmdlineargs, environment=os.environ):
     argvalues.ssl = option_with_default(configs.getboolean, 'connection', 'ssl', DEFAULT_SSL)
     argvalues.encoding = option_with_default(configs.get, 'ui', 'encoding', UTF8)
 
+    argvalues.consistency_level = option_with_default(configs.get, 'cql', 'consistency_level', 'ONE')
+    argvalues.serial_consistency_level = option_with_default(configs.get, 'cql', 'serial_consistency_level', 'SERIAL')
+
     argvalues.tty = option_with_default(configs.getboolean, 'ui', 'tty', sys.stdin.isatty())
     argvalues.protocol_version = option_with_default(configs.getint, 'protocol', 'version', None)
     argvalues.cqlversion = option_with_default(configs.get, 'cql', 'version', None)
@@ -2163,6 +2181,24 @@ def read_options(cmdlineargs, environment=os.environ):
     options.username = maybe_ensure_text(options.username)
     options.password = maybe_ensure_text(options.password)
     options.keyspace = maybe_ensure_text(options.keyspace)
+
+    serial_levels = [cassandra.ConsistencyLevel.SERIAL, cassandra.ConsistencyLevel.LOCAL_SERIAL]
+
+    try:
+        cl = cassandra.ConsistencyLevel.name_to_value[options.consistency_level.upper()]
+        if cl in serial_levels:
+            raise KeyError
+        options.consistency_level = cl
+    except KeyError:
+        parser.error('"{}" is not a valid consistency level'.format(options.consistency_level))
+
+    try:
+        cl = cassandra.ConsistencyLevel.name_to_value[options.serial_consistency_level.upper()]
+        if cl not in serial_levels:
+            raise KeyError
+        options.serial_consistency_level = cl
+    except KeyError:
+        parser.error('"{}" is not a valid serial consistency level'.format(options.serial_consistency_level))
 
     hostname = option_with_default(configs.get, 'connection', 'hostname', DEFAULT_HOST)
     port = option_with_default(configs.get, 'connection', 'port', DEFAULT_PORT)
@@ -2355,6 +2391,8 @@ def main(cmdline, pkgpath):
                       protocol_version=options.protocol_version,
                       cqlver=options.cqlversion,
                       keyspace=options.keyspace,
+                      consistency_level=options.consistency_level,
+                      serial_consistency_level=options.serial_consistency_level,
                       display_timestamp_format=options.time_format,
                       display_nanotime_format=options.nanotime_format,
                       display_date_format=options.date_format,


### PR DESCRIPTION
Add the --consistency-level and --serial-consistency-level options, and the matching consistency_level and serial_consistency_level settings in the [cql] section of cqlshrc. The defaults stay ONE and SERIAL. cqlsh fails to start when either value is invalid.

Upstreamed from datastax/cassandra commit 87929f133dfed4ec1a45cbfaac5246ca14723c26
