### PR TITLE
CASSANDRA-21675: Fix typos in cassandra.yaml and cassandra_latest.yaml (6.0)

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -114,7 +114,7 @@ max_hints_file_size: 128MiB
 # Disable the option in order to preserve those hints on the disk.
 auto_hints_cleanup_enabled: false
 
-# Enable/disable transfering hints to a peer during decommission. Even when enabled, this does not guarantee
+# Enable/disable transferring hints to a peer during decommission. Even when enabled, this does not guarantee
 # consistency for logged batches, and it may delay decommission when coupled with a strict hinted_handoff_throttle. 
 # Default: true
 # transfer_hints_on_decommission: true
@@ -502,7 +502,7 @@ commit_failure_policy: stop
 #
 # Valid values are either "auto" (omitting the value) or a value greater 0.
 #
-# Note that specifying a too large value will result in long running GCs and possbily
+# Note that specifying a too large value will result in long running GCs and possibly
 # out-of-memory errors. Keep the value at a small fraction of the heap.
 #
 # If you constantly see "prepared statements discarded in the last minute because
@@ -511,7 +511,7 @@ commit_failure_policy: stop
 # i.e. use bind markers for variable parts.
 #
 # Do only change the default value, if you really have more prepared statements than
-# fit in the cache. In most cases it is not neccessary to change this value.
+# fit in the cache. In most cases it is not necessary to change this value.
 # Constantly re-preparing statements is a performance penalty.
 #
 # Default value ("auto") is 1/256th of the heap or 10MiB, whichever is greater
@@ -863,7 +863,7 @@ memtable:
 memtable_allocation_type: heap_buffers
 
 # Limit memory usage for Merkle tree calculations during repairs of a certain
-# table and common token range. Repair commands targetting multiple tables or
+# table and common token range. Repair commands targeting multiple tables or
 # virtual nodes can exceed this limit depending on concurrent_merkle_tree_requests.
 #
 # The default is 1/16th of the available heap. The main tradeoff is that
@@ -966,7 +966,7 @@ memtable_allocation_type: heap_buffers
 # Min unit: ms
 # cdc_free_space_check_interval: 250ms
 
-# A fixed memory pool size in MB for for SSTable index summaries. If left
+# A fixed memory pool size in MB for SSTable index summaries. If left
 # empty, this will default to 5% of the heap size. If the memory usage of
 # all index summaries exceeds this limit, SSTables with low read rates will
 # shrink their index summaries in order to meet this limit.  However, this
@@ -1266,7 +1266,7 @@ column_index_cache_size: 2KiB
 
 # Number of simultaneous repair validations to allow. If not set or set to
 # a value less than 1, it defaults to the value of concurrent_compactors.
-# To set a value greeater than concurrent_compactors at startup, the system
+# To set a value greater than concurrent_compactors at startup, the system
 # property cassandra.allow_unlimited_concurrent_validations must be set to
 # true. To dynamically resize to a value > concurrent_compactors on a running
 # node, first call the bypassConcurrentValidatorsLimit method on the
@@ -1511,7 +1511,7 @@ slow_query_log_timeout: 500ms
 
 # IEndpointSnitch has been deprecated in Cassandra 6.0
 # Configuring a cluster with an IEndpointSnitch implementation using the endpoint_snitch setting remains supported,
-# but is superceded by the new settings detailed below.
+# but is superseded by the new settings detailed below.
 # endpoint_snitch -- Set this to a class that implements
 # IEndpointSnitch.  The snitch has two functions:
 #
@@ -1630,7 +1630,7 @@ endpoint_snitch: SimpleSnitch
 #
 # AzureCloudLocationProvider:
 #    Maps datacenter to `location` and rack to `zone` fields of the `compute` object obtained
-#    from the Azure metadata service. If the availablity zone is not enabled, it will use the
+#    from the Azure metadata service. If the availability zone is not enabled, it will use the
 #    failure domain and get its respective value. Intended to replace use of AzureSnitch.
 #
 # CloudstackLocationProvider:
