### PR TITLE
Fix Client RequestsSize metric always reporting 0 for native protocol v5 connections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Fix Client RequestsSize metric always reporting 0 for native protocol v5+ connections (CASSANDRA-21091)
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
  * Support pluggable default role initialization (CASSANDRA-21546)
  * Add prepared statement cache stats to nodetool info (CASSANDRA-14366)

--- a/src/java/org/apache/cassandra/metrics/ClientMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientMetrics.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Predicate;
 
 import com.codahale.metrics.Gauge;
@@ -84,6 +85,7 @@ public final class ClientMetrics
     final Map<AuthenticationMode, Gauge<Integer>> connectedNativeClientsByAuthMode = new HashMap<>();
 
     private AtomicInteger pausedConnections;
+    private final LongAdder requestsSize = new LongAdder();
 
     @SuppressWarnings({ "unused", "FieldCanBeLocal" })
     private Gauge<Integer> pausedConnectionsGauge;
@@ -195,7 +197,7 @@ public final class ClientMetrics
         connectedNativeClientsByUser = registerGauge("ConnectedNativeClientsByUser", "connectedNativeClientsByUser", this::countConnectedClientsByUser);
         registerGauge("Connections", "connections", this::connectedClients);
         registerGauge("ClientsByProtocolVersion", "clientsByProtocolVersion", this::recentClientStats);
-        registerGauge("RequestsSize", ClientResourceLimits::getCurrentGlobalUsage);
+        registerGauge("RequestsSize", this::currentRequestsSize);
 
         CassandraReservoir ipUsageReservoir = ClientResourceLimits.ipUsageReservoir();
         Metrics.register(factory.createMetricName("RequestsSizeByIpDistribution"),
@@ -334,5 +336,18 @@ public final class ClientMetrics
     public void queueTime(long value, TimeUnit unit)
     {
         queueTime.update(value, unit);
+    }
+
+    public void requestBytesAcquired(long bytes)
+    {
+        requestsSize.add(bytes);
+    }
+    public void requestBytesReleased(long bytes)
+    {
+        requestsSize.add(-bytes);
+    }
+    public long currentRequestsSize()
+    {
+        return requestsSize.sum();
     }
 }

--- a/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
@@ -425,6 +425,7 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
         if (currentQueueSize + bytes <= queueCapacity)
         {
             queueSizeUpdater.addAndGet(this, bytes);
+            onCapacityAcquired(bytes);
             return ResourceLimits.Outcome.SUCCESS;
         }
 
@@ -461,6 +462,7 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
             globalWaitQueue.signal();
         }
 
+        onCapacityAcquired(bytes);
         return ResourceLimits.Outcome.SUCCESS;
     }
 
@@ -477,6 +479,15 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
             endpointWaitQueue.signal();
             globalWaitQueue.signal();
         }
+        onCapacityReleased(bytes);
+    }
+
+    protected void onCapacityAcquired(int bytes)
+    {
+    }
+
+    protected void onCapacityReleased(int bytes)
+    {
     }
 
     /**

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -518,6 +518,18 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
         channelPayloadBytesInFlight -= header.bodySizeInBytes;
     }
 
+    @Override
+    protected void onCapacityAcquired(int bytes)
+    {
+        ClientMetrics.instance.requestBytesAcquired(bytes);
+    }
+
+    @Override
+    protected void onCapacityReleased(int bytes)
+    {
+        ClientMetrics.instance.requestBytesReleased(bytes);
+    }
+
     /*
      * Handling of multi-frame large messages
      */

--- a/src/java/org/apache/cassandra/transport/PreV5Handlers.java
+++ b/src/java/org/apache/cassandra/transport/PreV5Handlers.java
@@ -95,6 +95,7 @@ public class PreV5Handlers
             // The only reason we won't process this message is if checkLimits() throws an OverloadedException.
             // (i.e. Even if backpressure is applied, the current request is allowed to finish.)
             checkLimits(ctx, request);
+            ClientMetrics.instance.requestBytesAcquired(request.getSource().header.bodySizeInBytes);
             dispatcher.dispatch(ctx.channel(), request, this::toFlushItem, ctx, backpressure);
         }
 
@@ -115,6 +116,8 @@ public class PreV5Handlers
             // releasing them is handled by the pipeline itself.
             long itemSize = item.requestEnvelope.header.bodySizeInBytes;
             item.requestEnvelope.release();
+
+            ClientMetrics.instance.requestBytesReleased(itemSize);
 
             // since the request has been processed, decrement inflight payload at channel, endpoint and global levels
             channelPayloadBytesInFlight -= itemSize;

--- a/test/unit/org/apache/cassandra/transport/CQLConnectionTest.java
+++ b/test/unit/org/apache/cassandra/transport/CQLConnectionTest.java
@@ -363,6 +363,95 @@ public class CQLConnectionTest
     }
 
     @Test
