### PR TITLE
CASSANDRA-21094 Advise sequential access on descriptors owned by bulk SSTable scans and streaming

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Advise buffered background SSTable scans and whole-file streaming reads as sequential on Linux; bulk scans now use a private descriptor that bypasses the shared chunk cache (CASSANDRA-21094)
  * Allow CQLSSTableWriter to specify SSTable id generator to use (CASSANDRA-21012)
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
  * Support pluggable default role initialization (CASSANDRA-21546)

--- a/src/java/org/apache/cassandra/db/streaming/CassandraCompressedStreamWriter.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraCompressedStreamWriter.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.streaming.ProgressInfo;
 import org.apache.cassandra.streaming.StreamSession;
 import org.apache.cassandra.streaming.StreamingDataOutputPlus;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NativeLibrary;
 
 /**
  * CassandraStreamWriter for compressed SSTable.
@@ -67,6 +68,10 @@ public class CassandraCompressedStreamWriter extends CassandraStreamWriter
 
             // we want to send continuous chunks together to minimise reads from disk and network writes
             List<Section> sections = fuseAdjacentChunks(compressionInfo.chunks());
+
+            // Sequential readahead overshoots the end of every section, so only advise a whole-file stream.
+            if (sections.size() == 1 && isWholeFileSection(sections.get(0).start, sections.get(0).end, fc.size()))
+                NativeLibrary.trySetSequential(fc.getFileDescriptor(), fc.filePath());
 
             int sectionIdx = 0;
 

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamWriter.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamWriter.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.streaming.StreamSession;
 import org.apache.cassandra.streaming.StreamingDataOutputPlus;
 import org.apache.cassandra.streaming.async.StreamCompressionSerializer;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NativeLibrary;
 import org.apache.cassandra.utils.memory.BufferPools;
 
 import static org.apache.cassandra.net.MessagingService.current_version;
@@ -83,6 +84,10 @@ public class CassandraStreamWriter
         try(ChannelProxy proxy = sstable.getDataChannel().newChannel();
             ChecksumValidator validator = sstable.maybeGetChecksumValidator())
         {
+            // Sequential readahead overshoots the end of every section, so only advise a whole-file stream.
+            SSTableReader.PartitionPositionBounds only = sections.size() == 1 ? sections.iterator().next() : null;
+            if (only != null && isWholeFileSection(only.lowerPosition, only.upperPosition, proxy.size()))
+                NativeLibrary.trySetSequential(proxy.getFileDescriptor(), proxy.filePath());
             int bufferSize = validator == null ? DEFAULT_CHUNK_SIZE: validator.chunkSize;
 
             // setting up data compression stream
@@ -125,6 +130,12 @@ public class CassandraStreamWriter
     protected long totalSize()
     {
         return totalSize;
+    }
+
+    /** True when a single stream section spans the whole file: the case worth advising as sequential. */
+    protected static boolean isWholeFileSection(long start, long end, long fileSize)
+    {
+        return start == 0 && end == fileSize;
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
+++ b/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.NativeLibrary;
 
 public class ComponentContext implements AutoCloseable
 {
@@ -80,6 +81,7 @@ public class ComponentContext implements AutoCloseable
 
         assert size == channel.size() : String.format("Entire sstable streaming expects %s file size to be %s but got %s.",
                                                       component, size, channel.size());
+        NativeLibrary.trySetSequential(NativeLibrary.getfd(channel), toTransfer.path());
         return channel;
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableCursorReader.java
@@ -608,7 +608,7 @@ public class SSTableCursorReader implements AutoCloseable
         serializationHeader = reader.header;
         sstableHasDroppedColumns = anyDroppedColumn(deserializationHelper, serializationHeader);
 
-        dataReader = reader.openDataReaderForScan(diskAccessMode);
+        dataReader = reader.openDataReaderForBulkScan(diskAccessMode);
         // the HEADER decides whether this sstable can contain static rows: after
         // ALTER TABLE ... DROP of the last static column, current metadata has no static
         // columns but older sstables legitimately still carry static rows

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1421,42 +1421,58 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
 
     public RandomAccessReader openDataReader()
     {
-        return openDataReaderInternal(null, null, false);
+        return openDataReaderInternal(null, null, false, false);
     }
 
     public RandomAccessReader openDataReader(RateLimiter limiter)
     {
         assert limiter != null;
-        return openDataReaderInternal(null, limiter, false);
+        return openDataReaderInternal(null, limiter, false, false);
     }
 
     public RandomAccessReader openDataReader(DiskAccessMode diskAccessMode)
     {
-        return openDataReaderInternal(diskAccessMode, null, false);
+        return openDataReaderInternal(diskAccessMode, null, false, false);
     }
 
     public RandomAccessReader openDataReaderForScan()
     {
-        return openDataReaderInternal(null, null, true);
+        return openDataReaderInternal(null, null, true, false);
     }
 
-    public RandomAccessReader openDataReaderForScan(DiskAccessMode diskAccessMode)
+    /**
+     * A background bulk scan (compaction, cleanup, streaming, offline tools) reads the file once, so it may take
+     * a private descriptor advised as sequential. User range reads must use {@link #openDataReaderForScan()}.
+     */
+    public RandomAccessReader openDataReaderForBulkScan(DiskAccessMode diskAccessMode)
     {
-        return openDataReaderInternal(diskAccessMode, null, true);
+        return openDataReaderInternal(diskAccessMode, null, true, true);
     }
 
     private RandomAccessReader openDataReaderInternal(@Nullable DiskAccessMode diskAccessMode,
                                                       @Nullable RateLimiter limiter,
-                                                      boolean forScan)
+                                                      boolean forScan,
+                                                      boolean bulkScan)
     {
-        if (canReuseDfile(diskAccessMode))
+        boolean reuseDfile = canReuseDfile(diskAccessMode);
+        DiskAccessMode effectiveMode = reuseDfile ? dfile.diskAccessMode() : diskAccessMode;
+        // Mmap reads access the file through MmappedRegions, not the descriptor's read()/readahead path, so
+        // fadvise has nothing to act on there; direct I/O bypasses the page cache, so advice is a no-op too.
+        boolean advise = bulkScan && effectiveMode != DiskAccessMode.mmap && effectiveMode != DiskAccessMode.direct;
+        if (reuseDfile && !advise)
             return dfile.createReader(limiter, forScan, OnReaderClose.RETAIN_FILE_OPEN);
 
         FileHandle handle = dfile.toBuilder()
-                                 .withDiskAccessMode(diskAccessMode)
+                                 .withDiskAccessMode(effectiveMode)
+                                 // A temporary handle must not reopen through the writer's closed regions cache,
+                                 // nor own and invalidate the SSTable's shared chunk cache.
+                                 .withMmappedRegionsCache(null)
+                                 .withChunkCache(null)
                                  .complete();
         try
         {
+            if (advise)
+                NativeLibrary.trySetSequential(handle.channel.getFileDescriptor(), handle.path());
             return handle.createReader(limiter, forScan, OnReaderClose.CLOSE_FILE);
         }
         catch (Throwable t)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
@@ -78,7 +78,7 @@ implements ISSTableScanner
     {
         assert sstable != null;
 
-        this.dfile = sstable.openDataReaderForScan(diskAccessMode);
+        this.dfile = sstable.openDataReaderForBulkScan(diskAccessMode);
         this.sstable = sstable;
         this.tableMetadata = sstable.metadata();
         this.sizeInBytes = boundsList.stream().mapToLong(ppb -> ppb.upperPosition - ppb.lowerPosition).sum();

--- a/src/java/org/apache/cassandra/utils/NativeLibrary.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibrary.java
@@ -273,6 +273,44 @@ public final class NativeLibrary
         }
     }
 
+    /**
+     * Advises the kernel that this descriptor will be read sequentially; affects the open file description,
+     * so advise only an exclusively owned read fd, never one shared with random readers.
+     */
+    public static void trySetSequential(int fd, String path)
+    {
+        if (fd < 0)
+            return;
+
+        try
+        {
+            if (osType == LINUX)
+            {
+                int result = wrappedLibrary.callPosixFadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+                if (result != 0)
+                    NoSpamLogger.log(
+                            logger,
+                            NoSpamLogger.Level.WARN,
+                            10,
+                            TimeUnit.MINUTES,
+                            "Failed trySetSequential on file: {} Error: " + wrappedLibrary.callStrerror(result).getString(0),
+                            path);
+            }
+        }
+        catch (UnsatisfiedLinkError e)
+        {
+            // if JNA is unavailable just skipping
+        }
+        catch (RuntimeException e)
+        {
+            if (!(e instanceof LastErrorException))
+                throw e;
+
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 10, TimeUnit.MINUTES,
+                             "posix_fadvise({}, SEQUENTIAL) failed, errno ({}).", fd, errno(e));
+        }
+    }
+
     public static int tryFcntl(int fd, int command, int flags)
     {
         // fcntl return value may or may not be useful, depending on the command

--- a/test/unit/org/apache/cassandra/io/sstable/format/SSTableReaderDataReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/SSTableReaderDataReaderTest.java
@@ -17,15 +17,23 @@
  */
 package org.apache.cassandra.io.sstable.format;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.config.Config.DiskAccessMode;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -37,20 +45,25 @@ import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.concurrent.Ref;
 
 import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
- * Tests for {@code SSTableReader#canReuseDfile} / {@code SSTableReader#openDataReaderInternal}.
+ * Tests for {@code SSTableReader#canReuseDfile} / {@code SSTableReader#openDataReaderInternal}, and for
+ * reader contents and resource lifetime across foreground reads and scans.
  */
+@RunWith(BMUnitRunner.class)
 public class SSTableReaderDataReaderTest
 {
     private static final String KEYSPACE = "SSTableReaderDataReaderTest";
@@ -58,6 +71,8 @@ public class SSTableReaderDataReaderTest
     private static final String CF_COMPRESSED = "Compressed";
 
     private static DiskAccessMode originalDiskAccessMode;
+    private static final ThreadLocal<Set<Integer>> advisedDescriptors = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> sequentialRead = new ThreadLocal<>();
     private final List<Ref<?>> refsToRelease = new ArrayList<>();
 
     @BeforeClass
@@ -84,6 +99,7 @@ public class SSTableReaderDataReaderTest
     @After
     public void teardown()
     {
+        DatabaseDescriptor.setDiskAccessMode(DiskAccessMode.standard);
         Throwable exceptions = null;
         for (Ref<?> ref : refsToRelease)
         {
@@ -216,24 +232,141 @@ public class SSTableReaderDataReaderTest
     }
 
     @Test
-    public void testForScanReusesWithNullMode()
+    public void testFlushedMmapScanRetainsLiveRegions() throws IOException
     {
-        SSTableReader sstable = createSSTable(CF_UNCOMPRESSED);
-
-        try (RandomAccessReader reader = sstable.openDataReaderForScan())
+        DatabaseDescriptor.setDiskAccessMode(DiskAccessMode.mmap);
+        for (String table : new String[]{ CF_UNCOMPRESSED, CF_COMPRESSED })
         {
-            assertReaderSharesDfileChannel(sstable, reader);
+            SSTableReader sstable = createSSTable(table);
+            assertEquals(DiskAccessMode.mmap, sstable.dfile.diskAccessMode());
+            byte[] expected = readData(sstable.openDataReader());
+            // Flush has already closed the writer and its MmappedRegionsCache.
+            assertArrayEquals(expected, readData(sstable.openDataReaderForScan()));
+            assertArrayEquals(expected, readData(sstable.openDataReaderForBulkScan(DiskAccessMode.mmap)));
+            assertArrayEquals(expected, readData(sstable.openDataReader()));
         }
     }
 
     @Test
-    public void testForScanCreatesNewHandleWithDirect()
+    public void testScanClosePreservesWarmedSharedCache() throws IOException
     {
-        SSTableReader sstable = createSSTable(CF_COMPRESSED);
-
-        try (RandomAccessReader reader = sstable.openDataReaderForScan(DiskAccessMode.direct))
+        assertNotNull("This regression requires the enabled file cache in test/conf/cassandra.yaml", ChunkCache.instance);
+        for (String table : new String[]{ CF_UNCOMPRESSED, CF_COMPRESSED })
         {
-            assertReaderHasOwnChannel(sstable, reader);
+            SSTableReader sstable = createSSTable(table);
+            byte[] expected = readData(sstable.openDataReader());
+            long misses = ChunkCache.instance.metrics.misses.getCount();
+            assertArrayEquals(expected, readData(sstable.openDataReaderForScan()));
+            assertArrayEquals(expected, readData(sstable.openDataReaderForBulkScan(DiskAccessMode.standard)));
+            assertArrayEquals(expected, readData(sstable.openDataReader()));
+            assertEquals("Neither a user scan nor a closed bulk scan may evict chunks warmed by foreground readers",
+                         misses, ChunkCache.instance.metrics.misses.getCount());
+        }
+    }
+
+    @Test
+    public void testUncompressedDirectScanFallsBack() throws IOException
+    {
+        assertScanContents(CF_UNCOMPRESSED, DiskAccessMode.direct);
+    }
+
+    @Test
+    public void testOnlyBulkScanOpensItsOwnChannel()
+    {
+        SSTableReader sstable = createSSTable(CF_UNCOMPRESSED);
+        try (RandomAccessReader reader = sstable.openDataReaderForScan())
+        {
+            assertSame("A user range read must not open the data file again", sstable.dfile.channel, reader.getChannel());
+        }
+        RandomAccessReader bulk = sstable.openDataReaderForBulkScan(DiskAccessMode.standard);
+        ChannelProxy bulkChannel = bulk.getChannel();
+        assertNotSame(sstable.dfile.channel, bulkChannel);
+        bulk.close();
+        assertTrue("A bulk scan must close its private descriptor", bulkChannel.isCleanedUp());
+        assertFalse("A bulk scan must not close the shared data channel", sstable.dfile.channel.isCleanedUp());
+    }
+
+    @Test
+    @BMRules(rules = {
+        @BMRule(name = "record advice on active scan descriptors",
+                targetClass = "org.apache.cassandra.utils.NativeLibraryLinux",
+                targetMethod = "callPosixFadvise(int, long, int, int)",
+                targetLocation = "AT ENTRY",
+                condition = "org.apache.cassandra.io.sstable.format.SSTableReaderDataReaderTest.isRecordingReads()",
+                action = "return org.apache.cassandra.io.sstable.format.SSTableReaderDataReaderTest.recordAdvice($1)"),
+        @BMRule(name = "check advice at actual read boundary",
+                targetClass = "org.apache.cassandra.io.util.ChannelProxy",
+                targetMethod = "read",
+                targetLocation = "AT ENTRY",
+                condition = "org.apache.cassandra.io.sstable.format.SSTableReaderDataReaderTest.isRecordingReads()",
+                action = "org.apache.cassandra.io.sstable.format.SSTableReaderDataReaderTest.checkReadAdvice($0.getFileDescriptor())")
+    })
+    public void testBulkScanAdviceDoesNotAffectOtherReads() throws IOException
+    {
+        assumeTrue("Sequential advice is Linux-only", FBUtilities.isLinux);
+        SSTableReader sstable = createSSTable(CF_UNCOMPRESSED);
+        byte[] expected = readData(sstable.openDataReader());
+        // Force subsequent foreground reads through their actual descriptor, not the chunk cache.
+        ChunkCache.instance.invalidateFile(sstable.dfile.path());
+        advisedDescriptors.set(new HashSet<>());
+        try
+        {
+            sequentialRead.set(true);
+            assertArrayEquals(expected, readData(sstable.openDataReaderForBulkScan(DiskAccessMode.standard)));
+            sequentialRead.set(false);
+            int advised = advisedDescriptors.get().size();
+            assertArrayEquals(expected, readData(sstable.openDataReaderForScan()));
+            assertEquals("A user range read must not be advised", advised, advisedDescriptors.get().size());
+            assertArrayEquals(expected, readData(sstable.openDataReader()));
+        }
+        finally
+        {
+            sequentialRead.remove();
+            advisedDescriptors.remove();
+        }
+    }
+
+    public static boolean isRecordingReads()
+    {
+        return advisedDescriptors.get() != null;
+    }
+
+    public static int recordAdvice(int fd)
+    {
+        advisedDescriptors.get().add(fd);
+        return 0;
+    }
+
+    public static void checkReadAdvice(int fd)
+    {
+        assertEquals("Advice must apply to the descriptor performing scan reads, not foreground reads",
+                     sequentialRead.get(), Boolean.valueOf(advisedDescriptors.get().contains(fd)));
+    }
+
+    private void assertScanContents(String table, DiskAccessMode mode) throws IOException
+    {
+        SSTableReader sstable = createSSTable(table);
+        byte[] expected = readData(sstable.openDataReader());
+        try (RandomAccessReader foreground = sstable.openDataReader())
+        {
+            assertEquals(expected[0], foreground.readByte());
+            assertArrayEquals(expected, readData(sstable.openDataReaderForBulkScan(mode)));
+            foreground.seek(0);
+            byte[] actual = new byte[expected.length];
+            foreground.readFully(actual);
+            assertArrayEquals(expected, actual);
+        }
+        assertArrayEquals(expected, readData(sstable.openDataReader()));
+    }
+
+    private byte[] readData(RandomAccessReader reader) throws IOException
+    {
+        try (RandomAccessReader input = reader)
+        {
+            byte[] contents = new byte[Math.toIntExact(input.length())];
+            input.readFully(contents);
+            assertEquals(-1, input.read());
+            return contents;
         }
     }
 
@@ -269,7 +402,7 @@ public class SSTableReaderDataReaderTest
         store.forceBlockingFlush(UNIT_TESTS);
 
         SSTableReader sstable = store.getLiveSSTables().iterator().next();
-        refsToRelease.add(sstable.selfRef());
+        refsToRelease.add(sstable.ref());
         return sstable;
     }
 }

--- a/test/unit/org/apache/cassandra/utils/NativeLibraryTest.java
+++ b/test/unit/org/apache/cassandra/utils/NativeLibraryTest.java
@@ -18,21 +18,76 @@
  */
 package org.apache.cassandra.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(BMUnitRunner.class)
 public class NativeLibraryTest
 {
+    private static final ThreadLocal<List<long[]>> advisedCalls = new ThreadLocal<>();
+
     @Test
     public void testSkipCache()
     {
         File file = FileUtils.createDeletableTempFile("testSkipCache", "1");
 
         NativeLibrary.trySkipCache(file.path(), 0, 0);
+    }
+
+    @Test
+    @BMRule(name = "record sequential advice",
+            targetClass = "org.apache.cassandra.utils.NativeLibraryLinux",
+            targetMethod = "callPosixFadvise(int, long, int, int)",
+            targetLocation = "AT ENTRY",
+            condition = "org.apache.cassandra.utils.NativeLibraryTest.isRecording()",
+            action = "return org.apache.cassandra.utils.NativeLibraryTest.recordAdvice($2, $3, $4)")
+    public void testSetSequential()
+    {
+        // POSIX_FADV_SEQUENTIAL (4th argument 2) is a mode switch on the open file description:
+        // exactly one call, no byte range, and nothing at all for a closed descriptor.
+        assertAdvice(Integer.MAX_VALUE, new long[][] { { 0, 0, 2 } });
+        assertAdvice(-1, new long[0][]);
+    }
+
+    private static void assertAdvice(int fd, long[][] expected)
+    {
+        assumeTrue("Sequential cache advice is Linux-only", FBUtilities.isLinux);
+        List<long[]> actual = new ArrayList<>();
+        advisedCalls.set(actual);
+        try
+        {
+            // Record at the native wrapper, without allocating a file or issuing a syscall.
+            NativeLibrary.trySetSequential(fd, "recorded-sequential");
+            Assert.assertEquals("Native advice call count", expected.length, actual.size());
+            for (int i = 0; i < expected.length; i++)
+                Assert.assertArrayEquals("Native advice " + i, expected[i], actual.get(i));
+        }
+        finally
+        {
+            advisedCalls.remove();
+        }
+    }
+
+    public static boolean isRecording()
+    {
+        return advisedCalls.get() != null;
+    }
+
+    public static int recordAdvice(long offset, int length, int advice)
+    {
+        advisedCalls.get().add(new long[] { offset, length, advice });
+        return 0;
     }
 
     @Test


### PR DESCRIPTION
CASSANDRA-21094: compaction and streaming read SSTables sequentially but never tell the kernel, so
readahead starts at its default window and ramps up heuristically.

posix_fadvise(POSIX_FADV_SEQUENTIAL) doubles the readahead window of the open file description it is
called on. It therefore has to be issued on a descriptor that only the sequential reader uses; the
SSTable's shared data handle also serves point reads and must not be advised.

Changes:
- SSTableReader.openDataReaderForBulkScan(mode): used by SSTableSimpleScanner and SSTableCursorReader
  (compaction, cleanup, scrub, offline tools). When the effective access mode is buffered (standard),
  it opens a private FileHandle for the scan, advises its descriptor as sequential, and closes it with
  the reader. The private handle does not share the SSTable's chunk cache or the writer's mmapped
  regions cache, so opening and closing it cannot invalidate cached chunks for other readers. Under
  mmap the file is not read through the descriptor's read()/readahead path and under direct I/O the
  page cache is bypassed, so in both cases the shared handle is reused unchanged and no advice is
  issued.
- openDataReaderForScan() (user range reads via SSTableScanner) is unchanged: it keeps reusing the
  shared handle and is never advised.
- Streaming: CassandraStreamWriter, CassandraCompressedStreamWriter and entire-SSTable ComponentContext
  each open their own channel per transfer and advise it, but only when a single section spans the
  whole file, since readahead past a section end would read bytes that are not sent.
- NativeLibrary.trySetSequential(fd, path): posix_fadvise(fd, 0, 0, SEQUENTIAL) on Linux (the OS type
  Cassandra also uses as the fallback for unrecognised systems); a failure is logged at WARN with
  rate limiting and is otherwise ignored, as for trySkipCache. No-op on macOS and AIX.

Behaviour change: buffered bulk scans no longer read through the shared chunk cache. They neither
warm it nor evict its entries; compaction reads previously did both.

Testing:
- SSTableReaderDataReaderTest (12): the private handle is opened only for bulk scans; closing it
  leaves the shared handle's cached chunks in place; a bulk scan of a freshly flushed SSTable under
  mmap works; direct mode on an uncompressed table falls back to the shared handle; user range reads
  are never advised; plus the existing reuse/close/leak cases.
- NativeLibraryTest.testSetSequential (Byteman on the native call): a single advice with offset 0,
  length 0 and POSIX_FADV_SEQUENTIAL on the given descriptor.
- Kernel-level check, Linux 6.19, ext4, 4 KiB pages: after a 1 MiB sequential read of a 64 MiB file
  the pages resident beyond the read position are 32 without advice and 96 with it (mincore); reading
  through a second, unadvised descriptor of the same file after advising the first shows 32, i.e. the
  advice does not leak between open file descriptions.
- No throughput measurement was made; the ticket's expected gain on IOPS-constrained storage is not
  quantified here.

CASSANDRA-21094
