### PR TITLE
CASSANDRA-21632: Read the BTI partition index preload in chunks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.10
+ * Support bounding the BTI partition index preload (CASSANDRA-21632)
  * Force repair should ignore min_repair_interval (CASSANDRA-21552)
  * Render SubnetGroups as JSON in system_views.settings (CASSANDRA-21579)
  * Avoid rebuilding per-SSTable SAI components unless missing or corrupted (CASSANDRA-21515)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -74,6 +74,8 @@ public enum CassandraRelevantProperties
      */
     BOOTSTRAP_SKIP_SCHEMA_CHECK("cassandra.skip_schema_check"),
     BROADCAST_INTERVAL_MS("cassandra.broadcast_interval_ms", "60000"),
+    /** Caps how much of a BTI partition index is preloaded, e.g. "16MiB". 0B disables preloading; negative (default) preloads it all. */
+    BTI_PARTITION_INDEX_PRELOAD_SIZE("cassandra.bti.partition_index_preload_size", "-1B"),
     BTREE_BRANCH_SHIFT("cassandra.btree.branchshift", "5"),
     BTREE_FAN_FACTOR("cassandra.btree.fanfactor"),
     /** Represents the maximum size (in bytes) of a serialized mutation that can be cached **/

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.IPartitioner;
@@ -196,19 +197,42 @@ public class PartitionIndex implements SharedCloseable
             DecoratedKey first = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             DecoratedKey last = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             if (preload)
-            {
-                int csum = 0;
-                // force a read of all the pages of the index
-                for (long pos = 0; pos < fh.dataLength(); pos += PageAware.PAGE_SIZE)
-                {
-                    rdr.seek(pos);
-                    csum += rdr.readByte();
-                }
-                logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
-            }
+                warmIndex(fh, rdr, firstPos);
 
             return new PartitionIndex(fh, root, keyCount, first, last);
         }
+    }
+
+    /**
+     * Warms the partition index so trie lookups don't each fault it in. When bounded, warms the
+     * trie's tail, since the trie is written bottom-up and every lookup traverses the upper levels
+     * that end up there. The bound is relative to {@code firstPos} (the trie's end), not the file's
+     * end, since the file tail past it isn't trie data.
+     *
+     * @param firstPos offset where the trie ends and the first/last key data begins
+     * @return size of the range warmed, in bytes
+     * @see CassandraRelevantProperties#BTI_PARTITION_INDEX_PRELOAD_SIZE
+     */
+    @VisibleForTesting
+    static long warmIndex(FileHandle fh, FileDataInput rdr, long firstPos) throws IOException
+    {
+        long limit = CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE.getSizeInBytes();
+        if (limit == 0)
+        {
+            logger.trace("Partition index warming is disabled, not warming {}", fh.path());
+            return 0;
+        }
+
+        long start = limit > 0 && limit < firstPos ? PageAware.pageStart(firstPos - limit) : 0;
+
+        int csum = 0;
+        for (long pos = start; pos < firstPos; pos += PageAware.PAGE_SIZE)
+        {
+            rdr.seek(pos);
+            csum += rdr.readByte();
+        }
+        logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
+        return firstPos - start;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.io.sstable.format.bti;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
@@ -38,7 +39,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
-import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.SizedInts;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -78,6 +79,13 @@ public class PartitionIndex implements SharedCloseable
     public static final long NOT_FOUND = Long.MIN_VALUE;
     public static final int FOOTER_LENGTH = 3 * 8;
     private static final int FLAG_HAS_HASH_BYTE = 8;
+
+    /**
+     * Chunk size used to warm the partition index in {@link #warmIndex}. Large enough that reads are
+     * device-bound rather than bounded by per-request overhead, small enough to be a negligible
+     * transient allocation per opening thread.
+     */
+    private static final int PRELOAD_CHUNK_SIZE = (int) FileUtils.ONE_MIB;
 
     @VisibleForTesting
     public PartitionIndex(FileHandle fh, long trieRoot, long keyCount, DecoratedKey first, DecoratedKey last)
@@ -197,24 +205,30 @@ public class PartitionIndex implements SharedCloseable
             DecoratedKey first = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             DecoratedKey last = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             if (preload)
-                warmIndex(fh, rdr, firstPos);
+                warmIndex(fh, firstPos);
 
             return new PartitionIndex(fh, root, keyCount, first, last);
         }
     }
 
     /**
-     * Warms the partition index so trie lookups don't each fault it in. When bounded, warms the
-     * trie's tail, since the trie is written bottom-up and every lookup traverses the upper levels
-     * that end up there. The bound is relative to {@code firstPos} (the trie's end), not the file's
-     * end, since the file tail past it isn't trie data.
+     * Warms the partition index so trie lookups don't each fault it in.
+     *
+     * Chunked positioned reads on the channel, not one byte per page through a {@link FileDataInput},
+     * which follows {@code disk_access_mode} and so costs a pread or a page fault per page. A
+     * positioned read is unaffected by access mode, and page cache is shared between the buffered and
+     * mapped views of a file, so a mapped lookup afterwards still finds the data resident.
+     *
+     * When bounded, warms the trie's tail, since the trie is written bottom-up and every lookup
+     * traverses the upper levels that end up there. The bound is relative to {@code firstPos} (the
+     * trie's end), not the file's end, since the file tail past it isn't trie data.
      *
      * @param firstPos offset where the trie ends and the first/last key data begins
-     * @return size of the range warmed, in bytes
+     * @return the number of bytes read
      * @see CassandraRelevantProperties#BTI_PARTITION_INDEX_PRELOAD_SIZE
      */
     @VisibleForTesting
