### PR TITLE
CASSANDRA-21417: Fix non-printable characters in Gossiper log for TOKENS

### DIFF
--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.gms;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -35,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -328,7 +331,51 @@ public class EndpointState
     public String toString()
     {
         View view = ref.get();
-        return "EndpointState: HeartBeatState = " + view.hbState + ", AppStateMap = " + view.applicationState + ", isAlive = " + isAlive;
+        return "EndpointState: HeartBeatState = " + view.hbState + ", AppStateMap = " + appStateMapToString(view.applicationState) + ", isAlive = " + isAlive;
+    }
+
+    /**
+     * Renders the application state map for logging/debugging purposes. This differs from the map's default
+     * toString() only in how it handles {@link ApplicationState#TOKENS}: that value is a serialized token
+     * collection stored as an ISO-8859-1-encoded string purely to round-trip the raw bytes losslessly, and is
+     * never meant to be printed as text - doing so produces unreadable, control-character-laden output
+     * (see CASSANDRA-21417). All other states are rendered normally.
+     */
+    private static String appStateMapToString(Map<ApplicationState, VersionedValue> applicationState)
+    {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<ApplicationState, VersionedValue> entry : applicationState.entrySet())
+        {
+            if (!first)
+                sb.append(", ");
+            first = false;
+
+            sb.append(entry.getKey()).append('=');
+            if (entry.getKey() == ApplicationState.TOKENS)
+                sb.append(tokensValueToString(entry.getValue()));
+            else
+                sb.append(entry.getValue());
+        }
+        return sb.append('}').toString();
+    }
+
+    private static String tokensValueToString(VersionedValue value)
+    {
+        try
+        {
+            int numTokens = TokenSerializer.deserialize(DatabaseDescriptor.getPartitioner(),
+                                                          new DataInputStream(new ByteArrayInputStream(value.toBytes())))
+                                            .size();
+            return "Value(<" + numTokens + " tokens>," + value.version + ')';
+        }
+        catch (Throwable t)
+        {
+            // Still avoid printing the raw bytes if we can't deserialize them for some reason. A corrupt
+            // length prefix can make TokenSerializer try to allocate an absurdly large array, so this must
+            // catch Throwable rather than just Exception to guard against OutOfMemoryError as well.
+            return "Value(<" + value.toBytes().length + " undecodable bytes>," + value.version + ')';
+        }
     }
 
     public boolean isSupersededBy(EndpointState that)

--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -331,51 +331,33 @@ public class EndpointState
     public String toString()
     {
         View view = ref.get();
-        return "EndpointState: HeartBeatState = " + view.hbState + ", AppStateMap = " + appStateMapToString(view.applicationState) + ", isAlive = " + isAlive;
+        return "EndpointState: HeartBeatState = " + view.hbState + ", AppStateMap = " + formatAppStateMapForLogging(view.applicationState) + ", isAlive = " + isAlive;
     }
 
     /**
-     * Renders the application state map for logging/debugging purposes. This differs from the map's default
-     * toString() only in how it handles {@link ApplicationState#TOKENS}: that value is a serialized token
-     * collection stored as an ISO-8859-1-encoded string purely to round-trip the raw bytes losslessly, and is
-     * never meant to be printed as text - doing so produces unreadable, control-character-laden output
-     * (see CASSANDRA-21417). All other states are rendered normally.
+     * TOKENS is stored as an ISO-8859-1 string just to hold raw bytes, so printing it as-is dumps unreadable
+     * control characters into the logs. This renders it as a token count instead (see CASSANDRA-21417).
      */
