### PR TITLE
CASSANDRA-21625 Column Comparison with null NPEs for Accord Transaction

### DIFF
--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -18,19 +18,25 @@
 
 package org.apache.cassandra.cql3.transactions;
 
+import java.nio.ByteBuffer;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.VariableSpecifications;
+import org.apache.cassandra.cql3.terms.Constants;
 import org.apache.cassandra.cql3.terms.Term;
 import org.apache.cassandra.service.accord.txn.TxnCondition;
 import org.apache.cassandra.service.accord.txn.TxnReference;
 
+import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 
 public class ConditionStatement
 {
+    public static final String NULL_COMPARISON_MESSAGE = "Invalid comparison with null for operator; use IS NULL or IS NOT NULL instead";
+
     public enum Kind
     {
         IS_NOT_NULL(TxnCondition.Kind.IS_NOT_NULL, null),
@@ -124,6 +130,11 @@ public class ConditionStatement
                 throw new IllegalStateException("Either the left-hand or right-hand side must be a reference!");
             }
 
+            // If we are in the IS NULL/IS NOT NULL we would have returned already in the (rhs == null) branch,
+            // for all other cases we need to reject the transaction when the rhs is null.
+            // Bind markers are checked in createCondition() below.
+            checkTrue(value != Constants.NULL_VALUE, NULL_COMPARISON_MESSAGE);
+
             reference.collectMarkerSpecification(bindVariables, null);
             value.collectMarkerSpecification(bindVariables, null);
             return new ConditionStatement(reference, kind, value, reversed);
@@ -146,9 +157,10 @@ public class ConditionStatement
                 // TODO: Support for references on LHS and RHS
                 TxnReference ref = reference.toTxnReference(options);
                 checkTrue(ref.kind == TxnReference.Kind.COLUMN, "Condition %s requires COLUMN reference but given %s", kind, ref.kind);
+                ByteBuffer bytes = checkNotNull(value.bindAndGet(options), NULL_COMPARISON_MESSAGE);
                 return new TxnCondition.Value(ref.asColumn(),
                                               kind.toTxnKind(reversed),
-                                              value.bindAndGet(options),
+                                              bytes,
                                               options.getProtocolVersion());
             default:
                 throw new IllegalStateException();

--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -130,8 +130,8 @@ public class ConditionStatement
                 throw new IllegalStateException("Either the left-hand or right-hand side must be a reference!");
             }
 
-            // If we are in the IS NULL/IS NOT NULL we would have returned already in the (rhs == null) branch,
-            // for all other cases we need to reject the transaction when the rhs is null.
+            // If we are in the IS NULL/IS NOT NULL we would have returned already in the (rhs == null) branch.
+            // For all other cases, null is parsed as Constants.NULL_VALUE, and we need to reject those transactions.
             // Bind markers are checked in createCondition() below.
             checkTrue(value != Constants.NULL_VALUE, NULL_COMPARISON_MESSAGE);
 

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -498,6 +498,7 @@ public abstract class TxnCondition
         {
             super(kind);
             Invariants.requireArgument(KINDS.contains(kind), "Kind " + kind + " cannot be used with a value condition");
+            value = reference.column().type.sanitize(value);
             Invariants.requireArgument(value != null, "Value conditions require a non null comparison value");
             this.reference = reference;
             this.value = value;

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnCondition.java
@@ -498,6 +498,7 @@ public abstract class TxnCondition
         {
             super(kind);
             Invariants.requireArgument(KINDS.contains(kind), "Kind " + kind + " cannot be used with a value condition");
+            Invariants.requireArgument(value != null, "Value conditions require a non null comparison value");
             this.reference = reference;
             this.value = value;
             this.version = version;

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceValue.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceValue.java
@@ -92,7 +92,7 @@ public abstract class TxnReferenceValue
         @Override
         public String toString()
         {
-            return "Constant=" + value == null ? "null" : ByteBufferUtil.bytesToHex(value);
+            return "Constant=" + (value == null ? "null" : ByteBufferUtil.bytesToHex(value));
         }
 
         @Override

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -67,6 +67,7 @@ import org.apache.cassandra.cql3.ast.Symbol;
 import org.apache.cassandra.cql3.ast.Txn;
 import org.apache.cassandra.cql3.functions.types.utils.Bytes;
 import org.apache.cassandra.cql3.statements.TransactionStatement;
+import org.apache.cassandra.cql3.transactions.ConditionStatement;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -298,6 +299,54 @@ public abstract class AccordCQLTestBase extends AccordTestBase
                          "COMMIT TRANSACTION";
 
             cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+        });