@@ -1642,12 +1642,12 @@ endpoint_snitch: SimpleSnitch
 #
 # Ec2LocationProvider:
 #    Loads Region and Availability Zone information from the EC2 API. The Region is treated as the
-#    datacenter and the AvailablilityZone as the rack. Intended to replace use of Ec2Snitch and
+#    datacenter and the AvailabilityZone as the rack. Intended to replace use of Ec2Snitch and
 #    Ec2MultiRegionSnitch.
 #
 # GoogleCloudLocationProvider:
 #    Fetches source data from the metadata service of Google Cloud. This provider maps the GCE
-#    region to datacenter and the availibility zone to the rack. Intended to replace use of
+#    region to datacenter and the availability zone to the rack. Intended to replace use of
 #    GoogleCloudSnitch.
 #initial_location_provider: SimpleLocationProvider
 
@@ -1811,7 +1811,7 @@ server_encryption_options:
   #outbound_keystore_password_file: conf/outbound_keystore_passwordfile.txt
   # Verify peer server certificates
   require_client_auth: false
-  # Set to a valid trustore if require_client_auth is true
+  # Set to a valid truststore if require_client_auth is true
   truststore: conf/.truststore
   #truststore_password: cassandra
   # Optional configuration to specify password for truststore in a separate file
@@ -1874,7 +1874,7 @@ client_encryption_options:
   # - optional, Optionally verifies the client if client certificate is sent, but doesn't force client certificate to send certificates
   require_client_auth: false
   # require_endpoint_verification: false
-  # Set trustore and truststore_password if require_client_auth is true
+  # Set truststore and truststore_password if require_client_auth is true
   # truststore: conf/.truststore
   # truststore_password: cassandra
   # Optional configuration to specify password for truststore in a separate file
@@ -1910,7 +1910,7 @@ client_encryption_options:
 # Similar to `client/server_encryption_options`, you can specify PEM-based
 # key material or customize the SSL configuration using `ssl_context_factory` in `jmx_encryption_options`.
 # If you uncomment this section, please be sure that you comment out configure_jmx function call in cassandra-env.sh
-# as it is errorneous to have JMX set by two ways, both in cassandra-env.sh and in this yaml.
+# as it is erroneous to have JMX set by two ways, both in cassandra-env.sh and in this yaml.
 #jmx_server_options:
   # enabled: true
   # remote: false
@@ -2011,7 +2011,7 @@ triggers_policy: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
-# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# the "key_alias" is the only key that will be used for encrypt operations; previously used keys
 # can still (and should!) be in the keystore and will be used on decrypt operations
 # (to handle the case of key rotation).
 #
@@ -2060,7 +2060,7 @@ sstables_per_read_log_threshold: 100
 # tombstones seen in memory so we can return them to the coordinator, which
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
+# problems and even exhaust the server heap.
 # (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
@@ -2480,7 +2480,7 @@ drop_compact_storage_enabled: false
 # column_text_and_varchar_value_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering larger size of collection data than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
@@ -2491,12 +2491,12 @@ drop_compact_storage_enabled: false
 # collection_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering larger size of map data than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
 # When collection_map_size_warn_threshold and/or collection_map_size_fail_threshold are defined, they take the precedence
-# over the cooresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
+# over the corresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
 # The two thresholds default to null to disable.
 # Min unit: B
 # collection_map_size_warn_threshold:
@@ -2504,12 +2504,12 @@ drop_compact_storage_enabled: false
 # collection_map_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering larger size of set data than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
 # When collection_set_size_warn_threshold and/or collection_set_size_fail_threshold are defined, they take the precedence
-# over the cooresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
+# over the corresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
 # The two thresholds default to null to disable.
 # Min unit: B
 # collection_set_size_warn_threshold:
@@ -2517,12 +2517,12 @@ drop_compact_storage_enabled: false
 # collection_set_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering larger size of list data than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
 # When collection_list_size_warn_threshold and/or collection_list_size_fail_threshold are defined, they take the precedence
-# over the cooresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
+# over the corresponding collection_size_warn_threshold and/or collection_size_fail_threshold.
 # The two thresholds default to null to disable.
 # Min unit: B
 # collection_list_size_warn_threshold:
