### PR TITLE
CASSANDRA-21012: Allow CQLSSTableWriter to specify SSTable id type (legacy/uuid)

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -54,6 +54,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected final RegularAndStaticColumns columns;
     protected SSTableFormat<?, ?> format = DatabaseDescriptor.getSelectedSSTableFormat();
     protected static final AtomicReference<SSTableId> id = new AtomicReference<>(SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
+    protected final SSTableId.Builder<SSTableId> idBuilder;
     protected boolean makeRangeAware = false;
     protected final Collection<Index.Group> indexGroups;
     protected Consumer<Collection<SSTableReader>> sstableProducedListener;
@@ -61,11 +62,12 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected CompressionDictionary compressionDictionary;
     protected SSTable.Owner owner;
 
-    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns)
+    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, SSTableId.Builder<SSTableId> idBuilder)
     {
         this.metadata = metadata;
         this.directory = directory;
         this.columns = columns;
+        this.idBuilder = idBuilder;
         indexGroups = new ArrayList<>();
     }
 
@@ -147,13 +149,13 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
                                        effectiveOwner);
     }
 
-    private static Descriptor createDescriptor(File directory, final String keyspace, final String columnFamily, final SSTableFormat<?, ?> fmt) throws IOException
+    private Descriptor createDescriptor(File directory, final String keyspace, final String columnFamily, final SSTableFormat<?, ?> fmt) throws IOException
     {
         SSTableId nextGen = getNextId(directory, columnFamily);
         return new Descriptor(directory, keyspace, columnFamily, nextGen, fmt);
     }
 
