### PR TITLE
CASSANDRA-21648: Handle error gracefully when client sends malformed IN-marker bytes

### DIFF
--- a/src/java/org/apache/cassandra/cql3/terms/InMarker.java
+++ b/src/java/org/apache/cassandra/cql3/terms/InMarker.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.MultiElementType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 /**
@@ -77,7 +78,15 @@ public final class InMarker extends Terms.NonTerminals
                                       ListType<T> type,
                                       java.util.function.Function<ByteBuffer, Term.Terminal> terminalConverter)
     {
-        List<T> elements = type.getSerializer().deserialize(value, ByteBufferAccessor.instance);
+        List<T> elements;
+        try
+        {
+            elements = type.getSerializer().deserialize(value, ByteBufferAccessor.instance);
+        }
+        catch (MarshalException e)
+        {
+            throw new InvalidRequestException(e.getMessage());
+        }
         List<Term.Terminal> terminals = new ArrayList<>(elements.size());
         for (T element : elements)
         {

--- a/src/java/org/apache/cassandra/cql3/terms/InMarker.java
+++ b/src/java/org/apache/cassandra/cql3/terms/InMarker.java
@@ -85,7 +85,7 @@ public final class InMarker extends Terms.NonTerminals
         }
         catch (MarshalException e)
         {
-            throw new InvalidRequestException(e.getMessage());
+            throw new InvalidRequestException(e.getMessage(), e);
         }
         List<Term.Terminal> terminals = new ArrayList<>(elements.size());
         for (T element : elements)

--- a/test/unit/org/apache/cassandra/cql3/terms/InMarkerTest.java
+++ b/test/unit/org/apache/cassandra/cql3/terms/InMarkerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.terms;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.service.QueryState;
+
+import static org.junit.Assert.fail;
+
+public class InMarkerTest extends CQLTester
+{
+    @Test
+    public void testNotEnoughBytesThrowsInvalidRequest() throws Throwable
+    {
+        assertInMarkerRejectsMalformedValue(new byte[]{ 0, 0, 0, 1 });
+    }
+
+    @Test
+    public void testExtraneousBytesThrowsInvalidRequest() throws Throwable
+    {
+        assertInMarkerRejectsMalformedValue(new byte[]{ 0, 0, 0, 0, 9, 9 });
+    }
+
+    private void assertInMarkerRejectsMalformedValue(byte[] malformedListBytes) throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v int)");
+        SelectStatement select = (SelectStatement) parseStatement("SELECT * FROM " + KEYSPACE + '.' + currentTable() + " WHERE pk IN ?");
+
+        QueryOptions options = QueryOptions.forInternalCalls(Collections.singletonList(ByteBuffer.wrap(malformedListBytes)));
+        try
+        {
+            select.getQuery(options, QueryState.forInternalCalls().getNowInSeconds());
+            fail("Expected InvalidRequestException to be thrown for a malformed IN marker value");
+        }
+        catch (InvalidRequestException e)
+        {
+            // expected
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/terms/InMarkerTest.java
+++ b/test/unit/org/apache/cassandra/cql3/terms/InMarkerTest.java
@@ -34,18 +34,18 @@ import static org.junit.Assert.fail;
 public class InMarkerTest extends CQLTester
 {
     @Test
-    public void testNotEnoughBytesThrowsInvalidRequest() throws Throwable
+    public void testNotEnoughBytesThrowsInvalidRequest()
     {
         assertInMarkerRejectsMalformedValue(new byte[]{ 0, 0, 0, 1 });
     }
 
     @Test
-    public void testExtraneousBytesThrowsInvalidRequest() throws Throwable
+    public void testExtraneousBytesThrowsInvalidRequest()
     {
         assertInMarkerRejectsMalformedValue(new byte[]{ 0, 0, 0, 0, 9, 9 });
     }
 
-    private void assertInMarkerRejectsMalformedValue(byte[] malformedListBytes) throws Throwable
+    private void assertInMarkerRejectsMalformedValue(byte[] malformedListBytes)
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v int)");
         SelectStatement select = (SelectStatement) parseStatement("SELECT * FROM " + KEYSPACE + '.' + currentTable() + " WHERE pk IN ?");


### PR DESCRIPTION
This patch fixes the regression where 6.0 stopped gracefully handling malformed IN-marker bytes sent by clients. Compare to 5.0: https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/cql3/Lists.java#L227-L241 

This causes an uninformative server-side error, instead of a more useful invalid-request error. 

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-21648)