@@ -2530,7 +2530,7 @@ drop_compact_storage_enabled: false
 # collection_list_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering more elements in collection than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
@@ -2668,7 +2668,7 @@ drop_compact_storage_enabled: false
 #  special_fail: 1
 #  # If a password contain illegal sequences that at least this long, it is invalid.
 #  # Illegal sequences might be either alphabetical (form 'abcde'),
-#  # numerical (form '34567'), or US qwerty (form 'asdfg') as well as sequencies from supported character sets.
+#  # numerical (form '34567'), or US qwerty (form 'asdfg') as well as sequences from supported character sets.
 #  # The minimum value for this property is 3, by default it is set to 5.
 #  illegal_sequence_length: 5
 #  # Dictionary to check the passwords against. Defaults to no dictionary.
@@ -2733,7 +2733,7 @@ max_security_label_length: 48
 
 # The default secondary index implementation when CREATE INDEX does not specify one via USING.
 # ex. "legacy_local_table" - (default) legacy secondary index, implemented as a hidden table
-# ex. "sai" - "storage-attched" index, implemented via optimized SSTable/Memtable-attached indexes
+# ex. "sai" - "storage-attached" index, implemented via optimized SSTable/Memtable-attached indexes
 #default_secondary_index: legacy_local_table
 
 # Whether a default secondary index implementation is allowed. If this is "false", CREATE INDEX must
@@ -2770,18 +2770,18 @@ max_security_label_length: 48
 #  unset: "0.0.0"
 
 # Startup Checks are executed as part of Cassandra startup process, not all of them
-# are configurable (so you can disable them) but these which are enumerated bellow.
+# are configurable (so you can disable them) but these which are enumerated below.
 # Uncomment the startup checks and configure them appropriately to cover your needs.
 #
-# It is possible to implement custom startup checks by implementing StatupCheck interface 
+# It is possible to implement custom startup checks by implementing StartupCheck interface 
 # and placing JAR on a classpath, using SPI mechanism.
 #
 #startup_checks:
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
 #  check_filesystem_ownership:
 #    enabled: false
-#    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
-#    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
+#    ownership_token: "sometoken" # (overridden by "CassandraOwnershipToken" system property)
+#    ownership_filename: ".cassandra_fs_ownership" # (overridden by "cassandra.fs_ownership_filename")
 # Enable this property to fail startup if the node is down for longer than max(gc_grace_seconds, minimum_threshold),
 # to potentially prevent data resurrection on tables with deletes.
 # By default, this will run against all keyspaces and tables except the
@@ -2913,7 +2913,7 @@ storage_compatibility_mode: NONE
 #       # so a more frequent schedule such as 1h is recommended.
 #       # NOTE: Please consult
 #       # https://cassandra.apache.org/doc/latest/cassandra/managing/operating/auto_repair.html#enabling-ir
-#       # for guidance on enabling incremental repair on ane exiting cluster.
+#       # for guidance on enabling incremental repair on an existing cluster.
 #       min_repair_interval: 24h
 #       token_range_splitter:
 #         parameters:

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -117,7 +117,7 @@ max_hints_file_size: 128MiB
 # Disable the option in order to preserve those hints on the disk.
 auto_hints_cleanup_enabled: false
 
-# Enable/disable transfering hints to a peer during decommission. Even when enabled, this does not guarantee
+# Enable/disable transferring hints to a peer during decommission. Even when enabled, this does not guarantee
 # consistency for logged batches, and it may delay decommission when coupled with a strict hinted_handoff_throttle. 
 # Default: true
 # transfer_hints_on_decommission: true
@@ -505,7 +505,7 @@ commit_failure_policy: stop
 #
 # Valid values are either "auto" (omitting the value) or a value greater 0.
 #
-# Note that specifying a too large value will result in long running GCs and possbily
+# Note that specifying a too large value will result in long running GCs and possibly
 # out-of-memory errors. Keep the value at a small fraction of the heap.
 #
 # If you constantly see "prepared statements discarded in the last minute because
