### PR TITLE
CASSANDRA-21659: Make schema diffing independent of the number of tables in the cluster

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Make schema diffing independent of the number of tables in the cluster (CASSANDRA-21659)
  * Upgrade async-profiler to 4.5 (CASSANDRA-21630)
  * Guardrail configurations of zero are now treated as zero instead of unlimited (CASSANDRA-21517)
  * Support multi-cell columns in cursor compaction (CASSANDRA-21463)

--- a/src/java/org/apache/cassandra/schema/Keyspaces.java
+++ b/src/java/org/apache/cassandra/schema/Keyspaces.java
@@ -17,8 +17,10 @@
  */
 package org.apache.cassandra.schema;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,6 +52,18 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
     public static Keyspaces none()
     {
         return NONE;
+    }
+
+    public static Keyspaces of(Iterable<KeyspaceMetadata> keyspaces)
+    {
+        BTreeMap<String, KeyspaceMetadata> newKeyspaces = BTreeMap.empty();
+        BTreeMap<TableId, TableMetadata> newTables = BTreeMap.empty();
+        for (KeyspaceMetadata ks : keyspaces)
+        {
+            newKeyspaces = newKeyspaces.with(ks.name, ks);
+            newTables = withTablesViews(newTables, ks);
+        }
+        return new Keyspaces(newKeyspaces, newTables);
     }
 
     public static Keyspaces of(KeyspaceMetadata... keyspaces)
@@ -281,18 +295,43 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
             if (before == after)
                 return NONE;
 
-            Keyspaces created = after.filter(k -> !before.containsKeyspace(k.name));
-            Keyspaces dropped = before.filter(k -> !after.containsKeyspace(k.name));
-
+            // Collect created and dropped keyspaces directly. filter() removes non-matching keyspaces from a copy of
+            // the by-TableId map one table at a time, so building these by filtering costs one BTreeMap removal per
+            // table in the cluster - on every diff, and several diffs are performed per schema change.
+            List<KeyspaceMetadata> created = null;
+            List<KeyspaceMetadata> dropped = null;
             ImmutableList.Builder<KeyspaceDiff> altered = ImmutableList.builder();
-            before.forEach(keyspaceBefore ->
+
+            for (KeyspaceMetadata keyspaceAfter : after)
+            {
+                if (!before.containsKeyspace(keyspaceAfter.name))
+                {
+                    if (created == null)
+                        created = new ArrayList<>();
+                    created.add(keyspaceAfter);
+                }
+            }
+
+            for (KeyspaceMetadata keyspaceBefore : before)
             {
                 KeyspaceMetadata keyspaceAfter = after.getNullable(keyspaceBefore.name);
-                if (null != keyspaceAfter)
+                if (null == keyspaceAfter)
+                {
+                    if (dropped == null)
+                        dropped = new ArrayList<>();
+                    dropped.add(keyspaceBefore);
+                }
+                else if (keyspaceAfter != keyspaceBefore)
+                {
+                    // Identity means nothing in this keyspace changed; KeyspaceDiff.diff would reach the same
+                    // conclusion, but only after walking the keyspace.
                     KeyspaceMetadata.diff(keyspaceBefore, keyspaceAfter).ifPresent(altered::add);
-            });
+                }
+            }
 
-            return new KeyspacesDiff(created, dropped, altered.build());
+            return new KeyspacesDiff(created == null ? Keyspaces.none() : Keyspaces.of(created),
+                                     dropped == null ? Keyspaces.none() : Keyspaces.of(dropped),
+                                     altered.build());
         }
 
         public boolean isEmpty()

--- a/src/java/org/apache/cassandra/schema/Tables.java
+++ b/src/java/org/apache/cassandra/schema/Tables.java
@@ -284,18 +284,48 @@ public final class Tables implements Iterable<TableMetadata>
             if (before == after)
                 return NONE;
 
-            Tables created = after.filter(t -> !before.containsTable(t.id));
-            Tables dropped = before.filter(t -> !after.containsTable(t.id));
-
+            // Collect the differences directly instead of filtering whole collections: a schema change touches a
+            // handful of tables, so allocating only for those keeps the cost of a diff proportional to what actually
+            // changed rather than to the size of the schema.
+            Builder created = null;
+            Builder dropped = null;
             ImmutableList.Builder<Altered<TableMetadata>> altered = ImmutableList.builder();
