### PR TITLE
CASSANDRA-21085 Preserve offsets when splitting cache eviction requests larger than 2 GiB

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0
+ * Preserve offsets when splitting cache eviction requests larger than 2 GiB and when advising through EOF (CASSANDRA-21085)
  * Allow CQLSSTableWriter to specify SSTable id generator to use (CASSANDRA-21012)
  * Reject LIKE patterns with a wildcard (%) anywhere other than the start or end (CASSANDRA-21068)
  * Support pluggable default role initialization (CASSANDRA-21546)

--- a/src/java/org/apache/cassandra/utils/NativeLibrary.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibrary.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sun.jna.LastErrorException;
 
 import org.slf4j.Logger;
@@ -72,6 +73,11 @@ public final class NativeLibrary
     private static final int POSIX_FADV_WILLNEED   = 3; /* fadvise.h */
     private static final int POSIX_FADV_DONTNEED   = 4; /* fadvise.h */
     private static final int POSIX_FADV_NOREUSE    = 5; /* fadvise.h */
+
+    // POSIX_FADV_DONTNEED only discards fully covered pages, so chunk on a boundary that is a multiple of
+    // every common page size (4K, 16K, 64K) instead of the unaligned Integer.MAX_VALUE.
+    @VisibleForTesting
+    static final int FADVISE_MAX_CHUNK = Integer.MAX_VALUE & ~((1 << 21) - 1);
 
     private static final NativeLibraryWrapper wrappedLibrary;
     private static boolean jnaLockable = false;
@@ -228,14 +234,17 @@ public final class NativeLibrary
     public static void trySkipCache(int fd, long offset, long len, String path)
     {
         if (len == 0)
-            trySkipCache(fd, 0, 0, path);
+        {
+            trySkipCache(fd, offset, 0, path);
+            return;
+        }
 
         while (len > 0)
         {
-            int sublen = (int) Math.min(Integer.MAX_VALUE, len);
+            int sublen = (int) Math.min(FADVISE_MAX_CHUNK, len);
             trySkipCache(fd, offset, sublen, path);
             len -= sublen;
-            offset -= sublen;
+            offset += sublen;
         }
     }
 

--- a/test/unit/org/apache/cassandra/utils/NativeLibraryTest.java
+++ b/test/unit/org/apache/cassandra/utils/NativeLibraryTest.java
@@ -18,21 +18,92 @@
  */
 package org.apache.cassandra.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(BMUnitRunner.class)
 public class NativeLibraryTest
 {
+    private static final ThreadLocal<List<long[]>> advisedRanges = new ThreadLocal<>();
+
     @Test
     public void testSkipCache()
     {
         File file = FileUtils.createDeletableTempFile("testSkipCache", "1");
 
         NativeLibrary.trySkipCache(file.path(), 0, 0);
+    }
+
+    @Test
+    @BMRule(name = "record large skip-cache ranges",
+            targetClass = "org.apache.cassandra.utils.NativeLibraryLinux",
+            targetMethod = "callPosixFadvise(int, long, int, int)",
+            targetLocation = "AT ENTRY",
+            condition = "org.apache.cassandra.utils.NativeLibraryTest.isRecording()",
+            action = "return org.apache.cassandra.utils.NativeLibraryTest.recordAdvice($2, $3)")
+    public void testSkipCacheLargeRange()
+    {
+        long offset = 4096;
+        // Chunks are aligned down to 2 MiB so no page straddles a boundary and is left in cache.
+        long chunk = NativeLibrary.FADVISE_MAX_CHUNK;
+        assertAdvisedRanges(offset, 2 * chunk + 17,
+                            new long[][] { { offset, chunk },
+                                           { offset + chunk, chunk },
+                                           { offset + 2 * chunk, 17 } });
+    }
+
+    @Test
+    @BMRule(name = "record zero-length skip-cache range",
+            targetClass = "org.apache.cassandra.utils.NativeLibraryLinux",
+            targetMethod = "callPosixFadvise(int, long, int, int)",
+            targetLocation = "AT ENTRY",
+            condition = "org.apache.cassandra.utils.NativeLibraryTest.isRecording()",
+            action = "return org.apache.cassandra.utils.NativeLibraryTest.recordAdvice($2, $3)")
+    public void testSkipCacheZeroLength()
+    {
+        long offset = 4096;
+        assertAdvisedRanges(offset, 0L, new long[][] { { offset, 0 } });
+    }
+
+    private static void assertAdvisedRanges(long offset, long length, long[][] expected)
+    {
+        assumeTrue("Range cache advice is Linux-only", FBUtilities.isLinux);
+        List<long[]> actual = new ArrayList<>();
+        advisedRanges.set(actual);
+        try
+        {
+            // Record at the native wrapper, without allocating a file or issuing a syscall.
+            NativeLibrary.trySkipCache(Integer.MAX_VALUE, offset, length, "recorded-skip-cache");
+            Assert.assertEquals("Native advice call count", expected.length, actual.size());
+            for (int i = 0; i < expected.length; i++)
+                Assert.assertArrayEquals("Native advice range " + i, expected[i], actual.get(i));
+        }
+        finally
+        {
+            advisedRanges.remove();
+        }
+    }
+
+    public static boolean isRecording()
+    {
+        return advisedRanges.get() != null;
+    }
+
+    public static int recordAdvice(long offset, int length)
+    {
+        advisedRanges.get().add(new long[] { offset, length });
+        return 0;
     }
 
     @Test


### PR DESCRIPTION
CASSANDRA-21085 reports "Failed trySkipCache on file: ... Error: Invalid argument" during compaction.

NativeLibrary.trySkipCache(fd, offset, len, path) splits a request into int-sized chunks for the native
binding. After the first chunk it subtracted the chunk length from the offset instead of adding it, so
every following chunk was issued with a negative offset and posix_fadvise returned EINVAL. This can only
happen when the requested range exceeds Integer.MAX_VALUE bytes, i.e. on data files larger than 2 GiB.
Separately, a zero-length request (meaning "to end of file") dropped its starting offset and was issued
from 0.

Changes:
- advance the offset after each chunk;
- keep the requested starting offset when len == 0;
- size chunks at 2 GiB rounded down to a 2 MiB multiple (FADVISE_MAX_CHUNK) instead of Integer.MAX_VALUE.
  POSIX_FADV_DONTNEED only drops pages fully covered by the range, so an unaligned chunk boundary leaves
  the page that straddles it resident; a boundary that is a multiple of every common page size
  (4K, 16K, 64K) does not.

Testing:
- NativeLibraryTest: testSkipCacheLargeRange (Byteman on the native call; asserts the exact (offset, len)
  tuples for a range of 2 * FADVISE_MAX_CHUNK + 17 bytes, three calls), testSkipCacheZeroLength (offset
  preserved), testSkipCache.
- Kernel-level check, Linux 6.19, ext4, 4 KiB pages, sparse 2 GiB + 8 MiB file: DONTNEED issued in
  Integer.MAX_VALUE chunks leaves the page straddling the first chunk boundary resident (mincore: 1 page);
  issued in FADVISE_MAX_CHUNK chunks it is evicted (0 pages).

CASSANDRA-21085
