### PR TITLE
Allow nodetool cms reconfigure to ignore specific hosts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 6.0-alpha3
- * Allow nodetool cms reconfigure to ignore nodes via --ignore, excluding them from the new CMS (CASSANDRA-21627)
+ * Allow nodetool cms reconfigure --ignore to accept hostnames, IPs or CIDR subnets (CASSANDRA-21627)
  * Guardrail configurations of zero are now treated as zero instead of unlimited (CASSANDRA-21517)
  * Support multi-cell columns in cursor compaction (CASSANDRA-21463)
  * Optimize authorization logic for BatchStatement and TransactionStatement when a single table is updated (CASSANDRA-21606)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Allow nodetool cms reconfigure to ignore nodes via --ignore, excluding them from the new CMS (CASSANDRA-21627)
  * Guardrail configurations of zero are now treated as zero instead of unlimited (CASSANDRA-21517)
  * Support multi-cell columns in cursor compaction (CASSANDRA-21463)
  * Optimize authorization logic for BatchStatement and TransactionStatement when a single table is updated (CASSANDRA-21606)

--- a/src/java/org/apache/cassandra/tcm/CMSOperations.java
+++ b/src/java/org/apache/cassandra/tcm/CMSOperations.java
@@ -164,17 +164,29 @@ public class CMSOperations implements CMSOperationsMBean
     @Override
     public void reconfigureCMS(int rf)
     {
+        reconfigureCMS(rf, Collections.emptyList());
+    }
+
+    @Override
+    public void reconfigureCMS(int rf, List<String> ignoredEndpoints)
+    {
         ReplicationParams params = ReplicationParams.simpleMeta(rf, ClusterMetadata.current().directory.knownDatacenters());
         guardMinimumCmsSize(params);
-        cms.reconfigureCMS(params);
+        cms.reconfigureCMS(params, ignoredEndpoints);
     }
 
     @Override
     public void reconfigureCMS(Map<String, Integer> rf)
     {
+        reconfigureCMS(rf, Collections.emptyList());
+    }
+
+    @Override
+    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignoredEndpoints)
+    {
         ReplicationParams params = ReplicationParams.ntsMeta(rf);
         guardMinimumCmsSize(params);
-        cms.reconfigureCMS(params);
+        cms.reconfigureCMS(params, ignoredEndpoints);
     }
 
     /**

--- a/src/java/org/apache/cassandra/tcm/CMSOperations.java
+++ b/src/java/org/apache/cassandra/tcm/CMSOperations.java
@@ -168,11 +168,11 @@ public class CMSOperations implements CMSOperationsMBean
     }
 
     @Override
-    public void reconfigureCMS(int rf, List<String> ignoredEndpoints)
+    public void reconfigureCMS(int rf, List<String> ignored)
     {
         ReplicationParams params = ReplicationParams.simpleMeta(rf, ClusterMetadata.current().directory.knownDatacenters());
         guardMinimumCmsSize(params);
-        cms.reconfigureCMS(params, ignoredEndpoints);
+        cms.reconfigureCMS(params, ignored);
     }
 
     @Override
@@ -182,11 +182,11 @@ public class CMSOperations implements CMSOperationsMBean
     }
 
     @Override
-    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignoredEndpoints)
+    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignored)
     {
         ReplicationParams params = ReplicationParams.ntsMeta(rf);
         guardMinimumCmsSize(params);
-        cms.reconfigureCMS(params, ignoredEndpoints);
+        cms.reconfigureCMS(params, ignored);
     }
 
     /**

--- a/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
+++ b/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
@@ -52,7 +52,9 @@ public interface CMSOperationsMBean
     public void abortInitialization(String initiator);
     public void resumeReconfigureCms();
     public void reconfigureCMS(int rf);
+    public void reconfigureCMS(int rf, List<String> ignoredEndpoints);
     public void reconfigureCMS(Map<String, Integer> rf);
+    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignoredEndpoints);
     public Map<String, List<String>> reconfigureCMSStatus();
     public void cancelReconfigureCms();
 

--- a/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
+++ b/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
@@ -52,9 +52,9 @@ public interface CMSOperationsMBean
     public void abortInitialization(String initiator);
     public void resumeReconfigureCms();
     public void reconfigureCMS(int rf);
-    public void reconfigureCMS(int rf, List<String> ignoredEndpoints);
+    public void reconfigureCMS(int rf, List<String> ignored);
     public void reconfigureCMS(Map<String, Integer> rf);
-    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignoredEndpoints);
+    public void reconfigureCMS(Map<String, Integer> rf, List<String> ignored);
     public Map<String, List<String>> reconfigureCMSStatus();
     public void cancelReconfigureCms();
 

--- a/src/java/org/apache/cassandra/tcm/ClusterMetadataService.java
+++ b/src/java/org/apache/cassandra/tcm/ClusterMetadataService.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -37,12 +38,15 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 
+import inet.ipaddr.IPAddressString;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.SubnetGroups;
 import org.apache.cassandra.exceptions.ExceptionCode;
 import org.apache.cassandra.exceptions.RequestFailure;
 import org.apache.cassandra.exceptions.StartupException;
@@ -503,20 +507,14 @@ public class ClusterMetadataService
     }
 
     /**
-     * Reconfigure the CMS so that its membership satisfies the supplied replication params.
-     *
-     * Nodes named in {@code ignoredEndpoints}, along with any node currently considered down, are not eligible for
-     * membership of the new CMS. Excluding nodes that are about to be decommissioned lets an operator shrink a cluster
-     * with a single reconfiguration up front, rather than one per departing CMS member. The ignore list applies only to
-     * this call; it is not remembered, and does not change whether the CMS is later reported as needing reconfiguration.
-     *
-     * Note that a subsequent bootstrap, replace or move recomputes placement without any ignore list and may therefore
-     * reintroduce an ignored node to the CMS.
+     * Reconfigure the CMS so its membership matches the given replication params. Anything in {@code ignored} (a
+     * hostname, IP, or CIDR subnet), plus any node that is down, is kept out of the new CMS. The list applies only to
+     * this call; it is not stored, so a later bootstrap, replace or move can put an ignored node back in the CMS.
      */
