### PR TITLE
CASSANDRA-21660: Back Tables with a persistent map so schema changes do not copy the collection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Make schema diffing independent of the number of tables in the cluster (CASSANDRA-21659)
  * Upgrade async-profiler to 4.5 (CASSANDRA-21630)
  * Guardrail configurations of zero are now treated as zero instead of unlimited (CASSANDRA-21517)
  * Support multi-cell columns in cursor compaction (CASSANDRA-21463)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 6.0-alpha3
+ * Back Tables with a persistent map so schema changes do not copy the collection (CASSANDRA-21660)
  * Make schema diffing independent of the number of tables in the cluster (CASSANDRA-21659)
  * Upgrade async-profiler to 4.5 (CASSANDRA-21630)
  * Guardrail configurations of zero are now treated as zero instead of unlimited (CASSANDRA-21517)

--- a/src/java/org/apache/cassandra/schema/Keyspaces.java
+++ b/src/java/org/apache/cassandra/schema/Keyspaces.java
@@ -17,8 +17,10 @@
  */
 package org.apache.cassandra.schema;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,6 +52,18 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
     public static Keyspaces none()
     {
         return NONE;
+    }
+
+    public static Keyspaces of(Iterable<KeyspaceMetadata> keyspaces)
+    {
+        BTreeMap<String, KeyspaceMetadata> newKeyspaces = BTreeMap.empty();
+        BTreeMap<TableId, TableMetadata> newTables = BTreeMap.empty();
+        for (KeyspaceMetadata ks : keyspaces)
+        {
+            newKeyspaces = newKeyspaces.with(ks.name, ks);
+            newTables = withTablesViews(newTables, ks);
+        }
+        return new Keyspaces(newKeyspaces, newTables);
     }
 
     public static Keyspaces of(KeyspaceMetadata... keyspaces)
@@ -281,18 +295,43 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
             if (before == after)
                 return NONE;
 
-            Keyspaces created = after.filter(k -> !before.containsKeyspace(k.name));
-            Keyspaces dropped = before.filter(k -> !after.containsKeyspace(k.name));
-
+            // Collect created and dropped keyspaces directly. filter() removes non-matching keyspaces from a copy of
+            // the by-TableId map one table at a time, so building these by filtering costs one BTreeMap removal per
+            // table in the cluster - on every diff, and several diffs are performed per schema change.
+            List<KeyspaceMetadata> created = null;
+            List<KeyspaceMetadata> dropped = null;
             ImmutableList.Builder<KeyspaceDiff> altered = ImmutableList.builder();
-            before.forEach(keyspaceBefore ->
+
+            for (KeyspaceMetadata keyspaceAfter : after)
+            {
+                if (!before.containsKeyspace(keyspaceAfter.name))
+                {
+                    if (created == null)
+                        created = new ArrayList<>();
+                    created.add(keyspaceAfter);
+                }
+            }
+
+            for (KeyspaceMetadata keyspaceBefore : before)
             {
                 KeyspaceMetadata keyspaceAfter = after.getNullable(keyspaceBefore.name);
-                if (null != keyspaceAfter)
+                if (null == keyspaceAfter)
+                {
+                    if (dropped == null)
+                        dropped = new ArrayList<>();
+                    dropped.add(keyspaceBefore);
+                }
+                else if (keyspaceAfter != keyspaceBefore)
+                {
+                    // Identity means nothing in this keyspace changed; KeyspaceDiff.diff would reach the same
+                    // conclusion, but only after walking the keyspace.
                     KeyspaceMetadata.diff(keyspaceBefore, keyspaceAfter).ifPresent(altered::add);
-            });
+                }
+            }
 
-            return new KeyspacesDiff(created, dropped, altered.build());
+            return new KeyspacesDiff(created == null ? Keyspaces.none() : Keyspaces.of(created),
+                                     dropped == null ? Keyspaces.none() : Keyspaces.of(dropped),
+                                     altered.build());
         }
 
         public boolean isEmpty()

--- a/src/java/org/apache/cassandra/schema/Tables.java
+++ b/src/java/org/apache/cassandra/schema/Tables.java
@@ -31,7 +31,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
@@ -43,6 +42,7 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.tcm.serialization.UDTAndFunctionsAwareMetadataSerializer;
 import org.apache.cassandra.tcm.serialization.Version;
