### PR TITLE
CASSANDRA-21654: Coordinator node experiences read failures on ungraceful shutdown of replica

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1116,6 +1116,16 @@ uuid_sstable_identifiers_enabled: false
 # Lowest acceptable value is 10 ms.
 # Min unit: ms
 read_request_timeout: 5000ms
+
+# What the coordinator does when a read message is dropped because the send queue for a
+# replica is full. This happens while a replica is unreachable and gossip has not yet marked
+# it down.
+# If true, the coordinator sends the read to another candidate replica, as a speculative
+# retry. The table must permit speculative retry, so a table with speculative_retry: NONE
+# keeps the behaviour below.
+# If false, the coordinator fails the read.
+# read_fallback_on_overloaded_connection: false
+
 # How long the coordinator should wait for seq or index scans to complete.
 # Lowest acceptable value is 10 ms.
 # Min unit: ms

--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -223,6 +223,10 @@ ongoing incremental repair
 |SpeculativeRetries |Counter |Number of times speculative retries were
 sent for this table.
 
+|OverloadSpeculativeRetries |Counter |Number of speculative retries that
+a read message dropped on an overloaded connection triggered. A subset of
+SpeculativeRetries.
+
 |SpeculativeFailedRetries |Counter |Number of speculative retries that
 failed to prevent a timeout
 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -132,6 +132,8 @@ public class Config
     @Replaces(oldName = "read_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound read_request_timeout = new DurationSpec.LongMillisecondsBound("5000ms");
 
+    public volatile boolean read_fallback_on_overloaded_connection = false;
+
     @Replaces(oldName = "range_request_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public volatile DurationSpec.LongMillisecondsBound range_request_timeout = new DurationSpec.LongMillisecondsBound("10000ms");
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1836,6 +1836,16 @@ public class DatabaseDescriptor
         conf.read_request_timeout = new DurationSpec.LongMillisecondsBound(timeOutInMillis);
     }
 
+    public static boolean getReadFallbackOnOverloadedConnection()
+    {
+        return conf.read_fallback_on_overloaded_connection;
+    }
+
+    public static void setReadFallbackOnOverloadedConnection(boolean enabled)
+    {
+        conf.read_fallback_on_overloaded_connection = enabled;
+    }
+
     public static long getRangeRpcTimeout(TimeUnit unit)
     {
         return conf.range_request_timeout.to(unit);

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -101,6 +101,8 @@ public class KeyspaceMetrics
     public final LatencyMetrics idealCLWriteLatency;
     /** Speculative retries **/
     public final Counter speculativeRetries;
+    /** The subset of speculative retries that a dropped read message triggered **/
+    public final Counter overloadSpeculativeRetries;
     /** Speculative retry occured but still timed out **/
     public final Counter speculativeFailedRetries;
     /** Needed to speculate, but didn't have enough replicas **/
@@ -238,6 +240,7 @@ public class KeyspaceMetrics
         idealCLWriteLatency = createLatencyMetrics("IdealCLWrite");
 
         speculativeRetries = createKeyspaceCounter("SpeculativeRetries", metric -> metric.speculativeRetries.getCount());
+        overloadSpeculativeRetries = createKeyspaceCounter("OverloadSpeculativeRetries", metric -> metric.overloadSpeculativeRetries.getCount());
         speculativeFailedRetries = createKeyspaceCounter("SpeculativeFailedRetries", metric -> metric.speculativeFailedRetries.getCount());
         speculativeInsufficientReplicas = createKeyspaceCounter("SpeculativeInsufficientReplicas", metric -> metric.speculativeInsufficientReplicas.getCount());
         additionalWrites = createKeyspaceCounter("AdditionalWrites", metric -> metric.additionalWrites.getCount());

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -221,6 +221,7 @@ public class TableMetrics
     private final MetricNameFactory aliasFactory;
 
     public final Counter speculativeRetries;
+    public final Counter overloadSpeculativeRetries;
     public final Counter speculativeFailedRetries;
     public final Counter speculativeInsufficientReplicas;
     public final Gauge<Long> speculativeSampleLatencyNanos;
@@ -823,6 +824,7 @@ public class TableMetrics
             }
         });
         speculativeRetries = createTableCounter("SpeculativeRetries");
+        overloadSpeculativeRetries = createTableCounter("OverloadSpeculativeRetries");
         speculativeFailedRetries = createTableCounter("SpeculativeFailedRetries");
         speculativeInsufficientReplicas = createTableCounter("SpeculativeInsufficientReplicas");
         speculativeSampleLatencyNanos = createTableGauge("SpeculativeSampleLatencyNanos", () -> MICROSECONDS.toNanos(cfs.sampleReadLatencyMicros));

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -339,8 +339,10 @@ public class OutboundConnection
                 // this is an optimisation only; messages will be expired on ~100ms cycle, and by Delivery when it runs
                 if (queue.maybePruneExpired() && SUCCESS == acquireCapacity(canonicalSize))
                     break;