@@ -514,7 +514,7 @@ commit_failure_policy: stop
 # i.e. use bind markers for variable parts.
 #
 # Do only change the default value, if you really have more prepared statements than
-# fit in the cache. In most cases it is not neccessary to change this value.
+# fit in the cache. In most cases it is not necessary to change this value.
 # Constantly re-preparing statements is a performance penalty.
 #
 # Default value ("auto") is 1/256th of the heap or 10MiB, whichever is greater
@@ -866,7 +866,7 @@ memtable:
 memtable_allocation_type: offheap_objects
 
 # Limit memory usage for Merkle tree calculations during repairs of a certain
-# table and common token range. Repair commands targetting multiple tables or
+# table and common token range. Repair commands targeting multiple tables or
 # virtual nodes can exceed this limit depending on concurrent_merkle_tree_requests.
 #
 # The default is 1/16th of the available heap. The main tradeoff is that
@@ -1242,7 +1242,7 @@ concurrent_compactors: 8
 
 # Number of simultaneous repair validations to allow. If not set or set to
 # a value less than 1, it defaults to the value of concurrent_compactors.
-# To set a value greeater than concurrent_compactors at startup, the system
+# To set a value greater than concurrent_compactors at startup, the system
 # property cassandra.allow_unlimited_concurrent_validations must be set to
 # true. To dynamically resize to a value > concurrent_compactors on a running
 # node, first call the bypassConcurrentValidatorsLimit method on the
@@ -1514,7 +1514,7 @@ slow_query_log_timeout: 500ms
 #
 # AzureCloudLocationProvider:
 #    Maps datacenter to `location` and rack to `zone` fields of the `compute` object obtained
-#    from the Azure metadata service. If the availablity zone is not enabled, it will use the
+#    from the Azure metadata service. If the availability zone is not enabled, it will use the
 #    failure domain and get its respective value. Intended to replace use of AzureSnitch.
 #
 # CloudstackLocationProvider:
@@ -1526,12 +1526,12 @@ slow_query_log_timeout: 500ms
 #
 # Ec2LocationProvider:
 #    Loads Region and Availability Zone information from the EC2 API. The Region is treated as the
-#    datacenter and the AvailablilityZone as the rack. Intended to replace use of Ec2Snitch and
+#    datacenter and the AvailabilityZone as the rack. Intended to replace use of Ec2Snitch and
 #    Ec2MultiRegionSnitch.
 #
 # GoogleCloudLocationProvider:
 #    Fetches source data from the metadata service of Google Cloud. This provider maps the GCE
-#    region to datacenter and the availibility zone to the rack. Intended to replace use of
+#    region to datacenter and the availability zone to the rack. Intended to replace use of
 #    GoogleCloudSnitch.
 initial_location_provider: SimpleLocationProvider
 
@@ -1693,7 +1693,7 @@ server_encryption_options:
   #outbound_keystore_password_file: conf/outbound_keystore_passwordfile.txt
   # Verify peer server certificates
   require_client_auth: false
-  # Set to a valid trustore if require_client_auth is true
+  # Set to a valid truststore if require_client_auth is true
   truststore: conf/.truststore
   #truststore_password: cassandra
   # Optional configuration to specify password for truststore in a separate file
@@ -1749,7 +1749,7 @@ client_encryption_options:
   # - optional, Optionally verifies the client if client certificate is sent, but doesn't force client certificate to send certificates
   require_client_auth: false
   # require_endpoint_verification: false
-  # Set trustore and truststore_password if require_client_auth is true
+  # Set truststore and truststore_password if require_client_auth is true
   # truststore: conf/.truststore
   # truststore_password: cassandra
   # Optional configuration to specify password for truststore in a separate file
@@ -1776,7 +1776,7 @@ client_encryption_options:
 # Similar to `client/server_encryption_options`, you can specify PEM-based
 # key material or customize the SSL configuration using `ssl_context_factory` in `jmx_encryption_options`.
 # If you uncomment this section, please be sure that you comment out configure_jmx function call in cassandra-env.sh