-    static long warmIndex(FileHandle fh, FileDataInput rdr, long firstPos) throws IOException
+    static long warmIndex(FileHandle fh, long firstPos) throws EOFException
     {
         long limit = CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE.getSizeInBytes();
         if (limit == 0)
@@ -223,16 +237,33 @@ public class PartitionIndex implements SharedCloseable
             return 0;
         }
 
-        long start = limit > 0 && limit < firstPos ? PageAware.pageStart(firstPos - limit) : 0;
+        if (firstPos <= 0)
+            return 0;
 
-        int csum = 0;
-        for (long pos = start; pos < firstPos; pos += PageAware.PAGE_SIZE)
+        long start = limit > 0 && limit < firstPos ? firstPos - limit : 0;
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect((int) Math.min(PRELOAD_CHUNK_SIZE, firstPos - start));
+        try
         {
-            rdr.seek(pos);
-            csum += rdr.readByte();
+            long pos = start;
+            while (pos < firstPos)
+            {
+                buffer.clear();
+                buffer.limit((int) Math.min(buffer.capacity(), firstPos - pos));
+
+                // ChannelProxy.read may return a short read; advance by what was actually read.
+                int read = fh.channel.read(buffer, pos);
+                if (read < 0)
+                    throw new EOFException("Failed to read " + fh.path() + " at position " + pos);
+
+                pos += read;
+            }
+            return pos - start;
         }
-        logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
-        return firstPos - start;
+        finally
+        {
+            FileUtils.clean(buffer);
+        }
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -53,9 +53,11 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.tries.TrieNode;
 import org.apache.cassandra.io.tries.Walker;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PageAware;
@@ -67,6 +69,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -126,6 +129,85 @@ public class PartitionIndexTest
     {
         testGetEq(generateRandomIndex(COUNT));
         testGetEq(generateSequentialIndex(COUNT));
+    }
+
+    @Test
+    public void testWarmIndexHonoursPreloadSize() throws IOException
+    {
+        Pair<List<DecoratedKey>, PartitionIndex> data = generateRandomIndex(COUNT);
+        try (PartitionIndex index = data.right)
+        {
+            FileHandle fh = index.getFileHandle();
+            long firstPos;
+            try (FileDataInput rdr = fh.createReader(fh.dataLength() - PartitionIndex.FOOTER_LENGTH))
+            {
+                firstPos = rdr.readLong();
+            }
+            assertTrue("Generated index is too small to bound: " + firstPos, firstPos > 2 * PageAware.PAGE_SIZE);
+
+            // the default warms the whole trie
+            assertEquals(firstPos, warmedBytes(fh, firstPos));
+
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "-1B"))
+            {
+                assertEquals(firstPos, warmedBytes(fh, firstPos));
+            }
+
+            // a bound at or above the trie length also warms the whole trie
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos + 1) + "B"))
+            {
+                assertEquals(firstPos, warmedBytes(fh, firstPos));
+            }
+
+            // a bound below the trie length warms that much of the tail, rounded up to a page boundary
+            // so that the start of the warmed range always aligns with the real page grid
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos / 2) + "B"))
+            {
+                long expected = firstPos - PageAware.pageStart(firstPos - firstPos / 2);
+                assertEquals(expected, warmedBytes(fh, firstPos));
+                assertTrue("warmed size should cover at least the requested bound", expected >= firstPos / 2);
+            }
+
+            // 0B disables warming entirely
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "0B"))
+            {
+                assertEquals(0, warmedBytes(fh, firstPos));
+            }
+        }
+    }
+
+    private long warmedBytes(FileHandle fh, long firstPos) throws IOException
+    {
+        try (FileDataInput rdr = fh.createReader(0))
+        {
+            return PartitionIndex.warmIndex(fh, rdr, firstPos);
+        }
+    }
+
+    @Test
+    public void testWarmIndexAlwaysCoversFinalPage() throws IOException
+    {
+        File file = FileUtils.createTempFile("PartitionIndexWarmTest", "");
+        int length = 2 * PageAware.PAGE_SIZE + 1; // deliberately not a multiple of PAGE_SIZE
+        FileHandle.Builder fhBuilder = makeHandle(file);
+        try (SequentialWriter writer = new SequentialWriter(file, SequentialWriterOption.newBuilder().finishOnClose(true).build()))
+        {
+            writer.write(new byte[length]);
+        }
+
+        try (FileHandle fh = fhBuilder.complete())
+        {
+            // limit chosen so that start = length - limit == 1: unaligned to a page boundary
+            long limit = length - 1;
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, limit + "B");
+                 FileDataInput rdr = fh.createReader(0))
+            {
+                long warmed = PartitionIndex.warmIndex(fh, rdr, length);
+                long start = length - warmed;
+                assertEquals("start of the warmed range must be page-aligned, or the final page can be skipped",
+                             0, start % PageAware.PAGE_SIZE);
+            }
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -146,66 +146,29 @@ public class PartitionIndexTest
             assertTrue("Generated index is too small to bound: " + firstPos, firstPos > 2 * PageAware.PAGE_SIZE);
 
             // the default warms the whole trie