+                onOverloaded(message, INSUFFICIENT_ENDPOINT);
+                return;
             case INSUFFICIENT_GLOBAL:
-                onOverloaded(message);
+                onOverloaded(message, INSUFFICIENT_GLOBAL);
                 return;
         }
 
@@ -452,7 +454,7 @@ public class OutboundConnection
         }
     }
 
-    private void onOverloaded(Message<?> message)
+    private void onOverloaded(Message<?> message, Outcome outcome)
     {
         overloadedCountUpdater.incrementAndGet(this);
         
@@ -463,7 +465,7 @@ public class OutboundConnection
                           this, FBUtilities.prettyPrintMemory(canonicalSize),
                           readablePendingBytes, readableReserveEndpointUsing, readableReserveGlobalUsing);
         
-        callbacks.onOverloaded(message, template.to);
+        callbacks.onOverloaded(message, template.to, outcome);
     }
 
     /**

--- a/src/java/org/apache/cassandra/net/OutboundMessageCallbacks.java
+++ b/src/java/org/apache/cassandra/net/OutboundMessageCallbacks.java
@@ -18,11 +18,17 @@
 package org.apache.cassandra.net;
 
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.ResourceLimits.Outcome;
 
 interface OutboundMessageCallbacks
 {
-    /** A message was not enqueued to the link because too many messages are already waiting to send */
-    void onOverloaded(Message<?> message, InetAddressAndPort peer);
+    /**
+     * A message was not enqueued to the link because too many messages are already waiting to send.
+     *
+     * {@code outcome} is {@link Outcome#INSUFFICIENT_ENDPOINT} when only this peer is out of capacity,
+     * and {@link Outcome#INSUFFICIENT_GLOBAL} when the node-wide reserve is exhausted.
+     */
+    void onOverloaded(Message<?> message, InetAddressAndPort peer, Outcome outcome);
 
     /** A message was not serialized to a frame because it had expired */
     void onExpired(Message<?> message, InetAddressAndPort peer);

--- a/src/java/org/apache/cassandra/net/RequestCallback.java
+++ b/src/java/org/apache/cassandra/net/RequestCallback.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.net;
 
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.ResourceLimits.Outcome;
 
 /**
  * implementors of {@link RequestCallback} need to make sure that any public methods
@@ -38,6 +39,31 @@ public interface RequestCallback<T>
      */
     default void onFailure(InetAddressAndPort from, RequestFailureReason failureReason)
     {
+    }
+
+    /**
+     * Called when the outbound connection to the peer was overloaded i.e., the request was dropped
+     * before it was sent.
+     *
+     * This method runs on the internal response stage, unless the callback asks for it to run inline
+     * with {@link #invokeOnOverloadedInline()}.
+     *
+     * @param outcome which capacity limit the request was refused by
+     */
+    default void onOverloaded(InetAddressAndPort from, Outcome outcome)
+    {
+        onFailure(from, RequestFailureReason.TIMEOUT);
+    }
+
+    /**
+     * Dictates whether the overloaded callback should run on the INTERNAL_RESPONSE threadpool or on the
+     * calling thread.
+     *
+     * @return true if {@link #onOverloaded} must run on the thread that dropped the request
+     */
+    default boolean invokeOnOverloadedInline()
+    {
+        return false;
     }
 
     /**

--- a/src/java/org/apache/cassandra/net/RequestCallbacks.java
+++ b/src/java/org/apache/cassandra/net/RequestCallbacks.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.net;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +37,7 @@ import org.apache.cassandra.io.IVersionedAsymmetricSerializer;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.metrics.InternodeOutboundMetrics;
+import org.apache.cassandra.net.ResourceLimits.Outcome;
 import org.apache.cassandra.service.AbstractWriteResponseHandler;
 
 import static java.lang.String.format;
@@ -128,6 +130,12 @@ public class RequestCallbacks implements OutboundMessageCallbacks
         if (null != ci) onExpired(ci);
     }
 
+    private void removeAndOverload(long id, InetAddressAndPort peer, Outcome outcome)
+    {
+        CallbackInfo ci = remove(id, peer);
+        if (null != ci) onOverloaded(ci, outcome);
+    }
+
     private void expire()
     {
         long start = preciseTime.now();
@@ -162,6 +170,18 @@ public class RequestCallbacks implements OutboundMessageCallbacks
 
         if (info.invokeOnFailure())
             INTERNAL_RESPONSE.submit(() -> info.callback.onFailure(info.peer, RequestFailureReason.TIMEOUT));
+    }
+
+
+    private void onOverloaded(CallbackInfo info, Outcome outcome)
+    {
+        if (!info.invokeOnFailure())
+            return;
+
+        if (info.callback.invokeOnOverloadedInline())
+            info.callback.onOverloaded(info.peer, outcome);
+        else
+            INTERNAL_RESPONSE.submit(() -> info.callback.onOverloaded(info.peer, outcome));
     }
 
     void shutdownNow(boolean expireCallbacks)
@@ -277,9 +297,9 @@ public class RequestCallbacks implements OutboundMessageCallbacks
     }
 
     @Override
-    public void onOverloaded(Message<?> message, InetAddressAndPort peer)
+    public void onOverloaded(Message<?> message, InetAddressAndPort peer, Outcome outcome)
     {
-        removeAndExpire(message, peer);
+        removeAndOverload(message, peer, outcome);
     }
 
     @Override
@@ -308,6 +328,16 @@ public class RequestCallbacks implements OutboundMessageCallbacks
         ForwardingInfo forwardTo = message.forwardTo();
         if (null != forwardTo)
             forwardTo.forEach(this::removeAndExpire);
+    }
+
+    private void removeAndOverload(Message message, InetAddressAndPort peer, Outcome outcome)
+    {
+        removeAndOverload(message.id(), peer, outcome);
+
+        /* in case of a write sent to a different DC, also fail all forwarding targets */
+        ForwardingInfo forwardTo = message.forwardTo();
+        if (null != forwardTo)
+            forwardTo.forEach((id, target) -> removeAndOverload(id, target, outcome));
     }
 
     public static long defaultExpirationInterval()