-    private static String appStateMapToString(Map<ApplicationState, VersionedValue> applicationState)
+    static String formatAppStateMapForLogging(Map<ApplicationState, VersionedValue> applicationState)
     {
-        StringBuilder sb = new StringBuilder("{");
-        boolean first = true;
-        for (Map.Entry<ApplicationState, VersionedValue> entry : applicationState.entrySet())
-        {
-            if (!first)
-                sb.append(", ");
-            first = false;
+        return applicationState.entrySet().stream().map(entry -> {
+            if (entry.getKey() != ApplicationState.TOKENS)
+                return entry.getKey() + "=" + entry.getValue();
 
-            sb.append(entry.getKey()).append('=');
-            if (entry.getKey() == ApplicationState.TOKENS)
-                sb.append(tokensValueToString(entry.getValue()));
-            else
-                sb.append(entry.getValue());
-        }
-        return sb.append('}').toString();
-    }
-
-    private static String tokensValueToString(VersionedValue value)
-    {
-        try
-        {
-            int numTokens = TokenSerializer.deserialize(DatabaseDescriptor.getPartitioner(),
-                                                          new DataInputStream(new ByteArrayInputStream(value.toBytes())))
-                                            .size();
-            return "Value(<" + numTokens + " tokens>," + value.version + ')';
-        }
-        catch (Throwable t)
-        {
-            // Still avoid printing the raw bytes if we can't deserialize them for some reason. A corrupt
-            // length prefix can make TokenSerializer try to allocate an absurdly large array, so this must
-            // catch Throwable rather than just Exception to guard against OutOfMemoryError as well.
-            return "Value(<" + value.toBytes().length + " undecodable bytes>," + value.version + ')';
-        }
+            VersionedValue value = entry.getValue();
+            try
+            {
+                int numTokens = TokenSerializer.deserialize(DatabaseDescriptor.getPartitioner(),
+                                                              new DataInputStream(new ByteArrayInputStream(value.toBytes())))
+                                                .size();
+                return entry.getKey() + "=Value(<" + numTokens + " tokens>," + value.version + ')';
+            }
+            catch (Throwable t)
+            {
+                // catches OutOfMemoryError too, since a corrupt length prefix can trigger a huge allocation
+                return entry.getKey() + "=Value(<" + value.toBytes().length + " undecodable bytes>," + value.version + ')';
+            }
+        }).collect(Collectors.joining(", ", "{", "}"));
     }
 
     public boolean isSupersededBy(EndpointState that)

--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -340,15 +341,15 @@ public class EndpointState
      */
     static String formatAppStateMapForLogging(Map<ApplicationState, VersionedValue> applicationState)
     {
+        IPartitioner partitioner = DatabaseDescriptor.getPartitioner();
         return applicationState.entrySet().stream().map(entry -> {
             if (entry.getKey() != ApplicationState.TOKENS)
                 return entry.getKey() + "=" + entry.getValue();
 
-            VersionedValue value = entry.getValue();
+            final VersionedValue value = entry.getValue();
             try
             {
-                int numTokens = TokenSerializer.deserialize(DatabaseDescriptor.getPartitioner(),
-                                                              new DataInputStream(new ByteArrayInputStream(value.toBytes())))
+                int numTokens = TokenSerializer.deserialize(partitioner, new DataInputStream(new ByteArrayInputStream(value.toBytes())))
                                                 .size();
                 return entry.getKey() + "=Value(<" + numTokens + " tokens>," + value.version + ')';
             }

--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -17,8 +17,6 @@
  */
 package org.apache.cassandra.gms;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -27,6 +25,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -37,9 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.TypeSizes;
-import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -337,28 +334,17 @@ public class EndpointState
 
     /**
      * TOKENS is stored as an ISO-8859-1 string just to hold raw bytes, so printing it as-is dumps unreadable
-     * control characters into the logs. This renders it as a token count instead (see CASSANDRA-21417).
+     * control characters into the logs. Hide it entirely instead, matching how nodetool gossipinfo already
+     * treats TOKENS (see CASSANDRA-10330, CASSANDRA-21417).
      */
     static String formatAppStateMapForLogging(Map<ApplicationState, VersionedValue> applicationState)
     {
-        IPartitioner partitioner = DatabaseDescriptor.getPartitioner();
-        return applicationState.entrySet().stream().map(entry -> {
-            if (entry.getKey() != ApplicationState.TOKENS)
-                return entry.getKey() + "=" + entry.getValue();
-
-            final VersionedValue value = entry.getValue();
-            try
-            {
-                int numTokens = TokenSerializer.deserialize(partitioner, new DataInputStream(new ByteArrayInputStream(value.toBytes())))
-                                                .size();
-                return entry.getKey() + "=Value(<" + numTokens + " tokens>," + value.version + ')';
-            }
-            catch (Throwable t)
-            {
-                // catches OutOfMemoryError too, since a corrupt length prefix can trigger a huge allocation
-                return entry.getKey() + "=Value(<" + value.toBytes().length + " undecodable bytes>," + value.version + ')';
-            }
-        }).collect(Collectors.joining(", ", "{", "}"));
+        Stream<String> otherStates = applicationState.entrySet()
+                                                       .stream()
+                                                       .filter(entry -> entry.getKey() != ApplicationState.TOKENS)
+                                                       .map(entry -> entry.getKey() + "=" + entry.getValue());
+        String tokensState = "TOKENS=" + (applicationState.containsKey(ApplicationState.TOKENS) ? "Value(<hidden>)" : "not present");
+        return Stream.concat(otherStates, Stream.of(tokensState)).collect(Collectors.joining(", ", "{", "}"));
     }
 
     public boolean isSupersededBy(EndpointState that)

--- a/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.gms;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -34,7 +35,9 @@ import org.junit.Test;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Token;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class EndpointStateTest
@@ -164,5 +167,51 @@ public class EndpointStateTest
         assertTrue(values.containsKey(ApplicationState.TOKENS));
         assertTrue(values.containsKey(ApplicationState.INTERNAL_IP));
         assertTrue(values.containsKey(ApplicationState.HOST_ID));
+    }
+
+    /**
+     * TOKENS is stored as a serialized token collection wrapped in an ISO-8859-1 string purely to round-trip
+     * the raw bytes losslessly, and toString() must not print that raw data (see CASSANDRA-21417).
+     */
+    @Test
+    public void testToStringDoesNotLeakRawTokenBytes()
+    {
+        List<Token> tokens = new ArrayList<>();
+        for (int i = 0; i < 16; i++)
+            tokens.add(DatabaseDescriptor.getPartitioner().getRandomToken());
+
+        HeartBeatState hb = new HeartBeatState(0);
+        EndpointState state = new EndpointState(hb);
+        VersionedValue tokensValue = valueFactory.tokens(tokens);
+        state.addApplicationState(ApplicationState.TOKENS, tokensValue);
+        state.addApplicationState(ApplicationState.RELEASE_VERSION, valueFactory.releaseVersion());
+
+        String rendered = state.toString();
+
+        assertTrue(rendered.contains("TOKENS=Value(<16 tokens>," + tokensValue.version + ')'));
+        assertFalse(rendered.contains(tokensValue.value));
+        // other states still render normally
+        assertTrue(rendered.contains("RELEASE_VERSION=Value("));
+    }
+
+    /**
+     * If the TOKENS value can't be deserialized for some reason, toString() must still avoid printing the
+     * raw bytes rather than throwing. Uses a truncated-but-otherwise-valid length-prefixed token blob (claims
+     * a 5 byte token but only supplies 2) so deserialization fails with a plain EOFException, rather than
+     * arbitrary garbage bytes whose first 4 bytes can decode to a huge length prefix and make
+     * TokenSerializer attempt a multi-gigabyte array allocation (see CASSANDRA-21417 discussion).
+     */
+    @Test
+    public void testToStringHandlesUndecodableTokensValue()
+    {
+        HeartBeatState hb = new HeartBeatState(0);
+        EndpointState state = new EndpointState(hb);
+        byte[] truncatedTokenBytes = { 0, 0, 0, 5, 'a', 'b' }; // claims a 5-byte token, only 2 bytes follow
+        String truncatedTokenBlob = new String(truncatedTokenBytes, ISO_8859_1);
+        state.addApplicationState(ApplicationState.TOKENS, VersionedValue.unsafeMakeVersionedValue(truncatedTokenBlob, 1));
+
+        String rendered = state.toString();
+
+        assertTrue(rendered.contains("TOKENS=Value(<6 undecodable bytes>,1)"));
     }
 }

--- a/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
@@ -169,48 +169,35 @@ public class EndpointStateTest
         assertTrue(values.containsKey(ApplicationState.HOST_ID));
     }
 