-    private static SSTableId getNextId(File directory, final String columnFamily) throws IOException
+    private SSTableId getNextId(File directory, final String columnFamily) throws IOException
     {
         while (true)
         {
@@ -165,7 +167,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
                                                              .map(d -> d.id);
 
                 SSTableId lastId = id.get();
-                SSTableId newId = SSTableIdFactory.instance.defaultBuilder().generator(Stream.concat(existingIds, Stream.of(lastId))).get();
+                SSTableId newId = idBuilder.generator(Stream.concat(existingIds, Stream.of(lastId))).get();
                 if (id.compareAndSet(lastId, newId))
                     return newId;
             }

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -54,7 +54,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected final RegularAndStaticColumns columns;
     protected SSTableFormat<?, ?> format = DatabaseDescriptor.getSelectedSSTableFormat();
     protected static final AtomicReference<SSTableId> id = new AtomicReference<>(SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
-    protected final SSTableId.Builder<SSTableId> idBuilder;
+    protected final SSTableId.Builder<? extends SSTableId> idBuilder;
     protected boolean makeRangeAware = false;
     protected final Collection<Index.Group> indexGroups;
     protected Consumer<Collection<SSTableReader>> sstableProducedListener;
@@ -62,7 +62,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected CompressionDictionary compressionDictionary;
     protected SSTable.Owner owner;
 
-    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, SSTableId.Builder<SSTableId> idBuilder)
+    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, SSTableId.Builder<? extends SSTableId> idBuilder)
     {
         this.metadata = metadata;
         this.directory = directory;

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -67,7 +67,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
         this.metadata = metadata;
         this.directory = directory;
         this.columns = columns;
-        this.idBuilder = idBuilder;
+        this.idBuilder = idBuilder != null ? idBuilder : SSTableIdFactory.instance.defaultBuilder();
         indexGroups = new ArrayList<>();
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.RegularAndStaticColumns;
@@ -62,7 +64,10 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected CompressionDictionary compressionDictionary;
     protected SSTable.Owner owner;
 
-    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, SSTableId.Builder<? extends SSTableId> idBuilder)
+    /**
+     * @param idBuilder builder used to generate SSTable identifiers; if {@code null}, the default builder is used.
+     */
+    protected AbstractSSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, @Nullable SSTableId.Builder<? extends SSTableId> idBuilder)
     {
         this.metadata = metadata;
         this.directory = directory;

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -419,6 +419,7 @@ public class CQLSSTableWriter implements Closeable
         private Consumer<Collection<SSTableReader>> sstableProducedListener;
         private boolean openSSTableOnProduced = false;
         private CompressionDictionary compressionDictionary = null;
+        private SSTableId.Builder<SSTableId> idBuilder = null;
 
         protected Builder()
         {
@@ -672,6 +673,19 @@ public class CQLSSTableWriter implements Closeable
         }
 
         /**
+         * Whether the created sstables should use UUID based identifiers instead of the legacy sequential ones.
+         * If not set, the uuid_sstable_identifiers_enabled setting from cassandra.yaml is used.
+         *
+         * @param enabled true for UUID based identifiers, false for legacy sequential identifiers.
+         * @return this builder.
+         */
+        public Builder withUUIDSSTableIdentifiers(boolean enabled)
+        {
+            this.idBuilder = SSTableIdFactory.instance.builderFor(enabled);
+            return this;
+        }
+
+        /**
          * Use specific compression dictionary upon writing the data.
          *
          * @param compressionDictionary compression dictionary to use
@@ -799,9 +813,10 @@ public class CQLSSTableWriter implements Closeable
                 ModificationStatement preparedModificationStatement = prepareModificationStatement();
 
                 TableMetadataRef ref = tableMetadata.ref;
+                SSTableId.Builder<SSTableId> effectiveIdBuilder = idBuilder != null ? idBuilder : SSTableIdFactory.instance.defaultBuilder();
                 AbstractSSTableSimpleWriter writer = sorted
-                                                     ? new SSTableSimpleWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB)
-                                                     : new SSTableSimpleUnsortedWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB);
+                                                     ? new SSTableSimpleWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder)
+                                                     : new SSTableSimpleUnsortedWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder);
 
                 if (format != null)
                     writer.setSSTableFormatType(format);

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -419,7 +419,7 @@ public class CQLSSTableWriter implements Closeable
         private Consumer<Collection<SSTableReader>> sstableProducedListener;
         private boolean openSSTableOnProduced = false;
         private CompressionDictionary compressionDictionary = null;
-        private SSTableId.Builder<SSTableId> idBuilder = null;
+        private SSTableId.Builder<? extends SSTableId> idBuilder = null;
 
         protected Builder()
         {
@@ -672,16 +672,9 @@ public class CQLSSTableWriter implements Closeable
             return this;
         }
 
-        /**
-         * Whether the created sstables should use UUID based identifiers instead of the legacy sequential ones.
-         * If not set, the uuid_sstable_identifiers_enabled setting from cassandra.yaml is used.
-         *
-         * @param enabled true for UUID based identifiers, false for legacy sequential identifiers.
-         * @return this builder.
-         */
-        public Builder withUUIDSSTableIdentifiers(boolean enabled)
+        public Builder withSSTableIdBuilder(SSTableId.Builder<? extends SSTableId> idBuilder)
         {
-            this.idBuilder = SSTableIdFactory.instance.builderFor(enabled);
+            this.idBuilder = idBuilder;
             return this;
         }
 
@@ -813,7 +806,7 @@ public class CQLSSTableWriter implements Closeable
                 ModificationStatement preparedModificationStatement = prepareModificationStatement();
 
                 TableMetadataRef ref = tableMetadata.ref;
-                SSTableId.Builder<SSTableId> effectiveIdBuilder = idBuilder != null ? idBuilder : SSTableIdFactory.instance.defaultBuilder();
+                SSTableId.Builder<? extends SSTableId> effectiveIdBuilder = idBuilder != null ? idBuilder : SSTableIdFactory.instance.defaultBuilder();
                 AbstractSSTableSimpleWriter writer = sorted
                                                      ? new SSTableSimpleWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder)
                                                      : new SSTableSimpleUnsortedWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder);

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -806,10 +806,9 @@ public class CQLSSTableWriter implements Closeable
                 ModificationStatement preparedModificationStatement = prepareModificationStatement();
 
                 TableMetadataRef ref = tableMetadata.ref;
-                SSTableId.Builder<? extends SSTableId> effectiveIdBuilder = idBuilder != null ? idBuilder : SSTableIdFactory.instance.defaultBuilder();
                 AbstractSSTableSimpleWriter writer = sorted