-    public void reconfigureCMS(ReplicationParams replicationParams, List<String> ignoredEndpoints)
+    public void reconfigureCMS(ReplicationParams replicationParams, List<String> ignored)
     {
         ClusterMetadata metadata = ClusterMetadata.current();
-        Set<NodeId> excludedNodes = new HashSet<>(resolveIgnoredEndpoints(metadata, ignoredEndpoints));
+        Set<NodeId> excludedNodes = new HashSet<>(resolveIgnoredEndpoints(metadata, ignored));
         Set<NodeId> allJoinedNodes = Sets.newHashSetWithExpectedSize(metadata.directory.allJoinedEndpoints().size());
         for (InetAddressAndPort ep : metadata.directory.allJoinedEndpoints())
         {
@@ -541,38 +539,73 @@ public class ClusterMetadataService
     }
 
     /**
-     * Resolve operator supplied hosts to the NodeIds they identify, rejecting any host which does not exist in the
-     * cluster.
+     * Resolve the operator's ignore entries to the NodeIds they refer to. Each entry is either a CIDR subnet (matched
+     * against every address in the cluster) or a hostname/IP (looked up by name and required to be a node).
      */
-    private static Set<NodeId> resolveIgnoredEndpoints(ClusterMetadata metadata, List<String> ignoredEndpoints)
+    @VisibleForTesting
+    Set<NodeId> resolveIgnoredEndpoints(ClusterMetadata metadata, List<String> ignored)
     {
-        if (ignoredEndpoints.isEmpty())
+        if (ignored.isEmpty())
             return Collections.emptySet();
 
-        Set<InetAddressAndPort> ignored = new HashSet<>(ignoredEndpoints.size());
-        for (String host : ignoredEndpoints)
+        Set<InetAddressAndPort> allAddresses = metadata.directory.allAddresses();
+        Set<InetAddressAndPort> resolved = new HashSet<>();
+        Set<InetAddressAndPort> named = new HashSet<>();
+        List<String> subnets = new ArrayList<>();
+
+        for (String entry : ignored)
         {
-            try
+            if (entry.indexOf('/') >= 0)
             {
-                ignored.add(InetAddressAndPort.getByName(host));
+                // Has a '/', so it is a CIDR subnet. Check if it is valid; the matching happens below.
+                if (!new IPAddressString(entry).isValid())
+                    throw new IllegalArgumentException("Invalid CIDR in ignore list: " + entry);
+                subnets.add(entry);
             }
-            catch (UnknownHostException e)
+            else
             {
-                throw new IllegalArgumentException("Unknown host in ignore list: " + host, e);
+                // A hostname or IP: resolve it now, and check below that it is a node in the cluster.
+                try
+                {
+                    named.add(InetAddressAndPort.getByName(entry));
+                }
+                catch (UnknownHostException e)
+                {
+                    throw new IllegalArgumentException("Unknown host in ignore list: " + entry, e);
+                }
             }
         }
 
-        // Unlike CMS initialization, the local node may legitimately be ignored here. Reconfiguring the CMS away from
-        // the node running the command is valid, and is expected when that node is itself due to be decommissioned.
-        Set<InetAddressAndPort> unknown = Sets.difference(ignored, metadata.directory.allAddresses());
-        if (!unknown.isEmpty())
+        if (!named.isEmpty())
         {
-            String msg = "Ignored host(s) " + unknown + " don't exist in the cluster";
-            logger.error(msg);
-            throw new IllegalStateException(msg);
+            // Every named host must exist in the cluster; report all of the unknown ones at once. Ignoring the local
+            // node is fine here (unlike CMS initialization) - reconfiguring the CMS away from the node running the
+            // command is expected when that node is being decommissioned.
+            Set<InetAddressAndPort> unknown = Sets.difference(named, allAddresses);
+            if (!unknown.isEmpty())
+            {
+                String msg = "Ignored host(s) " + unknown + " don't exist in the cluster";
+                logger.error(msg);
+                throw new IllegalStateException(msg);
+            }
+            resolved.addAll(named);
         }
 
-        Set<NodeId> ignoredIds = metadata.directory.toNodeIds(ignored);
+        if (!subnets.isEmpty())
+        {
+            SubnetGroups groups = new SubnetGroups(subnets);
+            Set<InetAddressAndPort> matched = new HashSet<>();
+            for (InetAddressAndPort address : allAddresses)
+            {
+                if (groups.contains(address))
+                    matched.add(address);
+            }
+            if (matched.isEmpty())
+                logger.warn("Ignored subnet(s) {} do not match any node in the cluster", subnets);
+            resolved.addAll(matched);
+        }
+
+        Set<NodeId> ignoredIds = metadata.directory.toNodeIds(resolved);
         logger.info("Excluding operator specified hosts from CMS reconfiguration: {}", ignoredIds);
         return ignoredIds;
     }

--- a/src/java/org/apache/cassandra/tcm/ClusterMetadataService.java
+++ b/src/java/org/apache/cassandra/tcm/ClusterMetadataService.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.tcm;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -498,18 +499,82 @@ public class ClusterMetadataService
 
     public void reconfigureCMS(ReplicationParams replicationParams)
     {
+        reconfigureCMS(replicationParams, Collections.emptyList());
+    }
+
+    /**
+     * Reconfigure the CMS so that its membership satisfies the supplied replication params.
+     *
+     * Nodes named in {@code ignoredEndpoints}, along with any node currently considered down, are not eligible for
+     * membership of the new CMS. Excluding nodes that are about to be decommissioned lets an operator shrink a cluster
+     * with a single reconfiguration up front, rather than one per departing CMS member. The ignore list applies only to
+     * this call; it is not remembered, and does not change whether the CMS is later reported as needing reconfiguration.
+     *
+     * Note that a subsequent bootstrap, replace or move recomputes placement without any ignore list and may therefore
+     * reintroduce an ignored node to the CMS.
+     */
+    public void reconfigureCMS(ReplicationParams replicationParams, List<String> ignoredEndpoints)
+    {
         ClusterMetadata metadata = ClusterMetadata.current();
-        Set<NodeId> downNodes = new HashSet<>();
+        Set<NodeId> excludedNodes = new HashSet<>(resolveIgnoredEndpoints(metadata, ignoredEndpoints));
+        Set<NodeId> allJoinedNodes = Sets.newHashSetWithExpectedSize(metadata.directory.allJoinedEndpoints().size());
         for (InetAddressAndPort ep : metadata.directory.allJoinedEndpoints())
+        {
+            NodeId id = metadata.directory.peerId(ep);
+            allJoinedNodes.add(id);
             if (!FailureDetector.instance.isAlive(ep))
-                downNodes.add(metadata.directory.peerId(ep));
-        PrepareCMSReconfiguration.Complex transformation = new PrepareCMSReconfiguration.Complex(replicationParams, downNodes);
+                excludedNodes.add(id);
+        }
+
+        // Placement needs at least one candidate to work with; leaving none is rejected here because the strategy
+        // itself would fail on an assertion rather than reporting anything useful.
+        if (!excludedNodes.isEmpty() && excludedNodes.size() >= allJoinedNodes.size() && excludedNodes.containsAll(allJoinedNodes))
+            throw new IllegalStateException("Cannot reconfigure CMS as all joined nodes are DOWN or ignored");
+
+        PrepareCMSReconfiguration.Complex transformation = new PrepareCMSReconfiguration.Complex(replicationParams, excludedNodes);
         transformation.verify(metadata);
 
         ClusterMetadataService.instance()
                               .commit(transformation);
 
         InProgressSequences.finishInProgressSequences(ReconfigureCMS.SequenceKey.instance);
+    }
+
+    /**
+     * Resolve operator supplied hosts to the NodeIds they identify, rejecting any host which does not exist in the
+     * cluster.
+     */
+    private static Set<NodeId> resolveIgnoredEndpoints(ClusterMetadata metadata, List<String> ignoredEndpoints)
+    {
+        if (ignoredEndpoints.isEmpty())
+            return Collections.emptySet();
+
+        Set<InetAddressAndPort> ignored = new HashSet<>(ignoredEndpoints.size());
+        for (String host : ignoredEndpoints)
+        {
+            try
+            {
+                ignored.add(InetAddressAndPort.getByName(host));
+            }
+            catch (UnknownHostException e)
+            {
+                throw new IllegalArgumentException("Unknown host in ignore list: " + host, e);
+            }
+        }
+
+        // Unlike CMS initialization, the local node may legitimately be ignored here. Reconfiguring the CMS away from
+        // the node running the command is valid, and is expected when that node is itself due to be decommissioned.
+        Set<InetAddressAndPort> unknown = Sets.difference(ignored, metadata.directory.allAddresses());
+        if (!unknown.isEmpty())
+        {
+            String msg = "Ignored host(s) " + unknown + " don't exist in the cluster";
+            logger.error(msg);
+            throw new IllegalStateException(msg);
+        }
+
+        Set<NodeId> ignoredIds = metadata.directory.toNodeIds(ignored);
+        logger.info("Excluding operator specified hosts from CMS reconfiguration: {}", ignoredIds);
+        return ignoredIds;
     }
 
     public void ensureCMSPlacement(ClusterMetadata metadata)

--- a/src/java/org/apache/cassandra/tcm/transformations/cms/PrepareCMSReconfiguration.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/cms/PrepareCMSReconfiguration.java
@@ -61,6 +61,12 @@ import static org.apache.cassandra.tcm.CMSOperations.REPLICATION_FACTOR;
 public abstract class PrepareCMSReconfiguration implements Transformation
 {
     private static final Logger logger = LoggerFactory.getLogger(PrepareCMSReconfiguration.class);
+
+    /**
+     * Nodes to exclude from the new CMS: those the failure detector considered down when the reconfiguration was
+     * initiated, plus any the operator excluded via {@code nodetool cms reconfigure --ignore}. Resolved by the
+     * initiating node and serialized so that every node executing or replaying this derives the same {@link Diff}.
+     */
     final Set<NodeId> downNodes;
 
     public PrepareCMSReconfiguration(Set<NodeId> downNodes)
@@ -118,7 +124,9 @@ public abstract class PrepareCMSReconfiguration implements Transformation
         int expectedSize = dcRf.values().stream().mapToInt(Integer::intValue).sum();
         Set<NodeId> newCms = prepareNewCMS(dcRf, prev);
         if (newCms.size() < (expectedSize / 2) + 1)
-            throw new IllegalStateException("Too many nodes are currently DOWN to safely perform the reconfiguration");
+            throw new IllegalStateException(String.format("Too many nodes are currently DOWN or ignored to safely perform " +
+                                                          "the reconfiguration (only %d of %d members could be placed)",
+                                                          newCms.size(), expectedSize));
     }
 
     private static void serializeDownNodes(PrepareCMSReconfiguration transformation, DataOutputPlus out, Version version) throws IOException

--- a/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
@@ -123,12 +123,13 @@ public class CMSAdmin extends AbstractCommand
                 description = "Cancels any in progress CMS reconfiguration")
         private boolean cancel = false;
 
