### PR TITLE
CASSANDRA-21333: Write zero delta when localDeletionTime overflows an int

### DIFF
--- a/src/java/org/apache/cassandra/db/SerializationHeader.java
+++ b/src/java/org/apache/cassandra/db/SerializationHeader.java
@@ -34,6 +34,7 @@ import accord.utils.Invariants;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.exceptions.UnknownColumnException;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -224,7 +225,13 @@ public class SerializationHeader
     public void writeDeletionTime(DeletionTime dt, DataOutputPlus out) throws IOException
     {
         writeTimestamp(dt.markedForDeleteAt(), out);
-        writeLocalDeletionTime(dt.localDeletionTime(), out);
+        // LIVE DeletionTime has localDeletionTime=Long.MAX_VALUE which overflows the 32-bit delta encoding
+        // (Long.MAX_VALUE - minLocalDeletionTime doesn't fit in an int). Write a zero delta instead;
+        // the read side recognizes LIVE by markedForDeleteAt == Long.MIN_VALUE.
+        if (dt.isLive())
+            writeLocalDeletionTime(stats.minLocalDeletionTime, out);
+        else
+            writeLocalDeletionTime(dt.localDeletionTime(), out);
     }
 
     public long readTimestamp(DataInputPlus in) throws IOException
@@ -246,6 +253,11 @@ public class SerializationHeader
     {
         long markedAt = readTimestamp(in);
         long localDeletionTime = readLocalDeletionTime(in);
+        // markedForDeleteAt == Long.MIN_VALUE means LIVE (no deletion). The localDeletionTime may be corrupt
+        // due to a 32-bit overflow bug in the delta encoding of Long.MAX_VALUE, so we
+        // ignore it and return LIVE directly. This handles both old (broken) and new (fixed) sstables.
+        if (markedAt == Long.MIN_VALUE)
+            return DeletionTime.LIVE;
         return DeletionTime.build(markedAt, localDeletionTime);
     }
 
@@ -253,7 +265,10 @@ public class SerializationHeader
     {
         long markedAt = readTimestamp(in);
         long localDeletionTime = readLocalDeletionTime(in);
-        reuse.reset(markedAt, localDeletionTime);
+        if (markedAt == Long.MIN_VALUE)
+            reuse.resetLive();
+        else
+            reuse.reset(markedAt, Cell.deletionTimeLongToUnsignedInteger(localDeletionTime));
     }
 
 
@@ -275,7 +290,7 @@ public class SerializationHeader
     public long deletionTimeSerializedSize(DeletionTime dt)
     {
         return timestampSerializedSize(dt.markedForDeleteAt())
-             + localDeletionTimeSerializedSize(dt.localDeletionTime());
+             + localDeletionTimeSerializedSize(dt.isLive() ? stats.minLocalDeletionTime : dt.localDeletionTime());
     }
 
     public void skipTimestamp(DataInputPlus in) throws IOException

--- a/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.cassandra.db;
 
+import org.apache.cassandra.db.rows.EncodingStats;
+import java.io.IOException;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.concurrent.Callable;
@@ -321,6 +325,64 @@ public class SerializationHeaderTest
             if (readerWithRegular != null)
                 readerWithRegular.selfRef().close();
             FileUtils.deleteRecursive(dir);