-    /**
-     * TOKENS is stored as a serialized token collection wrapped in an ISO-8859-1 string purely to round-trip
-     * the raw bytes losslessly, and toString() must not print that raw data (see CASSANDRA-21417).
-     */
     @Test
-    public void testToStringDoesNotLeakRawTokenBytes()
+    public void testFormatAppStateMapForLoggingSummarizesTokensInsteadOfPrintingRawBinaryData()
     {
         List<Token> tokens = new ArrayList<>();
         for (int i = 0; i < 16; i++)
             tokens.add(DatabaseDescriptor.getPartitioner().getRandomToken());
 
-        HeartBeatState hb = new HeartBeatState(0);
-        EndpointState state = new EndpointState(hb);
+        Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
         VersionedValue tokensValue = valueFactory.tokens(tokens);
-        state.addApplicationState(ApplicationState.TOKENS, tokensValue);
-        state.addApplicationState(ApplicationState.RELEASE_VERSION, valueFactory.releaseVersion());
+        states.put(ApplicationState.TOKENS, tokensValue);
+        states.put(ApplicationState.RELEASE_VERSION, valueFactory.releaseVersion());
 
-        String rendered = state.toString();
+        String rendered = EndpointState.formatAppStateMapForLogging(states);
 
         assertTrue(rendered.contains("TOKENS=Value(<16 tokens>," + tokensValue.version + ')'));
         assertFalse(rendered.contains(tokensValue.value));
-        // other states still render normally
         assertTrue(rendered.contains("RELEASE_VERSION=Value("));
     }
 
-    /**
-     * If the TOKENS value can't be deserialized for some reason, toString() must still avoid printing the
-     * raw bytes rather than throwing. Uses a truncated-but-otherwise-valid length-prefixed token blob (claims
-     * a 5 byte token but only supplies 2) so deserialization fails with a plain EOFException, rather than
-     * arbitrary garbage bytes whose first 4 bytes can decode to a huge length prefix and make
-     * TokenSerializer attempt a multi-gigabyte array allocation (see CASSANDRA-21417 discussion).
-     */
     @Test