--- a/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
@@ -173,10 +174,75 @@ public abstract class AbstractReadExecutor
     public abstract void maybeTryAdditionalReplicas();
 
     /**
+     * Perform an additional request because the outbound connection to a contacted replica was overloaded and
+     * dropped our request before it was sent. Unlike {@link #maybeTryAdditionalReplicas()} this never blocks,
+     * since we already know the request will not be answered.
+     *
+     * @return true if an additional replica was contacted
+     */
+    abstract boolean maybeTryAdditionalReplicasOnOverload();
+
+    /**
+     * Send an extra read to the next uncontacted candidate.
+     *
+     * @return true if an additional replica was contacted
+     */
+    boolean trySpeculativeRetry()
+    {
+        //Handle speculation stats first in case the callback fires immediately
+        cfs.metric.speculativeRetries.inc();
+
+        ReplicaPlan.ForTokenRead replicaPlan = replicaPlan();
+        ReadCommand retryCommand;
+        Replica extraReplica;
+        if (handler.resolver.isDataPresent())
+        {
+            extraReplica = replicaPlan.firstUncontactedCandidate(replica -> true);
+            if (extraReplica == null)
+            {
+                cfs.metric.speculativeInsufficientReplicas.inc();
+                return false;
+            }
+
+            retryCommand = extraReplica.isTransient()
+                    ? command.copyAsTransientQuery(extraReplica)
+                    : command.copyAsDigestQuery(extraReplica);
+        }
+        else
+        {
+            extraReplica = replicaPlan.firstUncontactedCandidate(Replica::isFull);
+            retryCommand = command;
+            if (extraReplica == null)
+            {
+                cfs.metric.speculativeInsufficientReplicas.inc();
+                // cannot safely speculate a new data request, without more work - requests assumed to be
+                // unique per endpoint, and we have no full nodes left to speculate against
+                return false;
+            }
+        }
+
+        // we must update the plan to include this new node, else when we come to read-repair, we may not include this
+        // speculated response in the data requests we make again, and we will not be able to 'speculate' an extra repair read,
+        // nor would we be able to speculate a new 'write' if the repair writes are insufficient
+        this.replicaPlan.addToContacts(extraReplica);
+
+        if (traceState != null)
+            traceState.trace("speculating read retry on {}", extraReplica);
+        logger.trace("speculating read retry on {}", extraReplica);
+
+        MessagingService.instance().sendWithCallback(retryCommand.createMessage(false, requestTime), extraReplica.endpoint(), handler);
+
+        return true;
+    }
+
+    /**
      * send the initial set of requests
      */
     public void executeAsync()
     {
+        // the handler needs us before the first send, because a send can drop its message and call back inline
+        handler.setExecutor(this);
+
         EndpointsForToken selected = replicaPlan().contacts();
         EndpointsForToken fullDataRequests = selected.filter(Replica::isFull, initialDataRequestCount);
         makeFullDataRequests(fullDataRequests);
@@ -281,6 +347,16 @@ public abstract class AbstractReadExecutor
                 cfs.metric.speculativeInsufficientReplicas.inc();
             }
         }
