### PR TITLE
CASSANDRA-21492 Share immutable range tombstone trees across partition snapshots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Avoid quadratic range tombstone copying across disjoint partition updates with persistent trees (CASSANDRA-21492)
  * Allow CQLSSTableWriter to specify SSTable id generator to use (CASSANDRA-21012)
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
  * Support pluggable default role initialization (CASSANDRA-21546)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -94,6 +94,10 @@ New features
 Upgrading
 ---------
 
+    - Range tombstone snapshots now use persistent trees rather than resizable arrays.
+      initial_range_tombstone_list_allocation_size, range_tombstone_list_growth_factor, and the
+      corresponding StorageService JMX methods are now deprecated no-ops. Existing SSTable and
+      commitlog formats are unchanged. (CASSANDRA-21492)
     - trickle_fsync is by default set to "true" instead of "false" in cassandra.yaml (see CASSANDRA-21572)
     - Authorizing a batch or an Accord transaction now performs the table permission checks once per run of
       consecutive statements on the same table rather than once per statement. The permissions required are

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -898,13 +898,11 @@ public class Config
      */
     public ConsistencyLevel denylist_consistency_level = ConsistencyLevel.QUORUM;
 
-    /**
-     * The intial capacity for creating RangeTombstoneList.
-     */
+    /** @deprecated RangeTombstoneList is now backed by a persistent tree; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public volatile int initial_range_tombstone_list_allocation_size = 1;
-    /**
-     * The growth factor to enlarge a RangeTombstoneList.
-     */
+    /** @deprecated RangeTombstoneList is now backed by a persistent tree; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public volatile double range_tombstone_list_growth_factor = 1.5;
 
     public StorageAttachedIndexOptions sai_options = new StorageAttachedIndexOptions();

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -5392,26 +5392,6 @@ public class DatabaseDescriptor
         conf.reject_repair_compaction_threshold = value;
     }
 
-    public static int getInitialRangeTombstoneListAllocationSize()
-    {
-        return conf.initial_range_tombstone_list_allocation_size;
-    }
-
-    public static void setInitialRangeTombstoneListAllocationSize(int size)
-    {
-        conf.initial_range_tombstone_list_allocation_size = size;
-    }
-
-    public static double getRangeTombstoneListGrowthFactor()
-    {
-        return conf.range_tombstone_list_growth_factor;
-    }
-
-    public static void setRangeTombstoneListGrowthFactor(double resizeFactor)
-    {
-        conf.range_tombstone_list_growth_factor = resizeFactor;
-    }
-
     public static boolean getAutocompactionOnStartupEnabled()
     {
         return conf.autocompaction_on_startup_enabled;

--- a/src/java/org/apache/cassandra/db/MutableDeletionInfo.java
+++ b/src/java/org/apache/cassandra/db/MutableDeletionInfo.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 
 import com.google.common.base.Objects;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -115,8 +114,8 @@ public class MutableDeletionInfo implements DeletionInfo
 
     public void add(RangeTombstone tombstone, ClusteringComparator comparator)
     {
-        if (ranges == null) // Introduce getInitialRangeTombstoneAllocationSize
-            ranges = new RangeTombstoneList(comparator, DatabaseDescriptor.getInitialRangeTombstoneListAllocationSize());
+        if (ranges == null)
+            ranges = new RangeTombstoneList(comparator);
 
         ranges.add(tombstone);
     }

--- a/src/java/org/apache/cassandra/db/RangeTombstoneList.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstoneList.java
@@ -18,19 +18,23 @@
 package org.apache.cassandra.db;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.collect.Iterators;
 
 import org.apache.cassandra.cache.IMeasurableMemory;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.utils.AbstractIterator;
+import org.apache.cassandra.utils.BulkIterator;
 import org.apache.cassandra.utils.CassandraUInt;
 import org.apache.cassandra.utils.ObjectSizes;
+import org.apache.cassandra.utils.btree.BTree;
+import org.apache.cassandra.utils.btree.UpdateFunction;
 import org.apache.cassandra.utils.memory.ByteBufferCloner;
 
 /**
@@ -46,46 +50,105 @@ import org.apache.cassandra.utils.memory.ByteBufferCloner;
  * the first one on [5, 10]. If such tombstones are added to a RangeTombstoneList,
  * the range tombstone list will store them as [[0, 5]@t1, [5, 15]@t2].
  * <p>
- * The only use of the local deletion time is to know when a given tombstone can
- * be purged, which will be done by the purge() method.
+ * Snapshots share immutable BTree nodes and interval entries. Inserting one disjoint range
+ * allocates O(log n) nodes; an overlapping update visits the affected intervals, copying
+ * O(log n) nodes per changed interval. The list itself, like its array-backed predecessor,
+ * requires a single writer; immutable snapshots may be read concurrently.
  */
-public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurableMemory
+public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurableMemory, UpdateFunction<RangeTombstoneList.Range, RangeTombstoneList.Range>
 {
-    private static long EMPTY_SIZE = ObjectSizes.measure(new RangeTombstoneList(null, 0));
+    private static final long EMPTY_SIZE = ObjectSizes.measure(new RangeTombstoneList((ClusteringComparator) null));
+    private static final long RANGE_SIZE = ObjectSizes.measure(new Range(null, null, 0, 0));
 
     private final ClusteringComparator comparator;
+    private final BoundComparator byStart;
+    private final BoundComparator byEnd;
 
-    // Note: we don't want to use a List for the markedAts and delTimes to avoid boxing. We could
-    // use a List for starts and ends, but having arrays everywhere is almost simpler.
-    private ClusteringBound<?>[] starts;
-    private ClusteringBound<?>[] ends;
-    private long[] markedAts;
-    private int[] delTimesUnsignedIntegers;
-
+    // Roots and entries are immutable. A writer replaces only its own root, never a published
+    // partition's nodes. In particular, copy followed by an append copies a tree path, not all ranges.
+    private Object[] tree = BTree.empty();
     private long boundaryHeapSize;
+    private long treeHeapSize;
     private int size;
 
-    private RangeTombstoneList(ClusteringComparator comparator,
-                               ClusteringBound<?>[] starts,
-                               ClusteringBound<?>[] ends,
-                               long[] markedAts,
-                               int[] delTimesUnsignedIntegers,
-                               long boundaryHeapSize,
-                               int size)
+    public RangeTombstoneList(ClusteringComparator comparator)
     {
-        assert starts.length == ends.length && starts.length == markedAts.length && starts.length == delTimesUnsignedIntegers.length;
         this.comparator = comparator;
-        this.starts = starts;
-        this.ends = ends;
-        this.markedAts = markedAts;
-        this.delTimesUnsignedIntegers = delTimesUnsignedIntegers;
-        this.size = size;
-        this.boundaryHeapSize = boundaryHeapSize;
+        this.byStart = new BoundComparator(comparator, true);
+        this.byEnd = new BoundComparator(comparator, false);
     }
 
-    public RangeTombstoneList(ClusteringComparator comparator, int capacity)
+    private RangeTombstoneList(RangeTombstoneList source)
     {
-        this(comparator, new ClusteringBound<?>[capacity], new ClusteringBound<?>[capacity], new long[capacity], new int[capacity], 0, 0);
+        comparator = source.comparator;
+        byStart = source.byStart;
+        byEnd = source.byEnd;
+        tree = source.tree;
+        boundaryHeapSize = source.boundaryHeapSize;
+        treeHeapSize = source.treeHeapSize;
+        size = source.size;
+    }
+
+    // UpdateFunction<Range, Range>, used only by addInternal to insert a single new entry by end bound.
+    public Range insert(Range range)
+    {
+        return range;
+    }
+
+    public Range merge(Range existing, Range update)
+    {
+        throw new IllegalStateException("Duplicate range end");
+    }
+
+    public void onAllocatedOnHeap(long delta)
+    {
+        treeHeapSize += delta;
+    }
+
+    static final class Range
+    {
+        final ClusteringBound<?> start;
+        final ClusteringBound<?> end;
+        final long markedAt;
+        final int delTime;
+
+        Range(ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTime)
+        {
+            this.start = start;
+            this.end = end;
+            this.markedAt = markedAt;
+            this.delTime = delTime;
+        }
+    }
+
+    private static final class BoundComparator implements Comparator<Object>
+    {
+        private final ClusteringComparator comparator;
+        private final boolean start;
+
+        BoundComparator(ClusteringComparator comparator, boolean start)
+        {
+            this.comparator = comparator;
+            this.start = start;
+        }
+
+        private ClusteringPrefix<?> bound(Object value)
+        {
+            if (!(value instanceof Range))
+                return (ClusteringPrefix<?>) value;
+            Range range = (Range) value;
+            return start ? range.start : range.end;
+        }
+
+        public int compare(Object left, Object right)
+        {
+            return comparator.compare(bound(left), bound(right));
+        }
+    }
+
+    private Range get(int index)
+    {
+        return BTree.findByIndex(tree, index);
     }
 
     public boolean isEmpty()
@@ -105,30 +168,15 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
     public RangeTombstoneList copy()
     {
-        return new RangeTombstoneList(comparator,
-                                      Arrays.copyOf(starts, size),
-                                      Arrays.copyOf(ends, size),
-                                      Arrays.copyOf(markedAts, size),
-                                      Arrays.copyOf(delTimesUnsignedIntegers, size),
-                                      boundaryHeapSize, size);
+        return new RangeTombstoneList(this);
     }
 
     public RangeTombstoneList clone(ByteBufferCloner cloner)
     {
-        RangeTombstoneList copy =  new RangeTombstoneList(comparator,
-                                                          new ClusteringBound<?>[size],
-                                                          new ClusteringBound<?>[size],
-                                                          Arrays.copyOf(markedAts, size),
-                                                          Arrays.copyOf(delTimesUnsignedIntegers, size),
-                                                          boundaryHeapSize, size);
-
-
-        for (int i = 0; i < size; i++)
-        {
-            copy.starts[i] = clone(starts[i], cloner);
-            copy.ends[i] = clone(ends[i], cloner);
-        }
-
+        RangeTombstoneList copy = copy();
+        copy.tree = BTree.<Range, Range>transform(tree, range -> new Range(clone(range.start, cloner),
+                                                                        clone(range.end, cloner),
+                                                                        range.markedAt, range.delTime));
         return copy;
     }
 
@@ -162,7 +210,10 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
             return;
         }
 
-        int c = comparator.compare(ends[size-1], start);
+        if (Slice.isEmpty(comparator, start, end))
+            return;
+
+        int c = comparator.compare(get(size-1).end, start);
 
         // Fast path if we add in sorted order
         if (c <= 0)
@@ -172,10 +223,9 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         else
         {
             // Note: insertFrom expect i to be the insertion point in term of interval ends
-            int pos = Arrays.binarySearch(ends, 0, size, start, comparator);
+            int pos = BTree.findIndex(tree, byEnd, start);
             insertFrom((pos >= 0 ? pos+1 : -pos-1), start, end, markedAt, delTimeUnsignedInteger);
         }
