### PR TITLE
CASSANDRA-21624: Reduce CI console logging

### DIFF
--- a/.build/run-python-dtests.sh
+++ b/.build/run-python-dtests.sh
@@ -196,7 +196,9 @@ fi
 SPLIT_TESTS="${SPLIT_TESTS//$'\n'/ }"
 
 pytest_results_file="${DIST_DIR}/test/output/nosetests.xml"
-pytest_opts="-vv --log-cli-level=DEBUG --junit-xml=${pytest_results_file} --junit-prefix=${DTEST_TARGET} -s"
+# WARNING (not DEBUG): the driver's reconnect loop logs full tracebacks at DEBUG, which
+#  floods the Jenkins console (tens of MB per cell) and the controller's in-memory step log
+pytest_opts="-vv --log-cli-level=WARNING --junit-xml=${pytest_results_file} --junit-prefix=${DTEST_TARGET} -s"
 
 echo ""
 echo "pytest ${pytest_opts} --cassandra-dir=${CASSANDRA_DIR} --keep-failed-test-dir ${DTEST_ARGS} ${SPLIT_TESTS}" 

--- a/.build/run-python-dtests.sh
+++ b/.build/run-python-dtests.sh
@@ -196,9 +196,9 @@ fi
 SPLIT_TESTS="${SPLIT_TESTS//$'\n'/ }"
 
 pytest_results_file="${DIST_DIR}/test/output/nosetests.xml"
-# WARNING (not DEBUG): the driver's reconnect loop logs full tracebacks at DEBUG, which
+# INFO (not DEBUG): the driver's reconnect loop logs full tracebacks at DEBUG, which
 #  floods the Jenkins console (tens of MB per cell) and the controller's in-memory step log
-pytest_opts="-vv --log-cli-level=WARNING --junit-xml=${pytest_results_file} --junit-prefix=${DTEST_TARGET} -s"
+pytest_opts="-vv --log-cli-level=INFO --junit-xml=${pytest_results_file} --junit-prefix=${DTEST_TARGET} -s"
 
 echo ""
 echo "pytest ${pytest_opts} --cassandra-dir=${CASSANDRA_DIR} --keep-failed-test-dir ${DTEST_ARGS} ${SPLIT_TESTS}" 

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -337,6 +337,22 @@ def isJdkEnabled(jdk) {
 }
 
 /**
+ * Noisy (but harmless) output lines, filtered from the in-memory console log.
+ * The full output is still saved in the archived stage log (build/*.log.xz),
+ * so this only trims what the controller holds in memory / renders in the UI.
+ **/
+def consoleNoiseFilters() {
+  return [
+    "Forking using command" // ant echoes the full forked classpath before every maven forked run
+  ]
+}
+
+// append a sed filter that drops lines matching consoleNoiseFilters() from a step's output
+def filterConsoleOutput(String script) {
+  return "${script} | sed -e " + consoleNoiseFilters().collect { "/${it}/d" }.join(" -e ")
+}
+
+/**
  * Renders build script into pipeline steps
  **/
 def build(command, cell) {
@@ -363,7 +379,7 @@ def build(command, cell) {
             script_vars = "${script_vars} m2_dir=\'${WORKSPACE}/build/m2\'"
             timeout(time: 1, unit: 'HOURS') {
               try {
-                def status = sh label: "RUNNING ${cell.step}...", script: "${script_vars} ${build_script} ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'", returnStatus: true
+                def status = sh label: "RUNNING ${cell.step}...", script: filterConsoleOutput("${script_vars} ${build_script} ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )"), returnStatus: true
                 dir("build") {
                   archiveArtifacts artifacts: "${logfile}", fingerprint: true
                   copyToNightlies("${logfile}", "${cell.step}/jdk${cell.jdk}/${cell.arch}/")
@@ -428,7 +444,7 @@ def test(command, cell) {
               try {
                 buildJVMDTestJars(cell, script_vars, logfile)
                 script_vars = "${script_vars} docker_timeout_hours=\"${command.timeout_hours}\""
-                def status = sh label: "RUNNING TESTS ${cell.step}...", script: "${script_vars} .build/docker/run-tests.sh -a ${cell.step} -c '${cell.split}/${splits}' -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'", returnStatus: true
+                def status = sh label: "RUNNING TESTS ${cell.step}...", script: filterConsoleOutput("${script_vars} .build/docker/run-tests.sh -a ${cell.step} -c '${cell.split}/${splits}' -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )"), returnStatus: true
                 dir("build") {
                   archiveArtifacts artifacts: "${logfile}", fingerprint: true
                 }
@@ -495,7 +511,7 @@ def buildJVMDTestJars(cell, script_vars, logfile) {
     try {
       unstash name: "jvm_dtests_${cell.arch}_${cell.jdk}"
     } catch (error) {
-      sh label: "RUNNING build_dtest_jars...", script: "${script_vars} .build/docker/run-tests.sh -a build_dtest_jars -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'"
+      sh label: "RUNNING build_dtest_jars...", script: filterConsoleOutput("${script_vars} .build/docker/run-tests.sh -a build_dtest_jars -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )")
       stash name: "jvm_dtests_${cell.arch}_${cell.jdk}", includes: '**/dtest*.jar'
     }
   }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -363,7 +363,7 @@ def build(command, cell) {
             script_vars = "${script_vars} m2_dir=\'${WORKSPACE}/build/m2\'"
             timeout(time: 1, unit: 'HOURS') {
               try {
-                def status = sh label: "RUNNING ${cell.step}...", script: "${script_vars} ${build_script} ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )", returnStatus: true
+                def status = sh label: "RUNNING ${cell.step}...", script: "${script_vars} ${build_script} ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'", returnStatus: true
                 dir("build") {
                   archiveArtifacts artifacts: "${logfile}", fingerprint: true
                   copyToNightlies("${logfile}", "${cell.step}/jdk${cell.jdk}/${cell.arch}/")
@@ -428,7 +428,7 @@ def test(command, cell) {
               try {
                 buildJVMDTestJars(cell, script_vars, logfile)
                 script_vars = "${script_vars} docker_timeout_hours=\"${command.timeout_hours}\""
-                def status = sh label: "RUNNING TESTS ${cell.step}...", script: "${script_vars} .build/docker/run-tests.sh -a ${cell.step} -c '${cell.split}/${splits}' -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )", returnStatus: true
+                def status = sh label: "RUNNING TESTS ${cell.step}...", script: "${script_vars} .build/docker/run-tests.sh -a ${cell.step} -c '${cell.split}/${splits}' -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'", returnStatus: true
                 dir("build") {
                   archiveArtifacts artifacts: "${logfile}", fingerprint: true
                 }
@@ -495,7 +495,7 @@ def buildJVMDTestJars(cell, script_vars, logfile) {
     try {
       unstash name: "jvm_dtests_${cell.arch}_${cell.jdk}"
     } catch (error) {
-      sh label: "RUNNING build_dtest_jars...", script: "${script_vars} .build/docker/run-tests.sh -a build_dtest_jars -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} )"
+      sh label: "RUNNING build_dtest_jars...", script: "${script_vars} .build/docker/run-tests.sh -a build_dtest_jars -j ${cell.jdk} 2>&1 | tee >( xz -c > build/${logfile} ) | sed -e '/Forking using command/d'"
       stash name: "jvm_dtests_${cell.arch}_${cell.jdk}", includes: '**/dtest*.jar'
     }
   }


### PR DESCRIPTION
* dtest: pytest --log-cli-level=DEBUG dropped to WARNING
* Jenkinsfile: filter ant "Forking using command" classpath echoes

Patch by brandonwilliams, reviewed by TBD