+        }
+    }
+
+    @Test
+    public void testLiveDeletionTimeRoundTrip() throws IOException
+    {
+        long realisticTimestamp = System.currentTimeMillis() * 1000;
+        long realisticLocalDeletionTime = System.currentTimeMillis() / 1000;
+        EncodingStats stats = new EncodingStats(realisticTimestamp, realisticLocalDeletionTime, 0);
+
+        TableMetadata metadata = TableMetadata.builder("ks", "tab")
+                                              .addPartitionKeyColumn("k", Int32Type.instance)
+                                              .addRegularColumn("v", Int32Type.instance)
+                                              .build();
+        SerializationHeader header = new SerializationHeader(true, metadata, metadata.regularAndStaticColumns(), stats);
+
+        try (DataOutputBuffer out = new DataOutputBuffer())
+        {
+            header.writeDeletionTime(DeletionTime.LIVE, out);
+
+            try (DataInputBuffer in = new DataInputBuffer(out.getData(), 0, out.getLength()))
+            {
+                DeletionTime.ReusableDeletionTime reuse = DeletionTime.ReusableDeletionTime.live();
+                header.readDeletionTime(in, reuse);
+                Assert.assertTrue(reuse.isLive());
+            }
+        }
+    }
+
+    @Test
+    public void testLiveDeletionTimeReadBackwardCompatibility() throws IOException
+    {
+        long realisticTimestamp = System.currentTimeMillis() * 1000;
+        long realisticLocalDeletionTime = System.currentTimeMillis() / 1000;
+        EncodingStats stats = new EncodingStats(realisticTimestamp, realisticLocalDeletionTime, 0);
+
+        TableMetadata metadata = TableMetadata.builder("ks", "tab")
+                                              .addPartitionKeyColumn("k", Int32Type.instance)
+                                              .addRegularColumn("v", Int32Type.instance)
+                                              .build();
+        SerializationHeader header = new SerializationHeader(true, metadata, metadata.regularAndStaticColumns(), stats);
+
+        try (DataOutputBuffer out = new DataOutputBuffer())
+        {
+            header.writeTimestamp(Long.MIN_VALUE, out);
+            out.writeUnsignedVInt32(-1);
+
+            try (DataInputBuffer in = new DataInputBuffer(out.getData(), 0, out.getLength()))
+            {
+                DeletionTime result = header.readDeletionTime(in);
+                Assert.assertTrue(result.isLive());
+            }
+            try (DataInputBuffer in = new DataInputBuffer(out.getData(), 0, out.getLength()))
+            {
+                DeletionTime.ReusableDeletionTime reuse = DeletionTime.ReusableDeletionTime.live();
+                header.readDeletionTime(in, reuse);
+                Assert.assertTrue(reuse.isLive());
+            }
         }
     }
 


### PR DESCRIPTION
### Jira Issue
* [CASSANDRA-21333](https://issues.apache.org/jira/browse/CASSANDRA-21333)

### Motivation
When a row has multiple complex columns but only a subset are updated, untouched columns carry `DeletionTime.LIVE` as their complex deletion. `DeletionTime.LIVE` has `localDeletionTime = Long.MAX_VALUE`, which causes `SerializationHeader.writeDeletionTime` to overflow the 32-bit delta encoding (`Long.MAX_VALUE - minLocalDeletionTime` doesn't fit in an `int`).

This caused:
1. `SerializationHeader` serializing an overflowed -1 delta (0xFFFFFFFF), corrupting the written `localDeletionTime`.
2. When reading such SSTables back during compaction, if `corrupted_tombstone_strategy` is set to `exception`, compaction throws and fails permanently.

### Changes
1. **`writeDeletionTime`:** When `dt.isLive()`, write a zero delta (`writeLocalDeletionTime(stats.minLocalDeletionTime, out)`); the read side unambiguously recognizes LIVE by `markedForDeleteAt == Long.MIN_VALUE`.
2. **`readDeletionTime` (both allocating and reusable):** When `markedAt == Long.MIN_VALUE`, directly return `DeletionTime.LIVE` or call `reuse.resetLive()`. This safely handles both newly written SSTables and legacy broken SSTables.
3. **`deletionTimeSerializedSize`:** Compute size based on zero delta for LIVE deletions.

### Testing
* `SerializationHeaderTest`: added `testLiveDeletionTimeRoundTrip` and `testLiveDeletionTimeReadBackwardCompatibility` verifying round-trip encoding and backward compatibility with old overflowed SSTables. All 9 tests pass cleanly.