-        @Option(paramLabel = "ignored_endpoints",
+        @Option(paramLabel = "host_or_subnet",
                 names = { "-i", "--ignore" },
-                description = "Hosts to exclude from the new CMS, in addition to any which are currently down. Useful " +
-                              "before shrinking a cluster: excluding the nodes which are about to be decommissioned " +
-                              "keeps the CMS membership stable, avoiding a reconfiguration per decommissioned member.")
-        private List<String> ignoredEndpoints = new ArrayList<>();
+                description = "Hosts (IP or hostname) or CIDR subnets to exclude from the new CMS, in addition to any " +
+                              "which are currently down. Useful before shrinking a cluster: excluding the nodes which " +
+                              "are about to be decommissioned keeps the CMS membership stable, avoiding a " +
+                              "reconfiguration per decommissioned member.")
+        private List<String> ignored = new ArrayList<>();
 
         @CassandraUsage(usage = "[<replication factor>] or <datacenter>:<replication_factor> ... ", description = "Replication factor of new CMS")
         @Parameters(paramLabel = "replication_factor", description = "Replication factors of new CMS in format <replication factor> or <datacenter>:<replication_factor>")
@@ -155,7 +156,7 @@ public class CMSAdmin extends AbstractCommand
             {
                 if (!args.isEmpty())
                     throw new IllegalArgumentException("Replication factor should not be set if previous operation is resumed");
-                if (!ignoredEndpoints.isEmpty())
+                if (!ignored.isEmpty())
                     throw new IllegalArgumentException("Ignored hosts should not be set if previous operation is resumed");
 
                 probe.getCMSOperationsProxy().resumeReconfigureCms();
@@ -164,7 +165,7 @@ public class CMSAdmin extends AbstractCommand
 
             if (cancel)
             {
-                if (!ignoredEndpoints.isEmpty())
+                if (!ignored.isEmpty())
                     throw new IllegalArgumentException("Ignored hosts should not be set when cancelling a reconfiguration");
 
                 probe.getCMSOperationsProxy().cancelReconfigureCms();
@@ -190,7 +191,7 @@ public class CMSAdmin extends AbstractCommand
                     {
                         throw new IllegalArgumentException(String.format("Can not parse replication factor from %s", args.get(0)));
                     }
-                    probe.getCMSOperationsProxy().reconfigureCMS(parsedRf, ignoredEndpoints);
+                    probe.getCMSOperationsProxy().reconfigureCMS(parsedRf, ignored);
                     return;
                 }
                 else
@@ -212,7 +213,7 @@ public class CMSAdmin extends AbstractCommand
                 }
             }
 