+
+        boolean maybeTryAdditionalReplicasOnOverload()
+        {
+            if (DatabaseDescriptor.getReadFallbackOnOverloadedConnection() && logFailedSpeculation)
+            {
+                cfs.metric.speculativeInsufficientReplicas.inc();
+            }
+
+            return false;
+        }
     }
 
     static class SpeculatingReadExecutor extends AbstractReadExecutor
@@ -302,48 +378,22 @@ public abstract class AbstractReadExecutor
         {
             if (shouldSpeculateAndMaybeWait())
             {
-                //Handle speculation stats first in case the callback fires immediately
-                cfs.metric.speculativeRetries.inc();
                 speculated = true;
-
-                ReplicaPlan.ForTokenRead replicaPlan = replicaPlan();
-                ReadCommand retryCommand;
-                Replica extraReplica;
-                if (handler.resolver.isDataPresent())
-                {
-                    extraReplica = replicaPlan.firstUncontactedCandidate(replica -> true);
-
-                    // we should only use a SpeculatingReadExecutor if we have an extra replica to speculate against
-                    assert extraReplica != null;
-
-                    retryCommand = extraReplica.isTransient()
-                            ? command.copyAsTransientQuery(extraReplica)
-                            : command.copyAsDigestQuery(extraReplica);
-                }
-                else
-                {
-                    extraReplica = replicaPlan.firstUncontactedCandidate(Replica::isFull);
-                    retryCommand = command;
-                    if (extraReplica == null)
-                    {
-                        cfs.metric.speculativeInsufficientReplicas.inc();
-                        // cannot safely speculate a new data request, without more work - requests assumed to be
-                        // unique per endpoint, and we have no full nodes left to speculate against
-                        return;
-                    }
-                }
-
-                // we must update the plan to include this new node, else when we come to read-repair, we may not include this
-                // speculated response in the data requests we make again, and we will not be able to 'speculate' an extra repair read,
-                // nor would we be able to speculate a new 'write' if the repair writes are insufficient
-                super.replicaPlan.addToContacts(extraReplica);
-
-                if (traceState != null)
-                    traceState.trace("speculating read retry on {}", extraReplica);
-                logger.trace("speculating read retry on {}", extraReplica);
-
-                MessagingService.instance().sendWithCallback(retryCommand.createMessage(false, requestTime), extraReplica.endpoint(), handler);
+                trySpeculativeRetry();
             }
+        }
+
+        boolean maybeTryAdditionalReplicasOnOverload()
+        {
+            if (!DatabaseDescriptor.getReadFallbackOnOverloadedConnection())
+                return false;
+
+            speculated = true;
+            if (!trySpeculativeRetry())
+                return false;
+
+            cfs.metric.overloadSpeculativeRetries.inc();
+            return true;
         }
 
         @Override
