### PR TITLE
CASSANDRA-21609: Guarantee postFlush latch decrement on flush failure

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1307,15 +1307,17 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             }
             catch (Throwable t)
             {
-                JVMStabilityInspector.inspectThrowable(t);
                 postFlush.flushFailure = t;
+                JVMStabilityInspector.inspectThrowable(t);
             }
+            finally
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("Flush task {}@{} signaling post flush task", hashCode(), name);
 
-            if (logger.isTraceEnabled())
-                logger.trace("Flush task {}@{} signaling post flush task", hashCode(), name);
-
-            // signal the post-flush we've done our work
-            postFlush.latch.decrement();
+                // signal the post-flush we've done our work
+                postFlush.latch.decrement();
+            }
 
             if (logger.isTraceEnabled())
                 logger.trace("Flush task task {}@{} finished", hashCode(), name);


### PR DESCRIPTION
## Status: changes requested — not ready to merge

Source review found no introduced production defect. The finally-block fix still needs a clean failure-injection test; it does not cover setup failures before the try block.

## Verification correction

Earlier descriptions overstated correctness and/or test coverage. Those claims are withdrawn. AI-assisted source review has been performed; this is not maintainer approval. Previously mixed build artifacts are not accepted as verification evidence. Corrective changes and clean, targeted verification are in progress; the published head has not yet been replaced.

Published head under review: `c70f180c8d1e59b561c36a00219c0c46b6d6c23e`.