-            probe.getCMSOperationsProxy().reconfigureCMS(parsedRfs, ignoredEndpoints);
+            probe.getCMSOperationsProxy().reconfigureCMS(parsedRfs, ignored);
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
@@ -123,6 +123,13 @@ public class CMSAdmin extends AbstractCommand
                 description = "Cancels any in progress CMS reconfiguration")
         private boolean cancel = false;
 
+        @Option(paramLabel = "ignored_endpoints",
+                names = { "-i", "--ignore" },
+                description = "Hosts to exclude from the new CMS, in addition to any which are currently down. Useful " +
+                              "before shrinking a cluster: excluding the nodes which are about to be decommissioned " +
+                              "keeps the CMS membership stable, avoiding a reconfiguration per decommissioned member.")
+        private List<String> ignoredEndpoints = new ArrayList<>();
+
         @CassandraUsage(usage = "[<replication factor>] or <datacenter>:<replication_factor> ... ", description = "Replication factor of new CMS")
         @Parameters(paramLabel = "replication_factor", description = "Replication factors of new CMS in format <replication factor> or <datacenter>:<replication_factor>")
         private List<String> args = new ArrayList<>();
@@ -148,6 +155,8 @@ public class CMSAdmin extends AbstractCommand
             {
                 if (!args.isEmpty())
                     throw new IllegalArgumentException("Replication factor should not be set if previous operation is resumed");
+                if (!ignoredEndpoints.isEmpty())
+                    throw new IllegalArgumentException("Ignored hosts should not be set if previous operation is resumed");
 
                 probe.getCMSOperationsProxy().resumeReconfigureCms();
                 return;
@@ -155,6 +164,9 @@ public class CMSAdmin extends AbstractCommand
 
             if (cancel)
             {
+                if (!ignoredEndpoints.isEmpty())
+                    throw new IllegalArgumentException("Ignored hosts should not be set when cancelling a reconfiguration");
+
                 probe.getCMSOperationsProxy().cancelReconfigureCms();
                 return;
             }
@@ -178,7 +190,7 @@ public class CMSAdmin extends AbstractCommand
                     {
                         throw new IllegalArgumentException(String.format("Can not parse replication factor from %s", args.get(0)));
                     }
-                    probe.getCMSOperationsProxy().reconfigureCMS(parsedRf);
+                    probe.getCMSOperationsProxy().reconfigureCMS(parsedRf, ignoredEndpoints);
                     return;
                 }
                 else