@@ -371,6 +421,15 @@ public abstract class AbstractReadExecutor
         public void maybeTryAdditionalReplicas()
         {
             // no-op
+        }
+
+        boolean maybeTryAdditionalReplicasOnOverload()
+        {
+            if (!DatabaseDescriptor.getReadFallbackOnOverloadedConnection() || !trySpeculativeRetry())
+                return false;
+
+            cfs.metric.overloadSpeculativeRetries.inc();
+            return true;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/service/reads/ReadCallback.java
+++ b/src/java/org/apache/cassandra/service/reads/ReadCallback.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.ParamType;
 import org.apache.cassandra.net.RequestCallback;
+import org.apache.cassandra.net.ResourceLimits.Outcome;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
 import org.apache.cassandra.service.reads.thresholds.WarningContext;
@@ -51,6 +52,7 @@ import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+import static org.apache.cassandra.net.ResourceLimits.Outcome.INSUFFICIENT_ENDPOINT;
 import static org.apache.cassandra.tracing.Tracing.isTracing;
 import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
 
@@ -73,6 +75,9 @@ public class ReadCallback<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
     private volatile WarningContext warningContext;
     private static final AtomicReferenceFieldUpdater<ReadCallback, WarningContext> warningsUpdater
         = AtomicReferenceFieldUpdater.newUpdater(ReadCallback.class, WarningContext.class, "warningContext");
+    // set by AbstractReadExecutor before its first send. A range read, a read repair and the short read
+    // and replica filtering protections have no executor, and leave this null
+    private volatile AbstractReadExecutor executor;
 
     public ReadCallback(ResponseResolver<E, P> resolver, ReadCommand command, ReplicaPlan.Shared<E, P> replicaPlan, Dispatcher.RequestTime requestTime)
     {
@@ -92,6 +97,11 @@ public class ReadCallback<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
     protected P replicaPlan()
     {
         return replicaPlan.get();
+    }
+
+    void setExecutor(AbstractReadExecutor executor)
+    {
+        this.executor = executor;
     }
 
     public boolean await(long commandTimeout, TimeUnit unit)
@@ -239,6 +249,27 @@ public class ReadCallback<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
 
         if (blockFor + failuresUpdater.incrementAndGet(this) > replicaPlan().contacts().size())
             condition.signalAll();
+    }
+
+    /**
+     * Try an additional replica when the connection to one peer is overloaded. Fails when we run out of possible
+     * candidates, and fails without trying at all once the node-wide reserve is exhausted, since no connection to
+     * any peer can be allocated from it.
+     */
+    @Override
+    public void onOverloaded(InetAddressAndPort from, Outcome outcome)
+    {
+        AbstractReadExecutor executor = this.executor;
+        if (executor != null && INSUFFICIENT_ENDPOINT == outcome)
+            executor.maybeTryAdditionalReplicasOnOverload();
+
+        onFailure(from, RequestFailureReason.TIMEOUT);
+    }
+
+    @Override
+    public boolean invokeOnOverloadedInline()
+    {
+        return DatabaseDescriptor.getReadFallbackOnOverloadedConnection();
     }
 
     @Override

--- a/test/burn/org/apache/cassandra/net/Connection.java
+++ b/test/burn/org/apache/cassandra/net/Connection.java
@@ -364,7 +364,7 @@ public class Connection implements InboundMessageCallbacks, OutboundMessageCallb
         verifier.onConnectInbound(messagingVersion, handler);
     }
 
