### PR TITLE
CASSANDRA-21635 Unwrap LongType properly when calculating min/max terms in V1SSTableIndex

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@
  * Make cqlsh prompt to reset to no keyspace set by USE after dropping that keyspace (CASSANDRA-21548)
  * Implement CMS rediscovery and recovery protocol (CASSANDRA-20476)
 Merged from 5.0:
+ * Unwrap LongType properly when calculating min/max terms in V1SSTableIndex (CASSANDRA-21635)
  * Force repair should ignore min_repair_interval (CASSANDRA-21552)
  * Render SubnetGroups as JSON in system_views.settings (CASSANDRA-21579)
  * Avoid rebuilding per-SSTable SAI components unless missing or corrupted (CASSANDRA-21515)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SSTableIndex.java
@@ -99,8 +99,8 @@ public class V1SSTableIndex extends SSTableIndex
 
             this.bounds = AbstractBounds.bounds(minKey, true, maxKey, true);
 
-            this.minTerm = metadatas.stream().map(m -> m.minTerm).min(indexTermType.comparator()).orElse(null);
-            this.maxTerm = metadatas.stream().map(m -> m.maxTerm).max(indexTermType.comparator()).orElse(null);
+            this.minTerm = metadatas.stream().map(m -> m.minTerm).reduce(indexTermType::min).orElse(null);
+            this.maxTerm = metadatas.stream().map(m -> m.maxTerm).reduce(indexTermType::max).orElse(null);
 
             this.numRows = metadatas.stream().mapToLong(m -> m.numRows).sum();
 

--- a/src/java/org/apache/cassandra/index/sai/utils/IndexTermType.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexTermType.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -539,15 +538,6 @@ public class IndexTermType
         }
 
         return result;
-    }
-
-    public Comparator<ByteBuffer> comparator()
-    {
-        // Override the comparator for BigInteger, BigDecimal and composite types
-        if (isBigInteger() || isBigDecimal() || isComposite())
-            return FastByteOperations::compareUnsigned;
-
-        return indexType;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/ClusteringKeyIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ClusteringKeyIndexTest.java
@@ -17,12 +17,15 @@
  */
 package org.apache.cassandra.index.sai.cql;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.v1.segment.SegmentBuilder;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 public class ClusteringKeyIndexTest extends SAITester
 {
@@ -33,6 +36,12 @@ public class ClusteringKeyIndexTest extends SAITester
         createIndex("CREATE CUSTOM INDEX pk2_idx ON %s(pk2) USING 'StorageAttachedIndex'");
 
         disableCompaction();
+    }
+
+    @After
+    public void resetSegmentSize()
+    {
+        SegmentBuilder.updateLastValidSegmentRowId(-1);
     }
 
     private void insertData1() throws Throwable
@@ -55,6 +64,33 @@ public class ClusteringKeyIndexTest extends SAITester
         insertData1();
         insertData2();
         runQueries();
+    }
+
+
+    @Test
+    public void reversedBigintClusteringMultiSegment()
+    {
+        createTable("CREATE TABLE %s (pk int, ck bigint, PRIMARY KEY (pk, ck)) WITH CLUSTERING ORDER BY (ck DESC)");
+        createIndex("CREATE INDEX ON %s(ck) USING 'sai'");
+        disableCompaction(keyspace());
+
+        for (long ck = 10; ck < 16; ck++)
+            execute("INSERT INTO %s (pk, ck) VALUES (?, ?)", 1, ck);
+        flush();
+
+        for (long ck = 16; ck < 22; ck++)
+            execute("INSERT INTO %s (pk, ck) VALUES (?, ?)", 1, ck);
+        flush();
+
+        // Force compaction with a small segment size cap, producing multiple segments.
+        SegmentBuilder.updateLastValidSegmentRowId(3);
+        compact();
+
+        for (long ck = 10; ck < 22; ck++)
+        {
+            int cnt = getRows(execute("SELECT ck FROM %s WHERE ck = ?", ck)).length;
+            assertEquals("Missing row for ck=" + ck, 1, cnt);
+        }
     }
 
     private Object[] expectedRow(int index)


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by David Capwell for CASSANDRA-21635