-        boundaryHeapSize += start.unsharedHeapSize() + end.unsharedHeapSize();
     }
 
     /**
@@ -188,52 +238,18 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
         if (isEmpty())
         {
-            copyArrays(tombstones, this);
+            tree = tombstones.tree;
+            size = tombstones.size;
+            boundaryHeapSize = tombstones.boundaryHeapSize;
+            treeHeapSize = tombstones.treeHeapSize;
             return;
         }
 
-        /*
-         * We basically have 2 techniques we can use here: either we repeatedly call add() on tombstones values,
-         * or we do a merge of both (sorted) lists. If this lists is bigger enough than the one we add, then
-         * calling add() will be faster, otherwise it's merging that will be faster.
-         *
-         * Let's note that during memtables updates, it might not be uncommon that a new update has only a few range
-         * tombstones, while the CF we're adding it to (the one in the memtable) has many. In that case, using add() is
-         * likely going to be faster.
-         *
-         * In other cases however, like when diffing responses from multiple nodes, the tombstone lists we "merge" will
-         * be likely sized, so using add() might be a bit inefficient.
-         *
-         * Roughly speaking (this ignore the fact that updating an element is not exactly constant but that's not a big
-         * deal), if n is the size of this list and m is tombstones size, merging is O(n+m) while using add() is O(m*log(n)).
-         *
-         * But let's not crank up a logarithm computation for that. Long story short, merging will be a bad choice only
-         * if this list size is lot bigger that the other one, so let's keep it simple.
-         */
-        if (size > 10 * tombstones.size)
+        Iterator<Range> ranges = BTree.iterator(tombstones.tree);
+        while (ranges.hasNext())
         {
-            for (int i = 0; i < tombstones.size; i++)
-                add(tombstones.starts[i], tombstones.ends[i], tombstones.markedAts[i], tombstones.delTimesUnsignedIntegers[i]);
-        }
-        else
-        {
-            int i = 0;
-            int j = 0;
-            while (i < size && j < tombstones.size)
-            {
-                if (comparator.compare(tombstones.starts[j], ends[i]) < 0)
-                {
-                    insertFrom(i, tombstones.starts[j], tombstones.ends[j], tombstones.markedAts[j], tombstones.delTimesUnsignedIntegers[j]);
-                    j++;
-                }
-                else
-                {
-                    i++;
-                }
-            }
-            // Addds the remaining ones from tombstones if any (note that addInternal will increment size if relevant).
-            for (; j < tombstones.size; j++)
-                addInternal(size, tombstones.starts[j], tombstones.ends[j], tombstones.markedAts[j], tombstones.delTimesUnsignedIntegers[j]);
+            Range range = ranges.next();
+            add(range.start, range.end, range.markedAt, range.delTime);
         }
     }
 
@@ -243,9 +259,9 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
      */
     public boolean isDeleted(Clustering<?> clustering, Cell<?> cell)
     {
-        int idx = searchInternal(clustering, 0, size);
+        int idx = searchInternal(clustering);
         // No matter what the counter cell's timestamp is, a tombstone always takes precedence. See CASSANDRA-7346.
-        return idx >= 0 && (cell.isCounterCell() || markedAts[idx] >= cell.timestamp());
+        return idx >= 0 && (cell.isCounterCell() || get(idx).markedAt >= cell.timestamp());
     }
 
     /**
@@ -254,14 +270,17 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
      */
     public DeletionTime searchDeletionTime(Clustering<?> name)
     {
-        int idx = searchInternal(name, 0, size);
-        return idx < 0 ? null : DeletionTime.buildUnsafeWithUnsignedInteger(markedAts[idx], delTimesUnsignedIntegers[idx]);
+        int idx = searchInternal(name);
+        if (idx < 0)
+            return null;
+        Range range = get(idx);
+        return DeletionTime.buildUnsafeWithUnsignedInteger(range.markedAt, range.delTime);
     }
 
     public RangeTombstone search(Clustering<?> name)
     {
-        int idx = searchInternal(name, 0, size);
-        return idx < 0 ? null : rangeTombstone(idx);
+        int idx = searchInternal(name);
+        return idx < 0 ? null : rangeTombstone(get(idx));
     }
 
     /*
@@ -270,15 +289,15 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
      *
      * Note that bounds are not in the range if they fall on its boundary.
      */
-    private int searchInternal(ClusteringPrefix<?> name, int startIdx, int endIdx)
+    private int searchInternal(ClusteringPrefix<?> name)
     {
         if (isEmpty())
             return -1;
 
-        int pos = Arrays.binarySearch(starts, startIdx, endIdx, name, comparator);
+        int pos = BTree.findIndex(tree, byStart, name);
         if (pos >= 0)
         {
-            // Equality only happens for bounds (as used by forward/reverseIterator), and bounds are equal only if they
+            // Equality only happens for bounds (as used by slice iteration), and bounds are equal only if they
             // are the same or complementary, in either case the bound itself is not part of the range.
             return -pos - 1;
         }
@@ -289,18 +308,20 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
             if (idx < 0)
                 return -1;
 
-            return comparator.compare(name, ends[idx]) < 0 ? idx : -idx-2;
+            return comparator.compare(name, get(idx).end) < 0 ? idx : -idx-2;
         }
     }
 
     public int dataSize()
     {
         int dataSize = TypeSizes.sizeof(size);
-        for (int i = 0; i < size; i++)
+        Iterator<Range> ranges = BTree.iterator(tree);
+        while (ranges.hasNext())
         {
-            dataSize += starts[i].dataSize() + ends[i].dataSize();
-            dataSize += TypeSizes.sizeof(markedAts[i]);
-            dataSize += TypeSizes.sizeof(delTimesUnsignedIntegers[i]);
+            Range range = ranges.next();
+            dataSize += range.start.dataSize() + range.end.dataSize();
+            dataSize += TypeSizes.sizeof(range.markedAt);
+            dataSize += TypeSizes.sizeof(range.delTime);
         }
         return dataSize;
     }
@@ -308,54 +329,42 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
     public long maxMarkedAt()
     {
         long max = Long.MIN_VALUE;
-        for (int i = 0; i < size; i++)
-            max = Math.max(max, markedAts[i]);
+        Iterator<Range> ranges = BTree.iterator(tree);
+        while (ranges.hasNext())
+            max = Math.max(max, ranges.next().markedAt);
         return max;
     }
 
     public void collectStats(EncodingStats.Collector collector)
     {
-        for (int i = 0; i < size; i++)
+        Iterator<Range> ranges = BTree.iterator(tree);
+        while (ranges.hasNext())
         {
-            collector.updateTimestamp(markedAts[i]);
-            collector.updateLocalDeletionTime(CassandraUInt.toLong(delTimesUnsignedIntegers[i]));
+            Range range = ranges.next();
+            collector.updateTimestamp(range.markedAt);
+            collector.updateLocalDeletionTime(CassandraUInt.toLong(range.delTime));
         }
     }
 
     public void updateAllTimestamp(long timestamp)
     {
-        for (int i = 0; i < size; i++)
-            markedAts[i] = timestamp;
+        tree = BTree.<Range, Range>transform(tree, range -> range.markedAt == timestamp
+                                                        ? range
+                                                        : new Range(range.start, range.end, timestamp, range.delTime));
     }
 
     public void updateAllTimestampAndLocalDeletionTime(long timestamp, long localDeletionTime)
     {
-        int unsignedLocalDeletionTime = Cell.deletionTimeLongToUnsignedInteger(localDeletionTime);
-        for (int i = 0; i < size; i++)
-        {
-            markedAts[i] = timestamp;
-            delTimesUnsignedIntegers[i] = unsignedLocalDeletionTime;
-        }
+        int delTime = Cell.deletionTimeLongToUnsignedInteger(localDeletionTime);
+        tree = BTree.<Range, Range>transform(tree, range -> range.markedAt == timestamp && range.delTime == delTime
+                                                        ? range
+                                                        : new Range(range.start, range.end, timestamp, delTime));
     }
 
-    private RangeTombstone rangeTombstone(int idx)
+    private static RangeTombstone rangeTombstone(Range range)
     {
-        return new RangeTombstone(Slice.make(starts[idx], ends[idx]), DeletionTime.buildUnsafeWithUnsignedInteger(markedAts[idx], delTimesUnsignedIntegers[idx]));
-    }
-
-    private RangeTombstone rangeTombstoneWithNewStart(int idx, ClusteringBound<?> newStart)
-    {
-        return new RangeTombstone(Slice.make(newStart, ends[idx]), DeletionTime.buildUnsafeWithUnsignedInteger(markedAts[idx], delTimesUnsignedIntegers[idx]));
-    }
-
-    private RangeTombstone rangeTombstoneWithNewEnd(int idx, ClusteringBound<?> newEnd)
-    {
-        return new RangeTombstone(Slice.make(starts[idx], newEnd), DeletionTime.buildUnsafeWithUnsignedInteger(markedAts[idx], delTimesUnsignedIntegers[idx]));
-    }
-
-    private RangeTombstone rangeTombstoneWithNewBounds(int idx, ClusteringBound<?> newStart, ClusteringBound<?> newEnd)
-    {
-        return new RangeTombstone(Slice.make(newStart, newEnd), DeletionTime.buildUnsafeWithUnsignedInteger(markedAts[idx], delTimesUnsignedIntegers[idx]));
+        return new RangeTombstone(Slice.make(range.start, range.end),
+                                  DeletionTime.buildUnsafeWithUnsignedInteger(range.markedAt, range.delTime));
     }
 
     public Iterator<RangeTombstone> iterator()
@@ -365,128 +374,40 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
 
     public Iterator<RangeTombstone> iterator(boolean reversed)
     {
-        return reversed
-             ? new AbstractIterator<RangeTombstone>()
-             {
-                 private int idx = size - 1;
-
-                 protected RangeTombstone computeNext()
-                 {
-                     if (idx < 0)
-                         return endOfData();
-
-                     return rangeTombstone(idx--);
-                 }
-             }
-             : new AbstractIterator<RangeTombstone>()
-             {
-                 private int idx;
-
-                 protected RangeTombstone computeNext()
-                 {
-                     if (idx >= size)
-                         return endOfData();
-
-                     return rangeTombstone(idx++);
-                 }
-             };
+        return Iterators.transform(BTree.<Range>iterator(tree, reversed ? BTree.Dir.DESC : BTree.Dir.ASC),
+                                   RangeTombstoneList::rangeTombstone);
     }
 
     public Iterator<RangeTombstone> iterator(final Slice slice, boolean reversed)
     {
-        return reversed ? reverseIterator(slice) : forwardIterator(slice);
-    }
-
-    private Iterator<RangeTombstone> forwardIterator(final Slice slice)
-    {
-        int startIdx = slice.start().isBottom() ? 0 : searchInternal(slice.start(), 0, size);
-        final int start = startIdx < 0 ? -startIdx-1 : startIdx;
-
-        if (start >= size)
+        if (isEmpty() || Slice.isEmpty(comparator, slice.start(), slice.end()))
             return Collections.emptyIterator();
 
-        int finishIdx = slice.end().isTop() ? size - 1 : searchInternal(slice.end(), start, size);
-        // if stopIdx is the first range after 'slice.end()' we care only until the previous range
+        int startIdx = slice.start().isBottom() ? 0 : searchInternal(slice.start());
+        final int start = startIdx < 0 ? -startIdx-1 : startIdx;
+        int finishIdx = slice.end().isTop() ? size - 1 : searchInternal(slice.end());
         final int finish = finishIdx < 0 ? -finishIdx-2 : finishIdx;
-
         if (start > finish)
             return Collections.emptyIterator();
 
-        if (start == finish)
-        {
-            // We want to make sure the range are stricly included within the queried slice as this
-            // make it easier to combine things when iterating over successive slices.
-            ClusteringBound<?> s = comparator.compare(starts[start], slice.start()) < 0 ? slice.start() : starts[start];
-            ClusteringBound<?> e = comparator.compare(slice.end(), ends[start]) < 0 ? slice.end() : ends[start];
-            if (Slice.isEmpty(comparator, s, e))
-                return Collections.emptyIterator();
-            return Iterators.<RangeTombstone>singletonIterator(rangeTombstoneWithNewBounds(start, s, e));
-        }
-
+        Iterator<Range> ranges = BTree.iterator(tree, start, finish, reversed ? BTree.Dir.DESC : BTree.Dir.ASC);
         return new AbstractIterator<RangeTombstone>()
         {
-            private int idx = start;
+            private int idx = reversed ? finish : start;
 
             protected RangeTombstone computeNext()
             {
-                if (idx >= size || idx > finish)
+                if (!ranges.hasNext())
                     return endOfData();
 
-                // We want to make sure the range are stricly included within the queried slice as this
-                // make it easier to combine things when iterating over successive slices. This means that
-                // for the first and last range we might have to "cut" the range returned.
-                if (idx == start && comparator.compare(starts[idx], slice.start()) < 0)
-                    return rangeTombstoneWithNewStart(idx++, slice.start());
-                if (idx == finish && comparator.compare(slice.end(), ends[idx]) < 0)
-                    return rangeTombstoneWithNewEnd(idx++, slice.end());
-                return rangeTombstone(idx++);
-            }
-        };
-    }
-
-    private Iterator<RangeTombstone> reverseIterator(final Slice slice)
-    {
-        int startIdx = slice.end().isTop() ? size - 1 : searchInternal(slice.end(), 0, size);
-        // if startIdx is the first range after 'slice.end()' we care only until the previous range
-        final int start = startIdx < 0 ? -startIdx-2 : startIdx;
-
-        if (start < 0)
-            return Collections.emptyIterator();
-
-        int finishIdx = slice.start().isBottom() ? 0 : searchInternal(slice.start(), 0, start + 1);  // include same as finish
-        // if stopIdx is the first range after 'slice.end()' we care only until the previous range
-        final int finish = finishIdx < 0 ? -finishIdx-1 : finishIdx;
-
-        if (start < finish)
-            return Collections.emptyIterator();
-
-        if (start == finish)
-        {
-            // We want to make sure the range are stricly included within the queried slice as this
-            // make it easier to combine things when iterator over successive slices.
-            ClusteringBound<?> s = comparator.compare(starts[start], slice.start()) < 0 ? slice.start() : starts[start];
-            ClusteringBound<?> e = comparator.compare(slice.end(), ends[start]) < 0 ? slice.end() : ends[start];
-            if (Slice.isEmpty(comparator, s, e))
-                return Collections.emptyIterator();
-            return Iterators.<RangeTombstone>singletonIterator(rangeTombstoneWithNewBounds(start, s, e));
-        }
-
-        return new AbstractIterator<RangeTombstone>()
-        {
-            private int idx = start;
-
-            protected RangeTombstone computeNext()
-            {
-                if (idx < 0 || idx < finish)
-                    return endOfData();
-                // We want to make sure the range are stricly included within the queried slice as this
-                // make it easier to combine things when iterator over successive slices. This means that
-                // for the first and last range we might have to "cut" the range returned.
-                if (idx == start && comparator.compare(slice.end(), ends[idx]) < 0)
-                    return rangeTombstoneWithNewEnd(idx--, slice.end());
-                if (idx == finish && comparator.compare(starts[idx], slice.start()) < 0)
-                    return rangeTombstoneWithNewStart(idx--, slice.start());
-                return rangeTombstone(idx--);
+                Range range = ranges.next();
+                ClusteringBound<?> s = idx == start && comparator.compare(range.start, slice.start()) < 0
+                                       ? slice.start() : range.start;
+                ClusteringBound<?> e = idx == finish && comparator.compare(slice.end(), range.end) < 0
+                                       ? slice.end() : range.end;
+                idx += reversed ? -1 : 1;
+                return new RangeTombstone(Slice.make(s, e),
+                                          DeletionTime.buildUnsafeWithUnsignedInteger(range.markedAt, range.delTime));
             }
         };
     }
