### PR TITLE
CASSANDRA-21634 During major upgrade, if a node has replacement arguments it  attempt…

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -819,7 +819,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             BootstrapAndReplace.checkUnsafeReplace(shouldBootstrap());
         }
 
-        if (isReplacingSameAddress())
+        if (isReplacing() && isReplacingSameAddress())
         {
             BootstrapAndReplace.gossipStateToHibernate(ClusterMetadata.current(), ClusterMetadata.currentNullable().myNodeId());
             Gossiper.instance.start(SystemKeyspace.incrementAndGetGeneration(), false);

--- a/src/java/org/apache/cassandra/tcm/Startup.java
+++ b/src/java/org/apache/cassandra/tcm/Startup.java
@@ -681,7 +681,7 @@ import static org.apache.cassandra.utils.FBUtilities.getBroadcastAddressAndPort;
                     break;
                 }
             case JOINED:
-                if (StorageService.isReplacingSameAddress())
+                if (StorageService.instance.isReplacing() && StorageService.isReplacingSameAddress())
                 {
                     if (DatabaseDescriptor.getAccordTransactionsEnabled())
                     {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/ClusterMetadataUpgradeReplaceTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/ClusterMetadataUpgradeReplaceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.upgrade;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.distributed.Constants;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.shared.Versions;
+import org.apache.cassandra.distributed.shared.WithProperties;
+
+public class ClusterMetadataUpgradeReplaceTest extends UpgradeTestBase
+{
+    @Test
+    public void upgradeReplaceFirstBootTest() throws Throwable
+    {
+        new TestCase()
+        .nodes(3)
+        .nodesToUpgrade(1, 2)
+        .withConfig((cfg) -> cfg.with(Feature.NETWORK, Feature.GOSSIP)
+                                .set(Constants.KEY_DTEST_FULL_STARTUP, true))
+        .upgradesToCurrentFrom(v50)
+        .setup((cluster) -> {
+            cluster.schemaChange(withKeyspace("ALTER KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor':2}"));
+            cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        })
+        .runAfterClusterUpgrade((cluster) -> {
+            cluster.get(3).shutdown().get();
+            cluster.get(3).setVersion(Versions.find().getLatest(CURRENT));
+            String address = cluster.get(3).config().getString("broadcast_address");
+            try (WithProperties x = new WithProperties().set(CassandraRelevantProperties.REPLACE_ADDRESS_FIRST_BOOT, address))
+            {
+                cluster.get(3).startup();
+            }
+
+            cluster.get(1).nodetoolResult("cms", "initialize").asserts().success();
+        }).run();
+    }
+}


### PR DESCRIPTION
…s to bootstrap even if already bootstrapped, leaving itself in a hibernate state

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