-# as it is errorneous to have JMX set by two ways, both in cassandra-env.sh and in this yaml.
+# as it is erroneous to have JMX set by two ways, both in cassandra-env.sh and in this yaml.
 #jmx_server_options:
   # enabled: true
   # remote: false
@@ -1877,7 +1877,7 @@ triggers_policy: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
-# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# the "key_alias" is the only key that will be used for encrypt operations; previously used keys
 # can still (and should!) be in the keystore and will be used on decrypt operations
 # (to handle the case of key rotation).
 #
@@ -1917,7 +1917,7 @@ transparent_data_encryption_options:
 # tombstones seen in memory so we can return them to the coordinator, which
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
+# problems and even exhaust the server heap.
 # (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
@@ -2293,7 +2293,7 @@ drop_compact_storage_enabled: false
 # column_value_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering larger size of collection data than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
@@ -2304,7 +2304,7 @@ drop_compact_storage_enabled: false
 # collection_size_fail_threshold:
 #
 # Guardrail to warn or fail when encountering more elements in collection than threshold.
-# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# At query time this guardrail is applied only to the collection fragment that is being written, even though in the case
 # of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
 # prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
 # although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
@@ -2448,7 +2448,7 @@ drop_compact_storage_enabled: false
 #  special_fail: 1
 #  # If a password contain illegal sequences that at least this long, it is invalid.
 #  # Illegal sequences might be either alphabetical (form 'abcde'),
-#  # numerical (form '34567'), or US qwerty (form 'asdfg') as well as sequencies from supported character sets.
+#  # numerical (form '34567'), or US qwerty (form 'asdfg') as well as sequences from supported character sets.
 #  # The minimum value for this property is 3, by default it is set to 5.
 #  illegal_sequence_length: 5
 #  # Dictionary to check the passwords against. Defaults to no dictionary.
@@ -2505,7 +2505,7 @@ drop_compact_storage_enabled: false
 
 # The default secondary index implementation when CREATE INDEX does not specify one via USING.
 # ex. "legacy_local_table" - (default) legacy secondary index, implemented as a hidden table
-# ex. "sai" - "storage-attched" index, implemented via optimized SSTable/Memtable-attached indexes
+# ex. "sai" - "storage-attached" index, implemented via optimized SSTable/Memtable-attached indexes
 default_secondary_index: sai
 
 # Whether a default secondary index implementation is allowed. If this is "false", CREATE INDEX must
@@ -2542,18 +2542,18 @@ default_secondary_index_enabled: true
 #  unset: "0.0.0"
 
 # Startup Checks are executed as part of Cassandra startup process, not all of them
-# are configurable (so you can disable them) but these which are enumerated bellow.
+# are configurable (so you can disable them) but these which are enumerated below.
 # Uncomment the startup checks and configure them appropriately to cover your needs.
 #
-# It is possible to implement custom startup checks by implementing StatupCheck interface
+# It is possible to implement custom startup checks by implementing StartupCheck interface
 # and placing JAR on a classpath, using SPI mechanism.
 #
 #startup_checks:
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
 #  check_filesystem_ownership:
 #    enabled: false
-#    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
-#    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
+#    ownership_token: "sometoken" # (overridden by "CassandraOwnershipToken" system property)
+#    ownership_filename: ".cassandra_fs_ownership" # (overridden by "cassandra.fs_ownership_filename")
 # Enable this property to fail startup if the node is down for longer than max(gc_grace_seconds, minimum_threshold),
 # to potentially prevent data resurrection on tables with deletes.
 # By default, this will run against all keyspaces and tables except the


### PR DESCRIPTION
## Problem
Multiple spelling mistakes found in comments inside conf/cassandra.yaml 
and conf/cassandra_latest.yaml.

## Fix
Corrected the spelling mistakes in the comment text.

## Changes
- conf/cassandra.yaml
- conf/cassandra_latest.yaml

No config keys, default values, or commands were changed — only comment 
text was fixed. No functional/behavioral change.

Testing
Not applicable — comment-only change, no code or config values affected. 

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-21675)