@@ -500,15 +421,14 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         if (size != that.size)
             return false;
 
-        for (int i = 0; i < size; i++)
+        Iterator<Range> left = BTree.iterator(tree);
+        Iterator<Range> right = BTree.iterator(that.tree);
+        while (left.hasNext())
         {
-            if (!starts[i].equals(that.starts[i]))
-                return false;
-            if (!ends[i].equals(that.ends[i]))
-                return false;
-            if (markedAts[i] != that.markedAts[i])
-                return false;
-            if (delTimesUnsignedIntegers[i] != that.delTimesUnsignedIntegers[i])
+            Range a = left.next();
+            Range b = right.next();
+            if (!a.start.equals(b.start) || !a.end.equals(b.end)
+                || a.markedAt != b.markedAt || a.delTime != b.delTime)
                 return false;
         }
         return true;
@@ -518,24 +438,15 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
     public final int hashCode()
     {
         int result = size;
-        for (int i = 0; i < size; i++)
+        Iterator<Range> ranges = BTree.iterator(tree);
+        while (ranges.hasNext())
         {
-            result += starts[i].hashCode() + ends[i].hashCode();
-            result += (int)(markedAts[i] ^ (markedAts[i] >>> 32));
-            result += delTimesUnsignedIntegers[i];
+            Range range = ranges.next();
+            result += range.start.hashCode() + range.end.hashCode();
+            result += (int)(range.markedAt ^ (range.markedAt >>> 32));
+            result += range.delTime;
         }
         return result;
-    }
-
-    private static void copyArrays(RangeTombstoneList src, RangeTombstoneList dst)
-    {
-        dst.grow(src.size);
-        System.arraycopy(src.starts, 0, dst.starts, 0, src.size);
-        System.arraycopy(src.ends, 0, dst.ends, 0, src.size);
-        System.arraycopy(src.markedAts, 0, dst.markedAts, 0, src.size);
-        System.arraycopy(src.delTimesUnsignedIntegers, 0, dst.delTimesUnsignedIntegers, 0, src.size);
-        dst.size = src.size;
-        dst.boundaryHeapSize = src.boundaryHeapSize;
     }
 
     /*
@@ -552,46 +463,66 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
      */
     private void insertFrom(int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTimeUnsignedInternal)
     {
-        while (i < size)
+        // A tombstone that supersedes many intervals would path-copy the tree once per interval; past a small
+        // fraction of the list it is cheaper to merge the affected run in an array and rebuild the tree once.
+        int pos = BTree.findIndex(tree, byStart, end);
+        int to = pos >= 0 ? pos : -pos - 1;
+        if (to - i >= 32 && to - i >= size / 32)
         {
+            Window window = new Window(i, to);
+            insertFrom(window, 0, start, end, markedAt, delTimeUnsignedInternal);
+            window.commit(i, to);
+        }
+        else
+        {
+            insertFrom(new TreeRanges(), i, start, end, markedAt, delTimeUnsignedInternal);
+        }
+    }
+
+    private void insertFrom(Ranges ranges, int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTimeUnsignedInternal)
+    {
+        while (i < ranges.size())
+        {
+            Range current = ranges.get(i);
             assert start.isStart() && end.isEnd();
-            assert i == 0 || comparator.compare(ends[i-1], start) <= 0;
-            assert comparator.compare(start, ends[i]) < 0;
+            assert i == 0 || comparator.compare(ranges.get(i - 1).end, start) <= 0;
+            assert comparator.compare(start, current.end) < 0;
 
             if (Slice.isEmpty(comparator, start, end))
                 return;
 
             // Do we overwrite the current element?
-            if (markedAt > markedAts[i])
+            if (markedAt > current.markedAt)
             {
                 // We do overwrite.
 
                 // First deal with what might come before the newly added one.
-                if (comparator.compare(starts[i], start) < 0)
+                if (comparator.compare(current.start, start) < 0)
                 {
                     ClusteringBound<?> newEnd = start.invert();
-                    if (!Slice.isEmpty(comparator, starts[i], newEnd))
+                    if (!Slice.isEmpty(comparator, current.start, newEnd))
                     {
-                        addInternal(i, starts[i], newEnd, markedAts[i], delTimesUnsignedIntegers[i]);
+                        ranges.add(i, new Range(current.start, newEnd, current.markedAt, current.delTime));
                         i++;
-                        setInternal(i, start, ends[i], markedAts[i], delTimesUnsignedIntegers[i]);
+                        ranges.set(i, new Range(start, current.end, current.markedAt, current.delTime));
+                        current = ranges.get(i);
                     }
                 }
 
                 // now, start <= starts[i]
 
                 // Does the new element stops before the current one,
-                int endCmp = comparator.compare(end, starts[i]);
+                int endCmp = comparator.compare(end, current.start);
                 if (endCmp < 0)
                 {
                     // Here start <= starts[i] and end < starts[i]
                     // This means the current element is before the current one.
-                    addInternal(i, start, end, markedAt, delTimeUnsignedInternal);
+                    ranges.add(i, new Range(start, end, markedAt, delTimeUnsignedInternal));
                     return;
                 }
 
                 // Do we overwrite the current element fully?
-                int cmp = comparator.compare(ends[i], end);
+                int cmp = comparator.compare(current.end, end);
                 if (cmp <= 0)
                 {
                     // We do overwrite fully:
@@ -601,26 +532,28 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                     // Note that the comparison below is inclusive: if a end equals a start, this means they form a boundary, or
                     // in other words that they are for the same element but one is inclusive while the other exclusive. In which case we know
                     // we're good with the next element
-                    if (i == size-1 || comparator.compare(end, starts[i+1]) <= 0)
+                    Range next = i == ranges.size() - 1 ? null : ranges.get(i + 1);
+                    if (next == null || comparator.compare(end, next.start) <= 0)
                     {
-                        setInternal(i, start, end, markedAt, delTimeUnsignedInternal);
+                        ranges.set(i, new Range(start, end, markedAt, delTimeUnsignedInternal));
                         return;
                     }
 
-                    setInternal(i, start, starts[i+1].invert(), markedAt, delTimeUnsignedInternal);
-                    start = starts[i+1];
+                    ranges.set(i, new Range(start, next.start.invert(), markedAt, delTimeUnsignedInternal));
+                    start = next.start;
                     i++;
                 }
                 else
                 {
                     // We don't overwrite fully. Insert the new interval, and then update the now next
                     // one to reflect the not overwritten parts. We're then done.
-                    addInternal(i, start, end, markedAt, delTimeUnsignedInternal);
+                    ranges.add(i, new Range(start, end, markedAt, delTimeUnsignedInternal));
                     i++;
                     ClusteringBound<?> newStart = end.invert();
-                    if (!Slice.isEmpty(comparator, newStart, ends[i]))
+                    current = ranges.get(i);
+                    if (!Slice.isEmpty(comparator, newStart, current.end))
                     {
-                        setInternal(i, newStart, ends[i], markedAts[i], delTimesUnsignedIntegers[i]);
+                        ranges.set(i, new Range(newStart, current.end, current.markedAt, current.delTime));
                     }
                     return;
                 }
@@ -630,19 +563,19 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                 // we don't overwrite the current element
 
                 // If the new interval starts before the current one, insert that new interval
-                if (comparator.compare(start, starts[i]) < 0)
+                if (comparator.compare(start, current.start) < 0)
                 {
                     // If we stop before the start of the current element, just insert the new interval and we're done;
                     // otherwise insert until the beginning of the current element
-                    if (comparator.compare(end, starts[i]) <= 0)
+                    if (comparator.compare(end, current.start) <= 0)
                     {
-                        addInternal(i, start, end, markedAt, delTimeUnsignedInternal);
+                        ranges.add(i, new Range(start, end, markedAt, delTimeUnsignedInternal));
                         return;
                     }
-                    ClusteringBound<?> newEnd = starts[i].invert();
+                    ClusteringBound<?> newEnd = current.start.invert();
                     if (!Slice.isEmpty(comparator, start, newEnd))
                     {
-                        addInternal(i, start, newEnd, markedAt, delTimeUnsignedInternal);
+                        ranges.add(i, new Range(start, newEnd, markedAt, delTimeUnsignedInternal));
                         i++;
                     }
                 }
@@ -651,139 +584,130 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                 // some residual parts after ...
 
                 // ... unless we don't extend beyond it.
-                if (comparator.compare(end, ends[i]) <= 0)
+                if (comparator.compare(end, current.end) <= 0)
                     return;
 
-                start = ends[i].invert();
+                start = current.end.invert();
                 i++;
             }
         }
 
         // If we got there, then just insert the remainder at the end
-        addInternal(i, start, end, markedAt, delTimeUnsignedInternal);
-    }
-
-    private int capacity()
-    {
-        return starts.length;
+        ranges.add(i, new Range(start, end, markedAt, delTimeUnsignedInternal));
     }
 
     /*
-     * Adds the new tombstone at index i, growing and/or moving elements to make room for it.
+     * Entries are ordered by end bound. During a split the new left fragment can have the
+     * same start as its successor, but its end is strictly smaller.
      */
-    private void addInternal(int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTimeUnsignedInteger)
+    private void addInternal(int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTime)
     {
-        assert i >= 0;
+        addInternal(i, new Range(start, end, markedAt, delTime));
+    }
 