+    public void testRequestsSizeMetricPopulatedWithoutTouchingReserves() throws Throwable
+    {
+        // CASSANDRA-21091: for V5+ connections, a request is only allocated from the shared endpoint/global
+        // reserves once a connection's own private queue budget (native_transport_receive_queue_capacity_in_bytes)
+        // is exceeded. setup() sets that budget to 0 for the other (reserve-focused) tests in this class; restore
+        // a realistic, non-zero value here so that our single small request is satisfied entirely from the
+        // connection's private budget, and never touches the reserves at all.
+        DatabaseDescriptor.setNativeTransportReceiveQueueCapacityInBytes(1024 * 1024);
+
+        long baseline = ClientMetrics.instance.currentRequestsSize();
+
+        Condition requestReceived = newOneTimeCondition();
+        Condition releaseRequest = newOneTimeCondition();
+        AllocationObserver observer = new AllocationObserver(false);
+        Codec codec = Codec.crc(alloc);
+
+        // A consumer which pauses on the event loop after the request has been "accepted" (i.e. capacity
+        // has been acquired for it) but before it has been processed/released, giving the test a window in
+        // which to observe the RequestsSize metric while the request is genuinely in flight.
+        MessageConsumer<Message.Request> consumer = new MessageConsumer<Message.Request>()
+        {
+            public <P> void dispatch(Channel channel, Message.Request message, Dispatcher.FlushItemConverter<P> toFlushItem, P param, Overload backpressure)
+            {
+                requestReceived.signalAll();
+                releaseRequest.awaitUninterruptibly();
+
+                Message.Response fixedResponse = new ResultMessage.Void();
+                Envelope response = fixedResponse.encode(ProtocolVersion.V5, message.getSource().header.streamId);
+                SimpleClient.SimpleFlusher flusher = new SimpleClient.SimpleFlusher(codec.encoder);
+                flusher.enqueue(response);
+                flusher.schedule(channel.pipeline().lastContext());
+
+                // this simulates the release of the allocated resources that a real flusher would do
+                Flusher.FlushItem.Framed item = (Flusher.FlushItem.Framed) toFlushItem.toFlushItem(param, channel, message, fixedResponse);
+                item.release();
+            }
+
+            public boolean hasQueueCapacity() { return true; }
+        };
+
+        Message.Decoder<Message.Request> decoder = new FixedDecoder();
+        Predicate<Envelope.Header> responseMatcher = h -> h.type == Message.Type.RESULT;
+        ServerConfigurator configurator = ServerConfigurator.builder()
+                                                            .withConsumer(consumer)
+                                                            .withAllocationObserver(observer)
+                                                            .withDecoder(decoder)
+                                                            .build();
+
+        Server server = server(configurator);
+        Client client = new Client(codec, 1);
+        try
+        {
+            server.start();
+            client.connect(address, port);
+            assertTrue(configurator.waitUntilReady());
+
+            Envelope request = randomEnvelope(0, Message.Type.OPTIONS, 4096, 4096);
+            int requestSize = request.body.readableBytes();
+            client.send(request);
+            client.awaitFlushed();
+
+            assertTrue("timed out waiting for the request to be dispatched",
+                       requestReceived.await(10, TimeUnit.SECONDS));
+
+            // The request is now in flight on the server, but small enough to be satisfied entirely by this
+            // connection's private queue budget - so the shared endpoint/global reserves were never touched...
+            assertThat(observer.globalAllocationTotal()).isEqualTo(0);
+            // ...yet the client-facing RequestsSize metric must still reflect it.
+            assertThat(ClientMetrics.instance.currentRequestsSize() - baseline).isEqualTo(requestSize);
+
+            releaseRequest.signalAll();
+
+            client.awaitResponses();
+            Envelope response = client.pollResponses();
+            assertNotNull(response);
+            assertThat(response.header).matches(responseMatcher);
+            response.release();
+
+            // Once the request has completed, the metric must fall back to its baseline.
+            assertThat(ClientMetrics.instance.currentRequestsSize()).isEqualTo(baseline);
+        }
+        finally
+        {
+            client.stop();
+            server.stop();
+        }
+    }
+
+    @Test
     public void testRecoverableEnvelopeDecodingErrors()
     {
         // If an error is encountered while decoding an Envelope header,


### PR DESCRIPTION
V5 only touches the shared reserve once a connection's local queue budget is exceeded, so normal traffic never hits the counter this metric reads. V4 always hits it, which is why the gauge worked there but not on v5.

Added hooks in AbstractMessageHandler so both paths report to the same counter regardless of whether the reserve was actually used, and pointed ClientMetrics at that instead. Didn't touch backpressure/admission control at all.

Added a test in CQLConnectionTest that reproduces this - reserve stays at 0 but the gauge still moves.

Ran transport/metrics/net/cql3 test packages + ant check locally on JDK 17, all green.

[CASSANDRA-21091](https://issues.apache.org/jira/browse/CASSANDRA-21091)