+    }
+
+    @Test
+    public void testRejectColumnComparisonWithNull() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                String txn = "BEGIN TRANSACTION\n" +
+                             "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                             "  IF row1.v = null THEN\n" +
+                             "    UPDATE " + qualifiedAccordTableName + " SET v = 1 WHERE k = 1;\n" +
+                             "  END IF\n" +
+                             "COMMIT TRANSACTION";
+
+                cluster.coordinator(1).execute(txn, QUORUM);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals(ConditionStatement.NULL_COMPARISON_MESSAGE, t.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testRejectColumnComparisonWithNullBindMarker() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int PRIMARY KEY, v int) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                String txn = "BEGIN TRANSACTION\n" +
+                             "  LET row1 = (SELECT * FROM " + qualifiedAccordTableName + " WHERE k = 1);\n" +
+                             "  IF row1.v = ? THEN\n" +
+                             "    UPDATE " + qualifiedAccordTableName + " SET v = 1 WHERE k = 1;\n" +
+                             "  END IF\n" +
+                             "COMMIT TRANSACTION";
+
+                cluster.coordinator(1).execute(txn, QUORUM, (Object) null);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals(ConditionStatement.NULL_COMPARISON_MESSAGE, t.getMessage());
+            }
         });
     }
 

--- a/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
@@ -62,6 +62,7 @@ import static org.apache.cassandra.cql3.statements.TransactionStatement.TRANSACT
 import static org.apache.cassandra.cql3.statements.UpdateStatement.CANNOT_SET_KEY_WITH_REFERENCE_MESSAGE;
 import static org.apache.cassandra.cql3.statements.UpdateStatement.UPDATING_PRIMARY_KEY_MESSAGE;
 import static org.apache.cassandra.cql3.statements.schema.CreateTableStatement.parse;
+import static org.apache.cassandra.cql3.transactions.ConditionStatement.NULL_COMPARISON_MESSAGE;
 import static org.apache.cassandra.cql3.transactions.RowDataReference.CANNOT_FIND_TUPLE_MESSAGE;
 import static org.apache.cassandra.cql3.transactions.RowDataReference.COLUMN_NOT_IN_TUPLE_MESSAGE;
 import static org.apache.cassandra.schema.TableMetadata.UNDEFINED_COLUMN_NAME_MESSAGE;
@@ -608,6 +609,52 @@ public class TransactionStatementTest
                        "  END IF\n" +
                        "COMMIT TRANSACTION";
         Assertions.assertThat(prepare(query)).isNotNull();
+    }
+
+    @Test
+    public void shouldRejectColumnComparisonWithNullLiteral()
+    {
+        for (String operator : Arrays.asList("=", "!=", "<", "<=", ">", ">="))
+        {
+            String query = "BEGIN TRANSACTION\n" +
+                           "  LET row1 = (SELECT * FROM ks.tbl5 WHERE k=1);\n" +
+                           "  IF row1.v " + operator + " null THEN\n" +
+                           "    UPDATE ks.tbl5 SET v=1 WHERE k=1;\n" +
+                           "  END IF\n" +
+                           "COMMIT TRANSACTION";
+
+            Assertions.assertThatThrownBy(() -> prepare(query))
+                      .isInstanceOf(InvalidRequestException.class)
+                      .hasMessage(NULL_COMPARISON_MESSAGE);
+
+            // the reference may also appear on the RHS
+            String reversed = "BEGIN TRANSACTION\n" +
+                              "  LET row1 = (SELECT * FROM ks.tbl5 WHERE k=1);\n" +
+                              "  IF null " + operator + " row1.v THEN\n" +
+                              "    UPDATE ks.tbl5 SET v=1 WHERE k=1;\n" +
+                              "  END IF\n" +
+                              "COMMIT TRANSACTION";
+
+            Assertions.assertThatThrownBy(() -> prepare(reversed))
+                      .isInstanceOf(InvalidRequestException.class)
+                      .hasMessage(NULL_COMPARISON_MESSAGE);
+        }
+    }
+
+    @Test
+    public void shouldRejectColumnComparisonWithNullBindMarker()
+    {
+        String query = "BEGIN TRANSACTION\n" +
+                       "  LET row1 = (SELECT * FROM ks.tbl5 WHERE k=1);\n" +
+                       "  IF row1.v = ? THEN\n" +
+                       "    UPDATE ks.tbl5 SET v=1 WHERE k=1;\n" +
+                       "  END IF\n" +
+                       "COMMIT TRANSACTION";
+
+        Assertions.assertThat(prepare(query)).isNotNull();
+        Assertions.assertThatThrownBy(() -> execute(query, new Object[]{ null }))
+                  .isInstanceOf(InvalidRequestException.class)
+                  .hasMessage(NULL_COMPARISON_MESSAGE);
     }
 
     private static CQLStatement prepare(String query)


### PR DESCRIPTION
The following transaction NPEs, we should instead reject transactions that compare a column with null. IS NULL/IS NOT NULL should be used instead. 
 
```
BEGIN TRANSACTION
LET row1 = (SELECT * FROM distributed_test_keyspace.accordtbl0 WHERE k=1);
IF row1.v = null THEN
        UPDATE distributed_test_keyspace.accordtbl0 SET v=1 WHERE k=1;
END IF
COMMIT TRANSACTION
```

patch by Alan Wang;

reviewed by for [CASSANDRA-21625](https://issues.apache.org/jira/browse/CASSANDRA-21625)

Co-authored-by: Name1
Co-authored-by: Name2