@@ -200,7 +212,7 @@ public class CMSAdmin extends AbstractCommand
                 }
             }
 
-            probe.getCMSOperationsProxy().reconfigureCMS(parsedRfs);
+            probe.getCMSOperationsProxy().reconfigureCMS(parsedRfs, ignoredEndpoints);
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ReconfigureCMSTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ReconfigureCMSTest.java
@@ -241,6 +241,89 @@ public class ReconfigureCMSTest extends FuzzTestBase
     }
 
     @Test
+    public void testIgnoredNodesRemainExcludedWhileDecommissioning() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(5)
+                                           .withConfig(conf -> conf.with(Feature.NETWORK, Feature.GOSSIP))
+                                           .start()))
+        {
+            // A single reconfiguration up front, excluding the nodes which are about to be decommissioned. Ignoring
+            // nodes 2 and 3 must produce the same placement as those nodes being down (see
+            // testReconfigurePickAliveNodesIfPossible), even though every node here is up.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3",
+                                          "--ignore", broadcastAddress(cluster, 2),
+                                          "--ignore", broadcastAddress(cluster, 3))
+                   .asserts().success();
+
+            Set<String> expectedCMSMembers = expectedCMS(cluster, 1, 4, 5);
+            cluster.forEach(inst -> assertEquals(expectedCMSMembers, ClusterUtils.getCMSMembers(inst)));
+
+            // The ignore list is not persisted, so while the ignored nodes are still members of the cluster the CMS
+            // is legitimately reported as not matching the placement they imply.
+            cluster.get(1).runOnInstance(() -> assertTrue(PrepareCMSReconfiguration.needsReconfiguration(ClusterMetadata.current())));
+
+            // Decommissioning a node which is not a CMS member does not trigger a reconfiguration, so membership is
+            // stable for the duration of the shrink and no further reconfiguration is required per departing node.
+            cluster.get(2).nodetoolResult("decommission", "--force").asserts().success();
+            assertEquals(expectedCMSMembers, ClusterUtils.getCMSMembers(cluster.get(1)));
+
+            cluster.get(3).nodetoolResult("decommission", "--force").asserts().success();
+            assertEquals(expectedCMSMembers, ClusterUtils.getCMSMembers(cluster.get(1)));
+
+            // Once the ignored nodes have left, the CMS matches the placement implied by the remaining nodes again.
+            cluster.get(1).runOnInstance(() -> assertFalse(PrepareCMSReconfiguration.needsReconfiguration(ClusterMetadata.current())));
+        }
+    }
+
+    @Test
+    public void testReconfigureIgnoreRejectsUnknownAndExcessiveHosts() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(conf -> conf.with(Feature.NETWORK, Feature.GOSSIP))
+                                           .start()))
+        {
+            // Each case below fails for a different reason, so assert on the message rather than just the exit status.
+            // A bare failure() would pass even if the relevant check were removed.
+
+            // A host which is not part of the cluster is rejected rather than silently ignored.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3", "--ignore", "127.0.0.99")
+                   .asserts().failure()
+                   .errorContains("don't exist in the cluster")
+                   .errorContains("127.0.0.99");
+
+            // A host which cannot be resolved at all is rejected rather than being silently dropped from the list.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3", "--ignore", "999.999.999.999")
+                   .asserts().failure()
+                   .errorContains("Unknown host in ignore list: 999.999.999.999");
+
+            // Ignoring so many nodes that fewer than a quorum of the requested members can be placed is rejected.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3",
+                                          "--ignore", broadcastAddress(cluster, 2),
+                                          "--ignore", broadcastAddress(cluster, 3))
+                   .asserts().failure()
+                   .errorContains("Too many nodes are currently DOWN or ignored to safely perform the reconfiguration");
+
+            // Ignoring every joined node leaves placement with no candidates at all. This is rejected up front, as
+            // the placement strategy would otherwise fail on an assertion rather than reporting anything useful.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3",
+                                          "--ignore", broadcastAddress(cluster, 1),
+                                          "--ignore", broadcastAddress(cluster, 2),
+                                          "--ignore", broadcastAddress(cluster, 3))
+                   .asserts().failure()
+                   .errorContains("Cannot reconfigure CMS as all joined nodes are DOWN or ignored");
+
+            // Ignored hosts are meaningless when resuming or cancelling. Note that cancelling with nothing in flight
+            // fails on its own, so only the message distinguishes the guard from that unrelated failure.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "--resume", "--ignore", broadcastAddress(cluster, 2))
+                   .asserts().failure()
+                   .errorContains("Ignored hosts should not be set if previous operation is resumed");
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "--cancel", "--ignore", broadcastAddress(cluster, 2))
+                   .asserts().failure()
+                   .errorContains("Ignored hosts should not be set when cancelling a reconfiguration");
+        }
+    }
+
+    @Test
     public void testReconfigurationViolatesRackDiversityIfNecessary() throws Exception
     {
         // rack1: node1, node3
@@ -344,5 +427,10 @@ public class ReconfigureCMSTest extends FuzzTestBase
         for (int id : instanceIds)
             expectedCMSMembers.add(cluster.get(id).config().broadcastAddress().getAddress().toString());
         return expectedCMSMembers;
+    }
+
+    private String broadcastAddress(Cluster cluster, int instanceId)
+    {
+        return cluster.get(instanceId).config().broadcastAddress().getAddress().getHostAddress();
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ReconfigureCMSTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ReconfigureCMSTest.java
@@ -276,6 +276,41 @@ public class ReconfigureCMSTest extends FuzzTestBase
     }
 
     @Test