-                                                     ? new SSTableSimpleWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder)
-                                                     : new SSTableSimpleUnsortedWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, effectiveIdBuilder);
+                                                     ? new SSTableSimpleWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, idBuilder)
+                                                     : new SSTableSimpleUnsortedWriter(cfs, directory, ref, preparedModificationStatement.updatedColumns(), maxSSTableSizeInMiB, idBuilder);
 
                 if (format != null)
                     writer.setSSTableFormatType(format);

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
@@ -76,6 +76,18 @@ public class SSTableIdFactory
     }
 
     /**
+     * Returns identifiers builder for the given type, regardless of the uuid_sstable_identifiers_enabled setting.
+     */
+    @SuppressWarnings("unchecked")
+    public SSTableId.Builder<SSTableId> builderFor(boolean uuidBased)
+    {
+        SSTableId.Builder<? extends SSTableId> builder = uuidBased
+                                                         ? UUIDBasedSSTableId.Builder.instance
+                                                         : SequenceBasedSSTableId.Builder.instance;
+        return (SSTableId.Builder<SSTableId>) builder;
+    }
+
+    /**
      * Compare sstable identifiers so that UUID based identifier is always greater than sequence based identifier
      */
     public final static Comparator<SSTableId> COMPARATOR = Comparator.nullsFirst((id1, id2) -> {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
@@ -76,18 +76,6 @@ public class SSTableIdFactory
     }
 
     /**
-     * Returns identifiers builder for the given type, regardless of the uuid_sstable_identifiers_enabled setting.
-     */
-    @SuppressWarnings("unchecked")
-    public SSTableId.Builder<SSTableId> builderFor(boolean uuidBased)
-    {
-        SSTableId.Builder<? extends SSTableId> builder = uuidBased
-                                                         ? UUIDBasedSSTableId.Builder.instance
-                                                         : SequenceBasedSSTableId.Builder.instance;
-        return (SSTableId.Builder<SSTableId>) builder;
-    }
-
-    /**
      * Compare sstable identifiers so that UUID based identifier is always greater than sequence based identifier
      */
     public final static Comparator<SSTableId> COMPARATOR = Comparator.nullsFirst((id1, id2) -> {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -72,12 +72,17 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
 
     public SSTableSimpleUnsortedWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB)
     {
-        this(null, directory, metadata, columns, maxSSTableSizeInMiB);
+        this(null, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
     }
 
     SSTableSimpleUnsortedWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB)
     {
-        super(directory, metadata, columns);
+        this(owner, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
+    }
+
+    SSTableSimpleUnsortedWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<SSTableId> idBuilder)
+    {
+        super(directory, metadata, columns, idBuilder);
         this.maxSStableSizeInBytes = maxSSTableSizeInMiB * 1024L * 1024L;
         this.header = new SerializationHeader(true, metadata.get(), columns, EncodingStats.NO_STATS);
         this.helper = new SerializationHelper(this.header);

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -80,7 +80,7 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
         this(owner, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
     }
 
-    SSTableSimpleUnsortedWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<SSTableId> idBuilder)
+    SSTableSimpleUnsortedWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<? extends SSTableId> idBuilder)
     {
         super(directory, metadata, columns, idBuilder);
         this.maxSStableSizeInBytes = maxSSTableSizeInMiB * 1024L * 1024L;

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -86,7 +86,7 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
         this(owner, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
     }
 
-    protected SSTableSimpleWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<SSTableId> idBuilder)
+    protected SSTableSimpleWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<? extends SSTableId> idBuilder)
     {
         super(directory, metadata, columns, idBuilder);
         this.maxSSTableSizeInBytes = maxSSTableSizeInMiB * 1024L * 1024L;

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -66,7 +66,7 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
      */
     public SSTableSimpleWriter(File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB)
     {
-        this(null, directory, metadata, columns, maxSSTableSizeInMiB);
+        this(null, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
     }
 
     /**
@@ -83,7 +83,12 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
      */
     protected SSTableSimpleWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB)
     {
-        super(directory, metadata, columns);
+        this(owner, directory, metadata, columns, maxSSTableSizeInMiB, SSTableIdFactory.instance.defaultBuilder());
+    }
+
+    protected SSTableSimpleWriter(SSTable.Owner owner, File directory, TableMetadataRef metadata, RegularAndStaticColumns columns, long maxSSTableSizeInMiB, SSTableId.Builder<SSTableId> idBuilder)
+    {
+        super(directory, metadata, columns, idBuilder);
         this.maxSSTableSizeInBytes = maxSSTableSizeInMiB * 1024L * 1024L;
         this.owner = owner;
     }

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -146,6 +146,53 @@ public abstract class CQLSSTableWriterTest
         testWritingSstableWithFormat(btiFormat);
     }
 