-        if (size == capacity())
-            growToFree(i);
-        else if (i < size)
-            moveElements(i);
-
-        setInternal(i, start, end, markedAt, delTimeUnsignedInteger);
+    private void addInternal(int i, Range range)
+    {
+        assert i >= 0 && i <= size;
+        tree = BTree.update(tree, BTree.singleton(range), byEnd, this);
+        assert get(i) == range;
+        boundaryHeapSize += range.start.unsharedHeapSize() + range.end.unsharedHeapSize();
         size++;
     }
 
-    /*
-     * Grow the arrays, leaving index i "free" in the process.
-     */
-    private void growToFree(int i)
+    private void setInternal(int i, Range range)
     {
-        // Introduce getRangeTombstoneResizeFactor
-        int newLength = (int) Math.ceil(capacity() * DatabaseDescriptor.getRangeTombstoneListGrowthFactor());
-        // Fallback to the original calculation if the newLength calculated from the resize factor is not valid.
-        if (newLength <= capacity())
-            newLength = ((capacity() * 3) / 2) + 1;
-        
-        grow(i, newLength);
-    }
-
-    /*
-     * Grow the arrays to match newLength capacity.
-     */
-    private void grow(int newLength)
-    {
-        if (capacity() < newLength)
-            grow(-1, newLength);
-    }
-
-    private void grow(int i, int newLength)
-    {
-        starts = grow(starts, size, newLength, i);
-        ends = grow(ends, size, newLength, i);
-        markedAts = grow(markedAts, size, newLength, i);
-        delTimesUnsignedIntegers = grow(delTimesUnsignedIntegers, size, newLength, i);
-    }
-
-    private static ClusteringBound<?>[] grow(ClusteringBound<?>[] a, int size, int newLength, int i)
-    {
-        if (i < 0 || i >= size)
-            return Arrays.copyOf(a, newLength);
-
-        ClusteringBound<?>[] newA = new ClusteringBound<?>[newLength];
-        System.arraycopy(a, 0, newA, 0, i);
-        System.arraycopy(a, i, newA, i+1, size - i);
-        return newA;
-    }
-
-    private static long[] grow(long[] a, int size, int newLength, int i)
-    {
-        if (i < 0 || i >= size)
-            return Arrays.copyOf(a, newLength);
-
-        long[] newA = new long[newLength];
-        System.arraycopy(a, 0, newA, 0, i);
-        System.arraycopy(a, i, newA, i+1, size - i);
-        return newA;
-    }
-
-    private static int[] grow(int[] a, int size, int newLength, int i)
-    {
-        if (i < 0 || i >= size)
-            return Arrays.copyOf(a, newLength);
-
-        int[] newA = new int[newLength];
-        System.arraycopy(a, 0, newA, 0, i);
-        System.arraycopy(a, i, newA, i+1, size - i);
-        return newA;
-    }
-
-    /*
-     * Move elements so that index i is "free", assuming the arrays have at least one free slot at the end.
-     */
-    private void moveElements(int i)
-    {
-        if (i >= size)
+        Range previous = get(i);
+        if (previous.start == range.start && previous.end == range.end && previous.markedAt == range.markedAt && previous.delTime == range.delTime)
             return;
-
-        System.arraycopy(starts, i, starts, i+1, size - i);
-        System.arraycopy(ends, i, ends, i+1, size - i);
-        System.arraycopy(markedAts, i, markedAts, i+1, size - i);
-        System.arraycopy(delTimesUnsignedIntegers, i, delTimesUnsignedIntegers, i+1, size - i);
-        // we set starts[i] to null to indicate the position is now empty, so that we update boundaryHeapSize
-        // when we set it
-        starts[i] = null;
+        tree = BTree.replace(tree, i, range);
+        boundaryHeapSize += range.start.unsharedHeapSize() + range.end.unsharedHeapSize()
+                            - previous.start.unsharedHeapSize() - previous.end.unsharedHeapSize();
     }
 
-    private void setInternal(int i, ClusteringBound<?> start, ClusteringBound<?> end, long markedAt, int delTimeUnsignedInteger)
+    /** The intervals insertFrom merges into: either this list's tree or an array copy of the affected run. */
+    private interface Ranges
     {
-        if (starts[i] != null)
-            boundaryHeapSize -= starts[i].unsharedHeapSize() + ends[i].unsharedHeapSize();
-        starts[i] = start;
-        ends[i] = end;
-        markedAts[i] = markedAt;
-        delTimesUnsignedIntegers[i] = delTimeUnsignedInteger;
-        boundaryHeapSize += start.unsharedHeapSize() + end.unsharedHeapSize();
+        Range get(int i);
+        void add(int i, Range range);
+        void set(int i, Range range);
+        int size();
+    }
+
+    private final class TreeRanges implements Ranges
+    {
+        public Range get(int i)
+        {
+            return RangeTombstoneList.this.get(i);
+        }
+
+        public void add(int i, Range range)
+        {
+            addInternal(i, range);
+        }
+
+        public void set(int i, Range range)
+        {
+            setInternal(i, range);
+        }
+
+        public int size()
+        {
+            return size;
+        }
+    }
+
+    private final class Window implements Ranges
+    {
+        private final List<Range> ranges;
+        private long boundaryDelta;
+
+        Window(int from, int to)
+        {
+            ranges = new ArrayList<>(to - from + 1);
+            Iterators.addAll(ranges, BTree.iterator(tree, from, to - 1, BTree.Dir.ASC));
+        }
+
+        public Range get(int i)
+        {
+            return ranges.get(i);
+        }
+
+        public void add(int i, Range range)
+        {
+            ranges.add(i, range);
+            boundaryDelta += range.start.unsharedHeapSize() + range.end.unsharedHeapSize();
+        }
+
+        public void set(int i, Range range)
+        {
+            Range previous = ranges.set(i, range);
+            boundaryDelta += range.start.unsharedHeapSize() + range.end.unsharedHeapSize()
+                             - previous.start.unsharedHeapSize() - previous.end.unsharedHeapSize();
+        }
+
+        public int size()
+        {
+            return ranges.size();
+        }
+
+        /** Replaces the run [from, to) of the tree with this window's intervals, rebuilding the tree once. */
+        void commit(int from, int to)
+        {
+            int newSize = size - (to - from) + ranges.size();
+            Iterator<Range> merged = Iterators.concat(BTree.iterator(tree, 0, from - 1, BTree.Dir.ASC),
+                                                      ranges.iterator(),
+                                                      BTree.iterator(tree, to, size - 1, BTree.Dir.ASC));
+            treeHeapSize = 0;
+            tree = BTree.build(BulkIterator.of(merged), newSize, RangeTombstoneList.this);
+            size = newSize;
+            boundaryHeapSize += boundaryDelta;
+        }
     }
 
     @Override
     public long unsharedHeapSize()
     {
-        return EMPTY_SIZE
-                + boundaryHeapSize
-                + ObjectSizes.sizeOfArray(starts)
-                + ObjectSizes.sizeOfArray(ends)
-                + ObjectSizes.sizeOfArray(markedAts)
-                + ObjectSizes.sizeOfArray(delTimesUnsignedIntegers);
+        // byStart/byEnd are shared with every copy() derived from this list, so they are not counted here.
+        return EMPTY_SIZE + boundaryHeapSize + treeHeapSize + size * RANGE_SIZE;
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4997,39 +4997,32 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Updated batch_size_warn_threshold to {}", thresholdInKiB);
     }
 
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public int getInitialRangeTombstoneListAllocationSize()
     {
-        return DatabaseDescriptor.getInitialRangeTombstoneListAllocationSize();
+        return 1;
     }
 
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public void setInitialRangeTombstoneListAllocationSize(int size)
     {
-        if (size < 0 || size > 1024)
-        {
-            throw new IllegalStateException("Not updating initial_range_tombstone_allocation_size as it must be in the range [0, 1024] inclusive");
-        }
-        int originalSize = DatabaseDescriptor.getInitialRangeTombstoneListAllocationSize();
-        DatabaseDescriptor.setInitialRangeTombstoneListAllocationSize(size);
-        logger.info("Updated initial_range_tombstone_allocation_size from {} to {}", originalSize, size);
+        // no-op: RangeTombstoneList no longer uses resizable backing arrays
     }
 
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public double getRangeTombstoneResizeListGrowthFactor()
     {
-        return DatabaseDescriptor.getRangeTombstoneListGrowthFactor();
+        return 1.5;
     }
 
-    public void setRangeTombstoneListResizeGrowthFactor(double growthFactor) throws IllegalStateException
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
+    public void setRangeTombstoneListResizeGrowthFactor(double growthFactor)
     {
-        if (growthFactor < 1.2 || growthFactor > 5)
-        {
-            throw new IllegalStateException("Not updating range_tombstone_resize_factor as growth factor must be in the range [1.2, 5.0] inclusive");
-        }
-        else
-        {
-            double originalGrowthFactor = DatabaseDescriptor.getRangeTombstoneListGrowthFactor();
-            DatabaseDescriptor.setRangeTombstoneListGrowthFactor(growthFactor);
-            logger.info("Updated range_tombstone_resize_factor from {} to {}", originalGrowthFactor, growthFactor);
-        }
+        // no-op: RangeTombstoneList no longer uses resizable backing arrays
     }
 
     public void setHintedHandoffThrottleInKB(int throttleInKB)

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1269,16 +1269,20 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     CompositeData getFullQueryLoggerOptions();
 
-    /** Sets the initial allocation size of backing arrays for new RangeTombstoneList objects */
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public void setInitialRangeTombstoneListAllocationSize(int size);
 
-    /** Returns the initial allocation size of backing arrays for new RangeTombstoneList objects */
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public int getInitialRangeTombstoneListAllocationSize();
 
-    /** Sets the resize factor to use when growing/resizing a RangeTombstoneList */
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public void setRangeTombstoneListResizeGrowthFactor(double growthFactor);
 
-    /** Returns the resize factor to use when growing/resizing a RangeTombstoneList */
+    /** @deprecated RangeTombstoneList no longer uses resizable backing arrays; this setting is ignored. */
+    @Deprecated(since = "7.0")
     public double getRangeTombstoneResizeListGrowthFactor();
 
     /**

--- a/src/java/org/apache/cassandra/utils/btree/BTree.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTree.java
@@ -719,6 +719,50 @@ public class BTree
     }
 
     /**
+     * Replaces the value at {@code index}, copying only the path to that value. The replacement must preserve
+     * the tree's ordering (this is not enforced). Unchanged children and size maps are shared with the input.
+     *
+     * @return the updated tree, or the input tree if the replacement is the same object as the existing value
+     */
+    public static <V> Object[] replace(Object[] tree, int index, V replace)
+    {
+        if ((index < 0) | (index >= size(tree)))
+            throw new IndexOutOfBoundsException(index + " not in range [0.." + size(tree) + ")");
+
+        return replaceRecursive(tree, index, replace);
+    }
+
+    private static Object[] replaceRecursive(Object[] tree, int index, Object replace)
+    {
+        int slot = index;
+        if (!isLeaf(tree))
+        {
+            int[] sizeMap = sizeMap(tree);
+            int boundary = Arrays.binarySearch(sizeMap, index);
+            if (boundary >= 0)
+            {
+                assert boundary < sizeMap.length - 1;
+                slot = boundary;
+            }
+            else
+            {
+                boundary = -1 - boundary;
+                if (boundary > 0)
+                    index -= 1 + sizeMap[boundary - 1];
+                slot = getChildStart(tree) + boundary;
+                replace = replaceRecursive((Object[]) tree[slot], index, replace);
+            }
+        }
+
+        if (tree[slot] == replace)
+            return tree;
+
+        Object[] result = tree.clone();
+        result[slot] = replace;
+        return result;
+    }
+
+    /**
      * Modifies the provided btree directly. THIS SHOULD NOT BE USED WITHOUT EXTREME CARE as BTrees are meant to be immutable.
      * Finds and replaces the item provided by index in the tree.
      */