+import org.apache.cassandra.utils.btree.BTreeMap;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.transform;
@@ -56,15 +56,52 @@ public final class Tables implements Iterable<TableMetadata>
 
     private static final Tables NONE = builder().build();
 
-    private final ImmutableMap<String, TableMetadata> tables;
-    private final ImmutableMap<TableId, TableMetadata> tablesById;
-    private final ImmutableMap<String, TableMetadata> indexTables;
+    private final BTreeMap<String, TableMetadata> tables;
+    private final BTreeMap<TableId, TableMetadata> tablesById;
+    private final BTreeMap<String, TableMetadata> indexTables;
 
     private Tables(Builder builder)
     {
-        tables = builder.tables.build();
-        tablesById = builder.tablesById.build();
-        indexTables = builder.indexTables.build();
+        this(builder.tables, builder.tablesById, builder.indexTables);
+    }
+
+    private Tables(BTreeMap<String, TableMetadata> tables,
+                   BTreeMap<TableId, TableMetadata> tablesById,
+                   BTreeMap<String, TableMetadata> indexTables)
+    {
+        this.tables = tables;
+        this.tablesById = tablesById;
+        this.indexTables = indexTables;
+    }
+
+    /**
+     * Index tables are derived from their base table rather than stored independently, so they are added and removed
+     * alongside it. The key is the index name: {@link TableMetadata#indexTableName} builds the index table's name by
+     * appending it to the base table's, and {@link TableMetadata#indexName()} strips it back off again. Keying off
+     * {@link IndexMetadata#name} directly is therefore the same key without building the metadata to derive it, so
+     * removal costs a lookup per index. Either direction is bounded by the indexes on the one table being changed
+     * rather than by the size of the collection.
+     */
+    private static BTreeMap<String, TableMetadata> withIndexesOf(BTreeMap<String, TableMetadata> indexTables, TableMetadata table)
+    {
+        for (IndexMetadata index : table.indexes)
+        {
+            if (index.isCustom())
+                continue;
+            indexTables = indexTables.with(index.name, CassandraIndex.indexCfsMetadata(table, index));
+        }
+        return indexTables;
+    }
+
+    private static BTreeMap<String, TableMetadata> withoutIndexesOf(BTreeMap<String, TableMetadata> indexTables, TableMetadata table)
+    {
+        for (IndexMetadata index : table.indexes)
+        {
+            if (index.isCustom())
+                continue;
+            indexTables = indexTables.without(index.name);
+        }
+        return indexTables;
     }
 
     public static Builder builder()
@@ -102,7 +139,7 @@ public final class Tables implements Iterable<TableMetadata>
         return Iterables.filter(tables.values(), t -> t.referencesUserType(name));
     }
 
-    ImmutableMap<String, TableMetadata> indexTables()
+    Map<String, TableMetadata> indexTables()
     {
         return indexTables;
     }
@@ -161,7 +198,9 @@ public final class Tables implements Iterable<TableMetadata>
         if (get(table.name).isPresent())
             throw new IllegalStateException(String.format("Table %s already exists", table.name));
 
-        return builder().add(this).add(table).build();
+        return new Tables(tables.with(table.name, table),
+                          tablesById.with(table.id, table),
+                          withIndexesOf(indexTables, table));
     }
 
     public Tables withSwapped(TableMetadata table)
@@ -182,7 +221,9 @@ public final class Tables implements Iterable<TableMetadata>
 
     public Tables without(TableMetadata table)
     {
-        return filter(t -> t != table);
+        return new Tables(tables.without(table.name),
+                          tablesById.without(table.id),
+                          withoutIndexesOf(indexTables, table));
     }
 
     public Tables withUpdatedUserType(UserType udt)