-            assertEquals(firstPos, warmedBytes(fh, firstPos));
+            assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
 
             try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "-1B"))
             {
-                assertEquals(firstPos, warmedBytes(fh, firstPos));
+                assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
             }
 
             // a bound at or above the trie length also warms the whole trie
             try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos + 1) + "B"))
             {
-                assertEquals(firstPos, warmedBytes(fh, firstPos));
+                assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
             }
 
-            // a bound below the trie length warms that much of the tail, rounded up to a page boundary
-            // so that the start of the warmed range always aligns with the real page grid
+            // a bound below the trie length warms exactly that much of the tail
             try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos / 2) + "B"))
             {
-                long expected = firstPos - PageAware.pageStart(firstPos - firstPos / 2);
-                assertEquals(expected, warmedBytes(fh, firstPos));
-                assertTrue("warmed size should cover at least the requested bound", expected >= firstPos / 2);
+                assertEquals(firstPos / 2, PartitionIndex.warmIndex(fh, firstPos));
             }
 
             // 0B disables warming entirely
             try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "0B"))
             {
-                assertEquals(0, warmedBytes(fh, firstPos));
-            }
-        }
-    }
-
-    private long warmedBytes(FileHandle fh, long firstPos) throws IOException
-    {
-        try (FileDataInput rdr = fh.createReader(0))
-        {
-            return PartitionIndex.warmIndex(fh, rdr, firstPos);
-        }
-    }
-
-    @Test
-    public void testWarmIndexAlwaysCoversFinalPage() throws IOException
-    {
-        File file = FileUtils.createTempFile("PartitionIndexWarmTest", "");
-        int length = 2 * PageAware.PAGE_SIZE + 1; // deliberately not a multiple of PAGE_SIZE
-        FileHandle.Builder fhBuilder = makeHandle(file);
-        try (SequentialWriter writer = new SequentialWriter(file, SequentialWriterOption.newBuilder().finishOnClose(true).build()))
-        {
-            writer.write(new byte[length]);
-        }
-
-        try (FileHandle fh = fhBuilder.complete())
-        {
-            // limit chosen so that start = length - limit == 1: unaligned to a page boundary
-            long limit = length - 1;
-            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, limit + "B");
-                 FileDataInput rdr = fh.createReader(0))
-            {
-                long warmed = PartitionIndex.warmIndex(fh, rdr, length);
-                long start = length - warmed;
-                assertEquals("start of the warmed range must be page-aligned, or the final page can be skipped",
-                             0, start % PageAware.PAGE_SIZE);
+                assertEquals(0, PartitionIndex.warmIndex(fh, firstPos));
             }
         }
     }


### PR DESCRIPTION
**Meta**

- Optional improvement to be merged on top of https://github.com/apache/cassandra/pull/5086.
- Same patch for `cassandra-6.0`: https://github.com/apache/cassandra/pull/5091.
- Same patch for `trunk`: https://github.com/apache/cassandra/pull/5092.

**Description**

Bounding the preload makes startup survivable, but touching one byte per page is still a slow way to warm a range: one pread or one page fault per page, 81.1M reads on my 309 GiB index. Reading in 1 MiB positioned reads on the channel gets the same pages resident at device bandwidth instead. Positioned reads are unaffected by disk_access_mode, and page cache is shared between the buffered and mapped views of a file, so a mapped lookup still finds the data resident.

This matters most when the warm is large, which is to say at the default (whole index) or at a large bound. With a small bound the walk is already cheap and this buys little.

Trade-offs:
- The whole range is copied into userspace rather than one byte per page. The kernel reads the same pages either way, so this costs memory bandwidth, not I/O.
- Under a mapped access mode the walk also populated the process page table entries. Channel reads leave a minor fault per page to the first lookup that touches it. No I/O is involved, but it is not nothing.
- It allocates a 1 MiB direct buffer per opening thread, freed explicitly with FileUtils.clean rather than at GC.
- Under disk_access_mode: standard the warm no longer populates the chunk cache, nor evicts it. Lookups fill it on first touch instead. Under the default mmap_index_only the partition index was never in the chunk cache to begin with.

Assisted-by: Claude Code:claude-opus-5

patch by Alexandre Viau; reviewed by TBD for CASSANDRA-21632