-    public void onOverloaded(Message<?> message, InetAddressAndPort peer)
+    public void onOverloaded(Message<?> message, InetAddressAndPort peer, ResourceLimits.Outcome outcome)
     {
         controller.fail(message.serializedSize(current_version));
         verifier.onOverloaded(message.id());

--- a/test/distributed/org/apache/cassandra/distributed/test/OverloadedConnectionReadFallbackTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/OverloadedConnectionReadFallbackTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.shared.ClusterUtils;
+import org.apache.cassandra.locator.EndpointsForToken;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.locator.ReplicaLayout;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.OutboundConnections;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OverloadedConnectionReadFallbackTest extends TestBaseImpl
+{
+    private static final String TABLE = "t";
+    private static final int SEED_ROWS = 200;
+
+    private static final int COORDINATOR = 1;
+    private static final String COORDINATOR_ADDRESS = "127.0.0.1";
+
+    private static final String SMALL_SEND_QUEUE = "4KiB";
+
+    private static final int READ_THREADS = 128;
+
+    private static final int READ_SECONDS = 3;
+
+    private static final String UNAVAILABLE = "Cannot achieve consistency level";
+
+    private static final String TIMED_OUT = "Operation timed out - received only";
+
+    @Test
+    public void oneOverloadedConnectionFallsBackToTheSpareReplica() throws Throwable
+    {
+        assertOverloadedConnectionsDoNotFailReads(3, new int[]{ 3 });
+    }
+
+    @Test
+    public void twoOverloadedConnectionsFallBackTwice() throws Throwable
+    {
+        assertOverloadedConnectionsDoNotFailReads(5, new int[]{ 3, 4 });
+    }
+
+    private void assertOverloadedConnectionsDoNotFailReads(int rf, int[] downNodes) throws Throwable
+    {
+        int quorum = rf / 2 + 1;
+        List<String> downAddresses = addresses(downNodes);
+
+        try (Cluster cluster = startCluster(rf + 1, rf))
+        {
+            seed(cluster);
+
+            List<Integer> keys = keysContactingAllOf(cluster, quorum, downAddresses);
+            assertThat(keys)
+                .as("expected keys whose replicas exclude the coordinator and contact " + downAddresses)
+                .isNotEmpty();
+
+            for (int node : downNodes)
+                ClusterUtils.stopAbrupt(cluster, cluster.get(node));
+
+            ReadOutcome outcome = hammerReads(cluster, keys, ConsistencyLevel.QUORUM);
+
+            for (String downAddress : downAddresses)
+                assertThat(overloadedMessages(cluster, downAddress))
+                    .as("the send queue for " + downAddress + " should overload")
+                    .isGreaterThan(0L);
+
+            assertThat(overloadSpeculativeRetries(cluster))
+                .as("a dropped read message should move the read to another replica")
+                .isGreaterThan(0L);
+
+            assertThat(outcome.firstFailure)
+                .as("a QUORUM read with enough live replicas should not fail because a connection is overloaded"
+                    + " (" + outcome.timeouts + " reads timed out on the expiry route)")
+                .isNull();
+
+            assertThat(outcome.successes)
+                .as("reads should continue to be served from the remaining replicas")
+                .isGreaterThan(0);
+
+            assertThat(outcome.wrongResults)
+                .as("the fallback replicas should return the seeded row")
+                .isEqualTo(0);
+        }
+    }
+
+    private Cluster startCluster(int nodes, int rf) throws Throwable
+    {
+        return init(builder().withNodes(nodes)
+                             .withConfig(config -> {
+                                 config.with(NETWORK, GOSSIP);
+                                 config.set("read_request_timeout", "5s");
+                                 config.set("write_request_timeout", "5s");
+                                 config.set("internode_application_send_queue_capacity", SMALL_SEND_QUEUE);
+                                 config.set("dynamic_snitch", false);
+                                 config.set("read_fallback_on_overloaded_connection", true);
+                             })
+                             .start(), rf);
+    }
+
+    private void seed(Cluster cluster)
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TABLE + " (pk int PRIMARY KEY, v int)"));
+        for (int pk = 0; pk < SEED_ROWS; pk++)
+            cluster.coordinator(COORDINATOR)
+                   .execute(withKeyspace("INSERT INTO %s." + TABLE + " (pk, v) VALUES (" + pk + ", 1)"),
+                            ConsistencyLevel.ALL);
+    }
+
+    private List<Integer> keysContactingAllOf(Cluster cluster, int quorum, List<String> required)
+    {
+        String keyspace = KEYSPACE;
+        String table = TABLE;
+        int keyCount = SEED_ROWS;
+        String coordinator = COORDINATOR_ADDRESS;
+        ArrayList<String> mustContact = new ArrayList<>(required);
+
+        return cluster.get(COORDINATOR).callOnInstance(() -> {
+            Keyspace ks = Keyspace.open(keyspace);
+            List<Integer> selected = new ArrayList<>();
+
+            for (int pk = 0; pk < keyCount; pk++)
+            {
+                ByteBuffer key = Int32Type.instance.decompose(pk);
+                Token token = ks.getColumnFamilyStore(table).metadata().partitioner.decorateKey(key).getToken();
+                EndpointsForToken sorted = ReplicaLayout.forTokenReadLiveSorted(ks.getReplicationStrategy(), token)
+                                                        .natural();
+
+                List<String> ordered = new ArrayList<>();
+                for (Replica replica : sorted)
+                    ordered.add(replica.endpoint().getHostAddress(false));
+
+                if (ordered.contains(coordinator))
+                    continue;
+                if (ordered.subList(0, Math.min(quorum, ordered.size())).containsAll(mustContact))
+                    selected.add(pk);
+            }
+            return selected;
+        });
+    }
+
+    private long overloadSpeculativeRetries(Cluster cluster)
+    {
+        String keyspace = KEYSPACE;
+        String table = TABLE;
+
+        return cluster.get(COORDINATOR).callOnInstance(
+            () -> Keyspace.open(keyspace).getColumnFamilyStore(table).metric.overloadSpeculativeRetries.getCount());
+    }
+
+    private long overloadedMessages(Cluster cluster, String peerAddress)
+    {
+        return cluster.get(COORDINATOR).callOnInstance(() -> {
+            long overloaded = 0;
+            for (Map.Entry<InetAddressAndPort, OutboundConnections> entry :
+                 MessagingService.instance().channelManagers.entrySet())
+            {
+                if (!entry.getKey().getHostAddress(false).equals(peerAddress))
+                    continue;
+
+                OutboundConnections connections = entry.getValue();
+                overloaded += connections.small.overloadedCount()
+                              + connections.large.overloadedCount()
+                              + connections.urgent.overloadedCount();
+            }
+            return overloaded;
+        });
+    }
+
+    private ReadOutcome hammerReads(Cluster cluster, List<Integer> keys, ConsistencyLevel cl)
+    throws InterruptedException
+    {
+        String query = withKeyspace("SELECT pk, v FROM %s." + TABLE + " WHERE pk = ?");
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(READ_SECONDS);
+
+        AtomicReference<String> firstFailure = new AtomicReference<>();
+        AtomicInteger successes = new AtomicInteger();
+        AtomicInteger timeouts = new AtomicInteger();
+        AtomicInteger wrongResults = new AtomicInteger();
+
+        ExecutorService pool = Executors.newFixedThreadPool(READ_THREADS);
+        try
+        {
+            for (int i = 0; i < READ_THREADS; i++)
+            {
+                final int offset = i;
+                pool.submit(() -> {
+                    int index = offset;
+                    while (System.nanoTime() < deadline && firstFailure.get() == null)
+                    {
+                        int pk = keys.get(Math.floorMod(index, keys.size()));
+                        try
+                        {
+                            Object[][] rows = cluster.coordinator(COORDINATOR).execute(query, cl, pk);
+                            if (rows.length != 1 || !Integer.valueOf(pk).equals(rows[0][0])
+                                || !Integer.valueOf(1).equals(rows[0][1]))
+                                wrongResults.incrementAndGet();
+                            else
+                                successes.incrementAndGet();
+                        }
+                        catch (Throwable t)
+                        {
+                            String rendered = t.toString();
+
+                            if (rendered.contains(UNAVAILABLE))
+                                return;
+
+                            // A message that reached the send queue before it filled cannot be detected
+                            // at send time, so it expires and the read times out. The fallback cannot
+                            // prevent that, so a timeout is not a failure of the route under test.
+                            if (rendered.contains(TIMED_OUT))
+                                timeouts.incrementAndGet();
+                            else
+                                firstFailure.compareAndSet(null, rendered);
+                        }
+                        index += READ_THREADS;
+                    }
+                });
+            }
+            pool.shutdown();
+            pool.awaitTermination(READ_SECONDS * 3L, TimeUnit.SECONDS);
+        }
+        finally
+        {
+            pool.shutdownNow();
+        }
+
+        return new ReadOutcome(firstFailure.get(), successes.get(), timeouts.get(), wrongResults.get());
+    }
+
+    private static List<String> addresses(int[] nodes)
+    {
+        List<String> addresses = new ArrayList<>(nodes.length);
+        for (int node : nodes)
+            addresses.add("127.0.0." + node);
+        return addresses;
+    }
+
+    private static final class ReadOutcome
+    {
+        final String firstFailure;
+        final int successes;
+        final int timeouts;
+        final int wrongResults;
+
+        ReadOutcome(String firstFailure, int successes, int timeouts, int wrongResults)
+        {
+            this.firstFailure = firstFailure;
+            this.successes = successes;
+            this.timeouts = timeouts;
+            this.wrongResults = wrongResults;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/reads/ReadExecutorTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/ReadExecutorTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
@@ -50,7 +51,10 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM;
 import static org.apache.cassandra.locator.ReplicaUtils.full;
+import static org.apache.cassandra.net.ResourceLimits.Outcome.INSUFFICIENT_ENDPOINT;
+import static org.apache.cassandra.net.ResourceLimits.Outcome.INSUFFICIENT_GLOBAL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -83,7 +87,9 @@ public class ReadExecutorTest
     {
         cfs.metric.speculativeInsufficientReplicas.dec(cfs.metric.speculativeInsufficientReplicas.getCount());
         cfs.metric.speculativeRetries.dec(cfs.metric.speculativeRetries.getCount());
+        cfs.metric.overloadSpeculativeRetries.dec(cfs.metric.overloadSpeculativeRetries.getCount());
         cfs.metric.speculativeFailedRetries.dec(cfs.metric.speculativeFailedRetries.getCount());
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(false);
     }
 
     /**
@@ -236,6 +242,116 @@ public class ReadExecutorTest
             assertSame(ExceptionUtils.getStackTrace(t), ReadFailureException.class, t.getClass());
             assertTrue(t.getMessage().contains(RequestFailureReason.READ_TOO_MANY_TOMBSTONES.name()));
         }
+    }
+
+    @Test
+    public void testOverloadWhenCandidateAvailableShouldContactItAndNotFailRead()
+    {
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        AbstractReadExecutor executor = speculatingExecutor(targets.subList(0, 1));
+        executor.executeAsync();
+
+        executor.handler.onOverloaded(targets.get(0).endpoint(), INSUFFICIENT_ENDPOINT);
+
+        assertEquals(2, executor.replicaPlan().contacts().size());
+        assertEquals(1, cfs.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(1, ks.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(1, cfs.metric.speculativeRetries.getCount());
+        assertFalse(executor.handler.condition.isSignalled());
+    }
+
+    @Test
+    public void testOverloadOfGlobalReserveShouldFailReadWithoutContactingACandidate()
+    {
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        AbstractReadExecutor executor = speculatingExecutor(targets.subList(0, 1));
+        executor.executeAsync();
+
+        executor.handler.onOverloaded(targets.get(0).endpoint(), INSUFFICIENT_GLOBAL);
+
+        assertEquals(1, executor.replicaPlan().contacts().size());
+        assertEquals(0, cfs.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(0, cfs.metric.speculativeRetries.getCount());
+        assertTrue(executor.handler.condition.isSignalled());
+    }
+
+    @Test
+    public void testOverloadWhenTwoConnectionsDropShouldContactTwoCandidates()
+    {
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        AbstractReadExecutor executor = speculatingExecutor(targets.subList(0, 1));
+        executor.executeAsync();
+
+        executor.handler.onOverloaded(targets.get(0).endpoint(), INSUFFICIENT_ENDPOINT);
+        executor.handler.onOverloaded(targets.get(1).endpoint(), INSUFFICIENT_ENDPOINT);
+
+        assertEquals(3, executor.replicaPlan().contacts().size());
+        assertEquals(2, cfs.metric.overloadSpeculativeRetries.getCount());
+    }
+
+    @Test
+    public void testOverloadWhenFallbackDisabledShouldFailRead()
+    {
+        AbstractReadExecutor executor = speculatingExecutor(targets.subList(0, 1));
+        executor.executeAsync();
+
+        executor.handler.onOverloaded(targets.get(0).endpoint(), INSUFFICIENT_ENDPOINT);
+
+        assertEquals(1, executor.replicaPlan().contacts().size());
+        assertEquals(0, cfs.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(0, cfs.metric.speculativeRetries.getCount());
+        assertTrue(executor.handler.condition.isSignalled());
+    }
+
+    @Test
+    public void testOverloadWhenExecutorNeverSpeculatesShouldNotContactAnotherReplica()
+    {
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        AbstractReadExecutor executor = new AbstractReadExecutor.NeverSpeculatingReadExecutor(cfs, new MockSinglePartitionReadCommand(DAYS.toMillis(365)), plan(ConsistencyLevel.LOCAL_ONE, targets, targets.subList(0, 1)), Dispatcher.RequestTime.forImmediateExecution(), false);
+        executor.executeAsync();
+
+        executor.handler.onOverloaded(targets.get(0).endpoint(), INSUFFICIENT_ENDPOINT);
+
+        assertEquals(1, executor.replicaPlan().contacts().size());
+        assertEquals(0, cfs.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(0, cfs.metric.speculativeRetries.getCount());
+    }
+
+    @Test
+    public void testReadCallbackRunsInlineOnOverloadOnlyWhenFallbackEnabled()
+    {
+        AbstractReadExecutor executor = speculatingExecutor(targets.subList(0, 1));
+
+        assertFalse(executor.handler.invokeOnOverloadedInline());
+
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        assertTrue(executor.handler.invokeOnOverloadedInline());
+    }
+
+    @Test
+    public void testOverloadWhenNoCandidateLeftShouldCountInsufficientReplicas()
+    {
+        DatabaseDescriptor.setReadFallbackOnOverloadedConnection(true);
+
+        AbstractReadExecutor executor = speculatingExecutor(targets);
+
+        assertFalse(executor.maybeTryAdditionalReplicasOnOverload());
+        assertEquals(3, executor.replicaPlan().contacts().size());
+        assertEquals(0, cfs.metric.overloadSpeculativeRetries.getCount());
+        assertEquals(1, cfs.metric.speculativeInsufficientReplicas.getCount());
+    }
+
+    private AbstractReadExecutor speculatingExecutor(EndpointsForToken contacts)
+    {
+        return new AbstractReadExecutor.SpeculatingReadExecutor(cfs,
+                                                                new MockSinglePartitionReadCommand(DAYS.toMillis(365)),
+                                                                plan(ConsistencyLevel.LOCAL_ONE, targets, contacts),
+                                                                Dispatcher.RequestTime.forImmediateExecution());
     }
 
     public static class MockSinglePartitionReadCommand extends SinglePartitionReadCommand


### PR DESCRIPTION
Currently, when a node has crashed but has not yet been evicted from Gossip, coordinator nodes can continue selecting that node as a replica for read and write requests. When this happens, messages will begin to pile up on the `OutboundConnection` until `pendingCapacityInBytes` is reached for the connection. Once this has been reached, some requests to that connection start to fail due to the connection becoming overloaded. At high throughput, this surfaces as a read failure to clients even when other nodes in the cluster are healthy and could have serviced the request.

This PR changes the behavior on read requests when a replica connection reaches the maximum pending bytes. If a table has speculative retry enabled and the coordinator node has exhausted the send queue for that replica's `OutboundConnection`, we will perform an immediate speculation to another replica in the cluster so long as we have not exhausted the global pool for outbound requests from the node. 

If the table has configured speculative retry as `NONE`, or the client is using `EACH_QUORUM` or `ALL` for reads, we will not speculate to ensure that we retain the existing non-speculative behavior. Additionally, we guard this new behavior behind a feature flag, `read_fallback_on_overloaded_connection`, to ensure that users can safely roll out and test the new behavior in their fleets. 