@@ -223,9 +264,9 @@ public final class Tables implements Iterable<TableMetadata>
 
     public static final class Builder
     {
-        final ImmutableMap.Builder<String, TableMetadata> tables = new ImmutableMap.Builder<>();
-        final ImmutableMap.Builder<TableId, TableMetadata> tablesById = new ImmutableMap.Builder<>();
-        final ImmutableMap.Builder<String, TableMetadata> indexTables = new ImmutableMap.Builder<>();
+        BTreeMap<String, TableMetadata> tables = BTreeMap.empty();
+        BTreeMap<TableId, TableMetadata> tablesById = BTreeMap.empty();
+        BTreeMap<String, TableMetadata> indexTables = BTreeMap.empty();
 
         private Builder()
         {
@@ -238,15 +279,14 @@ public final class Tables implements Iterable<TableMetadata>
 
         public Builder add(TableMetadata table)
         {
-            tables.put(table.name, table);
+            // ImmutableMap.Builder rejected duplicates when it was built; a persistent map would silently overwrite,
+            // so the check is made explicit rather than dropped.
+            if (tables.containsKey(table.name))
+                throw new IllegalArgumentException(String.format("Table %s already exists", table.name));
 
-            tablesById.put(table.id, table);
-
-            table.indexes
-                 .stream()
-                 .filter(i -> !i.isCustom())
-                 .map(i -> CassandraIndex.indexCfsMetadata(table, i))
-                 .forEach(i -> indexTables.put(i.indexName().get(), i));
+            tables = tables.with(table.name, table);
+            tablesById = tablesById.with(table.id, table);
+            indexTables = withIndexesOf(indexTables, table);
 
             return this;
         }

--- a/src/java/org/apache/cassandra/schema/Tables.java
+++ b/src/java/org/apache/cassandra/schema/Tables.java
@@ -284,18 +284,48 @@ public final class Tables implements Iterable<TableMetadata>
             if (before == after)
                 return NONE;
 
-            Tables created = after.filter(t -> !before.containsTable(t.id));
-            Tables dropped = before.filter(t -> !after.containsTable(t.id));
-
+            // Collect the differences directly instead of filtering whole collections: a schema change touches a
+            // handful of tables, so allocating only for those keeps the cost of a diff proportional to what actually
+            // changed rather than to the size of the schema.
+            Builder created = null;
+            Builder dropped = null;
             ImmutableList.Builder<Altered<TableMetadata>> altered = ImmutableList.builder();
-            before.forEach(tableBefore ->
+
+            for (TableMetadata tableAfter : after)
+            {
+                if (!before.containsTable(tableAfter.id))
+                {
+                    if (created == null)
+                        created = builder();
+                    created.add(tableAfter);
+                }
+            }
+
+            for (TableMetadata tableBefore : before)
             {
                 TableMetadata tableAfter = after.getNullable(tableBefore.id);
-                if (null != tableAfter)
+                if (null == tableAfter)
+                {
+                    if (dropped == null)
+                        dropped = builder();
+                    dropped.add(tableBefore);
+                }
+                else if (tableAfter != tableBefore)
+                {
+                    // Untouched tables are carried over by reference (Builder.add stores the instance verbatim), and
+                    // compare() of an instance against itself is empty by construction, so identity is a sound and
+                    // exact substitute for the comparison here.
                     tableBefore.compare(tableAfter).ifPresent(kind -> altered.add(new Altered<>(tableBefore, tableAfter, kind)));
-            });
+                }
+            }
 
-            return new TablesDiff(created, dropped, altered.build());
+            ImmutableList<Altered<TableMetadata>> alteredTables = altered.build();
+            if (created == null && dropped == null && alteredTables.isEmpty())
+                return NONE;
+
+            return new TablesDiff(created == null ? Tables.none() : created.build(),
+                                  dropped == null ? Tables.none() : dropped.build(),
+                                  alteredTables);
         }
     }
 