-            before.forEach(tableBefore ->
+
+            for (TableMetadata tableAfter : after)
+            {
+                if (!before.containsTable(tableAfter.id))
+                {
+                    if (created == null)
+                        created = builder();
+                    created.add(tableAfter);
+                }
+            }
+
+            for (TableMetadata tableBefore : before)
             {
                 TableMetadata tableAfter = after.getNullable(tableBefore.id);
-                if (null != tableAfter)
+                if (null == tableAfter)
+                {
+                    if (dropped == null)
+                        dropped = builder();
+                    dropped.add(tableBefore);
+                }
+                else if (tableAfter != tableBefore)
+                {
+                    // Untouched tables are carried over by reference (Builder.add stores the instance verbatim), and
+                    // compare() of an instance against itself is empty by construction, so identity is a sound and
+                    // exact substitute for the comparison here.
                     tableBefore.compare(tableAfter).ifPresent(kind -> altered.add(new Altered<>(tableBefore, tableAfter, kind)));
-            });
+                }
+            }
 
-            return new TablesDiff(created, dropped, altered.build());
+            ImmutableList<Altered<TableMetadata>> alteredTables = altered.build();
+            if (created == null && dropped == null && alteredTables.isEmpty())
+                return NONE;
+
+            return new TablesDiff(created == null ? Tables.none() : created.build(),
+                                  dropped == null ? Tables.none() : dropped.build(),
+                                  alteredTables);
         }
     }
 