+    @Test
+    public void testUUIDSSTableIdentifiers() throws Exception
+    {
+        String schema = "CREATE TABLE " + qualifiedTable + " ("
+                        + "  k int PRIMARY KEY,"
+                        + "  v int"
+                        + ")";
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+        CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                  .inDirectory(dataDir)
+                                                  .forTable(schema)
+                                                  .withUUIDSSTableIdentifiers(true)
+                                                  .using(insert).build();
+
+        writer.addRow(0, 1);
+        writer.close();
+
+        File[] dataFiles = dataDir.tryList((dir, name) -> name.contains("Data.db"));
+        assertEquals(1, dataFiles.length);
+
+        Descriptor descriptor = Descriptor.fromFile(dataFiles[0]);
+        assertTrue(UUIDBasedSSTableId.Builder.instance.isUniqueIdentifier(descriptor.id.toString()));
+    }
+
+    @Test
+    public void testDefaultSSTableIdentifiersAreLegacy() throws Exception
+    {
+        String schema = "CREATE TABLE " + qualifiedTable + " ("
+                        + "  k int PRIMARY KEY,"
+                        + "  v int"
+                        + ")";
+        String insert = "INSERT INTO " + qualifiedTable + " (k, v) VALUES (?, ?)";
+        CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                  .inDirectory(dataDir)
+                                                  .forTable(schema)
+                                                  .using(insert).build();
+
+        writer.addRow(0, 1);
+        writer.close();
+
+        File[] dataFiles = dataDir.tryList((dir, name) -> name.contains("Data.db"));
+        assertEquals(1, dataFiles.length);
+
+        Descriptor descriptor = Descriptor.fromFile(dataFiles[0]);
+        assertTrue(SequenceBasedSSTableId.Builder.instance.isUniqueIdentifier(descriptor.id.toString()));
+    }
+
     private void testWritingSstableWithFormat(SSTableFormat<?, ?> format) throws Exception
     {
         try (AutoCloseable ignored = Util.switchPartitioner(ByteOrderedPartitioner.instance))

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -157,7 +157,7 @@ public abstract class CQLSSTableWriterTest
         CQLSSTableWriter writer = CQLSSTableWriter.builder()
                                                   .inDirectory(dataDir)
                                                   .forTable(schema)
-                                                  .withUUIDSSTableIdentifiers(true)
+                                                  .withSSTableIdBuilder(UUIDBasedSSTableId.Builder.instance)
                                                   .using(insert).build();
 
         writer.addRow(0, 1);


### PR DESCRIPTION
## Problem
`CQLSSTableWriter` always generates SSTables with legacy sequential identifiers. If someone writes SSTables standalone and loads them into a node with `uuid_sstable_identifiers_enabled: true` (via `nodetool refresh`), the legacy naming causes a mismatch since it's not converted to UUID format.

## Fix
Added `withUUIDSSTableIdentifiers(boolean)` to `CQLSSTableWriter.Builder`, letting users explicitly choose legacy or UUID identifiers at build time.Default behavior (unset) falls back to the existing config-flag based logic — fully backward compatible.

## Changes
- `SSTableIdFactory`: new `builderFor(boolean)` method
- `AbstractSSTableSimpleWriter`: instance-level `idBuilder` (static id counter 
  kept as-is for cross-instance uniqueness)
- `SSTableSimpleWriter` / `SSTableSimpleUnsortedWriter`: new constructor overloads
- `CQLSSTableWriter.Builder`: new `withUUIDSSTableIdentifiers(boolean)` method

## Testing
- Added unit tests for UUID mode and default (legacy) mode
- All existing tests pass (`CQLSSTableWriterDaemonTest`, `CQLSSTableWriterClientTest`)
- Manually verified end-to-end: wrote SSTables with UUID ids, copied into a live node with `uuid_sstable_identifiers_enabled: true`, ran `nodetool refresh`, confirmed data loaded correctly
- Verified both sorted and unsorted writer paths
- `ant checkstyle` passes

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-21012)