--- a/test/unit/org/apache/cassandra/schema/KeyspacesDiffScalingTest.java
+++ b/test/unit/org/apache/cassandra/schema/KeyspacesDiffScalingTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.sun.management.ThreadMXBean;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.db.marshal.Int32Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A single schema change must cost the same whether the cluster holds a hundred tables or a hundred thousand.
+ *
+ * <p>{@link Keyspaces#diff} is executed several times for every DDL statement - by the transformation, by
+ * {@link DistributedSchema#initializeKeyspaceInstances}, and again when change listeners are notified - so any per-call
+ * cost that scales with the size of the schema is paid on every {@code CREATE TABLE} and turns bulk schema creation
+ * into an O(n^2) operation.
+ *
+ * <p>These tests measure allocation rather than elapsed time. Allocation is counted exactly by the JVM rather than
+ * sampled, does not depend on GC timing or on what else the machine is doing, and is the quantity that actually
+ * matters here: the failure mode users hit is not gradual slowdown but a GC wall, reached because each statement
+ * allocates in proportion to the whole schema. A wall-clock assertion at this granularity would be flaky; this is not.
+ *
+ * <p>Both tests assert a growth <em>ratio</em> rather than an absolute byte count, so they do not need re-tuning for a
+ * different JDK, allocator, or machine.
+ */
+public class KeyspacesDiffScalingTest
+{
+    /** Table counts differing by 8x. An O(schema-size) diff allocates ~8x more at LARGE; a correct one allocates ~1x. */
+    private static final int SMALL = 400;
+    private static final int LARGE = 3200;
+
+    /**
+     * Generous: the honest expectation is ~1.0. Anything below this is flat enough to rule out per-table work; the
+     * behaviour under test allocates ~8x, so the gap between pass and fail is wide and no borderline case exists.
+     */
+    private static final double MAX_GROWTH = 3.0;
+
+    private static final int WARMUP = 10;
+    private static final int ITERATIONS = 20;
+
+    private static final ThreadMXBean THREADS = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    /** Kept live so the diffs under measurement cannot be optimised away. */
+    @SuppressWarnings("unused")
+    private static volatile Object sink;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        ServerTestUtils.prepareServerNoRegister();
+        assertTrue("This test requires per-thread allocation counting",
+                   THREADS.isThreadAllocatedMemorySupported() && THREADS.isThreadAllocatedMemoryEnabled());
+    }
+
+    /**
+     * The reported case: many tables in one keyspace. Adding table n+1 must not cost more than adding table 2.
+     */
+    @Test
+    public void addingOneTableDoesNotScaleWithExistingTablesInSameKeyspace()
+    {
+        long small = bytesPerDiff(oneKeyspaceWithTableAdded(SMALL));
+        long large = bytesPerDiff(oneKeyspaceWithTableAdded(LARGE));
+
+        assertGrowthIsFlat("adding one table to a keyspace already holding", small, large);
+    }
+
+    /**
+     * Tables in <em>other</em> keyspaces must not be touched at all. The changed keyspace holds a fixed 10 tables in
+     * both cases; only the unrelated keyspaces grow. CASSANDRA-7444 established this in 2.1.1 ("compare before/after
+     * schemas of the affected keyspaces only"); this test pins it.
+     */
+    @Test
+    public void addingOneTableDoesNotScaleWithTablesInOtherKeyspaces()
+    {
+        long small = bytesPerDiff(manyKeyspacesWithTableAdded(SMALL));
+        long large = bytesPerDiff(manyKeyspacesWithTableAdded(LARGE));
+
+        assertGrowthIsFlat("adding one table to a 10-table keyspace alongside unrelated tables numbering", small, large);
+    }
+
+    /** The optimisation must not change what the diff reports: one created table, nothing else. */
+    @Test
+    public void diffReportsExactlyTheCreatedTable()
+    {
+        Keyspaces[] pair = oneKeyspaceWithTableAdded(50);
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(pair[0], pair[1]);
+
+        assertEquals("no keyspaces created", 0, size(diff.created));
+        assertEquals("no keyspaces dropped", 0, size(diff.dropped));
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("exactly one table created", 1, size(ks.tables.created));
+        assertEquals("no tables dropped", 0, size(ks.tables.dropped));
+        assertEquals("no tables altered", 0, ks.tables.altered.size());
+        assertEquals("the added table", "table_50", ks.tables.created.iterator().next().name);
+    }
+
+    /** Same, for the reverse direction. */
+    @Test
+    public void diffReportsExactlyTheDroppedTable()
+    {
+        Keyspaces[] pair = oneKeyspaceWithTableAdded(50);
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(pair[1], pair[0]);
+
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("no tables created", 0, size(ks.tables.created));
+        assertEquals("exactly one table dropped", 1, size(ks.tables.dropped));
+        assertEquals("the removed table", "table_50", ks.tables.dropped.iterator().next().name);
+    }
+
+    /**
+     * An altered table must still be detected. This is the case an over-eager identity short-circuit would break: the
+     * instance genuinely differs, so it must be compared, not skipped.
+     */
+    @Test
+    public void diffReportsAnAlteredTable()
+    {
+        List<TableMetadata> tables = tables("ks", 50);
+        Keyspaces before = keyspaces(Tables.of(tables), ImmutableList.of());
+
+        TableMetadata altered = tables.get(10).unbuild().comment("changed").build();
+        List<TableMetadata> after = new ArrayList<>(tables);
+        after.set(10, altered);
+
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(before, keyspaces(Tables.of(after), ImmutableList.of()));
+
+        assertEquals("exactly one keyspace altered", 1, diff.altered.size());
+        KeyspaceMetadata.KeyspaceDiff ks = diff.altered.get(0);
+        assertEquals("no tables created", 0, size(ks.tables.created));
+        assertEquals("no tables dropped", 0, size(ks.tables.dropped));
+        assertEquals("exactly one table altered", 1, ks.tables.altered.size());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static void assertGrowthIsFlat(String what, long small, long large)
+    {
+        double growth = (double) large / small;
+        String detail = String.format("%s %,d tables allocated %,d bytes; at %,d tables it allocated %,d bytes " +
+                                      "(%.1fx). The schema is %dx larger, so a diff whose cost is independent of " +
+                                      "schema size should be near 1.0x.",
+                                      what, SMALL, small, LARGE, large, growth, LARGE / SMALL);
+        assertTrue(detail, growth < MAX_GROWTH);
+    }
+
+    /** Allocation attributable to one {@link Keyspaces#diff} call, warmed up so lazy initialisation is not counted. */
+    private static long bytesPerDiff(Keyspaces[] beforeAfter)
+    {
+        Keyspaces before = beforeAfter[0];
+        Keyspaces after = beforeAfter[1];
+
+        for (int i = 0; i < WARMUP; i++)
+            sink = Keyspaces.diff(before, after);
+
+        long id = Thread.currentThread().getId();
+        long start = THREADS.getThreadAllocatedBytes(id);
+        for (int i = 0; i < ITERATIONS; i++)
+            sink = Keyspaces.diff(before, after);
+        return (THREADS.getThreadAllocatedBytes(id) - start) / ITERATIONS;
+    }
+
+    /** {before, after} where a single keyspace holds {@code existing} tables and one more is added. */
+    private static Keyspaces[] oneKeyspaceWithTableAdded(int existing)
+    {
+        List<TableMetadata> tables = tables("ks", existing);
+        Keyspaces before = keyspaces(Tables.of(tables), ImmutableList.of());
+        Keyspaces after = keyspaces(Tables.of(tables).with(table("ks", existing)), ImmutableList.of());
+        return new Keyspaces[]{ before, after };
+    }
+
+    /**
+     * {before, after} where the changed keyspace always holds 10 tables, and {@code unrelated} further tables are
+     * spread across other keyspaces that do not change at all.
+     */
+    private static Keyspaces[] manyKeyspacesWithTableAdded(int unrelated)
+    {
+        int others = 10;
+        int perOther = unrelated / others;
+
+        // Built once and shared by both sides. A schema change rebuilds only the keyspace it touches and carries the
+        // rest over by reference, so sharing these instances is what the production path actually produces - a fixture
+        // that rebuilt them independently would be measuring a situation that never occurs.
+        List<KeyspaceMetadata> untouched = new ArrayList<>(others);
+        for (int i = 0; i < others; i++)
+        {
+            String name = "other_" + i;
+            untouched.add(KeyspaceMetadata.create(name, KeyspaceParams.simple(1), Tables.of(tables(name, perOther))));
+        }
+
+        List<TableMetadata> tables = tables("ks", 10);
+        Keyspaces before = keyspaces(Tables.of(tables), untouched);
+        Keyspaces after = keyspaces(Tables.of(tables).with(table("ks", 10)), untouched);
+        return new Keyspaces[]{ before, after };
+    }
+
+    /** Keyspace "ks" holding {@code tables}, alongside the given untouched keyspaces. */
+    private static Keyspaces keyspaces(Tables tables, List<KeyspaceMetadata> untouched)
+    {
+        return Keyspaces.of(KeyspaceMetadata.create("ks", KeyspaceParams.simple(1), tables)).with(untouched);
+    }
+
+    private static List<TableMetadata> tables(String keyspace, int count)
+    {
+        List<TableMetadata> tables = new ArrayList<>(count);
+        for (int i = 0; i < count; i++)
+            tables.add(table(keyspace, i));
+        return tables;
+    }
+
+    private static TableMetadata table(String keyspace, int i)
+    {
+        return TableMetadata.builder(keyspace, "table_" + i)
+                            .addPartitionKeyColumn("pk", Int32Type.instance)
+                            .addClusteringColumn("ck", Int32Type.instance)
+                            .addRegularColumn("v", Int32Type.instance)
+                            .build();
+    }
+
+    private static int size(Iterable<?> iterable)
+    {
+        int n = 0;
+        for (Object ignored : iterable) n++;
+        return n;
+    }
+}

--- a/test/unit/org/apache/cassandra/schema/TablesScalingTest.java
+++ b/test/unit/org/apache/cassandra/schema/TablesScalingTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.sun.management.ThreadMXBean;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.db.marshal.Int32Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Adding, replacing or removing one table must not cost in proportion to the tables already present.
+ *
+ * <p>{@link Tables} used to keep three {@link com.google.common.collect.ImmutableMap}s and rebuild all of them on
+ * every mutation - {@code with} was {@code builder().add(this).add(table).build()} - so a single {@code CREATE TABLE}
+ * copied every existing table into three fresh maps and recomputed index metadata for every indexed table while doing
+ * so. Several such rebuilds happen per DDL statement, which is what kept bulk schema creation quadratic even once
+ * diffing was cheap. The maps are persistent now, and these tests are what holds that.
+ *
+ * <p>As in {@link KeyspacesDiffScalingTest}, these assert allocation rather than elapsed time: it is counted exactly
+ * rather than sampled, is independent of GC timing and machine load, and is the quantity that produces the failure
+ * users hit. A persistent map allocates O(log n) per update rather than O(1), so the bar is "grows far slower than the
+ * collection" rather than "perfectly flat".
+ */
+public class TablesScalingTest
+{
+    private static final int SMALL = 400;
+    private static final int LARGE = 3200;
+
+    /**
+     * An O(n) rebuild allocates ~8x more at LARGE. A persistent map allocates O(log n), i.e. ~1.3x across this range.
+     * 3.0 sits far from both, so neither a pass nor a failure is borderline.
+     */
+    private static final double MAX_GROWTH = 3.0;
+
+    private static final int WARMUP = 10;
+    private static final int ITERATIONS = 20;
+
+    private static final ThreadMXBean THREADS = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    @SuppressWarnings("unused")
+    private static volatile Object sink;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        ServerTestUtils.prepareServerNoRegister();
+        assertTrue("This test requires per-thread allocation counting",
+                   THREADS.isThreadAllocatedMemorySupported() && THREADS.isThreadAllocatedMemoryEnabled());
+    }
+
+    @Test
+    public void addingATableDoesNotScaleWithExistingTables()
+    {
+        long small = bytesPerOp(fixture(SMALL), t -> t.with(table("ks", SMALL)));
+        long large = bytesPerOp(fixture(LARGE), t -> t.with(table("ks", LARGE)));
+        assertGrowthIsSublinear("adding one table to", small, large);
+    }
+
+    @Test
+    public void replacingATableDoesNotScaleWithExistingTables()
+    {
+        TableMetadata smallSwap = altered(fixture(SMALL), 7);
+        TableMetadata largeSwap = altered(fixture(LARGE), 7);
+        long small = bytesPerOp(fixture(SMALL), t -> t.withSwapped(smallSwap));
+        long large = bytesPerOp(fixture(LARGE), t -> t.withSwapped(largeSwap));
+        assertGrowthIsSublinear("replacing one table in", small, large);
+    }
+
+    @Test
+    public void removingATableDoesNotScaleWithExistingTables()
+    {
+        long small = bytesPerOp(fixture(SMALL), t -> t.without("table_7"));
+        long large = bytesPerOp(fixture(LARGE), t -> t.without("table_7"));
+        assertGrowthIsSublinear("removing one table from", small, large);
+    }
+
+    // -------------------------------------------------------------- correctness guards
+
+    @Test
+    public void withAddsExactlyOneTableAndPreservesTheRest()
+    {
+        Tables before = fixture(50);
+        Tables after = before.with(table("ks", 50));
+
+        assertEquals(51, size(after));
+        assertNotNull("added table is resolvable by name", after.getNullable("table_50"));
+        for (TableMetadata t : before)
+        {
+            assertNotNull("pre-existing table still resolvable by name: " + t.name, after.getNullable(t.name));
+            assertNotNull("pre-existing table still resolvable by id: " + t.name, after.getNullable(t.id));
+        }
+    }
+
+    @Test
+    public void withoutRemovesExactlyOneTable()
+    {
+        Tables after = fixture(50).without("table_7");
+
+        assertEquals(49, size(after));
+        assertNull("removed table is gone by name", after.getNullable("table_7"));
+        assertNotNull("neighbours survive", after.getNullable("table_6"));
+        assertNotNull("neighbours survive", after.getNullable("table_8"));
+    }
+
+    @Test
+    public void withSwappedReplacesInPlace()
+    {
+        Tables before = fixture(50);
+        TableMetadata swapped = altered(before, 7);
+        Tables after = before.withSwapped(swapped);
+
+        assertEquals(50, size(after));
+        assertEquals("the replacement is what resolves", "changed", after.getNullable("table_7").params.comment);
+        assertEquals("lookup by id agrees with lookup by name",
+                     after.getNullable("table_7"), after.getNullable(swapped.id));
+    }
+
+    /**
+     * Pins what callers may rely on about iteration. It is no longer insertion order - the backing map is sorted by
+     * table name - so this asserts the properties that actually have consequences: iteration is repeatable, it depends
+     * on the set of tables rather than on the order they were added, it agrees with lookup by name and by id, and
+     * changing one table leaves the relative order of the others alone. Serialization walks this collection, so two
+     * nodes holding the same schema must walk it the same way; the schema version itself is derived from the TCM
+     * epoch rather than hashed from content ({@link DistributedSchema}), so ordering cannot shift a digest.
+     */
+    @Test
+    public void iterationIsDeterministicAndAgreesWithLookup()
+    {
+        Tables tables = fixture(50);
+
+        List<String> first = names(tables);
+        assertEquals("iteration order is repeatable", first, names(tables));
+
+        List<TableMetadata> reversed = new ArrayList<>();
+        for (TableMetadata t : tables)
+            reversed.add(t);
+        Collections.reverse(reversed);
+        assertEquals("iteration order is a function of the tables, not of the order they were added",
+                     first, names(Tables.of(reversed)));
+
+        for (String name : first)
+        {
+            TableMetadata table = tables.getNullable(name);
+            assertNotNull("iterated table resolves by name: " + name, table);
+            assertSame("lookup by id agrees with iteration: " + name, table, tables.getNullable(table.id));
+        }
+
+        List<String> afterAdd = names(tables.with(table("ks", 50)));
+        assertTrue("the added table is iterated", afterAdd.contains("table_50"));
+        assertEquals("adding a table does not reorder the existing ones", first, discard(afterAdd, "table_50"));
+
+        assertEquals("removing a table does not reorder the others",
+                     discard(first, "table_7"), names(tables.without("table_7")));
+    }
+
+    // -------------------------------------------------------------- helpers
+
+    private interface Op
+    {
+        Tables apply(Tables tables);
+    }
+
+    private static void assertGrowthIsSublinear(String what, long small, long large)
+    {
+        double growth = (double) large / small;
+        String detail = String.format("%s %,d tables allocated %,d bytes; at %,d tables it allocated %,d bytes " +
+                                      "(%.1fx). The collection is %dx larger, so an update that does not copy it " +
+                                      "should be far below that.",
+                                      what, SMALL, small, LARGE, large, growth, LARGE / SMALL);
+        assertTrue(detail, growth < MAX_GROWTH);
+    }
+
+    private static long bytesPerOp(Tables tables, Op op)
+    {
+        for (int i = 0; i < WARMUP; i++)
+            sink = op.apply(tables);
+
+        long id = Thread.currentThread().getId();
+        long start = THREADS.getThreadAllocatedBytes(id);
+        for (int i = 0; i < ITERATIONS; i++)
+            sink = op.apply(tables);
+        return (THREADS.getThreadAllocatedBytes(id) - start) / ITERATIONS;
+    }
+
+    private static Tables fixture(int count)
+    {
+        List<TableMetadata> tables = new ArrayList<>(count);
+        for (int i = 0; i < count; i++)
+            tables.add(table("ks", i));
+        return Tables.of(tables);
+    }
+
+    private static TableMetadata altered(Tables tables, int i)
+    {
+        return tables.getNullable("table_" + i).unbuild().comment("changed").build();
+    }
+
+    private static TableMetadata table(String keyspace, int i)
+    {
+        return TableMetadata.builder(keyspace, "table_" + i)
+                            .addPartitionKeyColumn("pk", Int32Type.instance)
+                            .addClusteringColumn("ck", Int32Type.instance)
+                            .addRegularColumn("v", Int32Type.instance)
+                            .build();
+    }
+
+    private static List<String> discard(List<String> names, String name)
+    {
+        List<String> rest = new ArrayList<>(names);
+        assertTrue("expected " + name + " to be present", rest.remove(name));
+        return rest;
+    }
+
+    private static List<String> names(Tables tables)
+    {
+        List<String> names = new ArrayList<>();
+        for (TableMetadata t : tables)
+            names.add(t.name);
+        return names;
+    }
+
+    private static int size(Tables tables)
+    {
+        int n = 0;
+        for (TableMetadata ignored : tables) n++;
+        return n;
+    }
+}


### PR DESCRIPTION
[CASSANDRA-21660](https://issues.apache.org/jira/browse/CASSANDRA-21660)

> **Stacked on [#5121](https://github.com/apache/cassandra/pull/5121) (CASSANDRA-21659).** That commit is included here because both touch `Tables.java`. Review only the second commit; the diff against #5121 is `Tables.java` plus one new test.

**What**

`Tables` keeps three `ImmutableMap`s and rebuilds all of them on every mutation: `with()` is `builder().add(this).add(table).build()`, `withSwapped()` is `without().with()`. A single `CREATE TABLE` therefore copies every existing table into three fresh maps more than once, and `Builder.add` recomputes index metadata — including a `TargetParser.parse` — for every indexed table while doing so.

CEP-21 converted the outer collection, `Keyspaces`, to a persistent `BTreeMap`: TCM holds schema at several epochs at once, so copy-on-write would copy the world per epoch. The collections nested inside a keyspace were not converted. This does `Tables`, which is the one deployments have thousands of.

**Change**

* Back the three maps with `BTreeMap`, so `with`/`without`/`withSwapped` update rather than copy.
* Maintain index tables incrementally, keyed off `IndexMetadata.name` — provably the same key, since `indexTableName` is `base + '.' + index.name` and `indexName` is the substring after the dot. Removal no longer builds a whole index `TableMetadata` just to read its name back off it.
* `Builder` keeps the duplicate-name rejection `ImmutableMap.Builder.build()` provided; a persistent map would otherwise overwrite silently.

**Result**

Allocation per operation:

| operation | 400 before | 3200 before | growth | 400 after | 3200 after | growth |
|---|---|---|---|---|---|---|
| `with` | 218,951 B | 1,687,617 B | 7.7x | 5,728 B | 5,920 B | 1.0x |
| `withSwapped` | 425,824 B | 3,349,656 B | 7.9x | 1,936 B | 2,448 B | 1.3x |
| `without` | 213,896 B | 1,682,368 B | 7.9x | 928 B | 1,200 B | 1.3x |

The residual 1.3x is the O(log n) spine a persistent map allocates per update — the mechanism, not a defect.

**⚠️ Requires a clean build**

`Tables.indexTables()` narrows from `ImmutableMap` to `Map`. That is binary incompatible, and ant's timestamp-based javac will not recompile callers whose source did not change. With a stale `build/` you get a `NoSuchMethodError` thrown inside `SecondaryIndexManager.createIndex`, which `LocalLog.processPendingInternal` catches and logs as "Could not process the entry" — leaving an index silently unregistered and surfacing later as an apparently unrelated NPE in a different test. Run `ant clean` first. No source change can prevent this.

**Tests**

New `TablesScalingTest`: 3 allocation assertions, 4 correctness guards (add/remove/replace semantics; iteration deterministic and agreeing with lookup by both name and id). Like #5121's test it asserts an allocation *ratio* rather than an absolute byte count, so it needs no re-tuning per JDK or machine.

Regression on a clean build: `org.apache.cassandra.schema` 29 suites, `org.apache.cassandra.tcm` 13 suites, `org.apache.cassandra.index` 3 suites / 61 tests — 0 failures. `ant checkstyle` and `ant checkstyle-test` clean.

**Worth a separate ticket**

`LocalLog.processPendingInternal` catches `Throwable`, logs "Could not process the entry" and continues, leaving a half-applied schema and no failed operation. Pre-existing TCM behaviour, but it turned a hard linkage error into a mystery here and would do the same to an operator.
