### PR TITLE
CASSANDRA-21632: Support bounding the BTI partition index preload

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.10
+ * Support bounding the BTI partition index preload (CASSANDRA-21632)
  * Force repair should ignore min_repair_interval (CASSANDRA-21552)
  * Render SubnetGroups as JSON in system_views.settings (CASSANDRA-21579)
  * Avoid rebuilding per-SSTable SAI components unless missing or corrupted (CASSANDRA-21515)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -74,6 +74,8 @@ public enum CassandraRelevantProperties
      */
     BOOTSTRAP_SKIP_SCHEMA_CHECK("cassandra.skip_schema_check"),
     BROADCAST_INTERVAL_MS("cassandra.broadcast_interval_ms", "60000"),
+    /** Caps how much of a BTI partition index is preloaded, e.g. "16MiB". 0B disables preloading; negative (default) preloads it all. */
+    BTI_PARTITION_INDEX_PRELOAD_SIZE("cassandra.bti.partition_index_preload_size", "-1B"),
     BTREE_BRANCH_SHIFT("cassandra.btree.branchshift", "5"),
     BTREE_FAN_FACTOR("cassandra.btree.fanfactor"),
     /** Represents the maximum size (in bytes) of a serialized mutation that can be cached **/

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.IPartitioner;
@@ -196,19 +197,42 @@ public class PartitionIndex implements SharedCloseable
             DecoratedKey first = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             DecoratedKey last = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             if (preload)
-            {
-                int csum = 0;
-                // force a read of all the pages of the index
-                for (long pos = 0; pos < fh.dataLength(); pos += PageAware.PAGE_SIZE)
-                {
-                    rdr.seek(pos);
-                    csum += rdr.readByte();
-                }
-                logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
-            }
+                warmIndex(fh, rdr, firstPos);
 
             return new PartitionIndex(fh, root, keyCount, first, last);
         }