+    public void testReconfigureIgnoreAcceptsCidrNotation() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(5)
+                                           .withConfig(conf -> conf.with(Feature.NETWORK, Feature.GOSSIP))
+                                           .start()))
+        {
+            // A /32 subnet matches exactly one host, so ignoring nodes 2 and 3 this way
+            // must produce the same placement (1, 4, 5) as ignoring them by address.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3",
+                                          "--ignore", broadcastAddress(cluster, 2) + "/32",
+                                          "--ignore", broadcastAddress(cluster, 3) + "/32")
+                   .asserts().success();
+
+            Set<String> expectedCMSMembers = expectedCMS(cluster, 1, 4, 5);
+            cluster.forEach(inst -> assertEquals(expectedCMSMembers, ClusterUtils.getCMSMembers(inst)));
+        }
+    }
+
+    @Test
+    public void testReconfigureIgnoreSkipsSubnetMatchingNoNode() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(conf -> conf.with(Feature.NETWORK, Feature.GOSSIP))
+                                           .start()))
+        {
+            // A valid subnet that covers none of the cluster's addresses is not an error: it matches nothing and is
+            // skipped, so the reconfiguration proceeds using every node. The cluster runs on 127.0.0.x, so a subnet in
+            // 127.0.1.x is guaranteed to match none of it.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3", "--ignore", "127.0.1.0/24")
+                   .asserts().success();
+            cluster.get(1).runOnInstance(() -> assertEquals(3, ClusterMetadata.current().fullCMSMembers().size()));
+        }
+    }
+
+    @Test
     public void testReconfigureIgnoreRejectsUnknownAndExcessiveHosts() throws Exception
     {
         try (Cluster cluster = init(Cluster.build(3)
@@ -296,6 +331,11 @@ public class ReconfigureCMSTest extends FuzzTestBase
                    .asserts().failure()
                    .errorContains("Unknown host in ignore list: 999.999.999.999");
 
+            // A CIDR with an out-of-range prefix length is rejected rather than silently matching nothing.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3", "--ignore", "127.0.0.0/33")
+                   .asserts().failure()
+                   .errorContains("Invalid CIDR in ignore list: 127.0.0.0/33");
+
             // Ignoring so many nodes that fewer than a quorum of the requested members can be placed is rejected.
             cluster.get(1).nodetoolResult("cms", "reconfigure", "3",
                                           "--ignore", broadcastAddress(cluster, 2),
@@ -309,6 +349,12 @@ public class ReconfigureCMSTest extends FuzzTestBase
                                           "--ignore", broadcastAddress(cluster, 1),
                                           "--ignore", broadcastAddress(cluster, 2),
                                           "--ignore", broadcastAddress(cluster, 3))
+                   .asserts().failure()
+                   .errorContains("Cannot reconfigure CMS as all joined nodes are DOWN or ignored");
+
+            // A subnet which covers every node is just another way of ignoring them all, and is rejected for the same
+            // reason. This also confirms a CIDR entry is matched against more than one node.
+            cluster.get(1).nodetoolResult("cms", "reconfigure", "3", "--ignore", "127.0.0.0/24")
                    .asserts().failure()
                    .errorContains("Cannot reconfigure CMS as all joined nodes are DOWN or ignored");
 

--- a/test/resources/nodetool/help/cms
+++ b/test/resources/nodetool/help/cms
@@ -22,8 +22,10 @@ SYNOPSIS
                 [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] cms reconfigure
-                [(-c | --cancel)] [(-r | --resume)] [--status] [--] [<replication
-                factor>] or <datacenter>:<replication_factor> ...
+                [(-c | --cancel)]
+                [(-i <ignored_endpoints> | --ignore <ignored_endpoints>)...]
+                [(-r | --resume)] [--status] [--] [<replication factor>] or
+                <datacenter>:<replication_factor> ...
 
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pw <password> | --password <password>)]
@@ -102,6 +104,11 @@ COMMANDS
             should be resumed
 
             With --cancel option, Cancels any in progress CMS reconfiguration
+
+            With --ignore option, Hosts to exclude from the new CMS, in addition to any
+            which are currently down. Useful before shrinking a cluster: excluding the
+            nodes which are about to be decommissioned keeps the CMS membership stable,
+            avoiding a reconfiguration per decommissioned member.
         snapshot
             Request a checkpointing snapshot of cluster metadata
         unregister

--- a/test/resources/nodetool/help/cms
+++ b/test/resources/nodetool/help/cms
@@ -23,7 +23,7 @@ SYNOPSIS
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] cms reconfigure
                 [(-c | --cancel)]
-                [(-i <ignored_endpoints> | --ignore <ignored_endpoints>)...]
+                [(-i <host_or_subnet> | --ignore <host_or_subnet>)...]
                 [(-r | --resume)] [--status] [--] [<replication factor>] or
                 <datacenter>:<replication_factor> ...
 
@@ -105,10 +105,11 @@ COMMANDS
 
             With --cancel option, Cancels any in progress CMS reconfiguration
 
-            With --ignore option, Hosts to exclude from the new CMS, in addition to any
-            which are currently down. Useful before shrinking a cluster: excluding the
-            nodes which are about to be decommissioned keeps the CMS membership stable,
-            avoiding a reconfiguration per decommissioned member.
+            With --ignore option, Hosts (IP or hostname) or CIDR subnets to exclude
+            from the new CMS, in addition to any which are currently down. Useful
+            before shrinking a cluster: excluding the nodes which are about to be
+            decommissioned keeps the CMS membership stable, avoiding a reconfiguration
+            per decommissioned member.
         snapshot
             Request a checkpointing snapshot of cluster metadata
         unregister

