### PR TITLE
CASSANDRA-21675: Fix typos in cassandra.yaml (4.0)

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -86,7 +86,7 @@ hints_flush_period_in_ms: 10000
 # Maximum size for a single hints file, in megabytes.
 max_hints_file_size_in_mb: 128
 
-# Enable/disable transfering hints to a peer during decommission. Even when enabled, this does not guarantee
+# Enable/disable transferring hints to a peer during decommission. Even when enabled, this does not guarantee
 # consistency for logged batches, and it may delay decommission when coupled with a strict hinted_handoff_throttle.
 # Default: true
 #transfer_hints_on_decommission: true
@@ -305,7 +305,7 @@ commit_failure_policy: stop
 #
 # Valid values are either "auto" (omitting the value) or a value greater 0.
 #
-# Note that specifying a too large value will result in long running GCs and possbily
+# Note that specifying a too large value will result in long running GCs and possibly
 # out-of-memory errors. Keep the value at a small fraction of the heap.
 #
 # If you constantly see "prepared statements discarded in the last minute because
@@ -314,7 +314,7 @@ commit_failure_policy: stop
 # i.e. use bind markers for variable parts.
 #
 # Do only change the default value, if you really have more prepared statements than
-# fit in the cache. In most cases it is not neccessary to change this value.
+# fit in the cache. In most cases it is not necessary to change this value.
 # Constantly re-preparing statements is a performance penalty.
 #
 # Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
@@ -585,7 +585,7 @@ concurrent_materialized_view_writes: 32
 memtable_allocation_type: heap_buffers
 
 # Limit memory usage for Merkle tree calculations during repairs of a certain
-# table and common token range. Repair commands targetting multiple tables or
+# table and common token range. Repair commands targeting multiple tables or
 # virtual nodes can exceed this limit depending on concurrent_merkle_tree_requests.
 #
 # The default is 1/16th of the available heap. The main tradeoff is that
@@ -674,7 +674,7 @@ memtable_allocation_type: heap_buffers
 # new space for cdc-tracked tables has been made available. Default to 250ms
 # cdc_free_space_check_interval_ms: 250
 
-# A fixed memory pool size in MB for for SSTable index summaries. If left
+# A fixed memory pool size in MB for SSTable index summaries. If left
 # empty, this will default to 5% of the heap size. If the memory usage of
 # all index summaries exceeds this limit, SSTables with low read rates will
 # shrink their index summaries in order to meet this limit.  However, this
@@ -907,7 +907,7 @@ column_index_cache_size_in_kb: 2
 
 # Number of simultaneous repair validations to allow. If not set or set to
 # a value less than 1, it defaults to the value of concurrent_compactors.
-# To set a value greeater than concurrent_compactors at startup, the system
+# To set a value greater than concurrent_compactors at startup, the system
 # property cassandra.allow_unlimited_concurrent_validations must be set to
 # true. To dynamically resize to a value > concurrent_compactors on a running
 # node, first call the bypassConcurrentValidatorsLimit method on the
@@ -1188,7 +1188,7 @@ server_encryption_options:
     keystore_password: cassandra
     # Verify peer server certificates
     require_client_auth: false
-    # Set to a valid trustore if require_client_auth is true
+    # Set to a valid truststore if require_client_auth is true
     truststore: conf/.truststore
     truststore_password: cassandra
     # Verify that the host name in the certificate matches the connected host
@@ -1227,7 +1227,7 @@ client_encryption_options:
     keystore_password: cassandra
     # Verify client certificates
     require_client_auth: false
-    # Set trustore and truststore_password if require_client_auth is true
+    # Set truststore and truststore_password if require_client_auth is true
     # truststore: conf/.truststore
     # truststore_password: cassandra
     # More advanced defaults:
@@ -1286,7 +1286,7 @@ windows_timer_interval: 1
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
-# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# the "key_alias" is the only key that will be used for encrypt operations; previously used keys
 # can still (and should!) be in the keystore and will be used on decrypt operations
 # (to handle the case of key rotation).
 #
@@ -1320,7 +1320,7 @@ transparent_data_encryption_options:
 # tombstones seen in memory so we can return them to the coordinator, which
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
+# problems and even exhaust the server heap.
 # (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime


### PR DESCRIPTION
## Problem
Multiple spelling mistakes found in comments inside conf/cassandra.yaml.

## Fix
Corrected the spelling mistakes in the comment text.

## Changes
- conf/cassandra.yaml

No config keys, default values, or commands were changed — only comment 
text was fixed. No functional/behavioral change.

Testing
Not applicable — comment-only change, no code or config values affected. 

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-21675)