--- a/test/microbench/org/apache/cassandra/test/microbench/HarryRangeDeletionMemtableBenchTest.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/HarryRangeDeletionMemtableBenchTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.sun.management.ThreadMXBean;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.harry.ColumnSpec;
+import org.apache.cassandra.harry.SchemaSpec;
+import org.apache.cassandra.harry.dsl.HistoryBuilder;
+import org.apache.cassandra.harry.execution.CQLTesterVisitExecutor;
+import org.apache.cassandra.harry.execution.CQLVisitExecutor;
+import org.apache.cassandra.harry.execution.DataTracker;
+import org.apache.cassandra.harry.model.QuiescentChecker;
+import org.apache.cassandra.harry.op.Visit;
+
+import static org.apache.cassandra.harry.checker.TestHelper.withRandom;
+
+/**
+ * Many range deletions into one unflushed partition, generated and validated by Harry and executed
+ * through the regular write path (memtable merge). Reports wall time and bytes allocated on the
+ * executing thread for the deletion phase; the trailing full-partition select is validated by
+ * {@link QuiescentChecker} against the model, so a wrong merge fails the test rather than the timing.
+ */
+public class HarryRangeDeletionMemtableBenchTest extends CQLTester
+{
+    private static final int[] DELETIONS = { 1000, 4000, 16000 };
+    private static final int ROWS = 200_000;
+
+    @Test
+    public void measureRangeDeletionsIntoOnePartition()
+    {
+        ThreadMXBean threads = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+        StringBuilder report = new StringBuilder("\nRANGE_DELETION_BENCH deletions,disjoint,ms,allocated_mb\n");
+        for (boolean disjoint : new boolean[]{ true, false })
+        {
+            for (int deletions : DELETIONS)
+            {
+                long[] result = run(threads, deletions, disjoint);
+                report.append(String.format("RANGE_DELETION_BENCH %d,%s,%d,%.1f%n", deletions, disjoint, result[0], result[1] / 1048576.0));
+            }
+        }
+        System.out.print(report);
+        logger.info(report.toString());
+    }
+
+    private long[] run(ThreadMXBean threads, int deletions, boolean disjoint)
+    {
+        long[] result = new long[2];
+        withRandom(205413964293041L, rng -> {
+            String keyspace = "rd_bench_ks";
+            String table = "rd_bench_" + deletions + (disjoint ? "d" : "o");
+            SchemaSpec schema = new SchemaSpec(rng.next(), ROWS, keyspace, table,
+                                               Arrays.asList(ColumnSpec.pk("pk1", ColumnSpec.int64Type)),
+                                               Arrays.asList(ColumnSpec.ck("ck1", ColumnSpec.int64Type, false)),
+                                               Arrays.asList(ColumnSpec.regularColumn("r1", ColumnSpec.int64Type)),
+                                               Collections.emptyList());
+            schemaChange(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", keyspace));
+            createTable(schema.compile());
+
+            HistoryBuilder history = new HistoryBuilder(schema.valueGenerators);
+            // A handful of rows so the partition is not deletion-only.
+            for (int i = 0; i < 16; i++)
+                history.insert(0, rng.nextInt(0, ROWS));
+            int width = ROWS / deletions;
+            for (int i = 0; i < deletions; i++)
+            {
+                int lower = disjoint ? i * width : rng.nextInt(0, ROWS - 2);
+                int upper = disjoint ? lower + width - 2 : rng.nextInt(lower + 1, ROWS - 1);
+                history.deleteRowRange(0, lower, upper, 0, true, true);
+            }
+            history.selectPartition(0);
+
+            DataTracker tracker = new DataTracker.SequentialDataTracker();
+            CQLVisitExecutor executor = new CQLTesterVisitExecutor(schema, tracker,
+                                                                   new QuiescentChecker(schema.valueGenerators, tracker, history),
+                                                                   statement -> execute(statement.cql(), statement.bindings()));
+            long tid = Thread.currentThread().getId();
+            long allocatedBefore = threads.getThreadAllocatedBytes(tid);
+            long start = System.nanoTime();
+            Visit last = null;
+            for (Visit visit : history)
+            {
+                if (last != null)
+                    executor.execute(last);
+                last = visit;
+            }
+            result[0] = (System.nanoTime() - start) / 1_000_000;
+            result[1] = threads.getThreadAllocatedBytes(tid) - allocatedBefore;
+            // The final visit is the full-partition select validated against the model; excluded from the timing.
+            executor.execute(last);
+        });
+        return result;
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneMergeBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/RangeTombstoneMergeBench.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringBound;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.Slice;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.partitions.BTreePartitionData;
+import org.apache.cassandra.db.partitions.BTreePartitionUpdater;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.cassandra.utils.memory.HeapCloner;
+import org.apache.cassandra.utils.memory.HeapPool;
+import org.apache.cassandra.utils.memory.MemtableAllocator;
+
+/**
+ * Cost of merging one more range tombstone into an unflushed partition that already holds {@code existing}
+ * range tombstones, which is what every memtable write carrying a range tombstone pays
+ * (BTreePartitionUpdater.mergePartitions -> DeletionInfo.mutableCopy -> RangeTombstoneList.copy/add).
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class RangeTombstoneMergeBench
+{
+    @Param({ "16", "256", "4096", "65536" })
+    int existing;
+
+    private TableMetadata metadata;
+    private HeapPool pool;
+    private MemtableAllocator allocator;
+    private OpOrder.Group group;
+    private BTreePartitionData partition;
+    private PartitionUpdate disjointAfterAll;
+    private PartitionUpdate overlappingMiddle;
+    private PartitionUpdate overlappingHalf;
+    private PartitionUpdate[] sequence;
+
+    @Setup
+    public void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        metadata = TableMetadata.builder("ks", "range_merge_bench")
+                                .partitioner(Murmur3Partitioner.instance)
+                                .addPartitionKeyColumn("pk", Int32Type.instance)
+                                .addClusteringColumn("ck", Int32Type.instance)
+                                .build();
+        pool = new HeapPool(Long.MAX_VALUE, 1.0f, () -> ImmediateFuture.success(Boolean.TRUE));
+        allocator = pool.newAllocator("range-merge-bench");
+        group = new OpOrder().start();
+
+        sequence = new PartitionUpdate[existing];
+        for (int i = 0; i < existing; i++)
+            sequence[i] = update(range(10 * i, 10 * i + 6, 10));
+        partition = BTreePartitionData.EMPTY;
+        for (PartitionUpdate update : sequence)
+            partition = merge(partition, update);
+
+        disjointAfterAll = update(range(10 * existing, 10 * existing + 6, 10));
+        int middle = 10 * (existing / 2);
+        overlappingMiddle = update(range(middle + 2, middle + 4, 30));
+        // A newer tombstone superseding the middle half of the existing intervals.
+        overlappingHalf = update(range(10 * (existing / 4) + 2, 10 * (3 * existing / 4) + 4, 30));
+    }
+
+    @TearDown
+    public void teardown() throws InterruptedException, TimeoutException
+    {
+        group.close();
+        allocator.setDiscarding();
+        allocator.setDiscarded();
+        pool.shutdownAndWait(1, TimeUnit.MINUTES);
+    }
+
+    /** One disjoint tombstone appended after {@code existing} others: the ticket's sorted-append case. */
+    @Benchmark
+    public BTreePartitionData mergeDisjointIntoExisting()
+    {
+        return merge(partition, disjointAfterAll);
+    }
+
+    /** One tombstone splitting an existing interval in the middle of the partition. */
+    @Benchmark
+    public BTreePartitionData mergeOverlappingIntoExisting()
+    {
+        return merge(partition, overlappingMiddle);
+    }
+
+    /** One newer tombstone covering half of the existing intervals: the superseding wide-delete case. */
+    @Benchmark
+    public BTreePartitionData mergeWideOverlapIntoExisting()
+    {
+        return merge(partition, overlappingHalf);
+    }
+
+    /** {@code existing} disjoint tombstones merged one by one into an empty partition. */
+    @Benchmark
+    public BTreePartitionData mergeSequenceFromEmpty()
+    {
+        BTreePartitionData current = BTreePartitionData.EMPTY;
+        for (PartitionUpdate update : sequence)
+            current = merge(current, update);
+        return current;
+    }
+
+    private BTreePartitionData merge(BTreePartitionData current, PartitionUpdate update)
+    {
+        return new BTreePartitionUpdater(allocator, HeapCloner.instance, group, UpdateTransaction.NO_OP).mergePartitions(current, update);
+    }
+
+    private PartitionUpdate update(RangeTombstone range)
+    {
+        PartitionUpdate.Builder builder = new PartitionUpdate.Builder(metadata, ByteBufferUtil.bytes(0), RegularAndStaticColumns.NONE, 0);
+        builder.add(range);
+        return builder.build();
+    }
+
+    private RangeTombstone range(int start, int end, long timestamp)
+    {
+        return new RangeTombstone(Slice.make(ClusteringBound.create(metadata.comparator, true, true, start),
+                                             ClusteringBound.create(metadata.comparator, false, true, end)),
+                                  DeletionTime.build(timestamp, 100));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/RangeTombstoneListTest.java
+++ b/test/unit/org/apache/cassandra/db/RangeTombstoneListTest.java
@@ -19,9 +19,11 @@
 package org.apache.cassandra.db;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,17 +34,15 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.distributed.shared.ThrowingRunnable;
-import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.db.rows.BufferCell;
+import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RangeTombstoneListTest
 {
@@ -51,20 +51,13 @@ public class RangeTombstoneListTest
     @BeforeClass
     public static void beforeClass()
     {
-        // Needed to initialize initial_range_tombstone_allocation_size and range_tombstone_resize_factor
         DatabaseDescriptor.daemonInitialization();
     }
 
     @Test
     public void sortedAdditionTest()
     {
-        sortedAdditionTest(0);
-        sortedAdditionTest(10);
-    }
-
-    private void sortedAdditionTest(int initialCapacity)
-    {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, initialCapacity);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         RangeTombstone rt1 = rt(1, 5, 3);
         RangeTombstone rt2 = rt(7, 10, 2);
         RangeTombstone rt3 = rt(10, 13, 1);
@@ -89,7 +82,7 @@ public class RangeTombstoneListTest
         assertFalse(dt.validate());
 
         // use the invalid deletion time for a range tombstone and aggregate it
-        RangeTombstoneList rtl = new RangeTombstoneList(null, 1);
+        RangeTombstoneList rtl = new RangeTombstoneList(null);
         rtl.add(new RangeTombstone(Slice.ALL, dt));
 
         // undo the aggregation and see if the deletion time is still invalid
@@ -101,13 +94,7 @@ public class RangeTombstoneListTest
     @Test
     public void nonSortedAdditionTest()
     {
-        nonSortedAdditionTest(0);
-        nonSortedAdditionTest(10);
-    }
-
-    private void nonSortedAdditionTest(int initialCapacity)
-    {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, initialCapacity);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         RangeTombstone rt1 = rt(1, 5, 3);
         RangeTombstone rt2 = rt(7, 10, 2);
         RangeTombstone rt3 = rt(10, 13, 1);
@@ -127,13 +114,7 @@ public class RangeTombstoneListTest
     @Test
     public void overlappingAdditionTest()
     {
-        overlappingAdditionTest(0);
-        overlappingAdditionTest(10);
-    }
-
-    private void overlappingAdditionTest(int initialCapacity)
-    {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, initialCapacity);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(rt(4, 10, 3));
         l.add(rt(1, 7, 2));
@@ -148,7 +129,7 @@ public class RangeTombstoneListTest
         assertRT(rtei(13, 15, 1), iter.next());
         assert !iter.hasNext();
 
-        RangeTombstoneList l2 = new RangeTombstoneList(cmp, initialCapacity);
+        RangeTombstoneList l2 = new RangeTombstoneList(cmp);
         l2.add(rt(4, 10, 12L));
         l2.add(rt(0, 8, 25L));
 
@@ -160,7 +141,7 @@ public class RangeTombstoneListTest
     {
         int N = 3000;
         // Test that the StackOverflow from #6181 is fixed
-        RangeTombstoneList l = new RangeTombstoneList(cmp, N);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         for (int i = 0; i < N; i++)
             l.add(rt(2*i+1, 2*i+2, 1));
         assertEquals(l.size(), N);
@@ -171,7 +152,7 @@ public class RangeTombstoneListTest
     @Test
     public void simpleOverlapTest()
     {
-        RangeTombstoneList l1 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l1 = new RangeTombstoneList(cmp);
         l1.add(rt(0, 10, 3));
         l1.add(rt(3, 7, 5));
 
@@ -181,7 +162,7 @@ public class RangeTombstoneListTest
         assertRT(rtei(7, 10, 3), iter1.next());
         assert !iter1.hasNext();
 
-        RangeTombstoneList l2 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l2 = new RangeTombstoneList(cmp);
         l2.add(rt(0, 10, 3));
         l2.add(rt(3, 7, 2));
 
@@ -193,7 +174,7 @@ public class RangeTombstoneListTest
     @Test
     public void overlappingPreviousEndEqualsStartTest()
     {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         // add a RangeTombstone, so, last insert is not in insertion order
         l.add(rt(11, 12, 2));
         l.add(rt(1, 4, 2));
@@ -208,7 +189,7 @@ public class RangeTombstoneListTest
     @Test
     public void searchTest()
     {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         l.add(rt(0, 4, 5));
         l.add(rt(4, 6, 2));
         l.add(rt(9, 12, 1));
@@ -234,12 +215,12 @@ public class RangeTombstoneListTest
     @Test
     public void addAllTest()
     {
-        RangeTombstoneList l1 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l1 = new RangeTombstoneList(cmp);
         l1.add(rt(0, 4, 5));
         l1.add(rt(6, 10, 2));
         l1.add(rt(15, 17, 1));
 
-        RangeTombstoneList l2 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l2 = new RangeTombstoneList(cmp);
         l2.add(rt(3, 5, 7));
         l2.add(rt(7, 8, 3));
         l2.add(rt(8, 12, 1));
@@ -262,10 +243,10 @@ public class RangeTombstoneListTest
     @Test
     public void addAllSequentialTest()
     {
-        RangeTombstoneList l1 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l1 = new RangeTombstoneList(cmp);
         l1.add(rt(3, 5, 2));
 
-        RangeTombstoneList l2 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l2 = new RangeTombstoneList(cmp);
         l2.add(rt(5, 7, 7));
 
         l1.addAll(l2);
@@ -280,10 +261,10 @@ public class RangeTombstoneListTest
     @Test
     public void addAllIncludedTest()
     {
-        RangeTombstoneList l1 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l1 = new RangeTombstoneList(cmp);
         l1.add(rt(3, 10, 5));
 
-        RangeTombstoneList l2 = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l2 = new RangeTombstoneList(cmp);
         l2.add(rt(4, 5, 2));
         l2.add(rt(5, 7, 3));
         l2.add(rt(7, 9, 4));
@@ -307,7 +288,7 @@ public class RangeTombstoneListTest
 
     private RangeTombstoneList makeRandom(Random rand, int size, int maxItSize, int maxItDistance, int maxMarkedAt)
     {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, size);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         int prevStart = -1;
         int prevEnd = 0;
@@ -384,13 +365,7 @@ public class RangeTombstoneListTest
     @Test
     public void nonSortedAdditionTestWithOneTombstoneWithEmptyEnd()
     {
-        nonSortedAdditionTestWithOneRangeWithEmptyEnd(0);
-        nonSortedAdditionTestWithOneRangeWithEmptyEnd(10);
-    }
-
-  private static void nonSortedAdditionTestWithOneRangeWithEmptyEnd(int initialCapacity)
-    {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, initialCapacity);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         RangeTombstone rt1 = rt(1, 5, 3);
         RangeTombstone rt2 = rt(7, 10, 2);
         RangeTombstone rt3 = atLeast(11, 1, 0);
@@ -411,7 +386,7 @@ public class RangeTombstoneListTest
     public void addRangeWithEmptyEndWitchIncludeExistingRange()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(rt(4, 10, 3));
         l.add(atLeast(3, 4, 0));
@@ -425,7 +400,7 @@ public class RangeTombstoneListTest
     public void addRangeWithEmptyStartAndEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(rt(4, 10, 3));
         l.add(atMost(12, 4, 0));
@@ -439,7 +414,7 @@ public class RangeTombstoneListTest
     public void addRangeWithEmptyEndToRangeWithEmptyStartAndEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(new RangeTombstone(Slice.ALL, DeletionTime.build(2, 0)));
         l.add(atLeast(12, 4, 0));
@@ -454,7 +429,7 @@ public class RangeTombstoneListTest
     public void addRangeWithEmptyEndWitchIncludeExistingRangeWithEmptyEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(atLeast(5, 3, 0));
         l.add(atLeast(3, 4, 0));
@@ -468,7 +443,7 @@ public class RangeTombstoneListTest
     public void addIncludedRangeToRangeWithEmptyEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(atLeast(3, 3, 0));
         l.add(rt(4, 10, 4));
@@ -484,7 +459,7 @@ public class RangeTombstoneListTest
     public void addIncludedRangeWithEmptyEndToRangeWithEmptyEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(atLeast(3, 3, 0));
         l.add(atLeast(5, 4, 0));
@@ -499,7 +474,7 @@ public class RangeTombstoneListTest
     public void addRangeWithEmptyEndWitchOverlapExistingRange()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(rt(4, 10, 3));
         l.add(atLeast(6, 4, 0));
@@ -514,7 +489,7 @@ public class RangeTombstoneListTest
     public void addOverlappingRangeToRangeWithEmptyEnd()
     {
 
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
 
         l.add(atLeast(3, 3, 0));
         l.add(rt(1, 10, 4));
@@ -528,7 +503,7 @@ public class RangeTombstoneListTest
     @Test
     public void searchTestWithEmptyStart()
     {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         l.add(atMost(4, 5, 0));
         l.add(rt(4, 6, 2));
         l.add(rt(9, 12, 1));
@@ -553,7 +528,7 @@ public class RangeTombstoneListTest
     @Test
     public void searchTestWithRangeWithEmptyEnd()
     {
-        RangeTombstoneList l = new RangeTombstoneList(cmp, 0);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         l.add(rt(0, 4, 5));
         l.add(rt(4, 6, 2));
         l.add(rt(9, 12, 1));
@@ -574,72 +549,6 @@ public class RangeTombstoneListTest
 
         assertEquals(6, l.searchDeletionTime(clustering(15)).markedForDeleteAt());
         assertEquals(6, l.searchDeletionTime(clustering(1000)).markedForDeleteAt());
-    }
-
-    @Test
-    public void testSetResizeFactor()
-    {
-        double original = DatabaseDescriptor.getRangeTombstoneListGrowthFactor();
-        final StorageService storageService = StorageService.instance;
-        final Consumer<Throwable> expectIllegalStateExceptio = exception -> {
-            assertSame(IllegalStateException.class, exception.getClass());
-            assertEquals("Not updating range_tombstone_resize_factor as growth factor must be in the range [1.2, 5.0] inclusive" , exception.getMessage());
-        };
-        try
-        {
-            // prevent bad ones
-            assertHasException(() -> storageService.setRangeTombstoneListResizeGrowthFactor(-1), expectIllegalStateExceptio);
-            assertHasException(() -> storageService.setRangeTombstoneListResizeGrowthFactor(0), expectIllegalStateExceptio);
-            assertHasException(() -> storageService.setRangeTombstoneListResizeGrowthFactor(1.1), expectIllegalStateExceptio);
-            assertHasException(() -> storageService.setRangeTombstoneListResizeGrowthFactor(5.1), expectIllegalStateExceptio);
-
-            // accept good ones
-            storageService.setRangeTombstoneListResizeGrowthFactor(1.2);
-            storageService.setRangeTombstoneListResizeGrowthFactor(2.0);
-            storageService.setRangeTombstoneListResizeGrowthFactor(5.0);
-        }
-        finally
-        {
-            storageService.setRangeTombstoneListResizeGrowthFactor(original);
-        }
-    }
-
-    @Test
-    public void testSetInitialAllocationSize()
-    {
-        int original = DatabaseDescriptor.getInitialRangeTombstoneListAllocationSize();
-        final StorageService storageService = StorageService.instance;
-        final Consumer<Throwable> expectIllegalStateExceptio = exception -> {
-            assertSame(String.format("The actual exception message:<%s>", exception.getMessage()), IllegalStateException.class, exception.getClass());
-            assertEquals("Not updating initial_range_tombstone_allocation_size as it must be in the range [0, 1024] inclusive" , exception.getMessage());
-        };
-        try
-        {
-            // prevent bad ones
-            assertHasException(() -> storageService.setInitialRangeTombstoneListAllocationSize(-1), expectIllegalStateExceptio);
-            assertHasException(() -> storageService.setInitialRangeTombstoneListAllocationSize(1025), expectIllegalStateExceptio);
-
-            // accept good ones
-            storageService.setInitialRangeTombstoneListAllocationSize(1);
-            storageService.setInitialRangeTombstoneListAllocationSize(1024);
-        }
-        finally
-        {
-            storageService.setInitialRangeTombstoneListAllocationSize(original);
-        }
-    }
-
-    private void assertHasException(ThrowingRunnable block, Consumer<Throwable> verifier)
-    {
-        try
-        {
-            block.run();
-            fail("Expect the code block to throw but not");
-        }
-        catch (Throwable throwable)
-        {
-            verifier.accept(throwable);
-        }
     }
 
     private static void assertRT(RangeTombstone expected, RangeTombstone actual)
@@ -699,7 +608,7 @@ public class RangeTombstoneListTest
     {
         str = str.trim();
         String[] ranges = str.substring(1, str.length() - 1).split("-", 0);
-        RangeTombstoneList l = new RangeTombstoneList(cmp, ranges.length);
+        RangeTombstoneList l = new RangeTombstoneList(cmp);
         for (String range : ranges)
             l.add(rangeFromString(range));
         return l;
@@ -769,5 +678,196 @@ public class RangeTombstoneListTest
     private static RangeTombstone greaterThan(int start, long tstamp, int delTime)
     {
         return new RangeTombstone(Slice.make(BufferClusteringBound.exclusiveStartOf(bb(start)), BufferClusteringBound.TOP), DeletionTime.build(tstamp, delTime));
+    }
+
+    @Test
+    public void wideOverlapRebuildMatchesNarrowInsertsTest()
+    {
+        // A tombstone covering hundreds of intervals takes the rebuild path; the same span added as pieces
+        // narrow enough for the per-interval path must leave every clustering with the same deletion time.
+        Random rand = new Random(42);
+        RangeTombstoneList base = makeRandom(rand, 2000, 5, 3, 10);
+        int end = ByteBufferUtil.toInt(base.iterator(true).next().deletedSlice().end().bufferAt(0));
+        for (long timestamp : new long[]{ 0, 5, 20 })
+        {
+            RangeTombstoneList wide = base.copy();
+            RangeTombstoneList narrow = base.copy();
+            RangeTombstoneList snapshot = base.copy();
+            int from = end / 4, to = 3 * end / 4;
+            wide.add(rt(from, to, timestamp));
+            for (int piece = from; piece < to; piece += 16)
+                narrow.add(rt(piece, Math.min(piece + 16, to), timestamp));
+            assertValid(wide);
+            assertEquals(toString(base), toString(snapshot));
+            for (int x = from - 1; x <= to + 1; x++)
+            {
+                DeletionTime expected = narrow.searchDeletionTime(clustering(x));
+                DeletionTime actual = wide.searchDeletionTime(clustering(x));
+                assertEquals("timestamp " + timestamp + " at " + x, expected == null ? null : expected.markedForDeleteAt(), actual == null ? null : actual.markedForDeleteAt());
+            }
+        }
+    }
+
+    @Test
+    public void copyOnWriteOverlappingSplitsTest()
+    {
+        RangeTombstone first = rt(0, 10, 10, 100);
+        RangeTombstone second = rt(20, 30, 20, 200);
+        RangeTombstoneList original = list(first, second);
+        RangeTombstoneList copy = original.copy();
+        RangeTombstoneList copyOfCopy = copy.copy();
+
+        copy.add(rt(3, 7, 30, 300));
+        assertSnapshot(original, first, second);
+        assertSnapshot(copyOfCopy, first, second);
+
+        original.add(rt(25, 35, 40, 400));
+        copyOfCopy.add(rt(8, 22, 50, 500));
+
+        assertSnapshot(original, first, rtie(20, 25, 20, 200), rt(25, 35, 40, 400));
+        assertSnapshot(copy, rtie(0, 3, 10, 100), rt(3, 7, 30, 300), rtei(7, 10, 10, 100), second);
+        assertSnapshot(copyOfCopy, rtie(0, 8, 10, 100), rt(8, 22, 50, 500), rtei(22, 30, 20, 200));
+    }
+
+    @Test
+    public void copyOnWriteAddAllIsolationTest()
+    {
+        RangeTombstone first = rt(0, 10, 10, 100);
+        RangeTombstoneList source = list(first);
+        RangeTombstoneList sourceSnapshot = source.copy();
+        RangeTombstoneList destination = list();
+        RangeTombstoneList emptySnapshot = destination.copy();
+
+        destination.addAll(source);
+        destination.addAll(destination);
+        destination.addAll(sourceSnapshot);
+        destination.addAll(emptySnapshot);
+        assertSnapshot(destination, first);
+        assertSnapshot(emptySnapshot);
+
+        destination.add(rt(3, 7, 30, 300));
+        source.add(rt(8, 12, 40, 400));
+        assertSnapshot(sourceSnapshot, first);
+        assertSnapshot(destination, rtie(0, 3, 10, 100), rt(3, 7, 30, 300), rtei(7, 10, 10, 100));
+        assertSnapshot(source, rtie(0, 8, 10, 100), rt(8, 12, 40, 400));
+
+        // Exercise both similarly sized inputs and a large destination with a singleton update.
+        for (int count : new int[]{ 1, 12 })
+        {
+            RangeTombstone[] before = new RangeTombstone[count];
+            RangeTombstone[] after = new RangeTombstone[count + 2];
+            for (int i = 0; i < count; ++i)
+            {
+                before[i] = rt(10 * i, 10 * i + 6, 10, 100);
+                if (i > 0)
+                    after[i + 2] = before[i];
+            }
+            after[0] = rtie(0, 2, 10, 100);
+            after[1] = rt(2, 4, 30, 300);
+            after[2] = rtei(4, 6, 10, 100);
+            RangeTombstoneList target = list(before);
+            RangeTombstoneList oldTarget = target.copy();
+            RangeTombstoneList update = list(after[1]);
+            RangeTombstoneList oldUpdate = update.copy();
+
+            target.addAll(update);
+            update.updateAllTimestampAndLocalDeletionTime(50, 500);
+            assertSnapshot(target, after);
+            assertSnapshot(oldTarget, before);
+            assertSnapshot(oldUpdate, after[1]);
+            assertSnapshot(update, rt(2, 4, 50, 500));
+        }
+    }
+
+    @Test
+    public void copyOnWriteTimestampMutationTest()
+    {
+        RangeTombstone first = rt(0, 10, 10, 100);
+        RangeTombstone second = rt(20, 30, 20, 200);
+        RangeTombstoneList original = list(first, second);
+        RangeTombstoneList snapshot = original.copy();
+        RangeTombstoneList copy = original.copy();
+
+        copy.updateAllTimestamp(30);
+        RangeTombstoneList copyOfCopy = copy.copy();
+        copyOfCopy.updateAllTimestampAndLocalDeletionTime(40, 400);
+        original.updateAllTimestampAndLocalDeletionTime(50, 500);
+
+        assertSnapshot(snapshot, first, second);
+        assertSnapshot(copy, rt(0, 10, 30, 100), rt(20, 30, 30, 200));
+        assertSnapshot(copyOfCopy, rt(0, 10, 40, 400), rt(20, 30, 40, 400));
+        assertSnapshot(original, rt(0, 10, 50, 500), rt(20, 30, 50, 500));
+    }
+
+    private static RangeTombstoneList list(RangeTombstone... ranges)
+    {
+        RangeTombstoneList list = new RangeTombstoneList(cmp);
+        for (RangeTombstone range : ranges)
+            list.add(range);
+        return list;
+    }
+
+    private static void assertSnapshot(RangeTombstoneList list, RangeTombstone... expected)
+    {
+        // Adjacent fragments with the same deletion time need not be coalesced by the list.
+        // Compare their exact coverage, without imposing a canonical fragmentation on either iterator.
+        for (boolean reversed : new boolean[]{ false, true })
+        {
+            List<RangeTombstone> actual = new ArrayList<>();
+            list.iterator(reversed).forEachRemaining(actual::add);
+            assertEquals(list.size(), actual.size());
+            if (reversed)
+                Collections.reverse(actual);
+
+            List<RangeTombstone> coalesced = new ArrayList<>();
+            for (RangeTombstone range : actual)
+            {
+                assertFalse(Slice.isEmpty(cmp, range.deletedSlice().start(), range.deletedSlice().end()));
+                if (!coalesced.isEmpty())
+                {
+                    int last = coalesced.size() - 1;
+                    RangeTombstone previous = coalesced.get(last);
+                    int order = cmp.compare(previous.deletedSlice().end(), range.deletedSlice().start());
+                    assertTrue("Iterator ranges must be ordered and non-overlapping", order <= 0);
+                    if (order == 0 && previous.deletionTime().equals(range.deletionTime()))
+                    {
+                        coalesced.set(last, new RangeTombstone(Slice.make(previous.deletedSlice().start(), range.deletedSlice().end()),
+                                                              range.deletionTime()));
+                        continue;
+                    }
+                }
+                coalesced.add(range);
+            }
+            assertEquals(expected.length, coalesced.size());
+            for (int i = 0; i < expected.length; ++i)
+                assertRT(expected[i], coalesced.get(i));
+        }
+
+        ColumnMetadata column = ColumnMetadata.regularColumn("ks", "tbl", "v", Int32Type.instance, ColumnMetadata.NO_UNIQUE_ID);
+        // Probe endpoints, split interiors and gaps independently of the list's search implementation.
+        for (int key = -1; key <= 130; ++key)
+        {
+            Clustering<?> clustering = clustering(key);
+            RangeTombstone covering = null;
+            for (RangeTombstone range : expected)
+                if (range.deletedSlice().includes(cmp, clustering))
+                    covering = range;
+            assertEquals(covering == null ? null : covering.deletionTime(), list.searchDeletionTime(clustering));
+            if (covering == null)
+                assertEquals(null, list.search(clustering));
+            else
+            {
+                RangeTombstone found = list.search(clustering);
+                assertNotNull(found);
+                assertTrue(found.deletedSlice().includes(cmp, clustering));
+                assertEquals(covering.deletionTime(), found.deletionTime());
+            }
+            // Boundary check only: covering.deletionTime() itself was already verified above via search().
+            long ts = covering == null ? 0 : covering.deletionTime().markedForDeleteAt();
+            for (long timestamp : new long[]{ ts, ts + 1 })
+                assertEquals("key=" + key + ", timestamp=" + timestamp,
+                             covering != null && ts >= timestamp,
+                             list.isDeleted(clustering, BufferCell.live(column, timestamp, bb(0))));
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/partitions/BTreePartitionUpdaterTest.java
+++ b/test/unit/org/apache/cassandra/db/partitions/BTreePartitionUpdaterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.partitions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ClusteringBound;
+import org.apache.cassandra.db.DeletionInfo;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.Slice;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.cassandra.utils.memory.HeapCloner;
+import org.apache.cassandra.utils.memory.HeapPool;
+import org.apache.cassandra.utils.memory.MemtableAllocator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BTreePartitionUpdaterTest
+{
+    private static TableMetadata metadata;
+    private static HeapPool pool;
+
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        metadata = TableMetadata.builder("ks", "range_merge")
+                                .partitioner(Murmur3Partitioner.instance)
+                                .addPartitionKeyColumn("pk", Int32Type.instance)
+                                .addClusteringColumn("ck", Int32Type.instance)
+                                .build();
+        pool = new HeapPool(Long.MAX_VALUE, 1.0f, () -> ImmediateFuture.success(Boolean.TRUE));
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception
+    {
+        if (pool != null)
+            pool.shutdownAndWait(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void retainedSnapshotsSurviveDisjointAndOverlappingMerges()
+    {
+        int count = 128;
+        PartitionUpdate[] updates = new PartitionUpdate[2 * count];
+        for (int i = 0; i < count; ++i)
+        {
+            updates[i] = update(range(10 * i, true, 10 * i + 6, true, 10, 100));
+            updates[count + i] = update(range(10 * i + 2, true, 10 * i + 4, true, 30, 300));
+        }
+
+        BTreePartitionData[] snapshots = new BTreePartitionData[updates.length + 1];
+        MemtableAllocator allocator = pool.newAllocator("retained-range-snapshots");
+        try (OpOrder.Group group = new OpOrder().start())
+        {
+            mergeAll(updates, snapshots, allocator, group);
+
+            // Read every old version only after all later updates have had a chance to corrupt it.
+            for (int i = 0; i <= count; ++i)
+                assertSnapshot(snapshots[i], count, i, 0);
+            for (int i = 1; i <= count; ++i)
+                assertSnapshot(snapshots[count + i], count, count, i);
+
+            // The updater must not mutate its caller's PartitionUpdate either.
+            for (int i = 0; i < updates.length; ++i)
+            {
+                Iterator<RangeTombstone> ranges = updates[i].deletionInfo().rangeIterator(false);
+                boolean split = i >= count;
+                int start = 10 * (i % count) + (split ? 2 : 0);
+                assertRange(range(start, true, start + (split ? 2 : 6), true, split ? 30 : 10, split ? 300 : 100),
+                            ranges.next());
+                assertFalse(ranges.hasNext());
+            }
+        }
+        finally
+        {
+            allocator.setDiscarding();
+            allocator.setDiscarded();
+        }
+    }
+
+    private static void mergeAll(PartitionUpdate[] updates, BTreePartitionData[] snapshots,
+                                 MemtableAllocator allocator, OpOrder.Group group)
+    {
+        snapshots[0] = BTreePartitionData.EMPTY;
+        for (int i = 0; i < updates.length; ++i)
+        {
+            BTreePartitionUpdater updater = new BTreePartitionUpdater(allocator, HeapCloner.instance, group, UpdateTransaction.NO_OP);
+            snapshots[i + 1] = updater.mergePartitions(snapshots[i], updates[i]);
+        }
+    }
+
+    private static PartitionUpdate update(RangeTombstone range)
+    {
+        PartitionUpdate.Builder builder = new PartitionUpdate.Builder(metadata, ByteBufferUtil.bytes(0), RegularAndStaticColumns.NONE, 0);
+        builder.add(range);
+        return builder.build();
+    }
+
+    private static void assertSnapshot(BTreePartitionData snapshot, int total, int disjoint, int split)
+    {
+        List<RangeTombstone> expected = new ArrayList<>();
+        for (int i = 0; i < disjoint; ++i)
+        {
+            int start = 10 * i;
+            if (i < split)
+            {
+                expected.add(range(start, true, start + 2, false, 10, 100));
+                expected.add(range(start + 2, true, start + 4, true, 30, 300));
+                expected.add(range(start + 4, false, start + 6, true, 10, 100));
+            }
+            else
+            {
+                expected.add(range(start, true, start + 6, true, 10, 100));
+            }
+        }
+        DeletionInfo info = snapshot.deletionInfo;
+        assertEquals(DeletionTime.LIVE, info.getPartitionDeletion());
+        assertEquals(expected.size(), info.rangeCount());
+        Iterator<RangeTombstone> forward = info.rangeIterator(false);
+        Iterator<RangeTombstone> reverse = info.rangeIterator(true);
+        for (int i = 0; i < expected.size(); ++i)
+        {
+            assertTrue(forward.hasNext());
+            assertTrue(reverse.hasNext());
+            assertRange(expected.get(i), forward.next());
+            assertRange(expected.get(expected.size() - i - 1), reverse.next());
+        }
+        assertFalse(forward.hasNext());
+        assertFalse(reverse.hasNext());
+        assertNull(info.rangeCovering(clustering(-1)));
+        for (int i = 0; i <= total; ++i)
+        {
+            for (int offset = 0; offset <= 7; ++offset)
+            {
+                RangeTombstone actual = info.rangeCovering(clustering(10 * i + offset));
+                if (i >= disjoint || offset > 6)
+                {
+                    assertNull(actual);
+                }
+                else
+                {
+                    boolean newer = i < split && offset >= 2 && offset <= 4;
+                    assertEquals(DeletionTime.build(newer ? 30 : 10, newer ? 300 : 100), actual.deletionTime());
+                    assertTrue(actual.deletionTime().deletes(10));
+                    assertEquals(newer, actual.deletionTime().deletes(20));
+                    assertFalse(actual.deletionTime().deletes(31));
+                }
+            }
+        }
+    }
+
+    private static void assertRange(RangeTombstone expected, RangeTombstone actual)
+    {
+        assertEquals(0, metadata.comparator.compare(expected.deletedSlice().start(), actual.deletedSlice().start()));
+        assertEquals(0, metadata.comparator.compare(expected.deletedSlice().end(), actual.deletedSlice().end()));
+        assertEquals(expected.deletionTime(), actual.deletionTime());
+    }
+
+    private static Clustering<?> clustering(int value)
+    {
+        return Clustering.make(ByteBufferUtil.bytes(value));
+    }
+
+    private static RangeTombstone range(int start, boolean startInclusive, int end, boolean endInclusive,
+                                        long timestamp, long localDeletionTime)
+    {
+        return new RangeTombstone(Slice.make(ClusteringBound.create(metadata.comparator, true, startInclusive, start),
+                                             ClusteringBound.create(metadata.comparator, false, endInclusive, end)),
+                                  DeletionTime.build(timestamp, localDeletionTime));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/rows/RowAndDeletionMergeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/db/rows/RowAndDeletionMergeIteratorTest.java
@@ -365,7 +365,7 @@ public class RowAndDeletionMergeIteratorTest
     public void testWithNoopBoundaryMarkers()
     {
         PartitionUpdate update = PartitionUpdate.emptyUpdate(cfm, dk);
-        RangeTombstoneList rtl = new RangeTombstoneList(cfm.comparator, 10);
+        RangeTombstoneList rtl = new RangeTombstoneList(cfm.comparator);
         rtl.add(rt(1, 2, 5, 5));
         rtl.add(rt(3, 4, 5, 5));
         rtl.add(rt(5, 6, 5, 5));
@@ -395,7 +395,7 @@ public class RowAndDeletionMergeIteratorTest
 
     private Iterator<RangeTombstone> createRangeTombstoneIterator(RangeTombstone... tombstones)
     {
-        RangeTombstoneList list = new RangeTombstoneList(cfm.comparator, 10);
+        RangeTombstoneList list = new RangeTombstoneList(cfm.comparator);
 
         for (RangeTombstone tombstone : tombstones)
             list.add(tombstone);

--- a/test/unit/org/apache/cassandra/utils/btree/BTreeTest.java
+++ b/test/unit/org/apache/cassandra/utils/btree/BTreeTest.java
@@ -98,6 +98,92 @@ public class BTreeTest
     }
 
     @Test
+    public void testReplacePreservesSnapshots()
+    {
+        // Exceed the capacity of a root with only leaf children, exercising deeper paths and internal keys.
+        checkReplaceSnapshots((BTree.MAX_KEYS + 1) * (BTree.MAX_KEYS + 1));
+    }
+
+    private static void checkReplaceSnapshots(int count)
+    {
+        List<Accumulator> values = new ArrayList<>();
+        for (int i = 0; i < count; i++)
+            values.add(new Accumulator(i, 0));
+        Object[] original = BTree.build(values);
+
+        for (int index = 0; index < count; index++)
+        {
+            Assert.assertSame(original, BTree.replace(original, index, values.get(index)));
+
+            Accumulator firstValue = new Accumulator(index, 1);
+            Accumulator secondValue = new Accumulator(index, 2);
+            int siblingIndex = (index + 1) % count;
+            Accumulator siblingValue = new Accumulator(siblingIndex, 3);
+            Object[] first = BTree.replace(original, index, firstValue);
+            Object[] second = BTree.replace(first, index, secondValue);
+            Object[] sibling = BTree.replace(original, siblingIndex, siblingValue);
+
+            assertReplacementPath(original, first, index);
+            assertReplacementPath(first, second, index);
+            assertReplacementPath(original, sibling, siblingIndex);
+            assertEquals(BTree.sizeOnHeapOf(original), BTree.sizeOnHeapOf(first));
+            assertTrue(BTree.isWellFormed(first, Comparator.<Accumulator>naturalOrder()));
+            Assert.assertSame(first, BTree.replace(first, index, firstValue));
+
+            for (int i = 0; i < count; i++)
+            {
+                Assert.assertSame(values.get(i), BTree.findByIndex(original, i));
+                Assert.assertSame(i == index ? firstValue : values.get(i), BTree.findByIndex(first, i));
+                Assert.assertSame(i == index ? secondValue : values.get(i), BTree.findByIndex(second, i));
+                Assert.assertSame(i == siblingIndex ? siblingValue : values.get(i), BTree.findByIndex(sibling, i));
+            }
+        }
+    }
+
+    private static void assertReplacementPath(Object[] original, Object[] replaced, int index)
+    {
+        Assert.assertNotSame(original, replaced);
+        assertEquals(original.length, replaced.length);
+        assertEquals(BTree.size(original), BTree.size(replaced));
+        if (BTree.isLeaf(original))
+            return;
+
+        Assert.assertSame(BTree.sizeMap(original), BTree.sizeMap(replaced));
+        int offset = 0;
+        for (int child = BTree.getChildStart(original); child < BTree.getChildEnd(original); child++)
+        {
+            Object[] originalChild = (Object[]) original[child];
+            int childSize = BTree.size(originalChild);
+            if (index >= offset && index < offset + childSize)
+                assertReplacementPath(originalChild, (Object[]) replaced[child], index - offset);
+            else
+                Assert.assertSame(originalChild, replaced[child]);
+            offset += childSize + 1;
+        }
+    }
+
+    @Test
+    public void testReplaceInvalidIndex()
+    {
+        for (int count : new int[] { 0, 2, BTree.MAX_KEYS + 1 })
+        {
+            Object[] tree = BTree.build(seq(count));
+            for (int index : new int[] { Integer.MIN_VALUE, -1, count, Integer.MAX_VALUE })
+            {
+                try
+                {
+                    BTree.replace(tree, index, 0);
+                    Assert.fail("Expected an invalid replacement index to be rejected");
+                }
+                catch (IndexOutOfBoundsException expected)
+                {
+                }
+                assertTrue(Iterables.elementsEqual(seq(count), BTree.<Integer>iterable(tree)));
+            }
+        }
+    }
+
+    @Test
     public void testApply()
     {
         List<Integer> input = seq(71);


### PR DESCRIPTION
CASSANDRA-21492: every memtable write that carries a range tombstone goes through
DeletionInfo.mutableCopy() -> RangeTombstoneList.copy(), which copies the list's four parallel arrays
in full; N successive range-tombstone merges into one unflushed partition copy O(N^2) array entries.

Change: RangeTombstoneList stores its intervals in a persistent BTree ordered by end bound instead of
four resizable arrays.
- copy() shares the tree; nothing is copied until the copy is modified.
- Inserting a range disjoint from all existing ones path-copies O(log n) nodes. A range that overlaps
  existing intervals is merged with the same precedence rules as before through one implementation
  of the merge loop, applied to one of two targets: for a small number of affected intervals the
  tree itself, replacing each changed interval by path copy (BTree.replace, added for this); when
  the range supersedes at least 32 intervals and at least 1/32 of the list, an array copy of the
  affected run, after which the tree is rebuilt once from prefix, merged run and suffix (O(n), the
  same order as the previous array copy, but without per-interval path copies).
- Retained snapshots keep their own root and are unaffected by later writes to a copy.
- Lookups (searchDeletionTime, isDeleted) and slice iteration use the tree's search and range
  iterators. The list remains single-writer; only immutable snapshots may be read concurrently.
- The array sizing settings no longer have anything to size: initial_range_tombstone_list_allocation_size
  and range_tombstone_list_growth_factor stay in Config as @Deprecated no-op fields (the loader warns
  instead of rejecting them) and the four StorageServiceMBean accessors remain as deprecated no-ops
  returning the former defaults. NEWS.txt documents this. On-disk and commit-log formats are unchanged.

Measurements (same benchmark sources compiled against base and patch; JMH 1.37, single thread, avgt,
-prof gc; Xeon E5-2699 v3, OpenJDK 11.0.24). RangeTombstoneMergeBench merges one tombstone into a
partition already holding `existing` range tombstones:

  case                                    existing   base            patch
  disjoint append                          4096      67.8 us / 206 KB   2.2 us / 1.2 KB
                                          65536    1468 us / 3.3 MB    3.1 us / 1.6 KB
  split one interval                      65536    1755 us / 3.3 MB    8.6 us / 3.4 KB
  N disjoint merges from empty (total)     4096     161 ms / 423 MB    12 ms / 4.9 MB
                                          65536    39.8 s  / 107 GB   0.26 s / 103 MB
  supersede half of the intervals          4096     556 us / 255 KB   711 us / 156 KB
                                          65536    8.7 ms / 4.1 MB   11.1 ms / 2.5 MB

HarryRangeDeletionMemtableBenchTest issues CQL range deletes into one partition through the normal
write path (memtable merge) and validates the final partition against the Harry model; deletion
phase only, single run each:

  16000 disjoint deletes:            base 7.4 s / 7.5 GB allocated   patch 5.7 s / 1.4 GB
  16000 random, wide deletes:        base 47 s  / 14.4 GB            patch 62 s  / 6.4 GB

The superseding wide-delete case is 1.3x slower in wall time than the array implementation (one
BTree rebuild versus four array copies) while allocating 1.6-2.3x less. Without the rebuild path it
was 2.3x slower and allocated 4.5x more. JMH error bars are 10-30%; the Harry numbers are single runs.

Trade-offs:
- addAll inserts the source ranges one by one (O(m log n)) instead of the previous linear merge of
  two arrays.
- Memtable heap accounting is delta-based (BTreePartitionUpdater charges new minus old
  unsharedHeapSize), so shared nodes are charged once; but unsharedHeapSize() of a snapshot still
  reports the whole tree it references, so summing it over snapshots that share a tree over-counts.

Testing:
- RangeTombstoneListTest (28): the existing add/addAll/overlap/precedence/search/iterator cases, the
  snapshot assertions extended to check that a copy taken before a series of inserts still returns
  its original deletion times at every key, and wideOverlapRebuildMatchesNarrowInsertsTest: on 2000
  random intervals, a tombstone covering ~1000 of them added in one call (rebuild path) versus the
  same span added in pieces of 16 (per-interval path) yields the same deletion time at every
  clustering in and around the span, for a lower, equal and higher timestamp; the snapshot taken
  before is unchanged.
- BTreePartitionUpdaterTest.retainedSnapshotsSurviveDisjointAndOverlappingMerges: partition
  snapshots retained across disjoint and overlapping range-tombstone merges each still iterate
  exactly the ranges they held.
- BTreeTest: replace preserves earlier snapshots and rejects invalid indexes.
- RowAndDeletionMergeIteratorTest (10) adapted to the constructor without a capacity argument.
- RangeTombstoneMergeBench and HarryRangeDeletionMemtableBenchTest are included under
  test/microbench; the Harry one is run manually (about six minutes).

CASSANDRA-21492