--- a/test/resources/nodetool/help/cms$reconfigure
+++ b/test/resources/nodetool/help/cms$reconfigure
@@ -7,7 +7,7 @@ SYNOPSIS
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] cms reconfigure
                 [(-c | --cancel)]
-                [(-i <ignored_endpoints> | --ignore <ignored_endpoints>)...]
+                [(-i <host_or_subnet> | --ignore <host_or_subnet>)...]
                 [(-r | --resume)] [--status] [--] [<replication factor>] or
                 <datacenter>:<replication_factor> ...
 
@@ -18,11 +18,12 @@ OPTIONS
         -h <host>, --host <host>
             Node hostname or ip address
 
-        -i <ignored_endpoints>, --ignore <ignored_endpoints>
-            Hosts to exclude from the new CMS, in addition to any which are
-            currently down. Useful before shrinking a cluster: excluding the
-            nodes which are about to be decommissioned keeps the CMS membership
-            stable, avoiding a reconfiguration per decommissioned member.
+        -i <host_or_subnet>, --ignore <host_or_subnet>
+            Hosts (IP or hostname) or CIDR subnets to exclude from the new CMS,
+            in addition to any which are currently down. Useful before
+            shrinking a cluster: excluding the nodes which are about to be
+            decommissioned keeps the CMS membership stable, avoiding a
+            reconfiguration per decommissioned member.
 
         -p <port>, --port <port>
             Remote jmx agent port number

--- a/test/resources/nodetool/help/cms$reconfigure
+++ b/test/resources/nodetool/help/cms$reconfigure
@@ -6,8 +6,10 @@ SYNOPSIS
                 [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] cms reconfigure
-                [(-c | --cancel)] [(-r | --resume)] [--status] [--] [<replication
-                factor>] or <datacenter>:<replication_factor> ...
+                [(-c | --cancel)]
+                [(-i <ignored_endpoints> | --ignore <ignored_endpoints>)...]
+                [(-r | --resume)] [--status] [--] [<replication factor>] or
+                <datacenter>:<replication_factor> ...
 
 OPTIONS
         -c, --cancel
@@ -15,6 +17,12 @@ OPTIONS
 
         -h <host>, --host <host>
             Node hostname or ip address
+
+        -i <ignored_endpoints>, --ignore <ignored_endpoints>
+            Hosts to exclude from the new CMS, in addition to any which are
+            currently down. Useful before shrinking a cluster: excluding the
+            nodes which are about to be decommissioned keeps the CMS membership
+            stable, avoiding a reconfiguration per decommissioned member.
 
         -p <port>, --port <port>
             Remote jmx agent port number