+    }
+
+    /**
+     * Warms the partition index so trie lookups don't each fault it in. When bounded, warms the
+     * trie's tail, since the trie is written bottom-up and every lookup traverses the upper levels
+     * that end up there. The bound is relative to {@code firstPos} (the trie's end), not the file's
+     * end, since the file tail past it isn't trie data.
+     *
+     * @param firstPos offset where the trie ends and the first/last key data begins
+     * @return size of the range warmed, in bytes
+     * @see CassandraRelevantProperties#BTI_PARTITION_INDEX_PRELOAD_SIZE
+     */
+    @VisibleForTesting
+    static long warmIndex(FileHandle fh, FileDataInput rdr, long firstPos) throws IOException
+    {
+        long limit = CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE.getSizeInBytes();
+        if (limit == 0)
+        {
+            logger.trace("Partition index warming is disabled, not warming {}", fh.path());
+            return 0;
+        }
+
+        long start = limit > 0 && limit < firstPos ? PageAware.pageStart(firstPos - limit) : 0;
+
+        int csum = 0;
+        for (long pos = start; pos < firstPos; pos += PageAware.PAGE_SIZE)
+        {
+            rdr.seek(pos);
+            csum += rdr.readByte();
+        }
+        logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
+        return firstPos - start;
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -53,9 +53,11 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.tries.TrieNode;
 import org.apache.cassandra.io.tries.Walker;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PageAware;
@@ -67,6 +69,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -126,6 +129,85 @@ public class PartitionIndexTest
     {
         testGetEq(generateRandomIndex(COUNT));
         testGetEq(generateSequentialIndex(COUNT));
+    }
+
+    @Test
+    public void testWarmIndexHonoursPreloadSize() throws IOException
+    {
+        Pair<List<DecoratedKey>, PartitionIndex> data = generateRandomIndex(COUNT);
+        try (PartitionIndex index = data.right)
+        {
+            FileHandle fh = index.getFileHandle();
+            long firstPos;
+            try (FileDataInput rdr = fh.createReader(fh.dataLength() - PartitionIndex.FOOTER_LENGTH))
+            {
+                firstPos = rdr.readLong();
+            }
+            assertTrue("Generated index is too small to bound: " + firstPos, firstPos > 2 * PageAware.PAGE_SIZE);
+
+            // the default warms the whole trie
+            assertEquals(firstPos, warmedBytes(fh, firstPos));
+
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "-1B"))
+            {
+                assertEquals(firstPos, warmedBytes(fh, firstPos));
+            }
+
+            // a bound at or above the trie length also warms the whole trie
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos + 1) + "B"))
+            {
+                assertEquals(firstPos, warmedBytes(fh, firstPos));
+            }
+
+            // a bound below the trie length warms that much of the tail, rounded up to a page boundary
+            // so that the start of the warmed range always aligns with the real page grid
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos / 2) + "B"))
+            {
+                long expected = firstPos - PageAware.pageStart(firstPos - firstPos / 2);
+                assertEquals(expected, warmedBytes(fh, firstPos));
+                assertTrue("warmed size should cover at least the requested bound", expected >= firstPos / 2);
+            }
+
+            // 0B disables warming entirely
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "0B"))
+            {
+                assertEquals(0, warmedBytes(fh, firstPos));
+            }
+        }
+    }
+
+    private long warmedBytes(FileHandle fh, long firstPos) throws IOException
+    {
+        try (FileDataInput rdr = fh.createReader(0))
+        {
+            return PartitionIndex.warmIndex(fh, rdr, firstPos);
+        }
+    }
+
+    @Test
+    public void testWarmIndexAlwaysCoversFinalPage() throws IOException
+    {
+        File file = FileUtils.createTempFile("PartitionIndexWarmTest", "");
+        int length = 2 * PageAware.PAGE_SIZE + 1; // deliberately not a multiple of PAGE_SIZE
+        FileHandle.Builder fhBuilder = makeHandle(file);
+        try (SequentialWriter writer = new SequentialWriter(file, SequentialWriterOption.newBuilder().finishOnClose(true).build()))
+        {
+            writer.write(new byte[length]);
+        }
+
+        try (FileHandle fh = fhBuilder.complete())
+        {
+            // limit chosen so that start = length - limit == 1: unaligned to a page boundary
+            long limit = length - 1;
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, limit + "B");
+                 FileDataInput rdr = fh.createReader(0))
+            {
+                long warmed = PartitionIndex.warmIndex(fh, rdr, length);
+                long start = length - warmed;
+                assertEquals("start of the warmed range must be page-aligned, or the final page can be skipped",
+                             0, start % PageAware.PAGE_SIZE);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Startup takes 90 minutes on my 5TB nodes with high partitions count.

Opening a BTI SSTable whose bloom filter is uninformative (bloom_filter_fp_chance = 1) warms the whole Partitions.db, one byte per page through a reader that follows disk_access_mode. That costs one pread or one readahead-bounded page fault per page: on a 309 GiB index, 81.1M reads. 90 minutes of startup time on my machine. It also warms far more than the available page cache can hold.

Add cassandra.bti.partition_index_preload_size to bound how much is warmed. The tail is warmed because the trie is written bottom-up, so the upper levels traversed by every lookup are at the end of the file, while the bulk at the front is leaf pages that a lookup reads one of.

The property takes a human-readable size, e.g. 512MiB:
- 0B skips warming entirely, which was not previously possible: preload is enabled whenever the bloom filter is uninformative, so the only way to avoid it was to lower bloom_filter_fp_chance below 1.0.
- A negative value warms the whole index and is the default, so behaviour is unchanged unless the property is set.

Assisted-by: Claude Code:claude-opus-5

patch by Alexandre Viau; reviewed by TBD for CASSANDRA-21632

Note that I kept the change minimal to increase the chances of it getting merged. However, I think we could consider using a saner default for `cassandra.bti.partition_index_preload_size`. Feel free to set another default when merging if you want.

I also opened a follow-up PR here https://github.com/apache/cassandra/pull/5089 which changes the warmup so that it uses chunked reading.