--- a/test/unit/org/apache/cassandra/schema/KeyspacesDiffScalingTest.java
+++ b/test/unit/org/apache/cassandra/schema/KeyspacesDiffScalingTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.sun.management.ThreadMXBean;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.db.marshal.Int32Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A single schema change must cost the same whether the cluster holds a hundred tables or a hundred thousand.
+ *
+ * <p>{@link Keyspaces#diff} is executed several times for every DDL statement - by the transformation, by
+ * {@link DistributedSchema#initializeKeyspaceInstances}, and again when change listeners are notified - so any per-call
+ * cost that scales with the size of the schema is paid on every {@code CREATE TABLE} and turns bulk schema creation
+ * into an O(n^2) operation.
+ *
+ * <p>These tests measure allocation rather than elapsed time. Allocation is counted exactly by the JVM rather than
+ * sampled, does not depend on GC timing or on what else the machine is doing, and is the quantity that actually
+ * matters here: the failure mode users hit is not gradual slowdown but a GC wall, reached because each statement
+ * allocates in proportion to the whole schema. A wall-clock assertion at this granularity would be flaky; this is not.
+ *
+ * <p>Both tests assert a growth <em>ratio</em> rather than an absolute byte count, so they do not need re-tuning for a
+ * different JDK, allocator, or machine.
+ */
+public class KeyspacesDiffScalingTest
+{
+    /** Table counts differing by 8x. An O(schema-size) diff allocates ~8x more at LARGE; a correct one allocates ~1x. */
+    private static final int SMALL = 400;
+    private static final int LARGE = 3200;
+
+    /**
+     * Generous: the honest expectation is ~1.0. Anything below this is flat enough to rule out per-table work; the
+     * behaviour under test allocates ~8x, so the gap between pass and fail is wide and no borderline case exists.
+     */
+    private static final double MAX_GROWTH = 3.0;
+
+    private static final int WARMUP = 10;
+    private static final int ITERATIONS = 20;
+
+    private static final ThreadMXBean THREADS = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    /** Kept live so the diffs under measurement cannot be optimised away. */
+    @SuppressWarnings("unused")
+    private static volatile Object sink;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        ServerTestUtils.prepareServerNoRegister();
+        assertTrue("This test requires per-thread allocation counting",
+                   THREADS.isThreadAllocatedMemorySupported() && THREADS.isThreadAllocatedMemoryEnabled());
+    }
+
+    /**
+     * The reported case: many tables in one keyspace. Adding table n+1 must not cost more than adding table 2.
+     */
+    @Test
+    public void addingOneTableDoesNotScaleWithExistingTablesInSameKeyspace()
+    {
+        long small = bytesPerDiff(oneKeyspaceWithTableAdded(SMALL));
+        long large = bytesPerDiff(oneKeyspaceWithTableAdded(LARGE));
+
+        assertGrowthIsFlat("adding one table to a keyspace already holding", small, large);
+    }
+
+    /**
+     * Tables in <em>other</em> keyspaces must not be touched at all. The changed keyspace holds a fixed 10 tables in
+     * both cases; only the unrelated keyspaces grow. CASSANDRA-7444 established this in 2.1.1 ("compare before/after
+     * schemas of the affected keyspaces only"); this test pins it.
+     */
+    @Test
+    public void addingOneTableDoesNotScaleWithTablesInOtherKeyspaces()
+    {
+        long small = bytesPerDiff(manyKeyspacesWithTableAdded(SMALL));
+        long large = bytesPerDiff(manyKeyspacesWithTableAdded(LARGE));
+
+        assertGrowthIsFlat("adding one table to a 10-table keyspace alongside unrelated tables numbering", small, large);
+    }
+
+    /** The optimisation must not change what the diff reports: one created table, nothing else. */
+    @Test
+    public void diffReportsExactlyTheCreatedTable()
+    {
+        Keyspaces[] pair = oneKeyspaceWithTableAdded(50);
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(pair[0], pair[1]);
+
+        assertEquals("no keyspaces created", 0, size(diff.created));
+        assertEquals("no keyspaces dropped", 0, size(diff.dropped));
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("exactly one table created", 1, size(ks.tables.created));
+        assertEquals("no tables dropped", 0, size(ks.tables.dropped));
+        assertEquals("no tables altered", 0, ks.tables.altered.size());
+        assertEquals("the added table", "table_50", ks.tables.created.iterator().next().name);
+    }
+
+    /** Same, for the reverse direction. */
+    @Test
+    public void diffReportsExactlyTheDroppedTable()
+    {
+        Keyspaces[] pair = oneKeyspaceWithTableAdded(50);
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(pair[1], pair[0]);
+
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("no tables created", 0, size(ks.tables.created));
+        assertEquals("exactly one table dropped", 1, size(ks.tables.dropped));
+        assertEquals("the removed table", "table_50", ks.tables.dropped.iterator().next().name);
+    }
+
+    /**
+     * An altered table must still be detected. This is the case an over-eager identity short-circuit would break: the
+     * instance genuinely differs, so it must be compared, not skipped.
+     */
+    @Test
+    public void diffReportsAnAlteredTable()
+    {
+        List<TableMetadata> tables = tables("ks", 50);
+        Keyspaces before = keyspaces(Tables.of(tables), ImmutableList.of());
+
+        TableMetadata altered = tables.get(10).unbuild().comment("changed").build();
+        List<TableMetadata> after = new ArrayList<>(tables);
+        after.set(10, altered);
+
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(before, keyspaces(Tables.of(after), ImmutableList.of()));
+
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("no tables created", 0, size(ks.tables.created));
+        assertEquals("no tables dropped", 0, size(ks.tables.dropped));
+        assertEquals("exactly one table altered", 1, ks.tables.altered.size());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static void assertGrowthIsFlat(String what, long small, long large)
+    {
+        double growth = (double) large / small;
+        String detail = String.format("%s %,d tables allocated %,d bytes; at %,d tables it allocated %,d bytes " +
+                                      "(%.1fx). The schema is %dx larger, so a diff whose cost is independent of " +
+                                      "schema size should be near 1.0x.",
+                                      what, SMALL, small, LARGE, large, growth, LARGE / SMALL);
+        assertTrue(detail, growth < MAX_GROWTH);
+    }
+
+    /** Allocation attributable to one {@link Keyspaces#diff} call, warmed up so lazy initialisation is not counted. */
+    private static long bytesPerDiff(Keyspaces[] beforeAfter)
+    {
+        Keyspaces before = beforeAfter[0];
+        Keyspaces after = beforeAfter[1];
+
+        for (int i = 0; i < WARMUP; i++)
+            sink = Keyspaces.diff(before, after);
+
+        long id = Thread.currentThread().getId();
+        long start = THREADS.getThreadAllocatedBytes(id);
+        for (int i = 0; i < ITERATIONS; i++)
+            sink = Keyspaces.diff(before, after);
+        return (THREADS.getThreadAllocatedBytes(id) - start) / ITERATIONS;
+    }
+
+    /** {before, after} where a single keyspace holds {@code existing} tables and one more is added. */
+    private static Keyspaces[] oneKeyspaceWithTableAdded(int existing)
+    {
+        List<TableMetadata> tables = tables("ks", existing);
+        Keyspaces before = keyspaces(Tables.of(tables), ImmutableList.of());
+        Keyspaces after = keyspaces(Tables.of(tables).with(table("ks", existing)), ImmutableList.of());
+        return new Keyspaces[]{ before, after };
+    }
+
+    /**
+     * {before, after} where the changed keyspace always holds 10 tables, and {@code unrelated} further tables are
+     * spread across other keyspaces that do not change at all.
+     */
+    private static Keyspaces[] manyKeyspacesWithTableAdded(int unrelated)
+    {
+        int others = 10;
+        int perOther = unrelated / others;
+
+        // Built once and shared by both sides. A schema change rebuilds only the keyspace it touches and carries the
+        // rest over by reference, so sharing these instances is what the production path actually produces - a fixture
+        // that rebuilt them independently would be measuring a situation that never occurs.
+        List<KeyspaceMetadata> untouched = new ArrayList<>(others);
+        for (int i = 0; i < others; i++)
+        {
+            String name = "other_" + i;
+            untouched.add(KeyspaceMetadata.create(name, KeyspaceParams.simple(1), Tables.of(tables(name, perOther))));
+        }
+
+        List<TableMetadata> tables = tables("ks", 10);
+        Keyspaces before = keyspaces(Tables.of(tables), untouched);
+        Keyspaces after = keyspaces(Tables.of(tables).with(table("ks", 10)), untouched);
+        return new Keyspaces[]{ before, after };
+    }
+
+    /** Keyspace "ks" holding {@code tables}, alongside the given untouched keyspaces. */
+    private static Keyspaces keyspaces(Tables tables, List<KeyspaceMetadata> untouched)
+    {
+        return Keyspaces.of(KeyspaceMetadata.create("ks", KeyspaceParams.simple(1), tables)).with(untouched);
+    }
+
+    private static List<TableMetadata> tables(String keyspace, int count)
+    {
+        List<TableMetadata> tables = new ArrayList<>(count);
+        for (int i = 0; i < count; i++)
+            tables.add(table(keyspace, i));
+        return tables;
+    }
+
+    private static TableMetadata table(String keyspace, int i)
+    {
+        return TableMetadata.builder(keyspace, "table_" + i)
+                            .addPartitionKeyColumn("pk", Int32Type.instance)
+                            .addClusteringColumn("ck", Int32Type.instance)
+                            .addRegularColumn("v", Int32Type.instance)
+                            .build();
+    }
+
+    private static int size(Iterable<?> iterable)
+    {
+        int n = 0;
+        for (Object ignored : iterable) n++;
+        return n;
+    }
+}


### PR DESCRIPTION
[CASSANDRA-21659](https://issues.apache.org/jira/browse/CASSANDRA-21659)

Every schema change allocates in proportion to the whole schema rather than to what changed. This addresses the diffing component.

**What**

`Keyspaces.diff` and `Tables.diff` build `created`/`dropped` with `filter()`, which removes every non-matching entry from a copy one at a time. On a `CREATE TABLE` no keyspace is created or dropped, so `Keyspaces.filter` falls into `withoutKsTablesViews` and removes every table in the cluster individually — twice per diff. `Tables.diff` then calls `TableMetadata.compare` for every surviving table, and `compare` has no identity fast path.

Several diffs run per DDL: `AlterSchemaStatement:194` and `:200`, `AlterSchema:160`, `DistributedSchema:213`, `:260` and `:325`.

**Change**

* Collect `created`/`dropped` directly instead of filtering whole collections.
* Skip comparing entries carried over by reference. Untouched `TableMetadata` are reference-identical across a schema change (`Tables.Builder.add` stores the instance verbatim), and `x.compare(x)` is empty by construction — so identity is exact here, not an approximation.

No signature, serialized-format or API changes.

**Result**

Allocation for adding one table:

| | 400 tables | 3200 tables | growth |
|---|---|---|---|
| before | 292,552 B | 3,774,864 B | 12.9x |
| after | 3,944 B | 3,944 B | 1.0x |

Before is superlinear because the BTreeMap teardown is O(N log N). After is independent of schema size.

**Scope — please read before benchmarking**

This removes the allocation term, not the scan. Time stays O(N) per diff and bulk creation remains quadratic in wall-clock; at small N wall-clock will barely move. What it removes is allocation that scales with the size of the schema. Two further per-DDL allocation sites are being addressed separately.

**Tests**

New `KeyspacesDiffScalingTest`: 2 scaling assertions, 3 correctness guards. It asserts an allocation *ratio* between a 400-table and a 3200-table fixture rather than an absolute byte count, so it needs no re-tuning per JDK or machine. Allocation rather than elapsed time because it is counted exactly rather than sampled, is independent of GC timing and machine load, and is the quantity that produces the failure.

Verified red before the change and green after, and re-verified that the final test still fails with the fix stashed.

Regression: `org.apache.cassandra.schema` 27 suites / 130 tests, `org.apache.cassandra.tcm` 13 suites / 55 tests, 0 failures. `ant checkstyle` and `ant checkstyle-test` clean.