--- a/test/unit/org/apache/cassandra/tcm/ClusterMetadataServiceTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ClusterMetadataServiceTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.distributed.test.log.ClusterMetadataTestHelper;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.tcm.membership.Directory;
+import org.apache.cassandra.tcm.membership.Location;
+import org.apache.cassandra.tcm.membership.NodeAddresses;
+import org.apache.cassandra.tcm.membership.NodeId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ClusterMetadataService}.
+ */
+public class ClusterMetadataServiceTest
+{
+    private static final Location LOCATION = new Location("datacenter1", "rack1");
+
+    private static Set<NodeId> resolveIgnored(ClusterMetadata metadata, String... ignores)
+    {
+        return ClusterMetadataService.instance().resolveIgnoredEndpoints(metadata, Arrays.asList(ignores));
+    }
+
+    private static ClusterMetadata metadataWithNodes(int... lastOctets)
+    {
+        String[] addresses = new String[lastOctets.length];
+        for (int i = 0; i < lastOctets.length; i++)
+            addresses[i] = "127.0.0." + lastOctets[i];
+        return metadataWithAddresses(addresses);
+    }
+
+    private static ClusterMetadata metadataWithAddresses(String... addresses)
+    {
+        Directory directory = new Directory();
+        for (String address : addresses)
+            directory = directory.with(new NodeAddresses(InetAddressAndPort.getByNameUnchecked(address)), LOCATION);
+        return metadataWith(directory);
+    }
+
+    private static ClusterMetadata metadataWith(Directory directory)
+    {
+        return ClusterMetadataTestHelper.minimalForTesting(Murmur3Partitioner.instance)
+                                        .transformer().with(directory).build().metadata;
+    }
+
+    private static Set<NodeId> nodeIds(ClusterMetadata metadata, int... lastOctets)
+    {
+        String[] addresses = new String[lastOctets.length];
+        for (int i = 0; i < lastOctets.length; i++)
+            addresses[i] = "127.0.0." + lastOctets[i];
+        return nodeIdsFor(metadata, addresses);
+    }
+
+    private static Set<NodeId> nodeIdsFor(ClusterMetadata metadata, String... addresses)
+    {
+        Set<NodeId> ids = new HashSet<>();
+        for (String address : addresses)
+            ids.add(metadata.directory.peerId(InetAddressAndPort.getByNameUnchecked(address)));
+        return ids;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static InetAddressAndPort addr(int lastOctet)
+    {
+        return InetAddressAndPort.getByNameUnchecked("127.0.0." + lastOctet);
+    }
+
+    @Before
+    public void setup()
+    {
+        DatabaseDescriptor.toolInitialization();
+        ClusterMetadataService.initializeForTools(true);
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsReturnsNothingForEmptyList()
+    {
+        // No node is ignored, it should return empty set
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3);
+        assertThat(resolveIgnored(metadata)).isEmpty();
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsResolvesSingleAddress()
+    {
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3, 4, 5);
+        assertThat(resolveIgnored(metadata, "127.0.0.2")).isEqualTo(nodeIds(metadata, 2));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsResolvesMultipleAddresses()
+    {
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3, 4, 5);
+        assertThat(resolveIgnored(metadata, "127.0.0.2", "127.0.0.4")).isEqualTo(nodeIds(metadata, 2, 4));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsResolvesHostnameViaDns() throws UnknownHostException
+    {
+        // Whatever localhost resolves to is registered as a node, so ignoring "localhost" must map to that node. This
+        // exercises the name-resolution path without assuming localhost is 127.0.0.1 (it might be IPv6 on some hosts).
+        InetAddressAndPort local = InetAddressAndPort.getByName("localhost");
+        Directory directory = new Directory().with(new NodeAddresses(local), LOCATION)
+                                             .with(new NodeAddresses(addr(2)), LOCATION);
+        ClusterMetadata metadata = metadataWith(directory);
+
+        assertThat(resolveIgnored(metadata, "localhost")).isEqualTo(Collections.singleton(metadata.directory.peerId(local)));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsRejectsAddressNotInCluster()
+    {
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3);
+        assertThatThrownBy(() -> resolveIgnored(metadata, "127.0.0.99"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("don't exist in the cluster")
+        .hasMessageContaining("127.0.0.99");
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsRejectsUnresolvableHost()
+    {
+        // .invalid is reserved to never resolve (RFC 6761), so getByName is guaranteed to throw.
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3);
+        assertThatThrownBy(() -> resolveIgnored(metadata, "no-such-host.invalid"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown host in ignore list: no-such-host.invalid");
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsMatchesSingleNodeForSlash32Cidr()
+    {
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3, 4, 5);
+        assertThat(resolveIgnored(metadata, "127.0.0.3/32")).isEqualTo(nodeIds(metadata, 3));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsMatchesEveryNodeInSubnet()
+    {
+        // 127.0.0.0/30 covers 127.0.0.0 - 127.0.0.3, so it matches nodes .1, .2 and .3 but not .4 or .5.
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3, 4, 5);
+        assertThat(resolveIgnored(metadata, "127.0.0.0/30")).isEqualTo(nodeIds(metadata, 1, 2, 3));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsSkipsSubnetMatchingNoNode()
+    {
+        // A valid subnet which covers none of the cluster's addresses is not an error: it simply matches nothing.
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3);
+        assertThat(resolveIgnored(metadata, "127.0.1.0/24")).isEmpty();
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsRejectsInvalidCidr()
+    {
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3);
+        assertThatThrownBy(() -> resolveIgnored(metadata, "127.0.0.0/33"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid CIDR in ignore list: 127.0.0.0/33");
+
+        // should throw exception when malformed CIDR is passed
+        assertThatThrownBy(() -> resolveIgnored(metadata, "127.0.0.0/"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid CIDR in ignore list: 127.0.0.0/");
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsCombinesAndDeduplicatesAddressesAndCidrs()
+    {
+        // .4 given explicitly, the /30 covering .1, .2 and .3, and a /32 that overlaps .2 again: the result is their
+        // union with no duplicates.
+        ClusterMetadata metadata = metadataWithNodes(1, 2, 3, 4, 5);
+        assertThat(resolveIgnored(metadata, "127.0.0.4", "127.0.0.0/30", "127.0.0.2/32"))
+        .isEqualTo(nodeIds(metadata, 1, 2, 3, 4));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsResolvesIpv6Address()
+    {
+        ClusterMetadata metadata = metadataWithAddresses("fe80::1", "fe80::2", "fe80::3");
+        assertThat(resolveIgnored(metadata, "fe80::2")).isEqualTo(nodeIdsFor(metadata, "fe80::2"));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsMatchesIpv6Cidr()
+    {
+        // fe80::/126 covers fe80::0 - fe80::3, so it matches nodes ::1, ::2 and ::3 but not ::10.
+        ClusterMetadata metadata = metadataWithAddresses("fe80::1", "fe80::2", "fe80::3", "fe80::10");
+        assertThat(resolveIgnored(metadata, "fe80::/126")).isEqualTo(nodeIdsFor(metadata, "fe80::1", "fe80::2", "fe80::3"));
+    }
+
+    @Test
+    public void testResolveIgnoredEndpointsMatchesOnlyIpv6NodesForIpv6Cidr()
+    {
+        // In a mixed cluster an IPv6 subnet must match only the IPv6 nodes, leaving the IPv4 node untouched.
+        ClusterMetadata metadata = metadataWithAddresses("127.0.0.1", "fe80::1", "fe80::2");
+        assertThat(resolveIgnored(metadata, "fe80::/64")).isEqualTo(nodeIdsFor(metadata, "fe80::1", "fe80::2"));
+    }
+}


### PR DESCRIPTION
#### (Same as #5084 , but for cassandra-6.0 branch)
----

Add a `--ignore` option to `nodetool cms reconfigure`. Hosts given to it are excluded from the new CMS, on top of any nodes that are already down.

This helps when shrinking a cluster. Today, decommissioning a CMS member hands that role to another node which may itself be due for decommission, so the CMS has to be reconfigured again and again. Excluding the departing nodes up front keeps CMS membership stable for the whole shrink, because decommissioning a node that is not a CMS member does not trigger a reconfiguration.

The ignore list applies to that one command only. It is not stored, so cms describe still reports whether the CMS matches the nodes currently in the cluster.

patch by nvharikrishna; reviewed by  <Reviewers> for CASSANDRA-21627

[CASSANDRA-21627](https://issues.apache.org/jira/browse/CASSANDRA-21627)