-    public void testToStringHandlesUndecodableTokensValue()
+    public void testFormatAppStateMapForLoggingHandlesUndecodableTokensValue()
     {
-        HeartBeatState hb = new HeartBeatState(0);
-        EndpointState state = new EndpointState(hb);
-        byte[] truncatedTokenBytes = { 0, 0, 0, 5, 'a', 'b' }; // claims a 5-byte token, only 2 bytes follow
+        Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
+        // claims a 5-byte token but only 2 follow, so this fails cleanly instead of via a huge allocation
+        byte[] truncatedTokenBytes = { 0, 0, 0, 5, 'a', 'b' };
         String truncatedTokenBlob = new String(truncatedTokenBytes, ISO_8859_1);
-        state.addApplicationState(ApplicationState.TOKENS, VersionedValue.unsafeMakeVersionedValue(truncatedTokenBlob, 1));
+        states.put(ApplicationState.TOKENS, VersionedValue.unsafeMakeVersionedValue(truncatedTokenBlob, 1));
 
-        String rendered = state.toString();
+        String rendered = EndpointState.formatAppStateMapForLogging(states);
 
         assertTrue(rendered.contains("TOKENS=Value(<6 undecodable bytes>,1)"));
     }

--- a/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.gms;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -35,7 +34,6 @@ import org.junit.Test;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Token;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -170,35 +168,28 @@ public class EndpointStateTest
     }
 
     @Test
-    public void testFormatAppStateMapForLoggingSummarizesTokensInsteadOfPrintingRawBinaryData()
+    public void testFormatAppStateMapForLoggingHidesTokensValue()
     {
-        List<Token> tokens = new ArrayList<>();
-        for (int i = 0; i < 16; i++)
-            tokens.add(DatabaseDescriptor.getPartitioner().getRandomToken());
-
         Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
-        VersionedValue tokensValue = valueFactory.tokens(tokens);
+        VersionedValue tokensValue = VersionedValue.unsafeMakeVersionedValue("does-not-matter", 5);
         states.put(ApplicationState.TOKENS, tokensValue);
         states.put(ApplicationState.RELEASE_VERSION, valueFactory.releaseVersion());
 
         String rendered = EndpointState.formatAppStateMapForLogging(states);
 
-        assertTrue(rendered.contains("TOKENS=Value(<16 tokens>," + tokensValue.version + ')'));
+        assertTrue(rendered.contains("TOKENS=Value(<hidden>)"));
         assertFalse(rendered.contains(tokensValue.value));
         assertTrue(rendered.contains("RELEASE_VERSION=Value("));
     }
 
     @Test
-    public void testFormatAppStateMapForLoggingHandlesUndecodableTokensValue()
+    public void testFormatAppStateMapForLoggingShowsTokensNotPresentWhenMissing()
     {
         Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
-        // claims a 5-byte token but only 2 follow, so this fails cleanly instead of via a huge allocation
-        byte[] truncatedTokenBytes = { 0, 0, 0, 5, 'a', 'b' };
-        String truncatedTokenBlob = new String(truncatedTokenBytes, ISO_8859_1);
-        states.put(ApplicationState.TOKENS, VersionedValue.unsafeMakeVersionedValue(truncatedTokenBlob, 1));
+        states.put(ApplicationState.RELEASE_VERSION, valueFactory.releaseVersion());
 
         String rendered = EndpointState.formatAppStateMapForLogging(states);
 
-        assertTrue(rendered.contains("TOKENS=Value(<6 undecodable bytes>,1)"));
+        assertTrue(rendered.contains("TOKENS=not present"));
     }
 }


### PR DESCRIPTION
toString() on EndpointState was printing the raw TOKENS bytes directly. TOKENS is a serialized token collection stored as an ISO-8859-1 string just to preserve the raw bytes, so printing it as text dumps non-printable control characters into gossip debug logs.

Now TOKENS renders as `Value(<N tokens>,<version>)`, same shape as every other application state's `Value(<value>,<version>)`. If it can't be deserialized for any reason, including a corrupt length prefix that could otherwise blow up with an OutOfMemoryError, it falls back to `Value(<N undecodable bytes>,<version>)` instead of printing raw bytes.

Added two tests in EndpointStateTest.java: testToStringDoesNotLeakRawTokenBytes and testToStringHandlesUndecodableTokensValue.

ant test -Dtest.name=EndpointStateTest passes, 4/4.

[CASSANDRA-21417](https://issues.apache.org/jira/browse/CASSANDRA-21417)