### PR TITLE
CASSANDRA-21632: Bound and chunk the BTI partition index preload (for 6.0)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Bound and chunk the BTI partition index preload (CASSANDRA-21632)
  * Encode the CQL as raw bytes to avoid utf string serialization length limitation (CASSANDRA-21599)
  * Add a guardrail to disallow reconfiguring CMS below a minimum size (CASSANDRA-19195)
  * Node can report DECOMMISSION_FAILED while actively leaving after a rejected decommission attempt (CASSANDRA-21583)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -90,6 +90,8 @@ public enum CassandraRelevantProperties
      */
     BOOTSTRAP_SKIP_SCHEMA_CHECK("cassandra.skip_schema_check"),
     BROADCAST_INTERVAL_MS("cassandra.broadcast_interval_ms", "60000"),
+    /** Caps how much of a BTI partition index is preloaded, e.g. "16MiB". 0B disables preloading; negative (default) preloads it all. */
+    BTI_PARTITION_INDEX_PRELOAD_SIZE("cassandra.bti.partition_index_preload_size", "-1B"),
     BTREE_BRANCH_SHIFT("cassandra.btree.branchshift", "5"),
     BTREE_FAN_FACTOR("cassandra.btree.fanfactor"),
     BUILD_DATE("cassandra.buildDate"),

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.io.sstable.format.bti;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
@@ -26,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.IPartitioner;
@@ -38,7 +40,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
-import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.SizedInts;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -46,6 +48,7 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.SharedCloseable;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 /**
  * This class holds the partition index as an on-disk trie mapping unique prefixes of decorated keys to:
@@ -78,6 +81,13 @@ public class PartitionIndex implements SharedCloseable
     public static final long NOT_FOUND = Long.MIN_VALUE;
     public static final int FOOTER_LENGTH = 3 * 8;
     private static final int FLAG_HAS_HASH_BYTE = 8;
+
+    /**
+     * Chunk size used to warm the partition index in {@link #warmIndex}. Large enough that reads are
+     * device-bound rather than bounded by per-request overhead, small enough to be a negligible
+     * transient allocation per opening thread.
+     */
+    private static final int PRELOAD_CHUNK_SIZE = (int) FileUtils.ONE_MIB;
 
     @VisibleForTesting
     public PartitionIndex(FileHandle fh, long trieRoot, long keyCount, DecoratedKey first, DecoratedKey last)
@@ -197,18 +207,64 @@ public class PartitionIndex implements SharedCloseable
             DecoratedKey first = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             DecoratedKey last = partitioner != null ? partitioner.decorateKey(ByteBufferUtil.readWithShortLength(rdr)) : null;
             if (preload)
-            {
-                int csum = 0;
-                // force a read of all the pages of the index
-                for (long pos = 0; pos < fh.dataLength(); pos += PageAware.PAGE_SIZE)
-                {
-                    rdr.seek(pos);
-                    csum += rdr.readByte();
-                }
-                logger.trace("Checksum {}", csum);      // Note: trace is required so that reads aren't optimized away.
-            }
+                warmIndex(fh, firstPos);
 
             return new PartitionIndex(fh, root, keyCount, first, last);
+        }
+    }
+
+    /**
+     * Warms the partition index so trie lookups don't each fault it in.
+     *
+     * Chunked positioned reads on the channel, not one byte per page through a {@link FileDataInput},
+     * which follows {@code disk_access_mode} and so costs a pread or a page fault per page. A
+     * positioned read is unaffected by access mode, and page cache is shared between the buffered and
+     * mapped views of a file, so a mapped lookup afterwards still finds the data resident.
+     *
+     * When bounded, warms the trie's tail, since the trie is written bottom-up and every lookup
+     * traverses the upper levels that end up there. The bound is relative to {@code firstPos} (the
+     * trie's end), not the file's end, since the file tail past it isn't trie data.
+     *
+     * @param firstPos offset where the trie ends and the first/last key data begins
+     * @return the number of bytes read
+     * @see CassandraRelevantProperties#BTI_PARTITION_INDEX_PRELOAD_SIZE
+     */
+    @VisibleForTesting
+    static long warmIndex(FileHandle fh, long firstPos) throws EOFException
+    {
+        long limit = CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE.getSizeInBytes();
+        if (limit == 0)
+        {
+            logger.trace("Partition index warming is disabled, not warming {}", fh.path());
+            return 0;
+        }
+
+        if (firstPos <= 0)
+            return 0;
+
+        long start = limit > 0 && limit < firstPos ? firstPos - limit : 0;
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect((int) Math.min(PRELOAD_CHUNK_SIZE, firstPos - start));
+        try
+        {
+            long pos = start;
+            while (pos < firstPos)
+            {
+                buffer.clear();
+                buffer.limit((int) Math.min(buffer.capacity(), firstPos - pos));
+
+                // ChannelProxy.read may return a short read; advance by what was actually read.
+                int read = fh.channel.read(buffer, pos);
+                if (read < 0)
+                    throw new EOFException("Failed to read " + fh.path() + " at position " + pos);
+
+                pos += read;
+            }
+            return pos - start;
+        }
+        finally
+        {
+            MemoryUtil.clean(buffer);
         }
     }
 

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -54,9 +54,11 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.tries.TrieNode;
 import org.apache.cassandra.io.tries.Walker;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PageAware;
@@ -68,6 +70,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.BTI_PARTITION_INDEX_PRELOAD_SIZE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -127,6 +130,48 @@ public class PartitionIndexTest
     {
         testGetEq(generateRandomIndex(COUNT));
         testGetEq(generateSequentialIndex(COUNT));
+    }
+
+    @Test
+    public void testWarmIndexHonoursPreloadSize() throws IOException
+    {
+        Pair<List<DecoratedKey>, PartitionIndex> data = generateRandomIndex(COUNT);
+        try (PartitionIndex index = data.right)
+        {
+            FileHandle fh = index.getFileHandle();
+            long firstPos;
+            try (FileDataInput rdr = fh.createReader(fh.dataLength() - PartitionIndex.FOOTER_LENGTH))
+            {
+                firstPos = rdr.readLong();
+            }
+            assertTrue("Generated index is too small to bound: " + firstPos, firstPos > 2 * PageAware.PAGE_SIZE);
+
+            // the default warms the whole trie
+            assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
+
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "-1B"))
+            {
+                assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
+            }
+
+            // a bound at or above the trie length also warms the whole trie
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos + 1) + "B"))
+            {
+                assertEquals(firstPos, PartitionIndex.warmIndex(fh, firstPos));
+            }
+
+            // a bound below the trie length warms exactly that much of the tail
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, (firstPos / 2) + "B"))
+            {
+                assertEquals(firstPos / 2, PartitionIndex.warmIndex(fh, firstPos));
+            }
+
+            // 0B disables warming entirely
+            try (WithProperties ignored = new WithProperties().set(BTI_PARTITION_INDEX_PRELOAD_SIZE, "0B"))
+            {
+                assertEquals(0, PartitionIndex.warmIndex(fh, firstPos));
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
As [requested](https://issues.apache.org/jira/browse/CASSANDRA-21632?focusedCommentId=18110454&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18110454) by @driftx, this is the same as https://github.com/apache/cassandra/pull/5089 but for `cassandra-6.0`.